### PR TITLE
Use IEC 61499 Coord. System for Conn Bendpoints and Sizes

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/ConvertSubappToGroupCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/ConvertSubappToGroupCommand.java
@@ -22,6 +22,7 @@ import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.fordiac.ide.gef.utilities.ElementSelector;
+import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.commands.ScopedCommand;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeCommentCommand;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeNameCommand;
@@ -73,7 +74,8 @@ public class ConvertSubappToGroupCommand extends Command implements ScopedComman
 		convertToGroupCmd.add(new FlattenSubAppCommand(sourceSubapp, false));
 		// create new group from subapp network
 		final Rectangle bounds = new Rectangle(sourceSubapp.getPosition().toScreenPoint(),
-				new Dimension(sourceSubapp.getWidth(), sourceSubapp.getHeight()));
+				new Dimension(CoordinateConverter.INSTANCE.iec61499ToScreen(sourceSubapp.getWidth()),
+						CoordinateConverter.INSTANCE.iec61499ToScreen(sourceSubapp.getHeight())));
 		createGroupCmd = new CreateGroupCommand(fbNetwork, subappContents, bounds);
 		convertToGroupCmd.add(createGroupCmd);
 	}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/CommentEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/CommentEditPart.java
@@ -36,6 +36,7 @@ import org.eclipse.fordiac.ide.gef.editparts.AbstractPositionableElementEditPart
 import org.eclipse.fordiac.ide.gef.editparts.FigureCellEditorLocator;
 import org.eclipse.fordiac.ide.gef.editparts.TextDirectEditManager;
 import org.eclipse.fordiac.ide.gef.policies.AbstractViewRenameEditPolicy;
+import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeCommentCommand;
 import org.eclipse.fordiac.ide.model.commands.delete.DeleteFBNetworkElementCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.Comment;
@@ -262,7 +263,8 @@ public class CommentEditPart extends AbstractPositionableElementEditPart {
 	}
 
 	private Dimension getCommentSize() {
-		return new Dimension(getModel().getWidth(), getModel().getHeight());
+		return new Dimension(CoordinateConverter.INSTANCE.iec61499ToScreen(getModel().getWidth()),
+				CoordinateConverter.INSTANCE.iec61499ToScreen(getModel().getHeight()));
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/GroupEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/GroupEditPart.java
@@ -35,6 +35,7 @@ import org.eclipse.fordiac.ide.gef.editparts.AbstractPositionableElementEditPart
 import org.eclipse.fordiac.ide.gef.editparts.FigureCellEditorLocator;
 import org.eclipse.fordiac.ide.gef.editparts.TextDirectEditManager;
 import org.eclipse.fordiac.ide.gef.policies.AbstractViewRenameEditPolicy;
+import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeCommentCommand;
 import org.eclipse.fordiac.ide.model.commands.delete.DeleteGroupCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.Group;
@@ -298,7 +299,8 @@ public class GroupEditPart extends AbstractPositionableElementEditPart
 	}
 
 	private Dimension getGroupSize() {
-		return new Dimension(getModel().getWidth(), getModel().getHeight());
+		return new Dimension(CoordinateConverter.INSTANCE.iec61499ToScreen(getModel().getWidth()),
+				CoordinateConverter.INSTANCE.iec61499ToScreen(getModel().getHeight()));
 	}
 
 	private GroupContentEditPart getGroupContentEP() {

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/SubAppForFBNetworkEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/SubAppForFBNetworkEditPart.java
@@ -47,6 +47,7 @@ import org.eclipse.fordiac.ide.gef.editparts.InterfaceEditPart;
 import org.eclipse.fordiac.ide.gef.editparts.TextDirectEditManager;
 import org.eclipse.fordiac.ide.gef.policies.AbstractViewRenameEditPolicy;
 import org.eclipse.fordiac.ide.gef.policies.EmptyXYLayoutEditPolicy;
+import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeCommentCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
@@ -384,7 +385,8 @@ public class SubAppForFBNetworkEditPart extends AbstractFBNElementEditPart imple
 
 	private Dimension getSubappSize() {
 		if (getModel().isUnfolded()) {
-			return new Dimension(getModel().getWidth(), getModel().getHeight());
+			return new Dimension(CoordinateConverter.INSTANCE.iec61499ToScreen(getModel().getWidth()),
+					CoordinateConverter.INSTANCE.iec61499ToScreen(getModel().getHeight()));
 		}
 		return new Dimension(-1, -1);
 	}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/GroupPropertySection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/GroupPropertySection.java
@@ -15,6 +15,7 @@ package org.eclipse.fordiac.ide.application.properties;
 import org.eclipse.fordiac.ide.application.commands.ResizeGroupOrSubappCommand;
 import org.eclipse.fordiac.ide.application.editparts.GroupEditPart;
 import org.eclipse.fordiac.ide.gef.properties.AbstractDoubleColumnSection;
+import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeCommentCommand;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeGroupBoundsCommand;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeGroupSizeLockCommand;
@@ -67,8 +68,8 @@ public class GroupPropertySection extends AbstractDoubleColumnSection {
 			commandStack = null;
 			nameText.setText(getType().getName() != null ? getType().getName() : ""); //$NON-NLS-1$
 			commentText.setText(getType().getComment() != null ? getType().getComment() : ""); //$NON-NLS-1$
-			heightText.setText(Integer.toString(getType().getHeight()));
-			widthText.setText(Integer.toString(getType().getWidth()));
+			heightText.setText(Integer.toString(CoordinateConverter.INSTANCE.iec61499ToScreen(getType().getHeight())));
+			widthText.setText(Integer.toString(CoordinateConverter.INSTANCE.iec61499ToScreen(getType().getWidth())));
 			lockCheckbox.setSelection(getType().isLocked());
 			commandStack = commandStackBuffer;
 		}
@@ -119,7 +120,8 @@ public class GroupPropertySection extends AbstractDoubleColumnSection {
 			if (getType() != null) {
 				final int heightDiff;
 				try {
-					heightDiff = Integer.parseInt(heightText.getText()) - getType().getHeight();
+					heightDiff = Integer.parseInt(heightText.getText())
+							- CoordinateConverter.INSTANCE.iec61499ToScreen(getType().getHeight());
 				} catch (final Exception exc) {
 					return;
 				}
@@ -139,7 +141,8 @@ public class GroupPropertySection extends AbstractDoubleColumnSection {
 			if (getType() != null) {
 				final int widthDiff;
 				try {
-					widthDiff = Integer.parseInt(widthText.getText()) - getType().getWidth();
+					widthDiff = Integer.parseInt(widthText.getText())
+							- CoordinateConverter.INSTANCE.iec61499ToScreen(getType().getWidth());
 				} catch (final Exception exc) {
 					return;
 				}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/SubAppPropertySection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/SubAppPropertySection.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.application.properties;
 
+import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeSubAppBoundsCommand;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeSubAppSizeLockCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
@@ -72,7 +73,8 @@ public class SubAppPropertySection extends InstancePropertySection {
 			if (getType() != null) {
 				final int heightDelta;
 				try {
-					heightDelta = Integer.parseInt(heightText.getText()) - getType().getHeight();
+					heightDelta = Integer.parseInt(heightText.getText())
+							- CoordinateConverter.INSTANCE.iec61499ToScreen(getType().getHeight());
 				} catch (final NumberFormatException exception) {
 					return;
 				}
@@ -93,7 +95,8 @@ public class SubAppPropertySection extends InstancePropertySection {
 
 				final int widthDelta;
 				try {
-					widthDelta = Integer.parseInt(widthText.getText()) - getType().getWidth();
+					widthDelta = Integer.parseInt(widthText.getText())
+							- CoordinateConverter.INSTANCE.iec61499ToScreen(getType().getWidth());
 				} catch (final NumberFormatException exception) {
 					return;
 				}
@@ -116,8 +119,8 @@ public class SubAppPropertySection extends InstancePropertySection {
 		if ((getType() != null)) {
 			final CommandStack commandStackBuffer = commandStack;
 			commandStack = null;
-			heightText.setText(Integer.toString(getType().getHeight()));
-			widthText.setText(Integer.toString(getType().getWidth()));
+			heightText.setText(Integer.toString(CoordinateConverter.INSTANCE.iec61499ToScreen(getType().getHeight())));
+			widthText.setText(Integer.toString(CoordinateConverter.INSTANCE.iec61499ToScreen(getType().getWidth())));
 			lockCheckbox.setSelection(getType().isLocked());
 			commandStack = commandStackBuffer;
 		}

--- a/plugins/org.eclipse.fordiac.ide.elk/src/org/eclipse/fordiac/ide/elk/FordiacLayoutData.java
+++ b/plugins/org.eclipse.fordiac.ide.elk/src/org/eclipse/fordiac/ide/elk/FordiacLayoutData.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.eclipse.draw2d.geometry.PointList;
+import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.libraryElement.Connection;
 import org.eclipse.fordiac.ide.model.libraryElement.ConnectionRoutingData;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
@@ -83,14 +84,18 @@ public class FordiacLayoutData {
 		final ConnectionRoutingData routingData = LibraryElementFactory.eINSTANCE.createConnectionRoutingData();
 		if (pointList.size() > 2) {
 			// 3 segments
-			routingData.setDx1(pointList.getPoint(1).x() - pointList.getFirstPoint().x());
+			routingData.setDx1(fromScreen(pointList.getPoint(1).x() - pointList.getFirstPoint().x()));
 			if (pointList.size() > 4) {
 				// 5 segments
-				routingData.setDy(pointList.getPoint(2).y() - pointList.getFirstPoint().y());
-				routingData.setDx2(pointList.getLastPoint().x() - pointList.getPoint(pointList.size() - 2).x());
+				routingData.setDy(fromScreen(pointList.getPoint(2).y() - pointList.getFirstPoint().y()));
+				routingData.setDx2(
+						fromScreen(pointList.getLastPoint().x() - pointList.getPoint(pointList.size() - 2).x()));
 			}
 		}
 		return routingData;
 	}
 
+	private static double fromScreen(final int val) {
+		return CoordinateConverter.INSTANCE.screenToIEC61499(val);
+	}
 }

--- a/plugins/org.eclipse.fordiac.ide.elk/src/org/eclipse/fordiac/ide/elk/FordiacLayoutData.java
+++ b/plugins/org.eclipse.fordiac.ide.elk/src/org/eclipse/fordiac/ide/elk/FordiacLayoutData.java
@@ -46,7 +46,7 @@ public class FordiacLayoutData {
 	private final Map<FBNetworkElement, Position> positions = new HashMap<>();
 	private final List<ConnectionLayoutData> connData = new ArrayList<>();
 	private final Map<IInterfaceElement, Integer> pins = new HashMap<>();
-	private final Map<Group, Entry<Integer, Integer>> groups = new HashMap<>();
+	private final Map<Group, Entry<Double, Double>> groups = new HashMap<>();
 
 	public Map<FBNetworkElement, Position> getPositions() {
 		return positions;
@@ -60,7 +60,7 @@ public class FordiacLayoutData {
 		return pins;
 	}
 
-	public Map<Group, Entry<Integer, Integer>> getGroups() {
+	public Map<Group, Entry<Double, Double>> getGroups() {
 		return groups;
 	}
 
@@ -77,7 +77,8 @@ public class FordiacLayoutData {
 	}
 
 	public void addGroup(final Group group, final int height, final int width) {
-		groups.put(group, new SimpleEntry<>(Integer.valueOf(height), Integer.valueOf(width)));
+		groups.put(group, new SimpleEntry<>(Double.valueOf(CoordinateConverter.INSTANCE.screenToIEC61499(height)),
+				Double.valueOf(CoordinateConverter.INSTANCE.screenToIEC61499(width))));
 	}
 
 	private static ConnectionRoutingData createRoutingData(final PointList pointList) {

--- a/plugins/org.eclipse.fordiac.ide.elk/src/org/eclipse/fordiac/ide/elk/commands/LayoutCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.elk/src/org/eclipse/fordiac/ide/elk/commands/LayoutCommand.java
@@ -44,7 +44,7 @@ public class LayoutCommand extends AbstractLayoutCommand {
 
 	private final Map<FBNetworkElement, Position> oldPositions = new HashMap<>();
 	private final List<ConnectionLayoutData> oldRoutingData;
-	private final Map<Group, Entry<Integer, Integer>> oldGroupSizes = new HashMap<>();
+	private final Map<Group, Entry<Double, Double>> oldGroupSizes = new HashMap<>();
 
 	private final CompoundCommand pinPositionAttrCommand = new CompoundCommand();
 
@@ -85,7 +85,7 @@ public class LayoutCommand extends AbstractLayoutCommand {
 		data.getPositions().keySet().forEach(elem -> oldPositions.put(elem, EcoreUtil.copy(elem.getPosition())));
 		saveRoutingDataForUndo(data.getConnectionPoints(), oldRoutingData);
 		data.getGroups().keySet().forEach(group -> oldGroupSizes.put(group,
-				new SimpleEntry<>(Integer.valueOf(group.getHeight()), Integer.valueOf(group.getWidth()))));
+				new SimpleEntry<>(Double.valueOf(group.getHeight()), Double.valueOf(group.getWidth()))));
 	}
 
 	private void updateModelElements() {
@@ -98,7 +98,7 @@ public class LayoutCommand extends AbstractLayoutCommand {
 		data.getPins().forEach(this::updatePositionAttribute);
 	}
 
-	private static void setGroupSize(final Group group, final Entry<Integer, Integer> size) {
+	private static void setGroupSize(final Group group, final Entry<Double, Double> size) {
 		group.setHeight(size.getKey().intValue());
 		group.setWidth(size.getValue().intValue());
 	}

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/commands/AdjustConnectionCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/commands/AdjustConnectionCommand.java
@@ -21,6 +21,7 @@ import org.eclipse.draw2d.Connection;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.fordiac.ide.gef.Messages;
 import org.eclipse.fordiac.ide.gef.router.MoveableRouter;
+import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.libraryElement.ConnectionRoutingData;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
@@ -71,7 +72,7 @@ public class AdjustConnectionCommand extends Command {
 	private void updateNewRoutingData() {
 		final Point sourceP = getSourcePoint();
 		final Point destP = getDestinationPoint();
-		final int scaledMinDistance = (int) Math.floor(MoveableRouter.MIN_CONNECTION_FB_DISTANCE * zoom);
+		final int scaledMinDistance = (int) Math.floor(MoveableRouter.MIN_CONNECTION_FB_DISTANCE_SCREEN * zoom);
 
 		switch (index) {
 		case 2:
@@ -80,14 +81,14 @@ public class AdjustConnectionCommand extends Command {
 				// we have three segment connection check that we are not beyond the input
 				newDx1 = Math.min(newDx1, destP.x - sourceP.x - scaledMinDistance);
 			}
-			newRoutingData.setDx1((int) Math.floor(newDx1 / zoom));
+			newRoutingData.setDx1(fromScreen((int) Math.floor(newDx1 / zoom)));
 			break;
 		case 4:
-			newRoutingData.setDy((int) Math.floor((point.y - sourceP.y) / zoom));
+			newRoutingData.setDy(fromScreen((int) Math.floor((point.y - sourceP.y) / zoom)));
 			break;
 		case 6:
 			final int newDx2 = Math.max(destP.x - point.x, scaledMinDistance);
-			newRoutingData.setDx2((int) Math.floor(newDx2 / zoom));
+			newRoutingData.setDx2(fromScreen((int) Math.floor(newDx2 / zoom)));
 			break;
 		default:
 			FordiacLogHelper.logError(MessageFormat.format(Messages.AdjustConnectionCommand_WrongConnectionSegmentIndex,
@@ -111,4 +112,7 @@ public class AdjustConnectionCommand extends Command {
 		return connection.getSourceAnchor().getLocation(connection.getSourceAnchor().getReferencePoint()).getCopy();
 	}
 
+	private static double fromScreen(final int val) {
+		return CoordinateConverter.INSTANCE.screenToIEC61499(val);
+	}
 }

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/tools/FordiacConnectionDragCreationTool.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/tools/FordiacConnectionDragCreationTool.java
@@ -31,13 +31,13 @@ import org.eclipse.swt.widgets.Display;
 
 public class FordiacConnectionDragCreationTool extends ConnectionDragCreationTool {
 
-	// Safety border around the canvas to ensure that during dragging connections the canvas is not growing
+	// Safety border around the canvas to ensure that during dragging connections
+	// the canvas is not growing
 	private static final Insets NEW_CONNECTION_CANVAS_BORDER = new Insets(1,
-			1 + MoveableRouter.MIN_CONNECTION_FB_DISTANCE + HideableConnection.BEND_POINT_BEVEL_SIZE, 1,
-			1 + MoveableRouter.MIN_CONNECTION_FB_DISTANCE + HideableConnection.BEND_POINT_BEVEL_SIZE);
+			1 + MoveableRouter.MIN_CONNECTION_FB_DISTANCE_SCREEN + HideableConnection.BEND_POINT_BEVEL_SIZE, 1,
+			1 + MoveableRouter.MIN_CONNECTION_FB_DISTANCE_SCREEN + HideableConnection.BEND_POINT_BEVEL_SIZE);
 
 	public FordiacConnectionDragCreationTool() {
-		super();
 		setDefaultCursor(Display.getDefault().getSystemCursor(SWT.CURSOR_CROSS));
 		setDisabledCursor(Display.getDefault().getSystemCursor(SWT.CURSOR_NO));
 	}
@@ -50,14 +50,12 @@ public class FordiacConnectionDragCreationTool extends ConnectionDragCreationToo
 
 	@Override
 	public void mouseDrag(final MouseEvent me, final EditPartViewer viewer) {
-		if (isActive() && viewer instanceof AdvancedScrollingGraphicalViewer) {
-			((AdvancedScrollingGraphicalViewer) viewer)
-			.checkScrollPositionDuringDragBounded(me,
-					new Point(
-							MoveableRouter.MIN_CONNECTION_FB_DISTANCE + HideableConnection.BEND_POINT_BEVEL_SIZE
-							+ ConnectionPreferenceValues.HANDLE_SIZE,
+		if (isActive() && viewer instanceof final AdvancedScrollingGraphicalViewer advViewer) {
+			advViewer.checkScrollPositionDuringDragBounded(me,
+					new Point(MoveableRouter.MIN_CONNECTION_FB_DISTANCE_SCREEN
+							+ HideableConnection.BEND_POINT_BEVEL_SIZE + ConnectionPreferenceValues.HANDLE_SIZE,
 							ConnectionPreferenceValues.HANDLE_SIZE));
-			CanvasHelper.bindToContentPane(me, (AdvancedScrollingGraphicalViewer) viewer, NEW_CONNECTION_CANVAS_BORDER);
+			CanvasHelper.bindToContentPane(me, advViewer, NEW_CONNECTION_CANVAS_BORDER);
 		}
 		super.mouseDrag(me, viewer);
 	}
@@ -72,14 +70,14 @@ public class FordiacConnectionDragCreationTool extends ConnectionDragCreationToo
 
 	private void checkCurrentCommandforShiftMask() {
 		final Command curCmd = getCurrentCommand();
-		if (curCmd instanceof AbstractConnectionCreateCommand) {
-			((AbstractConnectionCreateCommand) curCmd).setVisible(false);
+		if (curCmd instanceof final AbstractConnectionCreateCommand conCreateCmd) {
+			conCreateCmd.setVisible(false);
 		}
 	}
 
 	@Override
 	protected void setCurrentCommand(final Command c) {
-		if(null == getCurrentCommand() && null != c) {
+		if (null == getCurrentCommand() && null != c) {
 			// Hover started
 			startHover();
 		} else if (null != getCurrentCommand() && null != c && c != getCurrentCommand()) {

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/tools/ScrollingConnectionEndpointTracker.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/tools/ScrollingConnectionEndpointTracker.java
@@ -39,14 +39,12 @@ import org.eclipse.swt.events.MouseEvent;
 
 public class ScrollingConnectionEndpointTracker extends ConnectionEndpointTracker {
 
-	// Safety border around the canvas to ensure that during dragging connections the canvas is not growing
-	private static final Insets CONNECTION_CANVAS_BORDER = new Insets(
-			ConnectionPreferenceValues.HANDLE_SIZE,
-			MoveableRouter.MIN_CONNECTION_FB_DISTANCE + HideableConnection.BEND_POINT_BEVEL_SIZE
-			+ ConnectionPreferenceValues.HANDLE_SIZE,
-			ConnectionPreferenceValues.HANDLE_SIZE,
-			ConnectionPreferenceValues.HANDLE_SIZE);
-
+	// Safety border around the canvas to ensure that during dragging connections
+	// the canvas is not growing
+	private static final Insets CONNECTION_CANVAS_BORDER = new Insets(ConnectionPreferenceValues.HANDLE_SIZE,
+			MoveableRouter.MIN_CONNECTION_FB_DISTANCE_SCREEN + HideableConnection.BEND_POINT_BEVEL_SIZE
+					+ ConnectionPreferenceValues.HANDLE_SIZE,
+			ConnectionPreferenceValues.HANDLE_SIZE, ConnectionPreferenceValues.HANDLE_SIZE);
 
 	private InlineConnectionCreationTool conCreationTool = null;
 
@@ -56,15 +54,14 @@ public class ScrollingConnectionEndpointTracker extends ConnectionEndpointTracke
 
 	@Override
 	public void mouseDrag(final MouseEvent me, final EditPartViewer viewer) {
-		if (isActive() && (viewer instanceof AdvancedScrollingGraphicalViewer)) {
-			final Point oldViewPort = ((AdvancedScrollingGraphicalViewer) viewer).getViewLocation();
-			((AdvancedScrollingGraphicalViewer) viewer)
-			.checkScrollPositionDuringDragBounded(me,
-					new Point(
-							MoveableRouter.MIN_CONNECTION_FB_DISTANCE + HideableConnection.BEND_POINT_BEVEL_SIZE
-							+ ConnectionPreferenceValues.HANDLE_SIZE,
+		if (isActive() && (viewer instanceof final AdvancedScrollingGraphicalViewer advViewer)) {
+			final Point oldViewPort = advViewer.getViewLocation();
+			advViewer.checkScrollPositionDuringDragBounded(me,
+					new Point(MoveableRouter.MIN_CONNECTION_FB_DISTANCE_SCREEN
+							+ HideableConnection.BEND_POINT_BEVEL_SIZE + ConnectionPreferenceValues.HANDLE_SIZE,
 							ConnectionPreferenceValues.HANDLE_SIZE));
-			final Dimension delta = oldViewPort.getDifference(((AdvancedScrollingGraphicalViewer) viewer).getViewLocation());
+			final Dimension delta = oldViewPort
+					.getDifference(((AdvancedScrollingGraphicalViewer) viewer).getViewLocation());
 			// Compensate the moved scrolling in the start position for correct dropping of
 			// moved parts
 			setStartLocation(getStartLocation().getTranslated(delta));
@@ -80,7 +77,7 @@ public class ScrollingConnectionEndpointTracker extends ConnectionEndpointTracke
 		}
 	}
 
-	@SuppressWarnings("static-method")  // allow sub-classes to override the border calculation
+	@SuppressWarnings("static-method") // allow sub-classes to override the border calculation
 	protected Insets getCanvasBorder() {
 		return CONNECTION_CANVAS_BORDER;
 	}
@@ -98,7 +95,7 @@ public class ScrollingConnectionEndpointTracker extends ConnectionEndpointTracke
 	private void startConnCreation() {
 		final EditPart target = (getCommandName().equals(RequestConstants.REQ_RECONNECT_SOURCE))
 				? getConnectionEditPart().getTarget()
-						: getConnectionEditPart().getSource();
+				: getConnectionEditPart().getSource();
 		conCreationTool = InlineConnectionCreationTool.createInlineConnCreationTool(target, getDomain(),
 				getCurrentViewer(), getLocation());
 		updateTarget(getStartLocation());
@@ -109,7 +106,7 @@ public class ScrollingConnectionEndpointTracker extends ConnectionEndpointTracke
 		request.setLocation(p);
 		final EditPart target = (getCommandName().equals(RequestConstants.REQ_RECONNECT_SOURCE))
 				? getConnectionEditPart().getSource()
-						: getConnectionEditPart().getTarget();
+				: getConnectionEditPart().getTarget();
 		request.setTargetEditPart(target);
 		getConnectionEditPart().showSourceFeedback(request);
 		getConnectionEditPart().showTargetFeedback(request);

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractChangeContainerBoundsCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractChangeContainerBoundsCommand.java
@@ -18,6 +18,7 @@ import java.util.Set;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.fordiac.ide.model.ConnectionLayoutTagger;
+import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.commands.ScopedCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.PositionableElement;
@@ -29,22 +30,22 @@ public abstract class AbstractChangeContainerBoundsCommand extends Command
 
 	private final int dx;
 	private final int dy;
-	private final int oldWidth;
-	private final int oldHeight;
-	private final int newWidth;
-	private final int newHeight;
+	private final double oldWidth;
+	private final double oldHeight;
+	private final double newWidth;
+	private final double newHeight;
 	private final PositionableElement target;
 	private CompoundCommand updatePositions;
 
 	protected AbstractChangeContainerBoundsCommand(final PositionableElement target, final int dx, final int dy,
-			final int dw, final int dh, final int oldWidth, final int oldHeight) {
+			final int dw, final int dh, final double oldWidth, final double oldHeight) {
 		this.target = Objects.requireNonNull(target);
 		this.dx = dx;
 		this.dy = dy;
 		this.oldWidth = oldWidth;
 		this.oldHeight = oldHeight;
-		newWidth = oldWidth + dw;
-		newHeight = oldHeight + dh;
+		newWidth = oldWidth + CoordinateConverter.INSTANCE.screenToIEC61499(dw);
+		newHeight = oldHeight + CoordinateConverter.INSTANCE.screenToIEC61499(dh);
 	}
 
 	@Override
@@ -97,7 +98,7 @@ public abstract class AbstractChangeContainerBoundsCommand extends Command
 		return Set.of(target);
 	}
 
-	protected abstract void updateSize(int width, int height);
+	protected abstract void updateSize(double width, double height);
 
 	protected abstract List<FBNetworkElement> getChildren();
 }

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeCommentBoundsCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeCommentBoundsCommand.java
@@ -25,7 +25,7 @@ public class ChangeCommentBoundsCommand extends AbstractChangeContainerBoundsCom
 	}
 
 	@Override
-	protected void updateSize(final int width, final int height) {
+	protected void updateSize(final double width, final double height) {
 		getTarget().setWidth(width);
 		getTarget().setHeight(height);
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeGroupBoundsCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeGroupBoundsCommand.java
@@ -24,7 +24,7 @@ public class ChangeGroupBoundsCommand extends AbstractChangeContainerBoundsComma
 	}
 
 	@Override
-	protected void updateSize(final int width, final int height) {
+	protected void updateSize(final double width, final double height) {
 		getTarget().setWidth(width);
 		getTarget().setHeight(height);
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeSubAppBoundsCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeSubAppBoundsCommand.java
@@ -24,7 +24,7 @@ public class ChangeSubAppBoundsCommand extends AbstractChangeContainerBoundsComm
 	}
 
 	@Override
-	protected void updateSize(final int width, final int height) {
+	protected void updateSize(final double width, final double height) {
 		getTarget().setWidth(width);
 		getTarget().setHeight(height);
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/CreateGroupCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/CreateGroupCommand.java
@@ -15,6 +15,7 @@ package org.eclipse.fordiac.ide.model.commands.create;
 import java.util.List;
 
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.commands.change.AddElementsToGroup;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
@@ -88,8 +89,10 @@ public class CreateGroupCommand extends AbstractCreateFBNetworkElementCommand {
 			posSizeRef.width += 2 * GROUP_BORDER;
 			posSizeRef.height += GROUP_TOP_BORDER + GROUP_BORDER;
 			// ensure that in the beginning the group has at least our default size
-			posSizeRef.width = Math.max(posSizeRef.width, getElement().getWidth());
-			posSizeRef.height = Math.max(posSizeRef.height, getElement().getHeight());
+			posSizeRef.width = Math.max(posSizeRef.width,
+					CoordinateConverter.INSTANCE.iec61499ToScreen(getElement().getWidth()));
+			posSizeRef.height = Math.max(posSizeRef.height,
+					CoordinateConverter.INSTANCE.iec61499ToScreen(getElement().getHeight()));
 		}
 		return posSizeRef;
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/CommentItemProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/CommentItemProvider.java
@@ -82,7 +82,7 @@ public class CommentItemProvider extends FBNetworkElementItemProvider {
 				 true,
 				 false,
 				 false,
-				 ItemPropertyDescriptor.INTEGRAL_VALUE_IMAGE,
+				 ItemPropertyDescriptor.REAL_VALUE_IMAGE,
 				 null,
 				 null));
 	}
@@ -104,7 +104,7 @@ public class CommentItemProvider extends FBNetworkElementItemProvider {
 				 true,
 				 false,
 				 false,
-				 ItemPropertyDescriptor.INTEGRAL_VALUE_IMAGE,
+				 ItemPropertyDescriptor.REAL_VALUE_IMAGE,
 				 null,
 				 null));
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/GroupItemProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/GroupItemProvider.java
@@ -112,7 +112,7 @@ public class GroupItemProvider extends FBNetworkElementItemProvider {
 				 true,
 				 false,
 				 false,
-				 ItemPropertyDescriptor.INTEGRAL_VALUE_IMAGE,
+				 ItemPropertyDescriptor.REAL_VALUE_IMAGE,
 				 null,
 				 null));
 	}
@@ -134,7 +134,7 @@ public class GroupItemProvider extends FBNetworkElementItemProvider {
 				 true,
 				 false,
 				 false,
-				 ItemPropertyDescriptor.INTEGRAL_VALUE_IMAGE,
+				 ItemPropertyDescriptor.REAL_VALUE_IMAGE,
 				 null,
 				 null));
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/SubAppItemProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/SubAppItemProvider.java
@@ -80,7 +80,7 @@ public class SubAppItemProvider extends FBNetworkElementItemProvider {
 				 true,
 				 false,
 				 false,
-				 ItemPropertyDescriptor.INTEGRAL_VALUE_IMAGE,
+				 ItemPropertyDescriptor.REAL_VALUE_IMAGE,
 				 null,
 				 null));
 	}
@@ -102,7 +102,7 @@ public class SubAppItemProvider extends FBNetworkElementItemProvider {
 				 true,
 				 false,
 				 false,
-				 ItemPropertyDescriptor.INTEGRAL_VALUE_IMAGE,
+				 ItemPropertyDescriptor.REAL_VALUE_IMAGE,
 				 null,
 				 null));
 	}

--- a/plugins/org.eclipse.fordiac.ide.model/model/fordiac.genmodel
+++ b/plugins/org.eclipse.fordiac.ide.model/model/fordiac.genmodel
@@ -341,9 +341,9 @@
     <genClasses ecoreClass="lib.ecore#//ErrorMarkerDataType"/>
     <genClasses ecoreClass="lib.ecore#//ErrorMarkerFBNElement">
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference lib.ecore#//ErrorMarkerFBNElement/repairedElement"/>
-      <genOperations ecoreOperation="lib.ecore#//ErrorMarkerFBNElement/getWidth" body="return org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getWidth(this);"/>
+      <genOperations ecoreOperation="lib.ecore#//ErrorMarkerFBNElement/getWidth" body="return org.eclipse.fordiac.ide.model.CoordinateConverter.INSTANCE.screenToIEC61499(org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getWidth(this));"/>
       <genOperations ecoreOperation="lib.ecore#//ErrorMarkerFBNElement/getHeight"
-          body="return org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getHeight(this);"/>
+          body="return org.eclipse.fordiac.ide.model.CoordinateConverter.INSTANCE.screenToIEC61499(org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getHeight(this));"/>
     </genClasses>
     <genClasses ecoreClass="lib.ecore#//ErrorMarkerInterface">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference lib.ecore#//ErrorMarkerInterface/value"/>
@@ -374,8 +374,8 @@
       <genOperations ecoreOperation="lib.ecore#//FB/getOutputParameters" body="return org.eclipse.fordiac.ide.model.libraryElement.impl.CallableAnnotations.getOutputParameters(this);"/>
       <genOperations ecoreOperation="lib.ecore#//FB/getInOutParameters" body="return org.eclipse.fordiac.ide.model.libraryElement.impl.CallableAnnotations.getInOutParameters(this);"/>
       <genOperations ecoreOperation="lib.ecore#//FB/getReturnType" body="return org.eclipse.fordiac.ide.model.libraryElement.impl.CallableAnnotations.getReturnType(this);"/>
-      <genOperations ecoreOperation="lib.ecore#//FB/getWidth" body="return org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getWidth(this);"/>
-      <genOperations ecoreOperation="lib.ecore#//FB/getHeight" body="return org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getHeight(this);"/>
+      <genOperations ecoreOperation="lib.ecore#//FB/getWidth" body="return org.eclipse.fordiac.ide.model.CoordinateConverter.INSTANCE.screenToIEC61499(org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getWidth(this));"/>
+      <genOperations ecoreOperation="lib.ecore#//FB/getHeight" body="return org.eclipse.fordiac.ide.model.CoordinateConverter.INSTANCE.screenToIEC61499(org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getHeight(this));"/>
     </genClasses>
     <genClasses ecoreClass="lib.ecore#//FBNetwork">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference lib.ecore#//FBNetwork/networkElements"/>
@@ -448,9 +448,9 @@
       <genOperations ecoreOperation="lib.ecore#//FBNetworkElement/getWidth" body="throw new UnsupportedOperationException();"/>
       <genOperations ecoreOperation="lib.ecore#//FBNetworkElement/getHeight" body="throw new UnsupportedOperationException();"/>
       <genOperations ecoreOperation="lib.ecore#//FBNetworkElement/getVisibleWidth"
-          body="return getWidth();"/>
+          body="return org.eclipse.fordiac.ide.model.CoordinateConverter.INSTANCE.iec61499ToScreen(getWidth());"/>
       <genOperations ecoreOperation="lib.ecore#//FBNetworkElement/getVisibleHeight"
-          body="return getHeight();"/>
+          body="return org.eclipse.fordiac.ide.model.CoordinateConverter.INSTANCE.iec61499ToScreen(getHeight());"/>
       <genOperations ecoreOperation="lib.ecore#//FBNetworkElement/getInput" body="return org.eclipse.fordiac.ide.model.annotations.FBNetworkElementAnnotations.getInput(this, name);">
         <genParameters ecoreParameter="lib.ecore#//FBNetworkElement/getInput/name"/>
       </genOperations>
@@ -728,8 +728,8 @@
       <genOperations ecoreOperation="lib.ecore#//SubApp/isTyped"/>
       <genOperations ecoreOperation="lib.ecore#//SubApp/getSubAppNetwork"/>
       <genOperations ecoreOperation="lib.ecore#//SubApp/loadSubAppNetwork"/>
-      <genOperations ecoreOperation="lib.ecore#//SubApp/getVisibleWidth" body="return isUnfolded() ? getWidth() : org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getWidth(this);"/>
-      <genOperations ecoreOperation="lib.ecore#//SubApp/getVisibleHeight" body="return isUnfolded() ? getHeight() : org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getHeight(this);"/>
+      <genOperations ecoreOperation="lib.ecore#//SubApp/getVisibleWidth" body="return isUnfolded() ? org.eclipse.fordiac.ide.model.CoordinateConverter.INSTANCE.iec61499ToScreen(getWidth()) : org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getWidth(this);"/>
+      <genOperations ecoreOperation="lib.ecore#//SubApp/getVisibleHeight" body="return isUnfolded() ? org.eclipse.fordiac.ide.model.CoordinateConverter.INSTANCE.iec61499ToScreen(getHeight()) : org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getHeight(this);"/>
     </genClasses>
     <genClasses ecoreClass="lib.ecore#//StructManipulator">
       <genOperations ecoreOperation="lib.ecore#//StructManipulator/updateConfiguration"/>

--- a/plugins/org.eclipse.fordiac.ide.model/model/fordiac.genmodel
+++ b/plugins/org.eclipse.fordiac.ide.model/model/fordiac.genmodel
@@ -212,11 +212,6 @@
       <genOperations ecoreOperation="lib.ecore#//Connection/getFBNetwork" body="throw new UnsupportedOperationException(&quot;subclasses will need to provide it&quot;);"/>
       <genOperations ecoreOperation="lib.ecore#//Connection/checkIfConnectionBroken"
           body="org.eclipse.fordiac.ide.model.Annotations.checkifConnectionBroken(this);"/>
-      <genOperations ecoreOperation="lib.ecore#//Connection/updateRoutingData" body="final ConnectionRoutingData newRoutingData = org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory.eINSTANCE.createConnectionRoutingData();&#xA;newRoutingData.setDx1(dx1);&#xA;newRoutingData.setDy(dy);&#xA;newRoutingData.setDx2(dx2);&#xA;setRoutingData(newRoutingData);">
-        <genParameters ecoreParameter="lib.ecore#//Connection/updateRoutingData/dx1"/>
-        <genParameters ecoreParameter="lib.ecore#//Connection/updateRoutingData/dy"/>
-        <genParameters ecoreParameter="lib.ecore#//Connection/updateRoutingData/dx2"/>
-      </genOperations>
       <genOperations ecoreOperation="lib.ecore#//Connection/isInterfaceConnection"
           body="return org.eclipse.fordiac.ide.model.Annotations.isInterfaceConnection(this);"/>
       <genOperations ecoreOperation="lib.ecore#//Connection/validateMissingSource"
@@ -280,11 +275,11 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute lib.ecore#//ConnectionRoutingData/dy"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute lib.ecore#//ConnectionRoutingData/needsValidation"/>
       <genOperations ecoreOperation="lib.ecore#//ConnectionRoutingData/is1SegementData"
-          body="return getDx1() == 0;"/>
+          body="return getDx1() == 0.0;"/>
       <genOperations ecoreOperation="lib.ecore#//ConnectionRoutingData/is3SegementData"
-          body="return getDx1() != 0 &amp;&amp; getDy() == 0;"/>
+          body="return getDx1() != 0.0 &amp;&amp; getDy() == 0.0;"/>
       <genOperations ecoreOperation="lib.ecore#//ConnectionRoutingData/is5SegementData"
-          body="return getDx1() != 0 &amp;&amp; getDy() != 0;"/>
+          body="return getDx1() != 0.0 &amp;&amp; getDy() != 0.0;"/>
     </genClasses>
     <genClasses ecoreClass="lib.ecore#//DataConnection">
       <genFeatures property="None" notify="false" createChild="false" ecoreFeature="ecore:EReference lib.ecore#//DataConnection/fBNetwork"/>

--- a/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
+++ b/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
@@ -464,14 +464,6 @@
         <details key="body" value="org.eclipse.fordiac.ide.model.Annotations.checkifConnectionBroken(this);"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="updateRoutingData" lowerBound="1">
-      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
-        <details key="body" value="final ConnectionRoutingData newRoutingData = org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory.eINSTANCE.createConnectionRoutingData();&#xA;newRoutingData.setDx1(dx1);&#xA;newRoutingData.setDy(dy);&#xA;newRoutingData.setDx2(dx2);&#xA;setRoutingData(newRoutingData);"/>
-      </eAnnotations>
-      <eParameters name="dx1" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Int"/>
-      <eParameters name="dy" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Int"/>
-      <eParameters name="dx2" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Int"/>
-    </eOperations>
     <eOperations name="isInterfaceConnection" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.model.Annotations.isInterfaceConnection(this);"/>
@@ -655,34 +647,34 @@
   <eClassifiers xsi:type="ecore:EClass" name="ConnectionRoutingData">
     <eOperations name="is1SegementData" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
-        <details key="body" value="return getDx1() == 0;"/>
+        <details key="body" value="return getDx1() == 0.0;"/>
       </eAnnotations>
     </eOperations>
     <eOperations name="is3SegementData" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
-        <details key="body" value="return getDx1() != 0 &amp;&amp; getDy() == 0;"/>
+        <details key="body" value="return getDx1() != 0.0 &amp;&amp; getDy() == 0.0;"/>
       </eAnnotations>
     </eOperations>
     <eOperations name="is5SegementData" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
-        <details key="body" value="return getDx1() != 0 &amp;&amp; getDy() != 0;"/>
+        <details key="body" value="return getDx1() != 0.0 &amp;&amp; getDy() != 0.0;"/>
       </eAnnotations>
     </eOperations>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="dx1" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Int"
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="dx1" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Double"
         defaultValueLiteral="0">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
         <details key="kind" value="attribute"/>
         <details key="name" value="dx1"/>
       </eAnnotations>
     </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="dx2" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Int"
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="dx2" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Double"
         defaultValueLiteral="0">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
         <details key="kind" value="attribute"/>
         <details key="name" value="dx2"/>
       </eAnnotations>
     </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="dy" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Int"
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="dy" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Double"
         defaultValueLiteral="0">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
         <details key="kind" value="attribute"/>

--- a/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
+++ b/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
@@ -1835,7 +1835,7 @@
         <details key="body" value="return org.eclipse.fordiac.ide.model.annotations.SegmentAnnotations.getSystemConfiguration(this); "/>
       </eAnnotations>
     </eOperations>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="width" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Int"
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="width" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Double"
         defaultValueLiteral="200">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
         <details key="kind" value="attribute"/>

--- a/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
+++ b/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
@@ -266,9 +266,9 @@
         <details key="body" value="return org.eclipse.fordiac.ide.model.annotations.FBNetworkElementAnnotations.EMPTY_INTERFACE_LIST;"/>
       </eAnnotations>
     </eOperations>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="width" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Int"
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="width" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Double"
         defaultValueLiteral="200"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="height" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Int"
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="height" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Double"
         defaultValueLiteral="100"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="CommunicationChannel" eSuperTypes="#//FB"/>
@@ -859,14 +859,14 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ErrorMarkerDataType" eSuperTypes="data.ecore#//DataType"/>
   <eClassifiers xsi:type="ecore:EClass" name="ErrorMarkerFBNElement" eSuperTypes="#//FBNetworkElement">
-    <eOperations name="getWidth" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Int">
+    <eOperations name="getWidth" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Double">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
-        <details key="body" value="return org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getWidth(this);"/>
+        <details key="body" value="return org.eclipse.fordiac.ide.model.CoordinateConverter.INSTANCE.screenToIEC61499(org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getWidth(this));"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getHeight" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Int">
+    <eOperations name="getHeight" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Double">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
-        <details key="body" value="return org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getHeight(this);"/>
+        <details key="body" value="return org.eclipse.fordiac.ide.model.CoordinateConverter.INSTANCE.screenToIEC61499(org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getHeight(this));"/>
       </eAnnotations>
     </eOperations>
     <eStructuralFeatures xsi:type="ecore:EReference" name="repairedElement" eType="#//FBNetworkElement"/>
@@ -970,14 +970,14 @@
         <details key="body" value="return org.eclipse.fordiac.ide.model.libraryElement.impl.CallableAnnotations.getReturnType(this);"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getWidth" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Int">
+    <eOperations name="getWidth" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Double">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
-        <details key="body" value="return org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getWidth(this);"/>
+        <details key="body" value="return org.eclipse.fordiac.ide.model.CoordinateConverter.INSTANCE.screenToIEC61499(org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getWidth(this));"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getHeight" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Int">
+    <eOperations name="getHeight" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Double">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
-        <details key="body" value="return org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getHeight(this);"/>
+        <details key="body" value="return org.eclipse.fordiac.ide.model.CoordinateConverter.INSTANCE.screenToIEC61499(org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getHeight(this));"/>
       </eAnnotations>
     </eOperations>
   </eClassifiers>
@@ -1174,24 +1174,24 @@
         <details key="body" value="return org.eclipse.fordiac.ide.model.libraryElement.impl.FBNetworkElementAnnotations.getQualifiedName(this);"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getWidth" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Int">
+    <eOperations name="getWidth" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Double">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="throw new UnsupportedOperationException();"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getHeight" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Int">
+    <eOperations name="getHeight" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Double">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="throw new UnsupportedOperationException();"/>
       </eAnnotations>
     </eOperations>
     <eOperations name="getVisibleWidth" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Int">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
-        <details key="body" value="return getWidth();"/>
+        <details key="body" value="return org.eclipse.fordiac.ide.model.CoordinateConverter.INSTANCE.iec61499ToScreen(getWidth());"/>
       </eAnnotations>
     </eOperations>
     <eOperations name="getVisibleHeight" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Int">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
-        <details key="body" value="return getHeight();"/>
+        <details key="body" value="return org.eclipse.fordiac.ide.model.CoordinateConverter.INSTANCE.iec61499ToScreen(getHeight());"/>
       </eAnnotations>
     </eOperations>
     <eOperations name="getInput" eType="#//IInterfaceElement">
@@ -1304,9 +1304,9 @@
         <details key="namespace" value="##targetNamespace"/>
       </eAnnotations>
     </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="width" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Int"
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="width" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Double"
         defaultValueLiteral="200"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="height" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Int"
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="height" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Double"
         defaultValueLiteral="100"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="locked" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Boolean"
         defaultValueLiteral="false"/>
@@ -1947,17 +1947,17 @@
     <eOperations name="loadSubAppNetwork" eType="#//FBNetwork"/>
     <eOperations name="getVisibleWidth" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Int">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
-        <details key="body" value="return isUnfolded() ? getWidth() : org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getWidth(this);"/>
+        <details key="body" value="return isUnfolded() ? org.eclipse.fordiac.ide.model.CoordinateConverter.INSTANCE.iec61499ToScreen(getWidth()) : org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getWidth(this);"/>
       </eAnnotations>
     </eOperations>
     <eOperations name="getVisibleHeight" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Int">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
-        <details key="body" value="return isUnfolded() ? getHeight() : org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getHeight(this);"/>
+        <details key="body" value="return isUnfolded() ? org.eclipse.fordiac.ide.model.CoordinateConverter.INSTANCE.iec61499ToScreen(getHeight()) : org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getHeight(this);"/>
       </eAnnotations>
     </eOperations>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="width" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Int"
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="width" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Double"
         defaultValueLiteral="200"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="height" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Int"
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="height" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Double"
         defaultValueLiteral="100"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="locked" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Boolean"
         defaultValueLiteral="false"/>

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/Comment.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/Comment.java
@@ -40,12 +40,12 @@ public interface Comment extends FBNetworkElement {
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Width</em>' attribute.
-	 * @see #setWidth(int)
+	 * @see #setWidth(double)
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage#getComment_Width()
-	 * @model default="200" dataType="org.eclipse.emf.ecore.xml.type.Int"
+	 * @model default="200" dataType="org.eclipse.emf.ecore.xml.type.Double"
 	 * @generated
 	 */
-	int getWidth();
+	double getWidth();
 
 	/**
 	 * Sets the value of the '{@link org.eclipse.fordiac.ide.model.libraryElement.Comment#getWidth <em>Width</em>}' attribute.
@@ -55,7 +55,7 @@ public interface Comment extends FBNetworkElement {
 	 * @see #getWidth()
 	 * @generated
 	 */
-	void setWidth(int value);
+	void setWidth(double value);
 
 	/**
 	 * Returns the value of the '<em><b>Height</b></em>' attribute.
@@ -63,12 +63,12 @@ public interface Comment extends FBNetworkElement {
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Height</em>' attribute.
-	 * @see #setHeight(int)
+	 * @see #setHeight(double)
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage#getComment_Height()
-	 * @model default="100" dataType="org.eclipse.emf.ecore.xml.type.Int"
+	 * @model default="100" dataType="org.eclipse.emf.ecore.xml.type.Double"
 	 * @generated
 	 */
-	int getHeight();
+	double getHeight();
 
 	/**
 	 * Sets the value of the '{@link org.eclipse.fordiac.ide.model.libraryElement.Comment#getHeight <em>Height</em>}' attribute.
@@ -78,7 +78,7 @@ public interface Comment extends FBNetworkElement {
 	 * @see #getHeight()
 	 * @generated
 	 */
-	void setHeight(int value);
+	void setHeight(double value);
 
 	/**
 	 * <!-- begin-user-doc -->

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/Connection.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/Connection.java
@@ -199,14 +199,6 @@ public interface Connection extends ConfigurableObject, HiddenElement {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @model dx1DataType="org.eclipse.emf.ecore.xml.type.Int" dx1Required="true" dyDataType="org.eclipse.emf.ecore.xml.type.Int" dyRequired="true" dx2DataType="org.eclipse.emf.ecore.xml.type.Int" dx2Required="true"
-	 * @generated
-	 */
-	void updateRoutingData(int dx1, int dy, int dx2);
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
 	 * @model kind="operation" required="true"
 	 * @generated
 	 */

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/ConnectionRoutingData.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/ConnectionRoutingData.java
@@ -44,13 +44,13 @@ public interface ConnectionRoutingData extends EObject {
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Dx1</em>' attribute.
-	 * @see #setDx1(int)
+	 * @see #setDx1(double)
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage#getConnectionRoutingData_Dx1()
-	 * @model default="0" dataType="org.eclipse.emf.ecore.xml.type.Int"
+	 * @model default="0" dataType="org.eclipse.emf.ecore.xml.type.Double"
 	 *        extendedMetaData="kind='attribute' name='dx1'"
 	 * @generated
 	 */
-	int getDx1();
+	double getDx1();
 
 	/**
 	 * Sets the value of the '{@link org.eclipse.fordiac.ide.model.libraryElement.ConnectionRoutingData#getDx1 <em>Dx1</em>}' attribute.
@@ -60,7 +60,7 @@ public interface ConnectionRoutingData extends EObject {
 	 * @see #getDx1()
 	 * @generated
 	 */
-	void setDx1(int value);
+	void setDx1(double value);
 
 	/**
 	 * Returns the value of the '<em><b>Dx2</b></em>' attribute.
@@ -68,13 +68,13 @@ public interface ConnectionRoutingData extends EObject {
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Dx2</em>' attribute.
-	 * @see #setDx2(int)
+	 * @see #setDx2(double)
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage#getConnectionRoutingData_Dx2()
-	 * @model default="0" dataType="org.eclipse.emf.ecore.xml.type.Int"
+	 * @model default="0" dataType="org.eclipse.emf.ecore.xml.type.Double"
 	 *        extendedMetaData="kind='attribute' name='dx2'"
 	 * @generated
 	 */
-	int getDx2();
+	double getDx2();
 
 	/**
 	 * Sets the value of the '{@link org.eclipse.fordiac.ide.model.libraryElement.ConnectionRoutingData#getDx2 <em>Dx2</em>}' attribute.
@@ -84,7 +84,7 @@ public interface ConnectionRoutingData extends EObject {
 	 * @see #getDx2()
 	 * @generated
 	 */
-	void setDx2(int value);
+	void setDx2(double value);
 
 	/**
 	 * Returns the value of the '<em><b>Dy</b></em>' attribute.
@@ -92,13 +92,13 @@ public interface ConnectionRoutingData extends EObject {
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Dy</em>' attribute.
-	 * @see #setDy(int)
+	 * @see #setDy(double)
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage#getConnectionRoutingData_Dy()
-	 * @model default="0" dataType="org.eclipse.emf.ecore.xml.type.Int"
+	 * @model default="0" dataType="org.eclipse.emf.ecore.xml.type.Double"
 	 *        extendedMetaData="kind='attribute' name='dy'"
 	 * @generated
 	 */
-	int getDy();
+	double getDy();
 
 	/**
 	 * Sets the value of the '{@link org.eclipse.fordiac.ide.model.libraryElement.ConnectionRoutingData#getDy <em>Dy</em>}' attribute.
@@ -108,7 +108,7 @@ public interface ConnectionRoutingData extends EObject {
 	 * @see #getDy()
 	 * @generated
 	 */
-	void setDy(int value);
+	void setDy(double value);
 
 	/**
 	 * Returns the value of the '<em><b>Needs Validation</b></em>' attribute.

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/ErrorMarkerFBNElement.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/ErrorMarkerFBNElement.java
@@ -59,17 +59,17 @@ public interface ErrorMarkerFBNElement extends FBNetworkElement {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @model kind="operation" dataType="org.eclipse.emf.ecore.xml.type.Int"
+	 * @model kind="operation" dataType="org.eclipse.emf.ecore.xml.type.Double"
 	 * @generated
 	 */
-	int getWidth();
+	double getWidth();
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @model kind="operation" dataType="org.eclipse.emf.ecore.xml.type.Int"
+	 * @model kind="operation" dataType="org.eclipse.emf.ecore.xml.type.Double"
 	 * @generated
 	 */
-	int getHeight();
+	double getHeight();
 
 } // ErrorMarkerFBNElement

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/FB.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/FB.java
@@ -90,17 +90,17 @@ public interface FB extends FBNetworkElement, ICallable {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @model kind="operation" dataType="org.eclipse.emf.ecore.xml.type.Int"
+	 * @model kind="operation" dataType="org.eclipse.emf.ecore.xml.type.Double"
 	 * @generated
 	 */
-	int getWidth();
+	double getWidth();
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @model kind="operation" dataType="org.eclipse.emf.ecore.xml.type.Int"
+	 * @model kind="operation" dataType="org.eclipse.emf.ecore.xml.type.Double"
 	 * @generated
 	 */
-	int getHeight();
+	double getHeight();
 
 } // FB

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/FBNetworkElement.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/FBNetworkElement.java
@@ -214,18 +214,18 @@ public interface FBNetworkElement extends TypedConfigureableObject, Positionable
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @model kind="operation" dataType="org.eclipse.emf.ecore.xml.type.Int"
+	 * @model kind="operation" dataType="org.eclipse.emf.ecore.xml.type.Double"
 	 * @generated
 	 */
-	int getWidth();
+	double getWidth();
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @model kind="operation" dataType="org.eclipse.emf.ecore.xml.type.Int"
+	 * @model kind="operation" dataType="org.eclipse.emf.ecore.xml.type.Double"
 	 * @generated
 	 */
-	int getHeight();
+	double getHeight();
 
 	/**
 	 * <!-- begin-user-doc -->

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/Group.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/Group.java
@@ -61,12 +61,12 @@ public interface Group extends FBNetworkElement {
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Width</em>' attribute.
-	 * @see #setWidth(int)
+	 * @see #setWidth(double)
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage#getGroup_Width()
-	 * @model default="200" dataType="org.eclipse.emf.ecore.xml.type.Int"
+	 * @model default="200" dataType="org.eclipse.emf.ecore.xml.type.Double"
 	 * @generated
 	 */
-	int getWidth();
+	double getWidth();
 
 	/**
 	 * Sets the value of the '{@link org.eclipse.fordiac.ide.model.libraryElement.Group#getWidth <em>Width</em>}' attribute.
@@ -76,7 +76,7 @@ public interface Group extends FBNetworkElement {
 	 * @see #getWidth()
 	 * @generated
 	 */
-	void setWidth(int value);
+	void setWidth(double value);
 
 	/**
 	 * Returns the value of the '<em><b>Height</b></em>' attribute.
@@ -84,12 +84,12 @@ public interface Group extends FBNetworkElement {
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Height</em>' attribute.
-	 * @see #setHeight(int)
+	 * @see #setHeight(double)
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage#getGroup_Height()
-	 * @model default="100" dataType="org.eclipse.emf.ecore.xml.type.Int"
+	 * @model default="100" dataType="org.eclipse.emf.ecore.xml.type.Double"
 	 * @generated
 	 */
-	int getHeight();
+	double getHeight();
 
 	/**
 	 * Sets the value of the '{@link org.eclipse.fordiac.ide.model.libraryElement.Group#getHeight <em>Height</em>}' attribute.
@@ -99,7 +99,7 @@ public interface Group extends FBNetworkElement {
 	 * @see #getHeight()
 	 * @generated
 	 */
-	void setHeight(int value);
+	void setHeight(double value);
 
 	/**
 	 * Returns the value of the '<em><b>Locked</b></em>' attribute.

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/Segment.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/Segment.java
@@ -43,13 +43,13 @@ public interface Segment extends TypedConfigureableObject, PositionableElement, 
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Width</em>' attribute.
-	 * @see #setWidth(int)
+	 * @see #setWidth(double)
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage#getSegment_Width()
-	 * @model default="200" dataType="org.eclipse.emf.ecore.xml.type.Int"
+	 * @model default="200" dataType="org.eclipse.emf.ecore.xml.type.Double"
 	 *        extendedMetaData="kind='attribute' name='dx1'"
 	 * @generated
 	 */
-	int getWidth();
+	double getWidth();
 
 	/**
 	 * Sets the value of the '{@link org.eclipse.fordiac.ide.model.libraryElement.Segment#getWidth <em>Width</em>}' attribute.
@@ -59,7 +59,7 @@ public interface Segment extends TypedConfigureableObject, PositionableElement, 
 	 * @see #getWidth()
 	 * @generated
 	 */
-	void setWidth(int value);
+	void setWidth(double value);
 
 	/**
 	 * Returns the value of the '<em><b>Out Connections</b></em>' reference list.

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/SubApp.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/SubApp.java
@@ -50,12 +50,12 @@ public interface SubApp extends FBNetworkElement {
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Width</em>' attribute.
-	 * @see #setWidth(int)
+	 * @see #setWidth(double)
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage#getSubApp_Width()
-	 * @model default="200" dataType="org.eclipse.emf.ecore.xml.type.Int"
+	 * @model default="200" dataType="org.eclipse.emf.ecore.xml.type.Double"
 	 * @generated
 	 */
-	int getWidth();
+	double getWidth();
 
 	/**
 	 * Sets the value of the '{@link org.eclipse.fordiac.ide.model.libraryElement.SubApp#getWidth <em>Width</em>}' attribute.
@@ -65,7 +65,7 @@ public interface SubApp extends FBNetworkElement {
 	 * @see #getWidth()
 	 * @generated
 	 */
-	void setWidth(int value);
+	void setWidth(double value);
 
 	/**
 	 * Returns the value of the '<em><b>Height</b></em>' attribute.
@@ -73,12 +73,12 @@ public interface SubApp extends FBNetworkElement {
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Height</em>' attribute.
-	 * @see #setHeight(int)
+	 * @see #setHeight(double)
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage#getSubApp_Height()
-	 * @model default="100" dataType="org.eclipse.emf.ecore.xml.type.Int"
+	 * @model default="100" dataType="org.eclipse.emf.ecore.xml.type.Double"
 	 * @generated
 	 */
-	int getHeight();
+	double getHeight();
 
 	/**
 	 * Sets the value of the '{@link org.eclipse.fordiac.ide.model.libraryElement.SubApp#getHeight <em>Height</em>}' attribute.
@@ -88,7 +88,7 @@ public interface SubApp extends FBNetworkElement {
 	 * @see #getHeight()
 	 * @generated
 	 */
-	void setHeight(int value);
+	void setHeight(double value);
 
 	/**
 	 * Returns the value of the '<em><b>Locked</b></em>' attribute.

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/CommentImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/CommentImpl.java
@@ -48,7 +48,7 @@ public class CommentImpl extends FBNetworkElementImpl implements Comment {
 	 * @generated
 	 * @ordered
 	 */
-	protected static final int WIDTH_EDEFAULT = 200;
+	protected static final double WIDTH_EDEFAULT = 200.0;
 
 	/**
 	 * The cached value of the '{@link #getWidth() <em>Width</em>}' attribute.
@@ -58,7 +58,7 @@ public class CommentImpl extends FBNetworkElementImpl implements Comment {
 	 * @generated
 	 * @ordered
 	 */
-	protected int width = WIDTH_EDEFAULT;
+	protected double width = WIDTH_EDEFAULT;
 
 	/**
 	 * The default value of the '{@link #getHeight() <em>Height</em>}' attribute.
@@ -68,7 +68,7 @@ public class CommentImpl extends FBNetworkElementImpl implements Comment {
 	 * @generated
 	 * @ordered
 	 */
-	protected static final int HEIGHT_EDEFAULT = 100;
+	protected static final double HEIGHT_EDEFAULT = 100.0;
 
 	/**
 	 * The cached value of the '{@link #getHeight() <em>Height</em>}' attribute.
@@ -78,7 +78,7 @@ public class CommentImpl extends FBNetworkElementImpl implements Comment {
 	 * @generated
 	 * @ordered
 	 */
-	protected int height = HEIGHT_EDEFAULT;
+	protected double height = HEIGHT_EDEFAULT;
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -105,7 +105,7 @@ public class CommentImpl extends FBNetworkElementImpl implements Comment {
 	 * @generated
 	 */
 	@Override
-	public int getWidth() {
+	public double getWidth() {
 		return width;
 	}
 
@@ -115,8 +115,8 @@ public class CommentImpl extends FBNetworkElementImpl implements Comment {
 	 * @generated
 	 */
 	@Override
-	public void setWidth(int newWidth) {
-		int oldWidth = width;
+	public void setWidth(double newWidth) {
+		double oldWidth = width;
 		width = newWidth;
 		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, LibraryElementPackage.COMMENT__WIDTH, oldWidth, width));
@@ -128,7 +128,7 @@ public class CommentImpl extends FBNetworkElementImpl implements Comment {
 	 * @generated
 	 */
 	@Override
-	public int getHeight() {
+	public double getHeight() {
 		return height;
 	}
 
@@ -138,8 +138,8 @@ public class CommentImpl extends FBNetworkElementImpl implements Comment {
 	 * @generated
 	 */
 	@Override
-	public void setHeight(int newHeight) {
-		int oldHeight = height;
+	public void setHeight(double newHeight) {
+		double oldHeight = height;
 		height = newHeight;
 		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, LibraryElementPackage.COMMENT__HEIGHT, oldHeight, height));
@@ -181,10 +181,10 @@ public class CommentImpl extends FBNetworkElementImpl implements Comment {
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
 			case LibraryElementPackage.COMMENT__WIDTH:
-				setWidth((Integer)newValue);
+				setWidth((Double)newValue);
 				return;
 			case LibraryElementPackage.COMMENT__HEIGHT:
-				setHeight((Integer)newValue);
+				setHeight((Double)newValue);
 				return;
 			default:
 				super.eSet(featureID, newValue);

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/ConnectionImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/ConnectionImpl.java
@@ -453,20 +453,6 @@ public abstract class ConnectionImpl extends ConfigurableObjectImpl implements C
 	 * @generated
 	 */
 	@Override
-	public void updateRoutingData(final int dx1, final int dy, final int dx2) {
-		final ConnectionRoutingData newRoutingData = org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory.eINSTANCE.createConnectionRoutingData();
-		newRoutingData.setDx1(dx1);
-		newRoutingData.setDy(dy);
-		newRoutingData.setDx2(dx2);
-		setRoutingData(newRoutingData);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	@Override
 	public void setVisible(final boolean visible) {
 		org.eclipse.fordiac.ide.model.annotations.HiddenElementAnnotations.setVisible(this,visible);
 	}

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/ConnectionRoutingDataImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/ConnectionRoutingDataImpl.java
@@ -51,7 +51,7 @@ public class ConnectionRoutingDataImpl extends EObjectImpl implements Connection
 	 * @generated
 	 * @ordered
 	 */
-	protected static final int DX1_EDEFAULT = 0;
+	protected static final double DX1_EDEFAULT = 0.0;
 
 	/**
 	 * The cached value of the '{@link #getDx1() <em>Dx1</em>}' attribute.
@@ -61,7 +61,7 @@ public class ConnectionRoutingDataImpl extends EObjectImpl implements Connection
 	 * @generated
 	 * @ordered
 	 */
-	protected int dx1 = DX1_EDEFAULT;
+	protected double dx1 = DX1_EDEFAULT;
 
 	/**
 	 * The default value of the '{@link #getDx2() <em>Dx2</em>}' attribute.
@@ -71,7 +71,7 @@ public class ConnectionRoutingDataImpl extends EObjectImpl implements Connection
 	 * @generated
 	 * @ordered
 	 */
-	protected static final int DX2_EDEFAULT = 0;
+	protected static final double DX2_EDEFAULT = 0.0;
 
 	/**
 	 * The cached value of the '{@link #getDx2() <em>Dx2</em>}' attribute.
@@ -81,7 +81,7 @@ public class ConnectionRoutingDataImpl extends EObjectImpl implements Connection
 	 * @generated
 	 * @ordered
 	 */
-	protected int dx2 = DX2_EDEFAULT;
+	protected double dx2 = DX2_EDEFAULT;
 
 	/**
 	 * The default value of the '{@link #getDy() <em>Dy</em>}' attribute.
@@ -91,7 +91,7 @@ public class ConnectionRoutingDataImpl extends EObjectImpl implements Connection
 	 * @generated
 	 * @ordered
 	 */
-	protected static final int DY_EDEFAULT = 0;
+	protected static final double DY_EDEFAULT = 0.0;
 
 	/**
 	 * The cached value of the '{@link #getDy() <em>Dy</em>}' attribute.
@@ -101,7 +101,7 @@ public class ConnectionRoutingDataImpl extends EObjectImpl implements Connection
 	 * @generated
 	 * @ordered
 	 */
-	protected int dy = DY_EDEFAULT;
+	protected double dy = DY_EDEFAULT;
 
 	/**
 	 * The default value of the '{@link #isNeedsValidation() <em>Needs Validation</em>}' attribute.
@@ -148,7 +148,7 @@ public class ConnectionRoutingDataImpl extends EObjectImpl implements Connection
 	 * @generated
 	 */
 	@Override
-	public int getDx1() {
+	public double getDx1() {
 		return dx1;
 	}
 
@@ -158,8 +158,8 @@ public class ConnectionRoutingDataImpl extends EObjectImpl implements Connection
 	 * @generated
 	 */
 	@Override
-	public void setDx1(int newDx1) {
-		int oldDx1 = dx1;
+	public void setDx1(double newDx1) {
+		double oldDx1 = dx1;
 		dx1 = newDx1;
 		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, LibraryElementPackage.CONNECTION_ROUTING_DATA__DX1, oldDx1, dx1));
@@ -171,7 +171,7 @@ public class ConnectionRoutingDataImpl extends EObjectImpl implements Connection
 	 * @generated
 	 */
 	@Override
-	public int getDx2() {
+	public double getDx2() {
 		return dx2;
 	}
 
@@ -181,8 +181,8 @@ public class ConnectionRoutingDataImpl extends EObjectImpl implements Connection
 	 * @generated
 	 */
 	@Override
-	public void setDx2(int newDx2) {
-		int oldDx2 = dx2;
+	public void setDx2(double newDx2) {
+		double oldDx2 = dx2;
 		dx2 = newDx2;
 		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, LibraryElementPackage.CONNECTION_ROUTING_DATA__DX2, oldDx2, dx2));
@@ -194,7 +194,7 @@ public class ConnectionRoutingDataImpl extends EObjectImpl implements Connection
 	 * @generated
 	 */
 	@Override
-	public int getDy() {
+	public double getDy() {
 		return dy;
 	}
 
@@ -204,8 +204,8 @@ public class ConnectionRoutingDataImpl extends EObjectImpl implements Connection
 	 * @generated
 	 */
 	@Override
-	public void setDy(int newDy) {
-		int oldDy = dy;
+	public void setDy(double newDy) {
+		double oldDy = dy;
 		dy = newDy;
 		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, LibraryElementPackage.CONNECTION_ROUTING_DATA__DY, oldDy, dy));
@@ -241,7 +241,7 @@ public class ConnectionRoutingDataImpl extends EObjectImpl implements Connection
 	 */
 	@Override
 	public boolean is1SegementData() {
-		return getDx1() == 0;
+		return getDx1() == 0.0;
 	}
 
 	/**
@@ -251,7 +251,7 @@ public class ConnectionRoutingDataImpl extends EObjectImpl implements Connection
 	 */
 	@Override
 	public boolean is3SegementData() {
-		return getDx1() != 0 && getDy() == 0;
+		return getDx1() != 0.0 && getDy() == 0.0;
 	}
 
 	/**
@@ -261,7 +261,7 @@ public class ConnectionRoutingDataImpl extends EObjectImpl implements Connection
 	 */
 	@Override
 	public boolean is5SegementData() {
-		return getDx1() != 0 && getDy() != 0;
+		return getDx1() != 0.0 && getDy() != 0.0;
 	}
 
 	/**
@@ -294,13 +294,13 @@ public class ConnectionRoutingDataImpl extends EObjectImpl implements Connection
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
 			case LibraryElementPackage.CONNECTION_ROUTING_DATA__DX1:
-				setDx1((Integer)newValue);
+				setDx1((Double)newValue);
 				return;
 			case LibraryElementPackage.CONNECTION_ROUTING_DATA__DX2:
-				setDx2((Integer)newValue);
+				setDx2((Double)newValue);
 				return;
 			case LibraryElementPackage.CONNECTION_ROUTING_DATA__DY:
-				setDy((Integer)newValue);
+				setDy((Double)newValue);
 				return;
 			case LibraryElementPackage.CONNECTION_ROUTING_DATA__NEEDS_VALIDATION:
 				setNeedsValidation((Boolean)newValue);

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/ErrorMarkerFBNElementImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/ErrorMarkerFBNElementImpl.java
@@ -116,8 +116,8 @@ public class ErrorMarkerFBNElementImpl extends FBNetworkElementImpl implements E
 	 * @generated
 	 */
 	@Override
-	public int getWidth() {
-		return org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getWidth(this);
+	public double getWidth() {
+		return org.eclipse.fordiac.ide.model.CoordinateConverter.INSTANCE.screenToIEC61499(org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getWidth(this));
 	}
 
 	/**
@@ -126,8 +126,8 @@ public class ErrorMarkerFBNElementImpl extends FBNetworkElementImpl implements E
 	 * @generated
 	 */
 	@Override
-	public int getHeight() {
-		return org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getHeight(this);
+	public double getHeight() {
+		return org.eclipse.fordiac.ide.model.CoordinateConverter.INSTANCE.screenToIEC61499(org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getHeight(this));
 	}
 
 	/**

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/FBImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/FBImpl.java
@@ -135,8 +135,8 @@ public class FBImpl extends FBNetworkElementImpl implements FB {
 	 * @generated
 	 */
 	@Override
-	public int getWidth() {
-		return org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getWidth(this);
+	public double getWidth() {
+		return org.eclipse.fordiac.ide.model.CoordinateConverter.INSTANCE.screenToIEC61499(org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getWidth(this));
 	}
 
 	/**
@@ -145,8 +145,8 @@ public class FBImpl extends FBNetworkElementImpl implements FB {
 	 * @generated
 	 */
 	@Override
-	public int getHeight() {
-		return org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getHeight(this);
+	public double getHeight() {
+		return org.eclipse.fordiac.ide.model.CoordinateConverter.INSTANCE.screenToIEC61499(org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getHeight(this));
 	}
 
 } //FBImpl

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/FBNetworkElementImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/FBNetworkElementImpl.java
@@ -514,7 +514,7 @@ public abstract class FBNetworkElementImpl extends TypedConfigureableObjectImpl 
 	 * @generated
 	 */
 	@Override
-	public int getWidth() {
+	public double getWidth() {
 		throw new UnsupportedOperationException();
 	}
 
@@ -524,7 +524,7 @@ public abstract class FBNetworkElementImpl extends TypedConfigureableObjectImpl 
 	 * @generated
 	 */
 	@Override
-	public int getHeight() {
+	public double getHeight() {
 		throw new UnsupportedOperationException();
 	}
 
@@ -535,7 +535,7 @@ public abstract class FBNetworkElementImpl extends TypedConfigureableObjectImpl 
 	 */
 	@Override
 	public int getVisibleWidth() {
-		return getWidth();
+		return org.eclipse.fordiac.ide.model.CoordinateConverter.INSTANCE.iec61499ToScreen(getWidth());
 	}
 
 	/**
@@ -545,7 +545,7 @@ public abstract class FBNetworkElementImpl extends TypedConfigureableObjectImpl 
 	 */
 	@Override
 	public int getVisibleHeight() {
-		return getHeight();
+		return org.eclipse.fordiac.ide.model.CoordinateConverter.INSTANCE.iec61499ToScreen(getHeight());
 	}
 
 	/**

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/GroupImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/GroupImpl.java
@@ -73,7 +73,7 @@ public class GroupImpl extends FBNetworkElementImpl implements Group {
 	 * @generated
 	 * @ordered
 	 */
-	protected static final int WIDTH_EDEFAULT = 200;
+	protected static final double WIDTH_EDEFAULT = 200.0;
 
 	/**
 	 * The cached value of the '{@link #getWidth() <em>Width</em>}' attribute.
@@ -83,7 +83,7 @@ public class GroupImpl extends FBNetworkElementImpl implements Group {
 	 * @generated
 	 * @ordered
 	 */
-	protected int width = WIDTH_EDEFAULT;
+	protected double width = WIDTH_EDEFAULT;
 
 	/**
 	 * The default value of the '{@link #getHeight() <em>Height</em>}' attribute.
@@ -93,7 +93,7 @@ public class GroupImpl extends FBNetworkElementImpl implements Group {
 	 * @generated
 	 * @ordered
 	 */
-	protected static final int HEIGHT_EDEFAULT = 100;
+	protected static final double HEIGHT_EDEFAULT = 100.0;
 
 	/**
 	 * The cached value of the '{@link #getHeight() <em>Height</em>}' attribute.
@@ -103,7 +103,7 @@ public class GroupImpl extends FBNetworkElementImpl implements Group {
 	 * @generated
 	 * @ordered
 	 */
-	protected int height = HEIGHT_EDEFAULT;
+	protected double height = HEIGHT_EDEFAULT;
 
 	/**
 	 * The default value of the '{@link #isLocked() <em>Locked</em>}' attribute.
@@ -163,7 +163,7 @@ public class GroupImpl extends FBNetworkElementImpl implements Group {
 	 * @generated
 	 */
 	@Override
-	public int getWidth() {
+	public double getWidth() {
 		return width;
 	}
 
@@ -173,8 +173,8 @@ public class GroupImpl extends FBNetworkElementImpl implements Group {
 	 * @generated
 	 */
 	@Override
-	public void setWidth(int newWidth) {
-		int oldWidth = width;
+	public void setWidth(double newWidth) {
+		double oldWidth = width;
 		width = newWidth;
 		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, LibraryElementPackage.GROUP__WIDTH, oldWidth, width));
@@ -186,7 +186,7 @@ public class GroupImpl extends FBNetworkElementImpl implements Group {
 	 * @generated
 	 */
 	@Override
-	public int getHeight() {
+	public double getHeight() {
 		return height;
 	}
 
@@ -196,8 +196,8 @@ public class GroupImpl extends FBNetworkElementImpl implements Group {
 	 * @generated
 	 */
 	@Override
-	public void setHeight(int newHeight) {
-		int oldHeight = height;
+	public void setHeight(double newHeight) {
+		double oldHeight = height;
 		height = newHeight;
 		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, LibraryElementPackage.GROUP__HEIGHT, oldHeight, height));
@@ -312,10 +312,10 @@ public class GroupImpl extends FBNetworkElementImpl implements Group {
 				getGroupElements().addAll((Collection<? extends FBNetworkElement>)newValue);
 				return;
 			case LibraryElementPackage.GROUP__WIDTH:
-				setWidth((Integer)newValue);
+				setWidth((Double)newValue);
 				return;
 			case LibraryElementPackage.GROUP__HEIGHT:
-				setHeight((Integer)newValue);
+				setHeight((Double)newValue);
 				return;
 			case LibraryElementPackage.GROUP__LOCKED:
 				setLocked((Boolean)newValue);

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
@@ -4409,11 +4409,6 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 
 		addEOperation(connectionEClass, null, "checkIfConnectionBroken", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		op = addEOperation(connectionEClass, null, "updateRoutingData", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
-		addEParameter(op, theXMLTypePackage.getInt(), "dx1", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
-		addEParameter(op, theXMLTypePackage.getInt(), "dy", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
-		addEParameter(op, theXMLTypePackage.getInt(), "dx2", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
-
 		addEOperation(connectionEClass, ecorePackage.getEBoolean(), "isInterfaceConnection", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		op = addEOperation(connectionEClass, ecorePackage.getEBoolean(), "validateMissingSource", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
@@ -4516,9 +4511,9 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 		addEParameter(op, g1, "context", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(connectionRoutingDataEClass, ConnectionRoutingData.class, "ConnectionRoutingData", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
-		initEAttribute(getConnectionRoutingData_Dx1(), theXMLTypePackage.getInt(), "dx1", "0", 0, 1, ConnectionRoutingData.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$ //$NON-NLS-2$
-		initEAttribute(getConnectionRoutingData_Dx2(), theXMLTypePackage.getInt(), "dx2", "0", 0, 1, ConnectionRoutingData.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$ //$NON-NLS-2$
-		initEAttribute(getConnectionRoutingData_Dy(), theXMLTypePackage.getInt(), "dy", "0", 0, 1, ConnectionRoutingData.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$ //$NON-NLS-2$
+		initEAttribute(getConnectionRoutingData_Dx1(), theXMLTypePackage.getDouble(), "dx1", "0", 0, 1, ConnectionRoutingData.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$ //$NON-NLS-2$
+		initEAttribute(getConnectionRoutingData_Dx2(), theXMLTypePackage.getDouble(), "dx2", "0", 0, 1, ConnectionRoutingData.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$ //$NON-NLS-2$
+		initEAttribute(getConnectionRoutingData_Dy(), theXMLTypePackage.getDouble(), "dy", "0", 0, 1, ConnectionRoutingData.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$ //$NON-NLS-2$
 		initEAttribute(getConnectionRoutingData_NeedsValidation(), theXMLTypePackage.getBoolean(), "needsValidation", null, 0, 1, ConnectionRoutingData.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
 		addEOperation(connectionRoutingDataEClass, ecorePackage.getEBoolean(), "is1SegementData", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
@@ -5910,6 +5905,12 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 			   "invariant", "true" //$NON-NLS-1$ //$NON-NLS-2$
 		   });
 		addAnnotation
+		  (connectionEClass.getEOperations().get(6),
+		   source,
+		   new String[] {
+			   "invariant", "true" //$NON-NLS-1$ //$NON-NLS-2$
+		   });
+		addAnnotation
 		  (connectionEClass.getEOperations().get(7),
 		   source,
 		   new String[] {
@@ -5965,12 +5966,6 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 		   });
 		addAnnotation
 		  (connectionEClass.getEOperations().get(16),
-		   source,
-		   new String[] {
-			   "invariant", "true" //$NON-NLS-1$ //$NON-NLS-2$
-		   });
-		addAnnotation
-		  (connectionEClass.getEOperations().get(17),
 		   source,
 		   new String[] {
 			   "invariant", "true" //$NON-NLS-1$ //$NON-NLS-2$

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
@@ -5023,7 +5023,7 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 		addEOperation(resourceTypeFBEClass, ecorePackage.getEBoolean(), "isResourceTypeFB", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(segmentEClass, Segment.class, "Segment", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
-		initEAttribute(getSegment_Width(), theXMLTypePackage.getInt(), "width", "200", 0, 1, Segment.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$ //$NON-NLS-2$
+		initEAttribute(getSegment_Width(), theXMLTypePackage.getDouble(), "width", "200", 0, 1, Segment.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$ //$NON-NLS-2$
 		initEReference(getSegment_OutConnections(), this.getLink(), this.getLink_Segment(), "outConnections", null, 0, -1, Segment.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEReference(getSegment_Communication(), this.getCommunicationConfiguration(), null, "communication", null, 0, 1, Segment.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
@@ -4313,8 +4313,8 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 		initEReference(getColorizableElement_Color(), this.getColor(), null, "color", null, 1, 1, ColorizableElement.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(commentEClass, Comment.class, "Comment", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
-		initEAttribute(getComment_Width(), theXMLTypePackage.getInt(), "width", "200", 0, 1, Comment.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$ //$NON-NLS-2$
-		initEAttribute(getComment_Height(), theXMLTypePackage.getInt(), "height", "100", 0, 1, Comment.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$ //$NON-NLS-2$
+		initEAttribute(getComment_Width(), theXMLTypePackage.getDouble(), "width", "200", 0, 1, Comment.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$ //$NON-NLS-2$
+		initEAttribute(getComment_Height(), theXMLTypePackage.getDouble(), "height", "100", 0, 1, Comment.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$ //$NON-NLS-2$
 
 		addEOperation(commentEClass, this.getInterfaceList(), "getInterface", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
@@ -4592,9 +4592,9 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 		initEClass(errorMarkerFBNElementEClass, ErrorMarkerFBNElement.class, "ErrorMarkerFBNElement", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getErrorMarkerFBNElement_RepairedElement(), this.getFBNetworkElement(), null, "repairedElement", null, 0, 1, ErrorMarkerFBNElement.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(errorMarkerFBNElementEClass, theXMLTypePackage.getInt(), "getWidth", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(errorMarkerFBNElementEClass, theXMLTypePackage.getDouble(), "getWidth", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(errorMarkerFBNElementEClass, theXMLTypePackage.getInt(), "getHeight", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(errorMarkerFBNElementEClass, theXMLTypePackage.getDouble(), "getHeight", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(errorMarkerInterfaceEClass, ErrorMarkerInterface.class, "ErrorMarkerInterface", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getErrorMarkerInterface_Value(), this.getValue(), null, "value", null, 0, 1, ErrorMarkerInterface.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
@@ -4642,9 +4642,9 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 
 		addEOperation(fbEClass, theDataPackage.getDataType(), "getReturnType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(fbEClass, theXMLTypePackage.getInt(), "getWidth", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(fbEClass, theXMLTypePackage.getDouble(), "getWidth", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(fbEClass, theXMLTypePackage.getInt(), "getHeight", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(fbEClass, theXMLTypePackage.getDouble(), "getHeight", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(fbNetworkEClass, FBNetwork.class, "FBNetwork", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getFBNetwork_NetworkElements(), this.getFBNetworkElement(), null, "networkElements", null, 0, -1, FBNetwork.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
@@ -4734,9 +4734,9 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 
 		addEOperation(fbNetworkElementEClass, ecorePackage.getEString(), "getQualifiedName", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(fbNetworkElementEClass, theXMLTypePackage.getInt(), "getWidth", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(fbNetworkElementEClass, theXMLTypePackage.getDouble(), "getWidth", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(fbNetworkElementEClass, theXMLTypePackage.getInt(), "getHeight", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(fbNetworkElementEClass, theXMLTypePackage.getDouble(), "getHeight", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		addEOperation(fbNetworkElementEClass, theXMLTypePackage.getInt(), "getVisibleWidth", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
@@ -4778,8 +4778,8 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 
 		initEClass(groupEClass, Group.class, "Group", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getGroup_GroupElements(), this.getFBNetworkElement(), this.getFBNetworkElement_Group(), "groupElements", null, 0, -1, Group.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
-		initEAttribute(getGroup_Width(), theXMLTypePackage.getInt(), "width", "200", 0, 1, Group.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$ //$NON-NLS-2$
-		initEAttribute(getGroup_Height(), theXMLTypePackage.getInt(), "height", "100", 0, 1, Group.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$ //$NON-NLS-2$
+		initEAttribute(getGroup_Width(), theXMLTypePackage.getDouble(), "width", "200", 0, 1, Group.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$ //$NON-NLS-2$
+		initEAttribute(getGroup_Height(), theXMLTypePackage.getDouble(), "height", "100", 0, 1, Group.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$ //$NON-NLS-2$
 		initEAttribute(getGroup_Locked(), theXMLTypePackage.getBoolean(), "locked", "false", 0, 1, Group.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$ //$NON-NLS-2$
 
 		addEOperation(groupEClass, this.getInterfaceList(), "getInterface", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
@@ -5076,8 +5076,8 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 		initEClass(stMethodEClass, STMethod.class, "STMethod", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 
 		initEClass(subAppEClass, SubApp.class, "SubApp", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
-		initEAttribute(getSubApp_Width(), theXMLTypePackage.getInt(), "width", "200", 0, 1, SubApp.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$ //$NON-NLS-2$
-		initEAttribute(getSubApp_Height(), theXMLTypePackage.getInt(), "height", "100", 0, 1, SubApp.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$ //$NON-NLS-2$
+		initEAttribute(getSubApp_Width(), theXMLTypePackage.getDouble(), "width", "200", 0, 1, SubApp.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$ //$NON-NLS-2$
+		initEAttribute(getSubApp_Height(), theXMLTypePackage.getDouble(), "height", "100", 0, 1, SubApp.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$ //$NON-NLS-2$
 		initEAttribute(getSubApp_Locked(), theXMLTypePackage.getBoolean(), "locked", "false", 0, 1, SubApp.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$ //$NON-NLS-2$
 
 		addEOperation(subAppEClass, this.getSubAppType(), "getType", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/SegmentImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/SegmentImpl.java
@@ -105,7 +105,7 @@ public class SegmentImpl extends TypedConfigureableObjectImpl implements Segment
 	 * @generated
 	 * @ordered
 	 */
-	protected static final int WIDTH_EDEFAULT = 200;
+	protected static final double WIDTH_EDEFAULT = 200.0;
 
 	/**
 	 * The cached value of the '{@link #getWidth() <em>Width</em>}' attribute.
@@ -115,7 +115,7 @@ public class SegmentImpl extends TypedConfigureableObjectImpl implements Segment
 	 * @generated
 	 * @ordered
 	 */
-	protected int width = WIDTH_EDEFAULT;
+	protected double width = WIDTH_EDEFAULT;
 
 	/**
 	 * The cached value of the '{@link #getOutConnections() <em>Out Connections</em>}' reference list.
@@ -298,7 +298,7 @@ public class SegmentImpl extends TypedConfigureableObjectImpl implements Segment
 	 * @generated
 	 */
 	@Override
-	public int getWidth() {
+	public double getWidth() {
 		return width;
 	}
 
@@ -308,8 +308,8 @@ public class SegmentImpl extends TypedConfigureableObjectImpl implements Segment
 	 * @generated
 	 */
 	@Override
-	public void setWidth(int newWidth) {
-		int oldWidth = width;
+	public void setWidth(double newWidth) {
+		double oldWidth = width;
 		width = newWidth;
 		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, LibraryElementPackage.SEGMENT__WIDTH, oldWidth, width));
@@ -551,7 +551,7 @@ public class SegmentImpl extends TypedConfigureableObjectImpl implements Segment
 				getVarDeclarations().addAll((Collection<? extends VarDeclaration>)newValue);
 				return;
 			case LibraryElementPackage.SEGMENT__WIDTH:
-				setWidth((Integer)newValue);
+				setWidth((Double)newValue);
 				return;
 			case LibraryElementPackage.SEGMENT__OUT_CONNECTIONS:
 				getOutConnections().clear();

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/SubAppImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/SubAppImpl.java
@@ -51,7 +51,7 @@ public abstract class SubAppImpl extends FBNetworkElementImpl implements SubApp 
 	 * @generated
 	 * @ordered
 	 */
-	protected static final int WIDTH_EDEFAULT = 200;
+	protected static final double WIDTH_EDEFAULT = 200.0;
 
 	/**
 	 * The cached value of the '{@link #getWidth() <em>Width</em>}' attribute.
@@ -61,7 +61,7 @@ public abstract class SubAppImpl extends FBNetworkElementImpl implements SubApp 
 	 * @generated
 	 * @ordered
 	 */
-	protected int width = WIDTH_EDEFAULT;
+	protected double width = WIDTH_EDEFAULT;
 
 	/**
 	 * The default value of the '{@link #getHeight() <em>Height</em>}' attribute.
@@ -71,7 +71,7 @@ public abstract class SubAppImpl extends FBNetworkElementImpl implements SubApp 
 	 * @generated
 	 * @ordered
 	 */
-	protected static final int HEIGHT_EDEFAULT = 100;
+	protected static final double HEIGHT_EDEFAULT = 100.0;
 
 	/**
 	 * The cached value of the '{@link #getHeight() <em>Height</em>}' attribute.
@@ -81,7 +81,7 @@ public abstract class SubAppImpl extends FBNetworkElementImpl implements SubApp 
 	 * @generated
 	 * @ordered
 	 */
-	protected int height = HEIGHT_EDEFAULT;
+	protected double height = HEIGHT_EDEFAULT;
 
 	/**
 	 * The default value of the '{@link #isLocked() <em>Locked</em>}' attribute.
@@ -128,7 +128,7 @@ public abstract class SubAppImpl extends FBNetworkElementImpl implements SubApp 
 	 * @generated
 	 */
 	@Override
-	public int getWidth() {
+	public double getWidth() {
 		return width;
 	}
 
@@ -138,8 +138,8 @@ public abstract class SubAppImpl extends FBNetworkElementImpl implements SubApp 
 	 * @generated
 	 */
 	@Override
-	public void setWidth(int newWidth) {
-		int oldWidth = width;
+	public void setWidth(double newWidth) {
+		double oldWidth = width;
 		width = newWidth;
 		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, LibraryElementPackage.SUB_APP__WIDTH, oldWidth, width));
@@ -151,7 +151,7 @@ public abstract class SubAppImpl extends FBNetworkElementImpl implements SubApp 
 	 * @generated
 	 */
 	@Override
-	public int getHeight() {
+	public double getHeight() {
 		return height;
 	}
 
@@ -161,8 +161,8 @@ public abstract class SubAppImpl extends FBNetworkElementImpl implements SubApp 
 	 * @generated
 	 */
 	@Override
-	public void setHeight(int newHeight) {
-		int oldHeight = height;
+	public void setHeight(double newHeight) {
+		double oldHeight = height;
 		height = newHeight;
 		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, LibraryElementPackage.SUB_APP__HEIGHT, oldHeight, height));
@@ -261,7 +261,7 @@ public abstract class SubAppImpl extends FBNetworkElementImpl implements SubApp 
 	 */
 	@Override
 	public int getVisibleWidth() {
-		return isUnfolded() ? getWidth() : org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getWidth(this);
+		return isUnfolded() ? org.eclipse.fordiac.ide.model.CoordinateConverter.INSTANCE.iec61499ToScreen(getWidth()) : org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getWidth(this);
 	}
 
 	/**
@@ -271,7 +271,7 @@ public abstract class SubAppImpl extends FBNetworkElementImpl implements SubApp 
 	 */
 	@Override
 	public int getVisibleHeight() {
-		return isUnfolded() ? getHeight() : org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getHeight(this);
+		return isUnfolded() ? org.eclipse.fordiac.ide.model.CoordinateConverter.INSTANCE.iec61499ToScreen(getHeight()) : org.eclipse.fordiac.ide.model.helpers.FBShapeHelper.getHeight(this);
 	}
 
 	/**
@@ -302,10 +302,10 @@ public abstract class SubAppImpl extends FBNetworkElementImpl implements SubApp 
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
 			case LibraryElementPackage.SUB_APP__WIDTH:
-				setWidth((Integer)newValue);
+				setWidth((Double)newValue);
 				return;
 			case LibraryElementPackage.SUB_APP__HEIGHT:
-				setHeight((Integer)newValue);
+				setHeight((Double)newValue);
 				return;
 			case LibraryElementPackage.SUB_APP__LOCKED:
 				setLocked((Boolean)newValue);

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/CoordinateConverter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/CoordinateConverter.java
@@ -87,21 +87,6 @@ public enum CoordinateConverter {
 	}
 
 	/**
-	 * Take the string representing the value from the 61499-2 XML file to an 4diac
-	 * IDE internal coordinate
-	 *
-	 * @param value string representation of a coordinate value
-	 * @return 4diac IDE internal coordinate value
-	 */
-	public int convertFrom1499XML(final String value) {
-		double parsedValue = 0;
-		if ((null != value) && (0 != value.length())) {
-			parsedValue = Double.parseDouble(value);
-		}
-		return iec61499ToScreen(parsedValue);
-	}
-
-	/**
 	 * Convert IEC 61499 coordinate to screen coordinate
 	 *
 	 * @param value IEC 61499 coordinate value
@@ -109,17 +94,6 @@ public enum CoordinateConverter {
 	 */
 	public int iec61499ToScreen(final double value) {
 		return (int) (value * transformationScale);
-	}
-
-	/**
-	 * Take an 4diac IDE internal coordinate and transform it to a string
-	 * representation suitable for an IEC 61499-2 XML
-	 *
-	 * @param value 4diac IDE internal coordinate
-	 * @return string representation of the value in IEC 61499-2 format
-	 */
-	public String convertTo1499XML(final int value) {
-		return Double.toString(screenToIEC61499(value));
 	}
 
 	/**

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/CommonElementExporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/CommonElementExporter.java
@@ -182,7 +182,7 @@ public class CommonElementExporter {
 	public static final String LINE_END = "\n"; //$NON-NLS-1$
 	public static final String TAB = "\t"; //$NON-NLS-1$
 	private static final Pattern CDATA_END_PATTERN = Pattern.compile("\\]\\]>"); //$NON-NLS-1$
-	private static final DecimalFormat positionFormater = new DecimalFormat("#.##"); //$NON-NLS-1$
+	protected static final DecimalFormat positionFormater = new DecimalFormat("#.##"); //$NON-NLS-1$
 
 	private final XMLStreamWriter writer;
 	private final ByteBufferOutputStream outputStream;

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/FBNetworkExporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/FBNetworkExporter.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import javax.xml.stream.XMLStreamException;
 
-import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.LibraryElementTags;
 import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes;
 import org.eclipse.fordiac.ide.model.libraryElement.AdapterType;
@@ -116,10 +115,8 @@ class FBNetworkExporter extends CommonElementExporter {
 
 		addCommentAttribute(comment.getComment());
 		addXYAttributes(comment);
-		getWriter().writeAttribute(LibraryElementTags.WIDTH_ATTRIBUTE,
-				CoordinateConverter.INSTANCE.convertTo1499XML(comment.getWidth()));
-		getWriter().writeAttribute(LibraryElementTags.HEIGHT_ATTRIBUTE,
-				CoordinateConverter.INSTANCE.convertTo1499XML(comment.getHeight()));
+		getWriter().writeAttribute(LibraryElementTags.WIDTH_ATTRIBUTE, positionFormater.format(comment.getWidth()));
+		getWriter().writeAttribute(LibraryElementTags.HEIGHT_ATTRIBUTE, positionFormater.format(comment.getHeight()));
 
 		if (comment.isInGroup()) {
 			addGroupAttribute(comment.getGroup());
@@ -134,10 +131,8 @@ class FBNetworkExporter extends CommonElementExporter {
 	}
 
 	private void addGroupAttributes(final Group group) throws XMLStreamException {
-		getWriter().writeAttribute(LibraryElementTags.WIDTH_ATTRIBUTE,
-				CoordinateConverter.INSTANCE.convertTo1499XML(group.getWidth()));
-		getWriter().writeAttribute(LibraryElementTags.HEIGHT_ATTRIBUTE,
-				CoordinateConverter.INSTANCE.convertTo1499XML(group.getHeight()));
+		getWriter().writeAttribute(LibraryElementTags.WIDTH_ATTRIBUTE, positionFormater.format(group.getWidth()));
+		getWriter().writeAttribute(LibraryElementTags.HEIGHT_ATTRIBUTE, positionFormater.format(group.getHeight()));
 		getWriter().writeAttribute(LibraryElementTags.LOCKED_ATTRIBUTE, Boolean.toString(group.isLocked()));
 	}
 
@@ -175,11 +170,11 @@ class FBNetworkExporter extends CommonElementExporter {
 	private void addSubappHeightAndWidthAttributes(final SubApp subApp) throws XMLStreamException {
 		if (subApp.getWidth() != 0) {
 			addAttributeElement(LibraryElementTags.WIDTH_ATTRIBUTE, IecTypes.ElementaryTypes.LREAL,
-					CoordinateConverter.INSTANCE.convertTo1499XML(subApp.getWidth()), null);
+					positionFormater.format(subApp.getWidth()), null);
 		}
 		if (subApp.getHeight() != 0) {
 			addAttributeElement(LibraryElementTags.HEIGHT_ATTRIBUTE, IecTypes.ElementaryTypes.LREAL,
-					CoordinateConverter.INSTANCE.convertTo1499XML(subApp.getHeight()), null);
+					positionFormater.format(subApp.getHeight()), null);
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/FBNetworkExporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/FBNetworkExporter.java
@@ -284,14 +284,13 @@ class FBNetworkExporter extends CommonElementExporter {
 		final ConnectionRoutingData routingData = connection.getRoutingData();
 		if (routingData != null && 0 != routingData.getDx1()) {
 			// only export connection routing information if not a straight line
-			getWriter().writeAttribute(LibraryElementTags.DX1_ATTRIBUTE,
-					CoordinateConverter.INSTANCE.convertTo1499XML(routingData.getDx1()));
+			getWriter().writeAttribute(LibraryElementTags.DX1_ATTRIBUTE, positionFormater.format(routingData.getDx1()));
 			if (0 != routingData.getDx2()) {
 				// only export the second two if a five segment connection
 				getWriter().writeAttribute(LibraryElementTags.DX2_ATTRIBUTE,
-						CoordinateConverter.INSTANCE.convertTo1499XML(routingData.getDx2()));
+						positionFormater.format(routingData.getDx2()));
 				getWriter().writeAttribute(LibraryElementTags.DY_ATTRIBUTE,
-						CoordinateConverter.INSTANCE.convertTo1499XML(routingData.getDy()));
+						positionFormater.format(routingData.getDy()));
 			}
 		}
 	}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/SystemExporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/SystemExporter.java
@@ -21,7 +21,6 @@ package org.eclipse.fordiac.ide.model.dataexport;
 import javax.xml.stream.XMLStreamException;
 
 import org.eclipse.emf.common.util.EList;
-import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.LibraryElementTags;
 import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes;
 import org.eclipse.fordiac.ide.model.libraryElement.Application;
@@ -85,8 +84,7 @@ public class SystemExporter extends AbstractTypeExporter {
 			addStartElement(LibraryElementTags.SEGMENT_ELEMENT);
 			addNameTypeCommentAttribute(segment, segment.getType());
 			addXYAttributes(segment);
-			getWriter().writeAttribute(LibraryElementTags.DX1_ATTRIBUTE,
-					CoordinateConverter.INSTANCE.convertTo1499XML(segment.getWidth()));
+			getWriter().writeAttribute(LibraryElementTags.DX1_ATTRIBUTE, positionFormater.format(segment.getWidth()));
 			addColorAttributeElement(segment);
 			addAttributes(segment.getAttributes());
 			addParamsConfig(segment.getCommunication().getParameters());

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/FBNetworkImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/FBNetworkImporter.java
@@ -33,7 +33,6 @@ import javax.xml.stream.XMLStreamException;
 
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
-import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.LibraryElementTags;
 import org.eclipse.fordiac.ide.model.NameRepository;
 import org.eclipse.fordiac.ide.model.data.DataType;
@@ -157,11 +156,11 @@ class FBNetworkImporter extends CommonElementImporter {
 
 		final String width = getAttributeValue(LibraryElementTags.WIDTH_ATTRIBUTE);
 		if (width != null) {
-			group.setWidth(CoordinateConverter.INSTANCE.convertFrom1499XML(width));
+			group.setWidth(Double.parseDouble(width));
 		}
 		final String height = getAttributeValue(LibraryElementTags.HEIGHT_ATTRIBUTE);
 		if (height != null) {
-			group.setHeight(CoordinateConverter.INSTANCE.convertFrom1499XML(height));
+			group.setHeight(Double.parseDouble(height));
 		}
 		final String locked = getAttributeValue(LibraryElementTags.LOCKED_ATTRIBUTE);
 		if (locked != null) {
@@ -189,11 +188,11 @@ class FBNetworkImporter extends CommonElementImporter {
 
 		final String width = getAttributeValue(LibraryElementTags.WIDTH_ATTRIBUTE);
 		if (width != null) {
-			comment.setWidth(CoordinateConverter.INSTANCE.convertFrom1499XML(width));
+			comment.setWidth(Double.parseDouble(width));
 		}
 		final String height = getAttributeValue(LibraryElementTags.HEIGHT_ATTRIBUTE);
 		if (height != null) {
-			comment.setHeight(CoordinateConverter.INSTANCE.convertFrom1499XML(height));
+			comment.setHeight(Double.parseDouble(height));
 		}
 
 		fbNetwork.getNetworkElements().add(comment);

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/FBNetworkImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/FBNetworkImporter.java
@@ -558,9 +558,9 @@ class FBNetworkImporter extends CommonElementImporter {
 	 * @param value
 	 * @return if value is valid the converted int of that otherwise 0
 	 */
-	private static int parseConnectionValue(final String value) {
+	private static double parseConnectionValue(final String value) {
 		try {
-			return CoordinateConverter.INSTANCE.convertFrom1499XML(value);
+			return Double.parseDouble(value);
 		} catch (final NumberFormatException ex) {
 			return 0;
 		}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/SubAppNetworkImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/SubAppNetworkImporter.java
@@ -18,7 +18,6 @@ import java.util.Map;
 
 import javax.xml.stream.XMLStreamException;
 
-import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.LibraryElementTags;
 import org.eclipse.fordiac.ide.model.dataimport.exceptions.TypeImportException;
 import org.eclipse.fordiac.ide.model.errormarker.FordiacMarkerHelper;
@@ -132,18 +131,18 @@ class SubAppNetworkImporter extends FBNetworkImporter {
 			case LibraryElementTags.WIDTH_ATTRIBUTE:
 				final String widthValue = getAttributeValue(LibraryElementTags.VALUE_ATTRIBUTE);
 				if (widthValue != null) {
-					subApp.setWidth(CoordinateConverter.INSTANCE.convertFrom1499XML(widthValue));
+					subApp.setWidth(Double.parseDouble(widthValue));
 				}
 				break;
 			case LibraryElementTags.HEIGHT_ATTRIBUTE:
 				final String heightValue = getAttributeValue(LibraryElementTags.VALUE_ATTRIBUTE);
 				if (heightValue != null) {
-					subApp.setHeight(CoordinateConverter.INSTANCE.convertFrom1499XML(heightValue));
+					subApp.setHeight(Double.parseDouble(heightValue));
 				}
 				break;
 			case LibraryElementTags.LOCKED_ATTRIBUTE:
 				final String isLocked = getAttributeValue(LibraryElementTags.VALUE_ATTRIBUTE);
-				subApp.setLocked(Boolean.valueOf(isLocked));
+				subApp.setLocked(Boolean.parseBoolean(isLocked));
 				break;
 			default:
 				parseGenericAttributeNode(subApp);

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/SystemImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/SystemImporter.java
@@ -31,7 +31,6 @@ import javax.xml.stream.XMLStreamException;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.LibraryElementTags;
 import org.eclipse.fordiac.ide.model.dataimport.exceptions.TypeImportException;
 import org.eclipse.fordiac.ide.model.helpers.FBNetworkHelper;
@@ -161,7 +160,7 @@ public class SystemImporter extends CommonElementImporter {
 		getXandY(segment);
 		final String dx1 = getAttributeValue(LibraryElementTags.DX1_ATTRIBUTE);
 		if (null != dx1) {
-			segment.setWidth(CoordinateConverter.INSTANCE.convertFrom1499XML(dx1));
+			segment.setWidth(Double.parseDouble(dx1));
 		}
 
 		final String type = getAttributeValue(LibraryElementTags.TYPE_ATTRIBUTE);

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/FBNetworkAnnotations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/FBNetworkAnnotations.java
@@ -94,7 +94,7 @@ final class FBNetworkAnnotations {
 
 			// check parent collision
 			final Optional<FBNetworkElement> parentCollision = parent.filter(outer -> elementBounds.x < 0
-					|| elementBounds.y < 0 || x2 > outer.getWidth() || y2 > outer.getHeight());
+					|| elementBounds.y < 0 || x2 > outer.getVisibleWidth() || y2 > outer.getVisibleHeight());
 			if (diagnostics != null) {
 				parentCollision.ifPresent(other -> diagnostics.add(createCollisionDiagnostic(element, other)));
 			}

--- a/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/commands/SegmentSetConstraintCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/commands/SegmentSetConstraintCommand.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2009, 2011, 2012, 2016, 2017 Profactor GbmH, TU Wien ACIN, fortiss GmbH
- * 				 2019 Johannes Keppler University Linz
+ * Copyright (c) 2008, 2024 Profactor GbmH, TU Wien ACIN, fortiss GmbH,
+ *                          Johannes Keppler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *   Gerhard Ebenhofer, Alois Zoitl
- *     - initial API and implementation and/or initial documentation
+ *               - initial API and implementation and/or initial documentation
  *   Alois Zoitl - removed editor check from canUndo
  *******************************************************************************/
 package org.eclipse.fordiac.ide.systemconfiguration.commands;
@@ -31,8 +31,8 @@ public class SegmentSetConstraintCommand extends Command {
 	private final Position newPos;
 	private Position oldPos;
 
-	private final int newWidth;
-	private int oldWidth;
+	private final double newWidth;
+	private final double oldWidth;
 
 	/** The request. */
 	private final ChangeBoundsRequest request;
@@ -48,7 +48,8 @@ public class SegmentSetConstraintCommand extends Command {
 		this.segment = segment;
 		this.request = request;
 		newPos = CoordinateConverter.INSTANCE.createPosFromScreenCoordinates(newBounds.x, newBounds.y);
-		newWidth = newBounds.width;
+		newWidth = CoordinateConverter.INSTANCE.screenToIEC61499(newBounds.width);
+		oldWidth = segment.getWidth();
 	}
 
 	/*
@@ -74,7 +75,6 @@ public class SegmentSetConstraintCommand extends Command {
 	@Override
 	public void execute() {
 		oldPos = segment.getPosition();
-		oldWidth = segment.getWidth();
 		setSegementPosAndWidth(newPos, newWidth);
 	}
 
@@ -97,7 +97,7 @@ public class SegmentSetConstraintCommand extends Command {
 		setSegementPosAndWidth(oldPos, oldWidth);
 	}
 
-	private void setSegementPosAndWidth(final Position pos, final int width) {
+	private void setSegementPosAndWidth(final Position pos, final double width) {
 		segment.setPosition(pos);
 		segment.setWidth(width);
 	}

--- a/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/editparts/SegmentEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/editparts/SegmentEditPart.java
@@ -44,6 +44,7 @@ import org.eclipse.fordiac.ide.gef.figures.InteractionStyleFigure;
 import org.eclipse.fordiac.ide.gef.figures.RoundedRectangleShadowBorder;
 import org.eclipse.fordiac.ide.gef.listeners.DiagramFontChangeListener;
 import org.eclipse.fordiac.ide.gef.listeners.IFontUpdateListener;
+import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
@@ -195,7 +196,8 @@ public class SegmentEditPart extends AbstractViewEditPart implements NodeEditPar
 
 	protected void refreshPosition() {
 		final Point position = getModel().getPosition().toScreenPoint();
-		final Rectangle bounds = new Rectangle(position.x, position.y, getModel().getWidth(), -1);
+		final Rectangle bounds = new Rectangle(position.x, position.y,
+				CoordinateConverter.INSTANCE.iec61499ToScreen(getModel().getWidth()), -1);
 		((GraphicalEditPart) getParent()).setLayoutConstraint(this, getFigure(), bounds);
 	}
 

--- a/tests/org.eclipse.fordiac.ide.test.model.commands/src/org/eclipse/fordiac/ide/elk/commands/LayoutCommandTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model.commands/src/org/eclipse/fordiac/ide/elk/commands/LayoutCommandTest.java
@@ -21,6 +21,7 @@ import org.eclipse.draw2d.geometry.PointList;
 import org.eclipse.fordiac.ide.application.commands.MoveElementsFromSubAppCommandTest;
 import org.eclipse.fordiac.ide.application.commands.NewSubAppCommandTest;
 import org.eclipse.fordiac.ide.elk.FordiacLayoutData;
+import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.commands.create.ConnectionCommandsTest;
 import org.eclipse.fordiac.ide.model.commands.create.WithCreateTest;
 import org.eclipse.fordiac.ide.model.commands.testinfra.FBNetworkTestBase;
@@ -137,8 +138,8 @@ public class LayoutCommandTest extends FBNetworkTestBase {
 		t.test(pos2.getY(), 200.0);
 
 		/* dx1 = middlePoint.x - firstPoint.x = 50 */
-		t.test(s.getFbNetwork().getDataConnections().get(0).getRoutingData().getDx1(), 50);
-		t.test(s.getFbNetwork().getEventConnections().get(0).getRoutingData().getDx1(), 50);
+		t.test(s.getFbNetwork().getDataConnections().get(0).getRoutingData().getDx1(), fromScreen(50));
+		t.test(s.getFbNetwork().getEventConnections().get(0).getRoutingData().getDx1(), fromScreen(50));
 	}
 
 	private static void verifySubAppLayout(final State s, final State o, final TestFunction t) {
@@ -170,8 +171,8 @@ public class LayoutCommandTest extends FBNetworkTestBase {
 		t.test(pos2.getY(), 200.0);
 
 		/* dx1 = middlePoint.x - firstPoint.x = 50 */
-		t.test(network.getDataConnections().get(0).getRoutingData().getDx1(), 50);
-		t.test(network.getEventConnections().get(0).getRoutingData().getDx1(), 50);
+		t.test(network.getDataConnections().get(0).getRoutingData().getDx1(), fromScreen(50));
+		t.test(network.getEventConnections().get(0).getRoutingData().getDx1(), fromScreen(50));
 	}
 
 	// parameter creation function
@@ -215,5 +216,9 @@ public class LayoutCommandTest extends FBNetworkTestBase {
 		));
 
 		return a;
+	}
+
+	private static double fromScreen(final int val) {
+		return CoordinateConverter.INSTANCE.screenToIEC61499(val);
 	}
 }


### PR DESCRIPTION
In order to minimize noise when saving on different screens we now store the bendpoints of connections and element sices in IEC 61499 coordinate system in the model. This should reduce noise in the change history.