### PR TITLE
fix ctrl+click for ECC to create state plus transition

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/commands/CreateTransitionCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/commands/CreateTransitionCommand.java
@@ -78,7 +78,9 @@ public class CreateTransitionCommand extends CreationCommand {
 		this.source = source;
 		this.sourceLocation = source.getPosition().toScreenPoint();
 		this.destination = destination;
-		this.destLocation = destination.getPosition().toScreenPoint();
+		if (destination.getPosition() != null) {
+			this.destLocation = destination.getPosition().toScreenPoint();
+		}
 		this.conditionEvent = conditionEvent;
 	}
 
@@ -136,7 +138,7 @@ public class CreateTransitionCommand extends CreationCommand {
 
 	@Override
 	public boolean canExecute() {
-		return ((null != source) && (null != destination) && (null != source.getECC()));
+		return ((null != source) && (null != destination) && (null != source.getECC()) && (null != destLocation));
 	}
 
 	/*

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editors/ECCEditorEditDomain.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editors/ECCEditorEditDomain.java
@@ -115,6 +115,7 @@ final class ECCEditorEditDomain extends FBTypeEditDomain {
 			final CreateECStateCommand createStateCommand = new CreateECStateCommand(destState, point, ecc);
 			final CreateTransitionCommand createTransitionCommand = new CreateTransitionCommand(sourceState, destState,
 					null);
+			createTransitionCommand.setDestinationLocation(point);
 			final CompoundCommand compCom = new CompoundCommand();
 			compCom.add(createStateCommand);
 			compCom.add(createTransitionCommand);


### PR DESCRIPTION
When pressing ctrl while dragging an ECC transition, a new state is created. This allows to quickly draw ECCs. With the recent change on the position, this caused now an NPE. Additionally, the state is now created directly under mouse position again (it had an offset for some time already).