### PR TITLE
Resolve target pin labels in follow connection handler

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/FollowConnectionHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/FollowConnectionHandler.java
@@ -124,6 +124,10 @@ public abstract class FollowConnectionHandler extends AbstractHandler {
 				@Override
 				public String getText(final Object element) {
 					if (element instanceof final IInterfaceElement iElem) {
+						if (originPin != null && originPin.getFBNetworkElement().getFbNetwork()
+								.equals(iElem.getFBNetworkElement().getFbNetwork())) {
+							return iElem.getFBNetworkElement().getName();
+						}
 						return getFullQualifiedPinName(iElem);
 					}
 					return super.getText(element);

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/FollowConnectionHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/FollowConnectionHandler.java
@@ -106,7 +106,7 @@ public abstract class FollowConnectionHandler extends AbstractHandler {
 				return sb.toString();
 			}
 			if (isInSameNetwork(originPin, iElem)) {
-				sb.append(iElem.getFBNetworkElement());
+				sb.append(iElem.getFBNetworkElement().getName());
 			} else {
 				sb.append(iElem.getFBNetworkElement().getQualifiedName());
 				sb.delete(0, sb.indexOf(".") + 1); //$NON-NLS-1$
@@ -195,7 +195,7 @@ public abstract class FollowConnectionHandler extends AbstractHandler {
 				if (e.character == SWT.CR) {
 					dialogArea.getShell().close();
 				}
-				if (opposites.getFirst().getInputConnections().isEmpty()) {
+				if (opposites.get(0).getInputConnections().isEmpty()) {
 					handleRight(e);
 				} else {
 					handleLeft(e);

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/FollowConnectionHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/FollowConnectionHandler.java
@@ -101,6 +101,17 @@ public abstract class FollowConnectionHandler extends AbstractHandler {
 			return titleAreaComposite;
 		}
 
+		private String getFullQualifiedPinName(final IInterfaceElement iElem) {
+			final StringBuilder sb = new StringBuilder();
+			if (null != iElem.getFBNetworkElement()) {
+				sb.append(iElem.getFBNetworkElement().getQualifiedName());
+				sb.delete(0, sb.indexOf(".") + 1); //$NON-NLS-1$
+			}
+			sb.append('.');
+			sb.append(iElem.getName());
+			return sb.toString();
+		}
+
 		@Override
 		protected Control createDialogArea(final Composite parent) {
 
@@ -113,11 +124,7 @@ public abstract class FollowConnectionHandler extends AbstractHandler {
 				@Override
 				public String getText(final Object element) {
 					if (element instanceof final IInterfaceElement iElem) {
-						String retVal = ""; //$NON-NLS-1$
-						if (null != iElem.getFBNetworkElement()) {
-							retVal = iElem.getFBNetworkElement().getName() + "."; //$NON-NLS-1$
-						}
-						return retVal + iElem.getName();
+						return getFullQualifiedPinName(iElem);
 					}
 					return super.getText(element);
 				}
@@ -237,7 +244,7 @@ public abstract class FollowConnectionHandler extends AbstractHandler {
 
 	protected static List<IInterfaceElement> resolveBorderElements(final List<IInterfaceElement> opposites,
 			final GraphicalViewer viewer) {
-		final List<IInterfaceElement> resolvedOpposites = new ArrayList();
+		final List<IInterfaceElement> resolvedOpposites = new ArrayList<>();
 		boolean changeFlag = false;
 		for (final IInterfaceElement element : opposites) {
 			final EditPart ep = (EditPart) (viewer.getEditPartRegistry().get(element));

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/FollowLeftConnectionHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/FollowLeftConnectionHandler.java
@@ -38,6 +38,9 @@ public class FollowLeftConnectionHandler extends FollowConnectionHandler {
 		final GraphicalViewer viewer = editor.getAdapter(GraphicalViewer.class);
 		final StructuredSelection selection = (StructuredSelection) HandlerUtil.getCurrentSelection(event);
 
+		final IInterfaceElement originPin = ((InterfaceEditPart) ((IStructuredSelection) selection).getFirstElement())
+				.getModel();
+
 		final InterfaceEditPart interfaceEditPart = (InterfaceEditPart) ((IStructuredSelection) selection)
 				.getFirstElement();
 		if (isEditorBorderPin(interfaceEditPart.getModel(), getFBNetwork(editor))
@@ -52,7 +55,7 @@ public class FollowLeftConnectionHandler extends FollowConnectionHandler {
 		}
 
 		final List<IInterfaceElement> opposites = getConnectionOposites(interfaceEditPart);
-		selectOpposites(event, viewer, null, opposites);
+		selectOpposites(event, viewer, originPin, opposites);
 		return Status.OK_STATUS;
 	}
 


### PR DESCRIPTION
The follow connection handler can now directly resolve the border labels for connections in an expanded subapp and will take the ref element of the border pin