### PR TITLE
Border crossing commands didn't accommodate membervar

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/BorderCrossingReconnectCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/BorderCrossingReconnectCommand.java
@@ -104,7 +104,8 @@ public class BorderCrossingReconnectCommand extends CompoundCommand {
 	@Override
 	public boolean canExecute() {
 		// equal types
-		if (!source.getClass().equals(target.getClass())) {
+		if (!source.getClass().isAssignableFrom(target.getClass())
+				&& !target.getClass().isAssignableFrom(source.getClass())) {
 			ErrorMessenger.popUpErrorMessage(Messages.LinkConstraints_ConnectingIncompatibleInterfaceTypes);
 			return false;
 		}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/CreateSubAppCrossingConnectionsCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/CreateSubAppCrossingConnectionsCommand.java
@@ -87,7 +87,8 @@ public class CreateSubAppCrossingConnectionsCommand extends Command implements S
 		// own checks
 
 		// equal types for source and dest
-		if (!source.getClass().equals(destination.getClass())) {
+		if (!source.getClass().isAssignableFrom(destination.getClass())
+				&& !destination.getClass().isAssignableFrom(source.getClass())) {
 			ErrorMessenger.popUpErrorMessage(Messages.LinkConstraints_ConnectingIncompatibleInterfaceTypes);
 			return false;
 		}


### PR DESCRIPTION
As struct manipulators are now having children of VarDeclaration as pins, the border crossing connection (re-)creation commands where wrongly failing because of type mismatch.