### PR TITLE
[demux] remove duplicate check against error markers

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/ConfigurableFBManagement.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/ConfigurableFBManagement.java
@@ -45,7 +45,7 @@ public final class ConfigurableFBManagement {
 	static void updateFbConfiguration(final ConfigurableFB fb) {
 		if (fb instanceof ConfigurableMoveFB) {
 			updateMoveFbConfiguration(fb);
-		} else if ((fb instanceof final StructManipulator sm) && (fb.getDataType() instanceof StructuredType)) {
+		} else if (fb instanceof final StructManipulator sm) {
 			updateStructManipulatorConfiguration(sm);
 		}
 	}


### PR DESCRIPTION
The method updateStructManipulatorConfiguration was only called if it was not an error marker, but the check for StructuredType happens again inside the method - and also is necessary.