### PR TITLE
Removed Ctrl+Click open Type in Editor Feature

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractStructManipulatorEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractStructManipulatorEditPart.java
@@ -36,7 +36,7 @@ public abstract class AbstractStructManipulatorEditPart extends AbstractFBNEleme
 
 	@Override
 	protected IFigure createFigureForModel() {
-		return new FBNetworkElementFigure(getModel(), this);
+		return new FBNetworkElementFigure(getModel());
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/ErrorMarkerFBNEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/ErrorMarkerFBNEditPart.java
@@ -31,7 +31,7 @@ public class ErrorMarkerFBNEditPart extends AbstractFBNElementEditPart {
 
 	@Override
 	protected IFigure createFigureForModel() {
-		errorMarkerFBNeworkElementFigure = new ErrorMarkerFBNeworkElementFigure(getModel(), this);
+		errorMarkerFBNeworkElementFigure = new ErrorMarkerFBNeworkElementFigure(getModel());
 		updateErrorText();
 		return errorMarkerFBNeworkElementFigure;
 	}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/FBEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/FBEditPart.java
@@ -30,10 +30,6 @@ import org.eclipse.gef.RequestConstants;
  */
 public class FBEditPart extends AbstractFBNElementEditPart {
 
-	public FBEditPart() {
-		super();
-	}
-
 	/**
 	 * Creates the figure (for the specified model) to be used as this parts
 	 * visuals.
@@ -44,11 +40,10 @@ public class FBEditPart extends AbstractFBNElementEditPart {
 	protected IFigure createFigureForModel() {
 		// extend this if FunctionBlock gets extended!
 		FBNetworkElementFigure f = null;
-		if (getModel() != null) {
-			f = new FBNetworkElementFigure(getModel(), this);
-		} else {
+		if (getModel() == null) {
 			throw new IllegalArgumentException(Messages.FBEditPart_ERROR_UnsupportedFBType);
 		}
+		f = new FBNetworkElementFigure(getModel());
 		return f;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/ErrorMarkerFBNeworkElementFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/ErrorMarkerFBNeworkElementFigure.java
@@ -12,15 +12,14 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.application.figures;
 
-import org.eclipse.fordiac.ide.application.editparts.AbstractFBNElementEditPart;
 import org.eclipse.fordiac.ide.gef.annotation.GraphicalAnnotationStyles;
 import org.eclipse.fordiac.ide.gef.annotation.GraphicalAnnotationStyles.AnnotationFeedbackBorder;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 
 public class ErrorMarkerFBNeworkElementFigure extends FBNetworkElementFigure {
 
-	public ErrorMarkerFBNeworkElementFigure(final FBNetworkElement model, final AbstractFBNElementEditPart editPart) {
-		super(model, editPart);
+	public ErrorMarkerFBNeworkElementFigure(final FBNetworkElement model) {
+		super(model);
 		getFbFigureContainer().setBorder(new AnnotationFeedbackBorder(GraphicalAnnotationStyles.ERROR_RED));
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/FBNetworkElementFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/FBNetworkElementFigure.java
@@ -19,59 +19,14 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.application.figures;
 
-import org.eclipse.draw2d.MouseEvent;
-import org.eclipse.draw2d.MouseListener;
-import org.eclipse.draw2d.MouseMotionListener;
 import org.eclipse.draw2d.geometry.Rectangle;
-import org.eclipse.fordiac.ide.application.editparts.AbstractFBNElementEditPart;
 import org.eclipse.fordiac.ide.gef.figures.FBShape;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
-import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
-import org.eclipse.fordiac.ide.ui.editors.EditorUtils;
-import org.eclipse.swt.SWT;
-import org.eclipse.ui.IEditorDescriptor;
-import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.part.FileEditorInput;
 
-/** The visualization of an FB. It Provides several containers for its interface. */
+/**
+ * The visualization of an FB. It Provides several containers for its interface.
+ */
 public class FBNetworkElementFigure extends FBShape {
-
-	private static final class OpenTypeListener implements MouseListener {
-		private final AbstractFBNElementEditPart editPart;
-
-		public OpenTypeListener(final AbstractFBNElementEditPart editPart) {
-			this.editPart = editPart;
-		}
-
-		@Override
-		public void mousePressed(final MouseEvent me) {
-			if ((0 != (me.getState() & SWT.CONTROL)) && editPart.isOnlyThisOrNothingSelected()) {
-				openTypeInEditor(editPart.getModel());
-			}
-		}
-
-		@Override
-		public void mouseReleased(final MouseEvent me) {
-			// nothing to be done here
-		}
-
-		@Override
-		public void mouseDoubleClicked(final MouseEvent me) {
-			// nothing to be done here
-		}
-
-	}
-
-	// TODO model refactoring - look for a better place for this function
-	public static void openTypeInEditor(final FBNetworkElement element) {
-		// open the default editor for the adapter file
-		final TypeEntry entry = element.getTypeEntry();
-		if (null != entry) {
-			final IEditorDescriptor desc = PlatformUI.getWorkbench().getEditorRegistry()
-					.getDefaultEditor(entry.getFile().getName());
-			EditorUtils.openEditor(new FileEditorInput(entry.getFile()), desc.getId());
-		}
-	}
 
 	/** The model. */
 	private FBNetworkElement model = null;
@@ -80,64 +35,15 @@ public class FBNetworkElementFigure extends FBShape {
 		return model;
 	}
 
-	/** Instantiates a new fB figure.
+	/**
+	 * Instantiates a new fB figure.
 	 *
-	 * @param model the model */
-	public FBNetworkElementFigure(final FBNetworkElement model, final AbstractFBNElementEditPart editPart) {
+	 * @param model the model
+	 */
+	public FBNetworkElementFigure(final FBNetworkElement model) {
 		super(model.getType());
 		this.model = model;
 		refreshToolTips();
-		if (null != editPart) {
-			setupMouseListener(editPart);
-		}
-	}
-
-	private void setupMouseListener(final AbstractFBNElementEditPart editPart) {
-
-		getMiddle().addMouseMotionListener(new MouseMotionListener() {
-
-			@Override
-			public void mouseDragged(final MouseEvent me) {
-				// nothing to bo done here
-			}
-
-			@Override
-			public void mouseEntered(final MouseEvent me) {
-				if ((0 != (me.getState() & SWT.CONTROL)) && editPart.isOnlyThisOrNothingSelected()) {
-					getTypeLabel().setDrawUnderline(true);
-				}
-			}
-
-			@Override
-			public void mouseExited(final MouseEvent me) {
-				getTypeLabel().setDrawUnderline(false);
-			}
-
-			@Override
-			public void mouseHover(final MouseEvent me) {
-				// currently mouseHover should be the same as mouse moved
-				mouseMoved(me);
-			}
-
-			@Override
-			public void mouseMoved(final MouseEvent me) {
-				if ((0 != (me.getState() & SWT.CONTROL)) && editPart.isOnlyThisOrNothingSelected()) {
-					if (!getTypeLabel().isDrawUnderline()) {
-						getTypeLabel().setDrawUnderline(true);
-					}
-				} else if (getTypeLabel().isDrawUnderline()) {
-					getTypeLabel().setDrawUnderline(false);
-				}
-			}
-
-		});
-
-		getMiddle().addMouseListener(createOpenTypeMouseListener(editPart));
-
-	}
-
-	private static OpenTypeListener createOpenTypeMouseListener(final AbstractFBNElementEditPart editPart) {
-		return new OpenTypeListener(editPart);
 	}
 
 	/** Refresh tool tips. */

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/SubAppForFbNetworkFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/SubAppForFbNetworkFigure.java
@@ -59,7 +59,7 @@ public class SubAppForFbNetworkFigure extends FBNetworkElementFigure {
 	private final ExpandedInterfacePositionMap interfacePositions;
 
 	public SubAppForFbNetworkFigure(final SubApp model, final SubAppForFBNetworkEditPart editPart) {
-		super(model, editPart);
+		super(model);
 		interfacePositions = editPart.getInterfacePositionMap();
 		updateTypeLabel(model);
 		updateExpandedFigure();

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/AdapterNodeEditPolicy.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/AdapterNodeEditPolicy.java
@@ -1,6 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 - 2018 fortiss GmbH, Johannes Kepler University
- * 				 2019 Johannes Kepler University Linz
+ * Copyright (c) 2016, 2024 fortiss GmbH, Johannes Kepler University
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,46 +13,18 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.application.policies;
 
-import org.eclipse.fordiac.ide.gef.editparts.InterfaceEditPart;
 import org.eclipse.fordiac.ide.model.commands.change.AbstractReconnectConnectionCommand;
 import org.eclipse.fordiac.ide.model.commands.change.ReconnectAdapterConnectionCommand;
 import org.eclipse.fordiac.ide.model.commands.create.AbstractConnectionCreateCommand;
 import org.eclipse.fordiac.ide.model.commands.create.AdapterConnectionCreateCommand;
-import org.eclipse.fordiac.ide.model.libraryElement.AdapterDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.Connection;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
-import org.eclipse.fordiac.ide.model.typelibrary.AdapterTypeEntry;
-import org.eclipse.fordiac.ide.ui.editors.EditorUtils;
-import org.eclipse.swt.SWT;
-import org.eclipse.ui.IEditorDescriptor;
-import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.part.FileEditorInput;
 
 public class AdapterNodeEditPolicy extends InterfaceElementEditPolicy {
 
 	@Override
 	protected AbstractConnectionCreateCommand createConnectionCreateCommand() {
-		final InterfaceEditPart host = (InterfaceEditPart) getHost();
-
-		if ((host.isAdapter()) && (0 != (host.getMouseState() & SWT.CONTROL))) {
-			openAdapterType(host);
-			return null;
-		}
-
-		final AdapterConnectionCreateCommand cmd = new AdapterConnectionCreateCommand(getParentNetwork());
-		cmd.setSource(((InterfaceEditPart) getHost()).getModel());
-		return cmd;
-
-	}
-
-	private static void openAdapterType(final InterfaceEditPart host) {
-		final AdapterTypeEntry entry = (AdapterTypeEntry) ((AdapterDeclaration) host.getModel()).getType()
-				.getTypeEntry();
-		if (null != entry) {
-			final IEditorDescriptor desc = PlatformUI.getWorkbench().getEditorRegistry()
-					.getDefaultEditor(entry.getFile().getName());
-			EditorUtils.openEditor(new FileEditorInput(entry.getFile()), desc.getId());
-		}
+		return new AdapterConnectionCreateCommand(getParentNetwork());
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/EventNodeEditPolicy.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/EventNodeEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2016, 2018 Profactor GmbH, fortiss GmbH, Johannes Kepler University
+ * Copyright (c) 2008, 2024 Profactor GmbH, fortiss GmbH, Johannes Kepler University
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.application.policies;
 
-import org.eclipse.fordiac.ide.gef.editparts.InterfaceEditPart;
 import org.eclipse.fordiac.ide.model.commands.change.AbstractReconnectConnectionCommand;
 import org.eclipse.fordiac.ide.model.commands.change.ReconnectEventConnectionCommand;
 import org.eclipse.fordiac.ide.model.commands.create.AbstractConnectionCreateCommand;
@@ -28,9 +27,7 @@ public class EventNodeEditPolicy extends InterfaceElementEditPolicy {
 
 	@Override
 	protected AbstractConnectionCreateCommand createConnectionCreateCommand() {
-		final EventConnectionCreateCommand cmd = new EventConnectionCreateCommand(getParentNetwork());
-		cmd.setSource(((InterfaceEditPart) getHost()).getModel());
-		return cmd;
+		return new EventConnectionCreateCommand(getParentNetwork());
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/InterfaceElementEditPolicy.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/InterfaceElementEditPolicy.java
@@ -36,8 +36,16 @@ import org.eclipse.gef.requests.ReconnectRequest;
 public abstract class InterfaceElementEditPolicy extends GraphicalNodeEditPolicy {
 
 	@Override
+	public InterfaceEditPart getHost() {
+		return (InterfaceEditPart) super.getHost();
+	}
+
+	@Override
 	protected final Command getConnectionCreateCommand(final CreateConnectionRequest request) {
 		final AbstractConnectionCreateCommand command = createConnectionCreateCommand();
+		if (command != null) {
+			command.setSource(getHost().getModel());
+		}
 		request.setStartCommand(command);
 		return command;
 	}
@@ -47,7 +55,7 @@ public abstract class InterfaceElementEditPolicy extends GraphicalNodeEditPolicy
 	@Override
 	protected Command getConnectionCompleteCommand(final CreateConnectionRequest request) {
 		final AbstractConnectionCreateCommand command = (AbstractConnectionCreateCommand) request.getStartCommand();
-		command.setDestination(((InterfaceEditPart) getHost()).getModel());
+		command.setDestination(getHost().getModel());
 
 		final FBNetwork newParent = checkConnectionParent(command.getSource(), command.getDestination(),
 				command.getParent());
@@ -74,7 +82,7 @@ public abstract class InterfaceElementEditPolicy extends GraphicalNodeEditPolicy
 		final var conn = (Connection) request.getConnectionEditPart().getModel();
 		final var sourcePin = conn.getSource();
 		final var targetPin = conn.getDestination();
-		final var newPin = (IInterfaceElement) getHost().getModel();
+		final var newPin = getHost().getModel();
 
 		// border crossing source reconnect
 		if (isSourceReconnect && isBorderCrossing(newPin, targetPin, conn.getFBNetwork())) {
@@ -171,8 +179,8 @@ public abstract class InterfaceElementEditPolicy extends GraphicalNodeEditPolicy
 
 	@Override
 	protected ConnectionAnchor getSourceConnectionAnchor(final CreateConnectionRequest request) {
-		if (getHost().getModel() instanceof final IInterfaceElement ie && ie.isIsInput()
-				&& ie.getFBNetworkElement() instanceof final SubApp subapp && subapp.isUnfolded()) {
+		final IInterfaceElement ie = getHost().getModel();
+		if (ie.isIsInput() && ie.getFBNetworkElement() instanceof final SubApp subapp && subapp.isUnfolded()) {
 			// we are unfolded and this is an internal connection
 			return new FixedAnchor(getHostFigure(), false);
 		}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/VariableNodeEditPolicy.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/VariableNodeEditPolicy.java
@@ -35,20 +35,16 @@ public class VariableNodeEditPolicy extends InterfaceElementEditPolicy {
 
 	@Override
 	protected AbstractConnectionCreateCommand createConnectionCreateCommand() {
-		final IInterfaceElement pin = (IInterfaceElement) getHost().getModel();
+		final IInterfaceElement pin = getHost().getModel();
 		if ((pin instanceof VarDeclaration) && (!LinkConstraints.isWithConstraintOK(pin))) {
 			// Elements which are not connected by a with construct are not allowed to be
 			// connected
 			return null;
 		}
 
-		final AbstractConnectionCreateCommand cmd = (AbstractConnectionCreateCommand.isStructManipulatorDefPin(pin))
+		return (AbstractConnectionCreateCommand.isStructManipulatorDefPin(pin))
 				? new StructDataConnectionCreateCommand(getParentNetwork())
 				: new DataConnectionCreateCommand(getParentNetwork());
-
-		cmd.setSource(pin);
-		return cmd;
-
 	}
 
 	@Override
@@ -60,7 +56,7 @@ public class VariableNodeEditPolicy extends InterfaceElementEditPolicy {
 	@Override
 	protected Command getConnectionCompleteCommand(final CreateConnectionRequest request) {
 		final AbstractConnectionCreateCommand command = (AbstractConnectionCreateCommand) request.getStartCommand();
-		final IInterfaceElement pin = (IInterfaceElement) getHost().getModel();
+		final IInterfaceElement pin = getHost().getModel();
 
 		if (command instanceof StructDataConnectionCreateCommand) {
 			// if we drag from a struct manipulater but target is not a struct use normal

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editparts/AdapterInterfaceEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editparts/AdapterInterfaceEditPart.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2011 - 2017 Profactor GmbH, fortiss GmbH
- * 				 2019 Johannes Kepler University Linz
+ * Copyright (c) 2011, 2024 Profactor GmbH, fortiss GmbH,
+ *                          Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -23,25 +23,10 @@ import org.eclipse.fordiac.ide.fbtypeeditor.policies.DeleteInterfaceEditPolicy;
 import org.eclipse.fordiac.ide.gef.draw2d.ConnectorBorder;
 import org.eclipse.fordiac.ide.gef.draw2d.UnderlineAlphaLabel;
 import org.eclipse.fordiac.ide.gef.policies.INamedElementRenameEditPolicy;
-import org.eclipse.fordiac.ide.model.libraryElement.AdapterDeclaration;
-import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
-import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
-import org.eclipse.fordiac.ide.ui.editors.EditorUtils;
-import org.eclipse.gef.DragTracker;
 import org.eclipse.gef.EditPolicy;
-import org.eclipse.gef.Request;
-import org.eclipse.gef.requests.SelectionRequest;
 import org.eclipse.swt.SWT;
-import org.eclipse.ui.IEditorDescriptor;
-import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.part.FileEditorInput;
 
 public class AdapterInterfaceEditPart extends InterfaceEditPart {
-	private final TypeLibrary typeLib;
-
-	AdapterInterfaceEditPart(final TypeLibrary typeLib) {
-		this.typeLib = typeLib;
-	}
 
 	private class AdapterInterfaceFigure extends UnderlineAlphaLabel {
 		public AdapterInterfaceFigure() {
@@ -116,27 +101,9 @@ public class AdapterInterfaceEditPart extends InterfaceEditPart {
 	}
 
 	@Override
-	public DragTracker getDragTracker(final Request request) {
-		if ((request instanceof final SelectionRequest selRequest)
-				&& ((selRequest.getLastButtonPressed() == 1) && (selRequest.isControlKeyPressed()))) {
-			// open the default editor for the adapter file
-			final TypeEntry entry = typeLib.getAdapterTypeEntry(getAdapter().getType().getName());
-			if (null != entry) {
-				final IEditorDescriptor desc = PlatformUI.getWorkbench().getEditorRegistry()
-						.getDefaultEditor(entry.getFile().getName());
-				EditorUtils.openEditor(new FileEditorInput(entry.getFile()), desc.getId());
-			}
-		}
-		return super.getDragTracker(request);
-	}
-
-	@Override
 	public void refreshName() {
 		((AdapterInterfaceFigure) getFigure()).setText(getINamedElement().getName());
 		super.refreshName();
 	}
 
-	private AdapterDeclaration getAdapter() {
-		return (AdapterDeclaration) getCastedModel();
-	}
 }

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editparts/FBInterfaceEditPartFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editparts/FBInterfaceEditPartFactory.java
@@ -51,7 +51,7 @@ public class FBInterfaceEditPartFactory extends Abstract4diacEditPartFactory {
 			return createInterfaceEditPart(varDecl);
 		}
 		if (modelElement instanceof AdapterDeclaration) {
-			return new AdapterInterfaceEditPart(typeLib);
+			return new AdapterInterfaceEditPart();
 		}
 		if (modelElement instanceof With) {
 			return new WithEditPart();

--- a/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/editparts/MonitoringAdapterEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/editparts/MonitoringAdapterEditPart.java
@@ -36,7 +36,7 @@ public class MonitoringAdapterEditPart extends AbstractMonitoringBaseEditPart {
 
 	@Override
 	protected IFigure createFigureForModel() {
-		return new FBNetworkElementFigure(getFB(), null);
+		return new FBNetworkElementFigure(getFB());
 	}
 
 	private FB getFB() {
@@ -56,8 +56,8 @@ public class MonitoringAdapterEditPart extends AbstractMonitoringBaseEditPart {
 
 	@Override
 	public FBNetworkElementFigure getFigure() {
-		if (super.getFigure() instanceof FBNetworkElementFigure) {
-			return (FBNetworkElementFigure) super.getFigure();
+		if (super.getFigure() instanceof final FBNetworkElementFigure fbnElFigure) {
+			return fbnElFigure;
 		}
 		return null;
 	}
@@ -88,8 +88,7 @@ public class MonitoringAdapterEditPart extends AbstractMonitoringBaseEditPart {
 	@Override
 	protected void addChildVisual(final EditPart childEditPart, final int index) {
 		final IFigure child = ((GraphicalEditPart) childEditPart).getFigure();
-		if (childEditPart instanceof InterfaceEditPart) {
-			final InterfaceEditPart interfaceEditPart = (InterfaceEditPart) childEditPart;
+		if (childEditPart instanceof final InterfaceEditPart interfaceEditPart) {
 			final IFigure ieContainer = (interfaceEditPart.isInput()) ? getInputIFigure(interfaceEditPart)
 					: getOutPutFigure(interfaceEditPart);
 			ieContainer.add(child);
@@ -127,8 +126,7 @@ public class MonitoringAdapterEditPart extends AbstractMonitoringBaseEditPart {
 	@Override
 	protected void removeChildVisual(final EditPart childEditPart) {
 		final IFigure child = ((GraphicalEditPart) childEditPart).getFigure();
-		if (childEditPart instanceof InterfaceEditPart) {
-			final InterfaceEditPart interfaceEditPart = (InterfaceEditPart) childEditPart;
+		if (childEditPart instanceof final InterfaceEditPart interfaceEditPart) {
 			final IFigure ieContainer = (interfaceEditPart.isInput()) ? getInputIFigure(interfaceEditPart)
 					: getOutPutFigure(interfaceEditPart);
 			ieContainer.remove(child);


### PR DESCRIPTION
With this commit the feature which allowed to ctrl+click on an FBType name or on an adapter pin is removed.

Furthermore some clean-ups in the touched files where performed.

Fixes #55