### PR TITLE
Add missing configurable fb dependency on save

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/FBNetworkExporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/FBNetworkExporter.java
@@ -148,6 +148,7 @@ class FBNetworkExporter extends CommonElementExporter {
 		}
 		if (fbnElement instanceof final ConfigurableFB configFb) {
 			addAttributes(configFb.getConfigurationAsAttributes());
+			addDependency(configFb.getDataType());
 		}
 		addAttributes(fbnElement.getAttributes());
 


### PR DESCRIPTION
Saving a type udpdates the dependency tracking of the type entry. For configurable types their dependencies where not added to the dependency list.