### PR TITLE
Fix convert subapp to group canExecute

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/ConvertSubappToGroupCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/ConvertSubappToGroupCommand.java
@@ -69,7 +69,7 @@ public class ConvertSubappToGroupCommand extends Command implements ScopedComman
 
 	private void createConvertToGroupCommand() {
 		final List<?> subappContents = new ArrayList<>(sourceSubapp.getSubAppNetwork().getNetworkElements());
-		// delete subapp
+		// delete subapp, this absolutely has to be done first
 		convertToGroupCmd.add(new FlattenSubAppCommand(sourceSubapp, false));
 		// create new group from subapp network
 		final Rectangle bounds = new Rectangle(sourceSubapp.getPosition().toScreenPoint(),
@@ -80,7 +80,7 @@ public class ConvertSubappToGroupCommand extends Command implements ScopedComman
 
 	@Override
 	public boolean canExecute() {
-		return isUntypedSubapp(sourceSubapp) && convertToGroupCmd.canExecute();
+		return isUntypedSubapp(sourceSubapp) && !sourceSubapp.isInGroup();
 	}
 
 	private static boolean isUntypedSubapp(final SubApp subapp) {


### PR DESCRIPTION
The canExecute method is composed of a flatten subapp command and a create group command (compoundcommand). At the time of the canExecute check, the flatten subapp command was not yet executed, meaning that the check for the netowrk of the subapp elements could not work in the create group command.