### PR TITLE
Fix bug when right-clicking in the background

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/ToggleConnectionsHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/ToggleConnectionsHandler.java
@@ -198,10 +198,11 @@ public class ToggleConnectionsHandler extends AbstractHandler implements IElemen
 			final GraphicalViewer viewer = currentActiveEditor.getAdapter(GraphicalViewer.class);
 			if (viewer != null) {
 				final boolean isVisible = checkVisibilityOfSelection(viewer.getSelectedEditParts());
-				setElementText(element, isVisible,
-						viewer.getSelectedEditParts().size() == 1
-								&& (viewer.getSelectedEditParts().get(0) instanceof ConnectionEditPart),
-						viewer.getSelectedEditParts().get(0) instanceof TargetInterfaceElementEditPart);
+				if (viewer.getSelectedEditParts().size() == 1) {
+					setElementText(element, isVisible,
+							viewer.getSelectedEditParts().get(0) instanceof ConnectionEditPart,
+							viewer.getSelectedEditParts().get(0) instanceof TargetInterfaceElementEditPart);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
When right-clicking in the background, the selection is empty. This caused an exception because selection.get(0) was accessed without checking whether anything is selected.

@sebHollersbacher @azoitl 