### PR TITLE
Ensure that change struct loads the right model

### DIFF
--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/DataTypeEntryMock.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/DataTypeEntryMock.java
@@ -37,6 +37,7 @@ public final class DataTypeEntryMock extends BasicNotifierImpl implements DataTy
 		this.dataType = dataType;
 		this.typelib = typelib;
 		this.file = file;
+		dataType.setTypeEntry(this);
 	}
 
 	public DataTypeEntryMock(final DataTypeEntryMock typeEntry) {


### PR DESCRIPTION
ChangeStruct for struct muxers and demuxers now always gets the new struct from the type entry. This helps if the struct was changed and the update should reload it.