### PR TITLE
Interface pins where not correctly added in expanded subapp viewers

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.network/src/org/eclipse/fordiac/ide/fbtypeeditor/network/viewer/CompositeViewerEditPartFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.network/src/org/eclipse/fordiac/ide/fbtypeeditor/network/viewer/CompositeViewerEditPartFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 - 2017 Profactor GmbH, fortiss GmbH
+ * Copyright (c) 2013, 2024 Profactor GmbH, fortiss GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -54,7 +54,7 @@ public class CompositeViewerEditPartFactory extends CompositeNetworkEditPartFact
 	@Override
 	protected EditPart getPartForElement(final EditPart context, final Object modelElement) {
 		if (modelElement instanceof final IInterfaceElement iElement) {
-			return getPartForInterfaceElement(iElement);
+			return getPartForInterfaceElement(context, iElement);
 		}
 		if (modelElement instanceof AdapterFB) {
 			return new AdapterFBEditPart() {
@@ -80,7 +80,7 @@ public class CompositeViewerEditPartFactory extends CompositeNetworkEditPartFact
 		return super.getPartForElement(context, modelElement);
 	}
 
-	protected EditPart getPartForInterfaceElement(final IInterfaceElement ie) {
+	protected EditPart getPartForInterfaceElement(final EditPart context, final IInterfaceElement ie) {
 		if (fbInstance == ie.eContainer().eContainer()) {
 			return new CompositeInternalInterfaceEditPartRO();
 		}

--- a/plugins/org.eclipse.fordiac.ide.subapptypeeditor/src/org/eclipse/fordiac/ide/subapptypeeditor/editparts/SubappViewerEditPartFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.subapptypeeditor/src/org/eclipse/fordiac/ide/subapptypeeditor/editparts/SubappViewerEditPartFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Primemetals Austria GmbH
+ * Copyright (c) 2021, 2024 Primemetals Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.subapptypeeditor.editparts;
 
+import org.eclipse.fordiac.ide.application.editparts.SubAppForFBNetworkEditPart;
 import org.eclipse.fordiac.ide.application.editparts.TargetInterfaceElement;
 import org.eclipse.fordiac.ide.fbtypeeditor.network.viewer.CompositeViewerEditPartFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
@@ -45,11 +46,11 @@ public class SubappViewerEditPartFactory extends CompositeViewerEditPartFactory 
 	}
 
 	@Override
-	protected EditPart getPartForInterfaceElement(final IInterfaceElement ie) {
-		if ((ie.getFBNetworkElement() instanceof UntypedSubApp)) {
+	protected EditPart getPartForInterfaceElement(final EditPart context, final IInterfaceElement ie) {
+		if ((ie.getFBNetworkElement() instanceof UntypedSubApp) && (context instanceof SubAppForFBNetworkEditPart)) {
 			return new UntypedSubAppInterfaceElementEditPartRO();
 		}
-		return super.getPartForInterfaceElement(ie);
+		return super.getPartForInterfaceElement(context, ie);
 	}
 
 }


### PR DESCRIPTION
when going into an expanded subapp we are now showing a non editable viewer of the expanded subapp content. In these viewers the interface pin of the expanded subapp where shown as it was an expanded subapp inside of the subapp. this lead to connection artifacts from the outside to be shown inside.