### PR TITLE
sleeptime in debug view: ensure consistent behavior

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/fb/FBLaunchConfigurationTab.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/fb/FBLaunchConfigurationTab.java
@@ -126,12 +126,12 @@ public abstract class FBLaunchConfigurationTab extends MainLaunchConfigurationTa
 		GridDataFactory.fillDefaults().applyTo(systemTimeRadio);
 
 		incrementTimeRadio = new Button(radioComp, SWT.RADIO);
-		incrementTimeRadio.setText(Messages.FBLaunchConfigurationTab_UseFixedClockWithSpecifiedTime);
+		incrementTimeRadio.setText(Messages.FBLaunchConfigurationTab_IncrementClockAfterEachEventBySpecifiedAmount);
 		incrementTimeRadio.addListener(SWT.Selection, e -> updateLaunchConfigurationDialog());
 		GridDataFactory.fillDefaults().applyTo(incrementTimeRadio);
 
 		manualTimeRadio = new Button(radioComp, SWT.RADIO);
-		manualTimeRadio.setText(Messages.FBLaunchConfigurationTab_IncrementClockAfterEachEventBySpecifiedAmount);
+		manualTimeRadio.setText(Messages.FBLaunchConfigurationTab_UseFixedClockWithSpecifiedTime);
 		manualTimeRadio.addListener(SWT.Selection, e -> updateLaunchConfigurationDialog());
 		GridDataFactory.fillDefaults().applyTo(manualTimeRadio);
 

--- a/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/DebugTimeComposite.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/DebugTimeComposite.java
@@ -160,7 +160,7 @@ public class DebugTimeComposite {
 		evaluator.getExecutor().setClock(AbstractEvaluator.MonotonicClock.UTC);
 		if (eventQueue != null) {
 			eventQueue.setEvaluatorProcess(evaluator);
-			eventQueue.setClockMode(FBDebugClockMode.SYSTEM);
+			eventQueue.setDebugTimeValue(FBDebugClockMode.SYSTEM, Duration.ZERO);
 		}
 	}
 
@@ -171,8 +171,7 @@ public class DebugTimeComposite {
 			final Duration sleepTime = Duration.of(value, ChronoUnit.MILLIS);
 			if (eventQueue != null) {
 				eventQueue.setEvaluatorProcess(evaluator);
-				eventQueue.setDebugTimeValue(sleepTime);
-				eventQueue.setClockMode(FBDebugClockMode.INCREMENT);
+				eventQueue.setDebugTimeValue(FBDebugClockMode.INCREMENT, sleepTime);
 			}
 		} catch (final NumberFormatException | java.lang.ArithmeticException e) {
 			throw new IllegalStateException("Debug Time Value is not accepted!"); //$NON-NLS-1$
@@ -183,12 +182,11 @@ public class DebugTimeComposite {
 		// time is fixed and set to user input
 		try {
 			final long value = Long.parseLong(text);
-			final Duration sleepTime = Duration.of(value, ChronoUnit.MILLIS);
-			final Instant instant = Instant.ofEpochSecond(sleepTime.getSeconds(), sleepTime.getNano());
+			final Duration manualTime = Duration.of(value, ChronoUnit.MILLIS);
+			final Instant instant = Instant.ofEpochSecond(manualTime.getSeconds(), manualTime.getNano());
 			if (eventQueue != null) {
 				eventQueue.setEvaluatorProcess(evaluator);
-				eventQueue.setDebugTimeValue(sleepTime);
-				eventQueue.setClockMode(FBDebugClockMode.MANUAL);
+				eventQueue.setDebugTimeValue(FBDebugClockMode.MANUAL, manualTime);
 			}
 			evaluator.getExecutor().setClock(Clock.fixed(instant, ZoneId.systemDefault()));
 		} catch (final NumberFormatException | java.lang.ArithmeticException e) {
@@ -225,7 +223,6 @@ public class DebugTimeComposite {
 			manualTimeRadio.setSelection(eventQueue.isDebugTimeManual());
 			debugTimeText.setText(String.valueOf(eventQueue.getDebugTimeValue().toMillis()));
 			eventQueue.setEvaluatorProcess(evaluator);
-			eventQueue.setDebugTime();
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.debug/src/org/eclipse/fordiac/ide/debug/fb/FBLaunchConfigurationDelegate.java
+++ b/plugins/org.eclipse.fordiac.ide.debug/src/org/eclipse/fordiac/ide/debug/fb/FBLaunchConfigurationDelegate.java
@@ -49,9 +49,8 @@ public abstract class FBLaunchConfigurationDelegate extends CommonLaunchConfigur
 
 			final FBLaunchEventQueue fBLaunchEventQueue = new FBLaunchEventQueue(event, repeatEvent,
 					keepRunningWhenIdle);
-			fBLaunchEventQueue.setDebugTimeValue(FBLaunchConfigurationAttributes.getClockInterval(configuration));
-			fBLaunchEventQueue.setClockMode(FBLaunchConfigurationAttributes.getClockMode(configuration));
-
+			fBLaunchEventQueue.setDebugTimeValue(FBLaunchConfigurationAttributes.getClockMode(configuration),
+					FBLaunchConfigurationAttributes.getClockInterval(configuration));
 			evaluator.setEventQueue(fBLaunchEventQueue);
 			launch(evaluator, configuration, mode, launch, monitor);
 		}


### PR DESCRIPTION
 - fixed incorrect labels in configuration tab
 - incremental mode now starts at 0
 - incremental mode now updates sleep time value before evaluating