### PR TITLE
Correctly show expanded subapps in viewers

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.network/src/org/eclipse/fordiac/ide/fbtypeeditor/network/viewer/CompositeViewerEditPartFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.network/src/org/eclipse/fordiac/ide/fbtypeeditor/network/viewer/CompositeViewerEditPartFactory.java
@@ -41,22 +41,20 @@ public class CompositeViewerEditPartFactory extends CompositeNetworkEditPartFact
 		this.fbInstance = fbInstance;
 	}
 
-	/** Maps an object to an EditPart.
+	/**
+	 * Maps an object to an EditPart.
 	 *
 	 * @param context      the context
 	 * @param modelElement the model element
 	 *
 	 * @return the part for element
 	 *
-	 * @throws RuntimeException if no match was found (programming error) */
+	 * @throws RuntimeException if no match was found (programming error)
+	 */
 	@Override
 	protected EditPart getPartForElement(final EditPart context, final Object modelElement) {
-		if (modelElement instanceof IInterfaceElement) {
-			final IInterfaceElement iElement = (IInterfaceElement) modelElement;
-			if (fbInstance == iElement.eContainer().eContainer()) {
-				return new CompositeInternalInterfaceEditPartRO();
-			}
-			return new InterfaceEditPartForFBNetworkRO();
+		if (modelElement instanceof final IInterfaceElement iElement) {
+			return getPartForInterfaceElement(iElement);
 		}
 		if (modelElement instanceof AdapterFB) {
 			return new AdapterFBEditPart() {
@@ -80,6 +78,13 @@ public class CompositeViewerEditPartFactory extends CompositeNetworkEditPartFact
 			return new ConnectionEditPartRO();
 		}
 		return super.getPartForElement(context, modelElement);
+	}
+
+	protected EditPart getPartForInterfaceElement(final IInterfaceElement ie) {
+		if (fbInstance == ie.eContainer().eContainer()) {
+			return new CompositeInternalInterfaceEditPartRO();
+		}
+		return new InterfaceEditPartForFBNetworkRO();
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.subapptypeeditor/src/org/eclipse/fordiac/ide/subapptypeeditor/editparts/SubappViewerEditPartFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.subapptypeeditor/src/org/eclipse/fordiac/ide/subapptypeeditor/editparts/SubappViewerEditPartFactory.java
@@ -13,9 +13,12 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.subapptypeeditor.editparts;
 
+import org.eclipse.fordiac.ide.application.editparts.TargetInterfaceElement;
 import org.eclipse.fordiac.ide.fbtypeeditor.network.viewer.CompositeViewerEditPartFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
+import org.eclipse.fordiac.ide.model.libraryElement.UntypedSubApp;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.ui.parts.GraphicalEditor;
 
@@ -26,11 +29,27 @@ public class SubappViewerEditPartFactory extends CompositeViewerEditPartFactory 
 	}
 
 	@Override
+	protected EditPart getPartForElement(final EditPart context, final Object modelElement) {
+		if (modelElement instanceof TargetInterfaceElement) {
+			return new TargetInterfaceElementEditPartRO();
+		}
+		return super.getPartForElement(context, modelElement);
+	}
+
+	@Override
 	protected EditPart getPartForFBNetwork(final FBNetwork fbNetwork) {
 		if (getFbInstance() == fbNetwork.eContainer()) {
 			return new SubAppInstanceViewerEditPart();
 		}
 		return super.getPartForFBNetwork(fbNetwork);
+	}
+
+	@Override
+	protected EditPart getPartForInterfaceElement(final IInterfaceElement ie) {
+		if ((ie.getFBNetworkElement() instanceof UntypedSubApp)) {
+			return new UntypedSubAppInterfaceElementEditPartRO();
+		}
+		return super.getPartForInterfaceElement(ie);
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.subapptypeeditor/src/org/eclipse/fordiac/ide/subapptypeeditor/editparts/TargetInterfaceElementEditPartRO.java
+++ b/plugins/org.eclipse.fordiac.ide.subapptypeeditor/src/org/eclipse/fordiac/ide/subapptypeeditor/editparts/TargetInterfaceElementEditPartRO.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Alois Zoitl - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.subapptypeeditor.editparts;
+
+import org.eclipse.fordiac.ide.application.editparts.TargetInterfaceElementEditPart;
+import org.eclipse.fordiac.ide.gef.policies.ModifiedNonResizeableEditPolicy;
+import org.eclipse.gef.EditPolicy;
+
+public class TargetInterfaceElementEditPartRO extends TargetInterfaceElementEditPart {
+
+	@Override
+	protected void createEditPolicies() {
+		installEditPolicy(EditPolicy.SELECTION_FEEDBACK_ROLE, new ModifiedNonResizeableEditPolicy());
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.subapptypeeditor/src/org/eclipse/fordiac/ide/subapptypeeditor/editparts/UntypedSubAppInterfaceElementEditPartRO.java
+++ b/plugins/org.eclipse.fordiac.ide.subapptypeeditor/src/org/eclipse/fordiac/ide/subapptypeeditor/editparts/UntypedSubAppInterfaceElementEditPartRO.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Alois Zoitl - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.subapptypeeditor.editparts;
+
+import org.eclipse.fordiac.ide.application.editparts.UntypedSubAppInterfaceElementEditPart;
+import org.eclipse.fordiac.ide.gef.policies.InterfaceElementSelectionPolicy;
+import org.eclipse.gef.EditPolicy;
+import org.eclipse.gef.Request;
+import org.eclipse.gef.RequestConstants;
+import org.eclipse.gef.editpolicies.GraphicalNodeEditPolicy;
+
+public class UntypedSubAppInterfaceElementEditPartRO extends UntypedSubAppInterfaceElementEditPart {
+
+	@Override
+	protected GraphicalNodeEditPolicy getNodeEditPolicy() {
+		return null;
+	}
+
+	@Override
+	public boolean isConnectable() {
+		return false;
+	}
+
+	@Override
+	protected void createEditPolicies() {
+		installEditPolicy(EditPolicy.SELECTION_FEEDBACK_ROLE, new InterfaceElementSelectionPolicy(this));
+	}
+
+	@Override
+	public void performRequest(final Request request) {
+		if (request.getType() != RequestConstants.REQ_DIRECT_EDIT) {
+			// only handle the request when it is not a direct edit request
+			super.performRequest(request);
+		}
+	}
+
+}


### PR DESCRIPTION
In viewers the interface pins of expanded subapps and target interface editparts where not shown.