### PR TITLE
Update instances in editor

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.attributetypeeditor/src/org/eclipse/fordiac/ide/attributetypeeditor/editors/AttributeTypeEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.attributetypeeditor/src/org/eclipse/fordiac/ide/attributetypeeditor/editors/AttributeTypeEditor.java
@@ -45,13 +45,13 @@ import org.eclipse.fordiac.ide.model.commands.change.ChangeAttributeDeclarationT
 import org.eclipse.fordiac.ide.model.data.AnyDerivedType;
 import org.eclipse.fordiac.ide.model.data.DirectlyDerivedType;
 import org.eclipse.fordiac.ide.model.data.StructuredType;
+import org.eclipse.fordiac.ide.model.edit.ITypeEntryEditor;
+import org.eclipse.fordiac.ide.model.edit.TypeEntryAdapter;
 import org.eclipse.fordiac.ide.model.libraryElement.AttributeDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.typelibrary.AttributeTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
-import org.eclipse.fordiac.ide.model.ui.editors.ITypeEntryEditor;
-import org.eclipse.fordiac.ide.model.ui.editors.TypeEntryAdapter;
 import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.gef.commands.CommandStackEvent;
@@ -498,9 +498,8 @@ public class AttributeTypeEditor extends EditorPart implements CommandStackEvent
 	}
 
 	@Override
-	public void updateInstances(final TypeEntry entry) {
-		// TODO Auto-generated method stub
-
+	public LibraryElement getEditedElement() {
+		return attributeDeclaration;
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.datatypeeditor/src/org/eclipse/fordiac/ide/datatypeeditor/editors/DataTypeEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.datatypeeditor/src/org/eclipse/fordiac/ide/datatypeeditor/editors/DataTypeEditor.java
@@ -45,6 +45,8 @@ import org.eclipse.fordiac.ide.model.commands.change.UpdateFBTypeCommand;
 import org.eclipse.fordiac.ide.model.commands.change.UpdateUntypedSubAppInterfaceCommand;
 import org.eclipse.fordiac.ide.model.data.AnyDerivedType;
 import org.eclipse.fordiac.ide.model.data.StructuredType;
+import org.eclipse.fordiac.ide.model.edit.ITypeEntryEditor;
+import org.eclipse.fordiac.ide.model.edit.TypeEntryAdapter;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
@@ -57,8 +59,6 @@ import org.eclipse.fordiac.ide.model.search.dialog.StructuredDataTypeDataHandler
 import org.eclipse.fordiac.ide.model.typelibrary.DataTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
-import org.eclipse.fordiac.ide.model.ui.editors.ITypeEntryEditor;
-import org.eclipse.fordiac.ide.model.ui.editors.TypeEntryAdapter;
 import org.eclipse.fordiac.ide.typemanagement.util.FBUpdater;
 import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 import org.eclipse.gef.commands.Command;
@@ -524,8 +524,7 @@ public class DataTypeEditor extends EditorPart implements CommandStackEventListe
 	}
 
 	@Override
-	public void updateInstances(final TypeEntry entry) {
-		// TODO Auto-generated method stub
-
+	public LibraryElement getEditedElement() {
+		return dataTypeEditable;
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/META-INF/MANIFEST.MF
@@ -15,6 +15,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.fordiac.ide.util,
  org.eclipse.swt,
  org.eclipse.jface,
+ org.eclipse.fordiac.ide.model.edit,
  org.eclipse.fordiac.ide.model.ui,
  org.eclipse.fordiac.ide.fb.interpreter
 Bundle-Vendor: Eclipse 4diac

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editors/FBTypeEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editors/FBTypeEditor.java
@@ -26,9 +26,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -52,10 +50,10 @@ import org.eclipse.fordiac.ide.gef.annotation.GraphicalAnnotationModel;
 import org.eclipse.fordiac.ide.gef.validation.ValidationJob;
 import org.eclipse.fordiac.ide.model.commands.change.AbstractChangeInterfaceElementCommand;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeNameCommand;
-import org.eclipse.fordiac.ide.model.commands.change.UpdateFBTypeCommand;
-import org.eclipse.fordiac.ide.model.commands.change.UpdateInternalFBCommand;
 import org.eclipse.fordiac.ide.model.commands.create.CreateInterfaceElementCommand;
 import org.eclipse.fordiac.ide.model.commands.delete.DeleteInterfaceCommand;
+import org.eclipse.fordiac.ide.model.edit.ITypeEntryEditor;
+import org.eclipse.fordiac.ide.model.edit.TypeEntryAdapter;
 import org.eclipse.fordiac.ide.model.libraryElement.AdapterType;
 import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.BasicFBType;
@@ -63,7 +61,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.CompositeFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.FunctionFBType;
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.ServiceInterfaceFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.SimpleFBType;
@@ -73,8 +70,6 @@ import org.eclipse.fordiac.ide.model.typelibrary.AdapterTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.FBTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
-import org.eclipse.fordiac.ide.model.ui.editors.ITypeEntryEditor;
-import org.eclipse.fordiac.ide.model.ui.editors.TypeEntryAdapter;
 import org.eclipse.fordiac.ide.typemanagement.FBTypeEditorInput;
 import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 import org.eclipse.fordiac.ide.ui.editors.AbstractCloseAbleFormEditor;
@@ -139,7 +134,7 @@ public class FBTypeEditor extends AbstractCloseAbleFormEditor implements ISelect
 	public void doSave(final IProgressMonitor monitor) {
 		if ((null != typeEntry) && (checkTypeSaveAble())) {
 			performPresaveHooks();
-			if (false /* deactivate temporarly */ && interfaceChanges != 0) {
+			if (interfaceChanges != 0) {
 				createSaveDialog(monitor);
 			} else {
 				doSaveInternal(monitor);
@@ -157,7 +152,7 @@ public class FBTypeEditor extends AbstractCloseAbleFormEditor implements ISelect
 		// Depending on the button clicked:
 		switch (fbSaveDialog.open()) {
 		case DEFAULT_BUTTON_INDEX:
-			doSaveWithUpdate(monitor, fbSaveDialog.getDataHandler().getCollectedElements());
+			doSaveInternal(monitor);
 			break;
 		case CANCEL_BUTTON_INDEX:
 			MessageDialog.openInformation(null, Messages.FBTypeEditor_ViewingComposite_Headline,
@@ -226,44 +221,9 @@ public class FBTypeEditor extends AbstractCloseAbleFormEditor implements ISelect
 		interfaceChanges = 0;
 	}
 
-	private void doSaveWithUpdate(final IProgressMonitor monitor, final Set<INamedElement> set) {
-		doSaveInternal(monitor);
-		updateFB(set);
-	}
-
 	@Override
 	public void doSaveAs() {
 		// TODO implement a save as new type method
-	}
-
-	private void updateFB(final Set<INamedElement> set) {
-		final Command cmd = getUpdateInstancesCommand(set);
-		Display.getDefault().asyncExec(cmd::execute);
-	}
-
-	private Command getUpdateInstancesCommand(final Set<INamedElement> set) {
-		final List<Command> commands = new ArrayList<>();
-		set.stream().forEach(instance -> {
-			if (instance instanceof final FBNetworkElement s) {
-				if (s.eContainer() instanceof final BaseFBType bte) {
-					if (bte.getTypeEntry().getTypeEditable() instanceof final BaseFBType bteedit) {
-						bteedit.getInternalFbs().stream()
-								.filter(fbe -> fbe.getName().equals(s.getName())
-										&& fbe.getFullTypeName().equals(s.getFullTypeName()))
-								.findAny().map(se -> new UpdateInternalFBCommand(se,
-										fbSaveDialog.getDataHandler().getTypeOfElement(s)))
-								.ifPresent(commands::add);
-					}
-				} else {
-					commands.add(new UpdateFBTypeCommand(s, fbSaveDialog.getDataHandler().getTypeOfElement(s)));
-				}
-			}
-		});
-		Command cmd = new CompoundCommand();
-		for (final Command subCmd : commands) {
-			cmd = cmd.chain(subCmd);
-		}
-		return cmd;
 	}
 
 	/**
@@ -683,9 +643,8 @@ public class FBTypeEditor extends AbstractCloseAbleFormEditor implements ISelect
 	}
 
 	@Override
-	public void updateInstances(final TypeEntry entry) {
-		// TODO Auto-generated method stub
-
+	public LibraryElement getEditedElement() {
+		return getFBType();
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.model.edit/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/META-INF/MANIFEST.MF
@@ -11,6 +11,7 @@ Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.fordiac.ide.model.buildpath.provider,
  org.eclipse.fordiac.ide.model.data.provider,
+ org.eclipse.fordiac.ide.model.edit,
  org.eclipse.fordiac.ide.model.edit.helper,
  org.eclipse.fordiac.ide.model.edit.providers,
  org.eclipse.fordiac.ide.model.libraryElement.provider
@@ -24,5 +25,10 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.fordiac.ide.ui,
  org.eclipse.jface,
  org.eclipse.emf.edit.ui,
- org.eclipse.fordiac.ide.model.eval
+ org.eclipse.fordiac.ide.model.eval,
+ org.eclipse.fordiac.ide.model.search,
+ org.eclipse.ui.workbench,
+ org.eclipse.ui.ide,
+ org.eclipse.fordiac.ide.model.commands,
+ org.eclipse.gef
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/ITypeEntryEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/ITypeEntryEditor.java
@@ -10,9 +10,9 @@
  * Contributors:
  *   Alois Zoitl - initial API and implementation and/or initial documentation
  *******************************************************************************/
-package org.eclipse.fordiac.ide.model.ui.editors;
+package org.eclipse.fordiac.ide.model.edit;
 
-import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 
@@ -36,10 +36,9 @@ public interface ITypeEntryEditor extends IEditorPart {
 	void setInput(IEditorInput input);
 
 	/**
-	 * After a typeEntry from an instance inside this editor has changed , the
-	 * editor needs to search and update all instances that are using this type.
+	 * Get the LibraryElement that is edited with this editor.
 	 *
-	 * @param typeEntry
+	 * @return libraryElement
 	 */
-	void updateInstances(TypeEntry typeEntry);
+	LibraryElement getEditedElement();
 }

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/Messages.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Primetals Technologies Germany GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Alois Zoitl - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.model.edit;
+
+import org.eclipse.osgi.util.NLS;
+
+@SuppressWarnings("squid:S3008") // tell sonar the java naming convention does not make sense for this class
+public final class Messages extends NLS {
+	private static final String BUNDLE_NAME = "org.eclipse.fordiac.ide.model.ui.messages"; //$NON-NLS-1$
+
+	public static String TypeEntryEditor_FileChangedTitle;
+	public static String TypeEntryEditor_filedchanged_message;
+	public static String TypeEntryEditor_replace_button_label;
+	public static String TypeEntryEditor_dontreplace_button_label;
+
+	static {
+		// initialize resource bundle
+		NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+	}
+
+	private Messages() {
+		// empty private constructor
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/messages.properties
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/messages.properties
@@ -1,0 +1,18 @@
+ ###############################################################################
+ # Copyright (c) 2024 Primetals Technologies Austria GmbH
+ # 
+ # This program and the accompanying materials are made available under the
+ # terms of the Eclipse Public License 2.0 which is available at
+ # http://www.eclipse.org/legal/epl-2.0.
+ #
+ # SPDX-License-Identifier: EPL-2.0
+ #
+ # Contributors:
+ #   Alois Zoitl - initial API and implementation and/or initial documentation
+ ###############################################################################
+
+TypeEntryEditor_FileChangedTitle=File Changed
+TypeEntryEditor_filedchanged_message=The file ''{0}'' has been changed. Replace the editor contents with these changes?
+
+TypeEntryEditor_replace_button_label=&Replace editor content
+TypeEntryEditor_dontreplace_button_label=&Ignore file change

--- a/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/types/BlockTypeInstanceSearch.java
+++ b/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/types/BlockTypeInstanceSearch.java
@@ -23,6 +23,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
 import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.CompositeFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.SubAppType;
 import org.eclipse.fordiac.ide.model.libraryElement.TypedConfigureableObject;
 import org.eclipse.fordiac.ide.model.libraryElement.UntypedSubApp;
@@ -37,6 +38,17 @@ public class BlockTypeInstanceSearch extends IEC61499ElementSearch {
 
 	public BlockTypeInstanceSearch(final TypeEntry entry) {
 		super(createSearchContext(entry),
+				searchCanditate -> searchCanditate instanceof final TypedConfigureableObject tco
+						&& entry == tco.getTypeEntry(),
+				createChildrenProvider());
+	}
+
+	/*
+	 * Search inside of a LibaryElement
+	 *
+	 */
+	public BlockTypeInstanceSearch(final LibraryElement typeEditable, final TypeEntry entry) {
+		super(createSearchContext(typeEditable),
 				searchCanditate -> searchCanditate instanceof final TypedConfigureableObject tco
 						&& entry == tco.getTypeEntry(),
 				createChildrenProvider());
@@ -58,6 +70,39 @@ public class BlockTypeInstanceSearch extends IEC61499ElementSearch {
 			@Override
 			public Collection<URI> getSubappTypes() {
 				return Collections.emptyList();
+			}
+
+			@Override
+			public Collection<URI> getFBTypes() {
+				return Collections.emptyList();
+			}
+
+			@Override
+			public Collection<URI> getAllTypes() {
+				return Collections.emptyList();
+			}
+		};
+	}
+
+	private static ISearchContext createSearchContext(final LibraryElement typeEditable) {
+		return new ISearchContext() {
+
+			@Override
+			public Stream<URI> getTypes() {
+				return Stream.of(typeEditable.getTypeEntry().getURI());
+			}
+
+			@Override
+			public Collection<URI> getSubappTypes() {
+				return Collections.emptyList();
+			}
+
+			@Override
+			public LibraryElement getLibraryElement(final URI uri) {
+				if (uri.equals(typeEditable.getTypeEntry().getURI())) {
+					return typeEditable;
+				}
+				return null;
 			}
 
 			@Override

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/Messages.java
@@ -32,11 +32,6 @@ public final class Messages extends NLS {
 	public static String DeviceTypeSelectionTreeContentProvider_DeviceTypes;
 	public static String ResourceTypeSelectionTreeContentProvider_ResourceTypes;
 
-	public static String TypeEntryEditor_FileChangedTitle;
-	public static String TypeEntryEditor_filedchanged_message;
-	public static String TypeEntryEditor_replace_button_label;
-	public static String TypeEntryEditor_dontreplace_button_label;
-
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/messages.properties
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/messages.properties
@@ -24,9 +24,3 @@ OpenEditorAction_text=&Open
 OpenEditorAction_viewertext=&Open in Instance Viewer
 OpenEditorProvider_OpenWithMenu_label=Open &With
 ResourceTypeSelectionTreeContentProvider_ResourceTypes=Resource Types
-
-TypeEntryEditor_FileChangedTitle=File Changed
-TypeEntryEditor_filedchanged_message=The file ''{0}'' has been changed. Replace the editor contents with these changes?
-
-TypeEntryEditor_replace_button_label=&Replace editor content
-TypeEntryEditor_dontreplace_button_label=&Ignore file change

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/editors/AutomationSystemEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/editors/AutomationSystemEditor.java
@@ -41,6 +41,8 @@ import org.eclipse.fordiac.ide.gef.DiagramOutlinePage;
 import org.eclipse.fordiac.ide.gef.annotation.FordiacMarkerGraphicalAnnotationModel;
 import org.eclipse.fordiac.ide.gef.annotation.GraphicalAnnotationModel;
 import org.eclipse.fordiac.ide.gef.validation.ValidationJob;
+import org.eclipse.fordiac.ide.model.edit.ITypeEntryEditor;
+import org.eclipse.fordiac.ide.model.edit.TypeEntryAdapter;
 import org.eclipse.fordiac.ide.model.helpers.FBNetworkHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.Application;
 import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
@@ -56,8 +58,6 @@ import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
 import org.eclipse.fordiac.ide.model.ui.actions.OpenListenerManager;
 import org.eclipse.fordiac.ide.model.ui.editors.AbstractBreadCrumbEditor;
-import org.eclipse.fordiac.ide.model.ui.editors.ITypeEntryEditor;
-import org.eclipse.fordiac.ide.model.ui.editors.TypeEntryAdapter;
 import org.eclipse.fordiac.ide.model.ui.listeners.EditorTabCommandStackListener;
 import org.eclipse.fordiac.ide.resourceediting.editors.ResourceDiagramEditor;
 import org.eclipse.fordiac.ide.resourceediting.editors.ResourceEditorInput;
@@ -487,8 +487,8 @@ public class AutomationSystemEditor extends AbstractBreadCrumbEditor implements 
 	}
 
 	@Override
-	public void updateInstances(final TypeEntry entry) {
-		// TODO Auto-generated method stub
+	public LibraryElement getEditedElement() {
+		return system;
 	}
 
 }


### PR DESCRIPTION
On change of dependent types the editor is automatically performing an update type on the children using a type.

Type save only informs about affected types but does not change them anymore.