### PR TITLE
Fix potential NPE in GetLocation of InterfaceEdiPart

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/InterfaceEditPartForFBNetwork.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/InterfaceEditPartForFBNetwork.java
@@ -79,8 +79,12 @@ public class InterfaceEditPartForFBNetwork extends InterfaceEditPart {
 		}
 
 		private boolean valueHasAnnotation() {
-			final Border border = getValueFigure().getBorder();
-			return border instanceof AnnotationFeedbackBorder || border instanceof AnnotationCompoundBorder;
+			final IFigure fig = getValueFigure();
+			if (fig != null) {
+				final Border border = fig.getBorder();
+				return border instanceof AnnotationFeedbackBorder || border instanceof AnnotationCompoundBorder;
+			}
+			return false;
 		}
 
 		private Value getValue() {


### PR DESCRIPTION
Depending on the creation order of EditParts
InterfaceEditPartForFBNetwork.getValueFigure() may return null. Therefore valeHasNannotiation threw an NPE in these cases.