### PR TITLE
Add typename for VAR_TEMP in hover label

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/hovering/STCoreHoverProvider.xtend
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/hovering/STCoreHoverProvider.xtend
@@ -40,7 +40,7 @@ class STCoreHoverProvider extends DefaultEObjectHoverProvider {
 
 	override protected getFirstLine(EObject o) {
 		val label = switch (o) {
-			VarDeclaration: o.label + " : " + o.type.name
+			VarDeclaration, STVarDeclaration: o.label + " : " + o.type.name
 			FB: o.typeEntry.type.name
 			default: o.label
 		}


### PR DESCRIPTION
Add STVarDeclaration as a possible source of elements with a instatiated Type

Current Behavior:
![image](https://github.com/eclipse-4diac/4diac-ide/assets/142894096/bbfc5dee-2e07-4ba0-9f6a-0575ef861b25)

Expected Behavior:
![image](https://github.com/eclipse-4diac/4diac-ide/assets/142894096/2c21ba1e-cc84-4c1a-9491-83cb988ba3b4)
