### PR TITLE
Fixed moving of several pins in NatTable

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.ui/src/org/eclipse/fordiac/ide/ui/widget/AddDeleteReorderListWidget.java
+++ b/plugins/org.eclipse.fordiac.ide.ui/src/org/eclipse/fordiac/ide/ui/widget/AddDeleteReorderListWidget.java
@@ -102,9 +102,14 @@ public class AddDeleteReorderListWidget extends AddDeleteWidget {
 			final CommandProvider commandProvider) {
 		return ev -> {
 			final SelectionLayer selectionLayer = NatTableWidgetFactory.getSelectionLayer(table);
-			final int[] rows = selectionLayer.getFullySelectedRowPositions();
 			final ListDataProvider<?> dataProvider = (ListDataProvider<?>) NatTableWidgetFactory.getDataLayer(table)
 					.getDataProvider();
+			if (!selectionLayer.hasRowSelection()
+					|| selectionLayer.isRowPositionSelected(dataProvider.getRowCount() - 1)) {
+				return;
+			}
+
+			final int[] rows = selectionLayer.getFullySelectedRowPositions();
 			final List<Object> rowObjects = new ArrayList<>();
 			for (final int row : rows) {
 				if (row >= 0) {
@@ -116,9 +121,9 @@ public class AddDeleteReorderListWidget extends AddDeleteWidget {
 				executeCompoundCommandForList(table, rowObjects, executor, commandProvider);
 				for (final int row : rows) {
 					if (row == dataProvider.getRowCount() - 1) {
-						selectionLayer.selectRow(0, row, false, true);
+						selectionLayer.selectRow(0, row, true, true);
 					} else {
-						selectionLayer.selectRow(0, row + 1, false, true);
+						selectionLayer.selectRow(0, row + 1, true, true);
 					}
 				}
 			}

--- a/plugins/org.eclipse.fordiac.ide.ui/src/org/eclipse/fordiac/ide/ui/widget/AddDeleteWidget.java
+++ b/plugins/org.eclipse.fordiac.ide.ui/src/org/eclipse/fordiac/ide/ui/widget/AddDeleteWidget.java
@@ -203,10 +203,13 @@ public class AddDeleteWidget {
 			final CommandProvider commandProvider) {
 		return ev -> {
 			final SelectionLayer selectionLayer = NatTableWidgetFactory.getSelectionLayer(table);
-			final int[] rows = selectionLayer.getFullySelectedRowPositions();
 			final ListDataProvider<?> dataProvider = (ListDataProvider<?>) NatTableWidgetFactory.getDataLayer(table)
 					.getDataProvider();
+			if (!selectionLayer.hasRowSelection() || selectionLayer.isRowPositionSelected(0)) {
+				return;
+			}
 
+			final int[] rows = selectionLayer.getFullySelectedRowPositions();
 			final List<Object> rowObjects = new ArrayList<>();
 			for (final int row : rows) {
 				if (row >= 0) {
@@ -217,9 +220,9 @@ public class AddDeleteWidget {
 				executeCompoundCommandForList(table, rowObjects, executor, commandProvider);
 				for (final int row : rows) {
 					if (row == 0) {
-						selectionLayer.selectRow(0, row, false, true);
+						selectionLayer.selectRow(0, row, true, true);
 					} else {
-						selectionLayer.selectRow(0, row - 1, false, true);
+						selectionLayer.selectRow(0, row - 1, true, true);
 					}
 				}
 			}


### PR DESCRIPTION
Fixed moving of pins in NatTable using the Reorder buttons to keep selection
Also fixed weird behaviour when reordering when selection is at the start or end of the list