### PR TITLE
[quickfix] add method to trace all endpoint interfaces from a given connections and the desired trace direction

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/FBEndpointFinder.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/FBEndpointFinder.java
@@ -116,6 +116,22 @@ public class FBEndpointFinder {
 		}
 		return connectedInt;
 	}
+	
+	/**
+	 * find the interfaces connected to the source (if traceThroughInput is true)
+	 * or destination (if traceThroughInput is false) of this connection
+	 *
+	 * @param connection the connection to trace
+	 * @param traceThroughInput if set to true the connection will be traced through the left (source side),
+	 *                          if set to false it will be traced through the right (destination side)
+	 * @return a Set of end-point interfaces/pins
+	 */
+	public static Set<IInterfaceElement> findConnectedInterfaceElements(final Connection connection, final boolean traceThroughInput) {
+		final Set<IInterfaceElement> connectedInt = new HashSet<>();
+		trace(new RecursionState(new ArrayDeque<>(), traceThroughInput,
+				traceThroughInput ? connection.getSource() : connection.getDestination(), connectedInt));
+		return connectedInt;
+	}
 
 	/**
 	 * find all connected interfaces for the supplied FB (only checks the output


### PR DESCRIPTION
As the actual trace function is private (which should stay that way) a new method for this functionality is necessary for a visdiac feature. It traces the given connection along the given direction to all connected endpoint interfaces.