### PR TITLE
Any to Any connections crossing interfaces shall not be flagged as error

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/ConnectionAnnotations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/ConnectionAnnotations.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import org.eclipse.emf.common.util.BasicDiagnostic;
 import org.eclipse.emf.common.util.Diagnostic;
 import org.eclipse.emf.common.util.DiagnosticChain;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.fordiac.ide.model.Messages;
 import org.eclipse.fordiac.ide.model.data.AnyStringType;
 import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes.GenericTypes;
@@ -27,9 +28,12 @@ import org.eclipse.fordiac.ide.model.helpers.VarInOutHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.Connection;
 import org.eclipse.fordiac.ide.model.libraryElement.ErrorMarkerFBNElement;
 import org.eclipse.fordiac.ide.model.libraryElement.ErrorMarkerInterface;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
+import org.eclipse.fordiac.ide.model.libraryElement.UntypedSubApp;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.util.LibraryElementValidator;
 import org.eclipse.fordiac.ide.model.validation.LinkConstraints;
@@ -117,33 +121,49 @@ public class ConnectionAnnotations {
 
 	public static boolean validateTypeMismatch(@NonNull final Connection connection, final DiagnosticChain diagnostics,
 			final Map<Object, Object> context) {
-		if (!LinkConstraints.typeCheck(connection.getSource(), connection.getDestination())) {
+		final IInterfaceElement src = connection.getSource();
+		final IInterfaceElement dest = connection.getDestination();
+		if (!LinkConstraints.typeCheck(src, dest)) {
 			if (diagnostics != null) {
 				diagnostics.add(new BasicDiagnostic(Diagnostic.ERROR, LibraryElementValidator.DIAGNOSTIC_SOURCE,
 						LibraryElementValidator.CONNECTION__VALIDATE_TYPE_MISMATCH,
-						MessageFormat.format(Messages.ConnectionAnnotations_TypeMismatch,
-								connection.getSource().getQualifiedName(), connection.getSource().getFullTypeName(),
-								connection.getDestination().getQualifiedName(),
-								connection.getDestination().getFullTypeName()),
+						MessageFormat.format(Messages.ConnectionAnnotations_TypeMismatch, src.getQualifiedName(),
+								src.getFullTypeName(), dest.getQualifiedName(), dest.getFullTypeName()),
 						FordiacMarkerHelper.getDiagnosticData(connection)));
 			}
 			return false;
 		}
-		if (connection.getSource() != null && connection.getDestination() != null
-				&& GenericTypes.isAnyType(connection.getSource().getType())
-				&& GenericTypes.isAnyType(connection.getDestination().getType())) {
+		if (src != null && dest != null && GenericTypes.isAnyType(src.getType())
+				&& GenericTypes.isAnyType(connection.getDestination().getType())
+				&& !isContainerPin(src.eContainer().eContainer(), dest.eContainer().eContainer())) {
 			if (diagnostics != null) {
 				diagnostics.add(new BasicDiagnostic(Diagnostic.ERROR, LibraryElementValidator.DIAGNOSTIC_SOURCE,
 						LibraryElementValidator.CONNECTION__VALIDATE_TYPE_MISMATCH,
-						MessageFormat.format(Messages.ConnectionAnnotations_GenericEndpoints,
-								connection.getSource().getQualifiedName(), connection.getSource().getFullTypeName(),
-								connection.getDestination().getQualifiedName(),
-								connection.getDestination().getFullTypeName()),
+						MessageFormat.format(Messages.ConnectionAnnotations_GenericEndpoints, src.getQualifiedName(),
+								src.getFullTypeName(), dest.getQualifiedName(), dest.getFullTypeName()),
 						FordiacMarkerHelper.getDiagnosticData(connection)));
 			}
 			return false;
 		}
 		return true;
+	}
+
+	private static boolean isContainerPin(final EObject srcParent, final EObject destParent) {
+		if ((srcParent instanceof FBType) || (destParent instanceof FBType)) {
+			// one of the pins is on the type so we are fine
+			return true;
+		}
+
+		if ((srcParent instanceof final FBNetworkElement srcElem
+				&& destParent instanceof final FBNetworkElement destElem)
+				&& ((srcParent instanceof UntypedSubApp) || (destParent instanceof UntypedSubApp))) {
+			// if at least one of the parents is an untyped subapp the connection will need
+			// to cross the interface, i.e., the two FBNetworkElement must not be in the
+			// same network
+			return (srcElem.getFbNetwork() != destElem.getFbNetwork());
+		}
+
+		return false;
 	}
 
 	public static boolean validateMappedVarInOutsDoNotCrossResourceBoundaries(@NonNull final Connection connection,


### PR DESCRIPTION
This change now will not mark any to any connections that are either leaving a type (e.g., going to the interface of a CFB or typed subapp) or that are crossing a untyped subapp, as an error. This is needed as you may want to encapsulate a generic SIFB with some logic but have generic data to be used (e.g., Client with response timeout checking).