### PR TITLE
Extended DnD for Re-connecting in split editors

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/dnd/ConnSourceTransfer.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/dnd/ConnSourceTransfer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Primetals Technologies Austria GmbH
+ * Copyright (c) 2023, 2024 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,23 +12,32 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.application.dnd;
 
-import org.eclipse.fordiac.ide.gef.editparts.InterfaceEditPart;
+import org.eclipse.gef.Request;
 import org.eclipse.gef.dnd.SimpleObjectTransfer;
 
 final class ConnSourceTransfer extends SimpleObjectTransfer {
 
+	public static final String CONNECTIONS_LIST = "Connections"; //$NON-NLS-1$
+
 	private static final ConnSourceTransfer INSTANCE = new ConnSourceTransfer();
 	private static final String TYPE_NAME = "ConnSourceTransver";//$NON-NLS-1$
 	private static final int TYPEID = registerType(TYPE_NAME);
-
 
 	public static ConnSourceTransfer getInstance() {
 		return INSTANCE;
 	}
 
 	@Override
-	public InterfaceEditPart getObject() {
-		return (InterfaceEditPart) super.getObject();
+	public Request getObject() {
+		return (Request) super.getObject();
+	}
+
+	@Override
+	public void setObject(final Object obj) {
+		if (obj != null && !(obj instanceof Request)) {
+			throw new IllegalArgumentException("ConnSourceTransfer requires a request as object!"); //$NON-NLS-1$
+		}
+		super.setObject(obj);
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/dnd/ConnectionDragSourceListener.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/dnd/ConnectionDragSourceListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Primetals Technologies Austria GmbH
+ * Copyright (c) 2023, 2024 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,21 +9,35 @@
  *
  * Contributors:
  *   Alois Zoitl - initial API and implementation and/or initial documentation
+ *               - added connection re-connection across editor boundaries
  *******************************************************************************/
 package org.eclipse.fordiac.ide.application.dnd;
 
 import java.util.List;
 
 import org.eclipse.core.runtime.Assert;
+import org.eclipse.draw2d.ConnectionLocator;
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.fordiac.ide.application.editparts.ConnectionEditPart;
 import org.eclipse.fordiac.ide.gef.editparts.InterfaceEditPart;
 import org.eclipse.fordiac.ide.gef.handlers.AdvancedGraphicalViewerKeyHandler;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartViewer;
+import org.eclipse.gef.LayerConstants;
+import org.eclipse.gef.Request;
+import org.eclipse.gef.RequestConstants;
 import org.eclipse.gef.dnd.AbstractTransferDragSourceListener;
+import org.eclipse.gef.editparts.LayerManager;
+import org.eclipse.gef.handles.ConnectionEndpointHandle;
+import org.eclipse.gef.requests.CreateConnectionRequest;
+import org.eclipse.gef.requests.ReconnectRequest;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.dnd.DragSourceEvent;
 
 public class ConnectionDragSourceListener extends AbstractTransferDragSourceListener {
+
+	private Request lastReq = null;
 
 	public ConnectionDragSourceListener(final EditPartViewer viewer) {
 		super(viewer, ConnSourceTransfer.getInstance());
@@ -32,38 +46,100 @@ public class ConnectionDragSourceListener extends AbstractTransferDragSourceList
 
 	@Override
 	public void dragStart(final DragSourceEvent event) {
-		final InterfaceEditPart selectedInterfaceEditPart = getSelectedInterfaceEditPart();
+		final Request req = createRequest(new Point(event.x, event.y));
 
-		if (!isAltKeyPressed() || selectedInterfaceEditPart == null) {
+		if (!isAltKeyPressed() || req == null) {
 			event.doit = false;
+			lastReq = null;
 			return;
 		}
-		ConnSourceTransfer.getInstance().setObject(selectedInterfaceEditPart);
+		lastReq = req;
+		ConnSourceTransfer.getInstance().setObject(req);
 	}
 
 	@Override
 	public void dragSetData(final DragSourceEvent event) {
-		event.data = getSelectedInterfaceEditPart();
+		event.data = lastReq;
 	}
 
 	@Override
 	public void dragFinished(final DragSourceEvent event) {
 		super.dragFinished(event);
 		ConnSourceTransfer.getInstance().setObject(null);
-	}
-
-	private InterfaceEditPart getSelectedInterfaceEditPart() {
-		final List<? extends EditPart> selectedEditParts = getViewer().getSelectedEditParts();
-		if (selectedEditParts.size() == 1 && selectedEditParts.get(0) instanceof final InterfaceEditPart iep) {
-			return iep;
-		}
-		return null;
+		lastReq = null;
 	}
 
 	private boolean isAltKeyPressed() {
 		final AdvancedGraphicalViewerKeyHandler keyHandler = (AdvancedGraphicalViewerKeyHandler) getViewer()
 				.getKeyHandler();
 		return keyHandler.getCurrentKeyCode() == SWT.ALT;
+	}
+
+	private Request createRequest(final Point point) {
+		final List<? extends EditPart> selectedEditParts = getViewer().getSelectedEditParts();
+		if (selectedEditParts.size() == 1 && selectedEditParts.get(0) instanceof final InterfaceEditPart iep) {
+			return createConnectionCreationRequest(iep);
+		}
+		final List<ConnectionEditPart> connections = selectedEditParts.stream()
+				.filter(ConnectionEditPart.class::isInstance).map(ep -> (ConnectionEditPart) ep).toList();
+		if (!connections.isEmpty()) {
+			return createReconnectRequest(connections, point);
+		}
+		return null;
+	}
+
+	private static Request createConnectionCreationRequest(final InterfaceEditPart iep) {
+		final CreateConnectionRequest req = new CreateConnectionRequest();
+		req.setType(RequestConstants.REQ_CONNECTION_START);
+		req.setSourceEditPart(iep);
+		req.setStartCommand(iep.getCommand(req));
+		req.setType(RequestConstants.REQ_CONNECTION_END);
+		return req;
+	}
+
+	private static Request createReconnectRequest(final List<ConnectionEditPart> connections, final Point point) {
+		final ConnectionEditPart first = connections.get(0);
+		final String reconnectType = getReconnectType(first, point);
+		if (reconnectType != null) {
+			// only create a ReconnectRequest when the drag was from a valid connection
+			// end point handle
+			final ReconnectRequest req = new ReconnectRequest(reconnectType);
+			req.setConnectionEditPart(first);
+			if (connections.size() > 1) {
+				// we are reconnecting a fanned connection
+				req.getExtendedData().put(ConnSourceTransfer.CONNECTIONS_LIST, connections);
+			}
+			final EditPart target = (req.getType().equals(RequestConstants.REQ_RECONNECT_SOURCE)) ? first.getSource()
+					: first.getTarget();
+			req.setTargetEditPart(target);
+			return req;
+		}
+		return null;
+	}
+
+	private static String getReconnectType(final ConnectionEditPart first, final Point point) {
+		final ConnectionEndpointHandle connectionHandle = getConnectionHandle(first, point);
+		if (connectionHandle != null) {
+			if (connectionHandle.getEndPoint() == ConnectionLocator.SOURCE) {
+				return RequestConstants.REQ_RECONNECT_SOURCE;
+			}
+			return RequestConstants.REQ_RECONNECT_TARGET;
+		}
+
+		return null;
+	}
+
+	private static ConnectionEndpointHandle getConnectionHandle(final ConnectionEditPart first, final Point point) {
+		final List<? extends IFigure> handles = LayerManager.Helper.find(first).getLayer(LayerConstants.HANDLE_LAYER)
+				.getChildren();
+		for (final IFigure handle : handles) {
+			final Point pointCopy = point.getCopy();
+			handle.translateToRelative(pointCopy);
+			if (handle.getBounds().contains(pointCopy) && handle instanceof final ConnectionEndpointHandle conHandle) {
+				return conHandle;
+			}
+		}
+		return null;
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/InterfaceElementEditPolicy.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/InterfaceElementEditPolicy.java
@@ -32,7 +32,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
-import org.eclipse.gef.EditPart;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.editpolicies.GraphicalNodeEditPolicy;
 import org.eclipse.gef.requests.CreateConnectionRequest;
@@ -79,7 +78,7 @@ public abstract class InterfaceElementEditPolicy extends GraphicalNodeEditPolicy
 		final var conn = (Connection) request.getConnectionEditPart().getModel();
 		final var sourcePin = conn.getSource();
 		final var targetPin = conn.getDestination();
-		final var newPin = (IInterfaceElement) request.getTarget().getModel();
+		final var newPin = (IInterfaceElement) getHost().getModel();
 
 		// border crossing source reconnect
 		if (isSourceReconnect && isBorderCrossing(targetPin, newPin)) {
@@ -92,8 +91,7 @@ public abstract class InterfaceElementEditPolicy extends GraphicalNodeEditPolicy
 		}
 
 		// local reconnect
-		final AbstractReconnectConnectionCommand cmd = createReconnectCommand(conn, isSourceReconnect,
-				getRequestTarget(request));
+		final AbstractReconnectConnectionCommand cmd = createReconnectCommand(conn, isSourceReconnect, newPin);
 		final FBNetwork newParent = checkConnectionParent(cmd.getNewSource(), cmd.getNewDestination(), cmd.getParent());
 		if (newParent != null) {
 			cmd.setParent(newParent);
@@ -177,14 +175,6 @@ public abstract class InterfaceElementEditPolicy extends GraphicalNodeEditPolicy
 			if (pin.eContainer().eContainer() instanceof final CompositeFBType cfbType) {
 				return cfbType.getFBNetwork();
 			}
-		}
-		return null;
-	}
-
-	private static IInterfaceElement getRequestTarget(final ReconnectRequest request) {
-		final EditPart target = request.getTarget();
-		if (target.getModel() instanceof final IInterfaceElement ie) {
-			return ie;
 		}
 		return null;
 	}


### PR DESCRIPTION
With this change it is now also possible to reconnect connections in split editor mode. This will also work across subapp boundaries as it is using the new reconnect functions.