### PR TITLE
group expanded interfaces in case of overflow

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/TargetInterfaceElement.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/TargetInterfaceElement.java
@@ -25,7 +25,7 @@ public class TargetInterfaceElement implements Comparable<TargetInterfaceElement
 			final FBNetwork parentNW) {
 		if (refElement.getFBNetworkElement() == null || (refElement.getFBNetworkElement() instanceof final SubApp subapp
 				&& subapp.getSubAppNetwork() == parentNW)) {
-			return new SubapTargetInterfaceElement(host, refElement);
+			return new SubappTargetInterfaceElement(host, refElement);
 		}
 		return new TargetInterfaceElement(host, refElement);
 	}
@@ -61,14 +61,14 @@ public class TargetInterfaceElement implements Comparable<TargetInterfaceElement
 
 	@Override
 	public int compareTo(final TargetInterfaceElement other) {
-		if (other instanceof SubapTargetInterfaceElement) {
+		if (other instanceof SubappTargetInterfaceElement) {
 			return 1;
 		}
 		return getRefPinFullName().compareTo(other.getRefPinFullName());
 	}
 
-	public static class SubapTargetInterfaceElement extends TargetInterfaceElement {
-		private SubapTargetInterfaceElement(final IInterfaceElement host, final IInterfaceElement refElement) {
+	public static class SubappTargetInterfaceElement extends TargetInterfaceElement {
+		private SubappTargetInterfaceElement(final IInterfaceElement host, final IInterfaceElement refElement) {
 			super(host, refElement);
 		}
 
@@ -79,11 +79,29 @@ public class TargetInterfaceElement implements Comparable<TargetInterfaceElement
 
 		@Override
 		public int compareTo(final TargetInterfaceElement other) {
-			if (other instanceof SubapTargetInterfaceElement) {
+			if (other instanceof SubappTargetInterfaceElement) {
 				return getRefPinFullName().compareTo(other.getRefPinFullName());
 			}
 			return -1;
 		}
+	}
+
+	public static class GroupTargetInterfaceElement extends SubappTargetInterfaceElement {
+		final SubApp subapp;
+		final int numConns;
+
+		public GroupTargetInterfaceElement(final IInterfaceElement host, final IInterfaceElement refElement,
+				final SubApp subapp, final int numConns) {
+			super(host, refElement);
+			this.subapp = subapp;
+			this.numConns = numConns;
+		}
+
+		@Override
+		public String getRefPinFullName() {
+			return subapp.getName() + ": " + numConns; //$NON-NLS-1$
+		}
+
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/TargetInterfaceElementEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/TargetInterfaceElementEditPart.java
@@ -179,7 +179,7 @@ public class TargetInterfaceElementEditPart extends AbstractGraphicalEditPart {
 	}
 
 	private boolean isSubappInterfaceTarget() {
-		return getModel() instanceof TargetInterfaceElement.SubapTargetInterfaceElement;
+		return getModel() instanceof TargetInterfaceElement.SubappTargetInterfaceElement;
 	}
 
 	private static String labelTruncate(final String label) {

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/UntypedSubAppInterfaceElementEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/UntypedSubAppInterfaceElementEditPart.java
@@ -66,6 +66,8 @@ public class UntypedSubAppInterfaceElementEditPart extends InterfaceEditPartForF
 	protected TargetInterfaceAdapter targetInteraceAdapter = null;
 	protected static int subappInterfaceBarMaxWidth = -1;
 
+	private boolean isOverflow = false;
+
 	private final class SubappInternalConnAnchor extends FixedAnchor {
 		private SubappInternalConnAnchor(final IFigure owner, final boolean isInput) {
 			super(owner, isInput);
@@ -170,8 +172,42 @@ public class UntypedSubAppInterfaceElementEditPart extends InterfaceEditPartForF
 		return new LabelDirectEditManager(this, getNameLabel());
 	}
 
+	public int getUncollapsedFigureHeight() {
+		final var children = targetPinManager.getModelChildren(false);
+		if (children.isEmpty()) {
+			return getFigure().getBounds().height;
+		}
+		int height = -(children.size() - 1) * 2;
+		for (final TargetInterfaceElement modelObject : children) {
+			final IFigure child = ((GraphicalEditPart) createChild(modelObject)).getFigure();
+			height += child.getPreferredSize().height;
+		}
+		return height;
+	}
+
+	public int getCollapsedFigureHeight() {
+		final var children = targetPinManager.getModelChildren(true);
+		if (children.isEmpty()) {
+			return getFigure().getBounds().height;
+		}
+		int height = -(children.size() - 1) * 2;
+		for (final TargetInterfaceElement modelObject : children) {
+			final IFigure child = ((GraphicalEditPart) createChild(modelObject)).getFigure();
+			height += child.getPreferredSize().height;
+		}
+		return height;
+	}
+
 	public Label getNameLabel() {
 		return (Label) getFigure();
+	}
+
+	public boolean isOverflow() {
+		return isOverflow;
+	}
+
+	public void setOverflow(final boolean isOverflow) {
+		this.isOverflow = isOverflow;
 	}
 
 	@Override
@@ -233,7 +269,7 @@ public class UntypedSubAppInterfaceElementEditPart extends InterfaceEditPartForF
 	@Override
 	protected List getModelChildren() {
 		if (isInExpandedSubapp()) {
-			return targetPinManager.getModelChildren();
+			return targetPinManager.getModelChildren(isOverflow);
 		}
 		return super.getModelChildren();
 	}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/utilities/ExpandedInterfacePositionMap.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/utilities/ExpandedInterfacePositionMap.java
@@ -25,10 +25,14 @@ import java.util.stream.Collectors;
 
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.fordiac.ide.application.editparts.ConnectionEditPart;
 import org.eclipse.fordiac.ide.application.editparts.SubAppForFBNetworkEditPart;
+import org.eclipse.fordiac.ide.application.editparts.UntypedSubAppInterfaceElementEditPart;
 import org.eclipse.fordiac.ide.gef.editparts.InterfaceEditPart;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
+import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.GraphicalEditPart;
 
 public class ExpandedInterfacePositionMap {
@@ -37,11 +41,13 @@ public class ExpandedInterfacePositionMap {
 	public Map<IFigure, Integer> inputPositions = null;
 	public Map<IFigure, Integer> outputPositions = null;
 	public Map<IFigure, Integer> directPositions = null;
+	public Map<IFigure, InterfaceEditPart> editPartMap = new HashMap<>();
+	public Map<IFigure, Integer> sizes = null;
 
 	private int inputUnconnectedStart = Integer.MAX_VALUE;
 	private int outputUnconnectedStart = Integer.MAX_VALUE;
-	private int inputDirectEnd = Integer.MAX_VALUE;
-	private int outputDirectEnd = Integer.MAX_VALUE;
+	private int inputDirectEnd;
+	private int outputDirectEnd;
 
 	public ExpandedInterfacePositionMap(final SubAppForFBNetworkEditPart ep) {
 		this.ep = ep;
@@ -55,7 +61,13 @@ public class ExpandedInterfacePositionMap {
 		return outputUnconnectedStart;
 	}
 
+	public void refreshParent() {
+		ep.getChildren().stream().filter(InterfaceEditPart.class::isInstance).forEach(EditPart::refresh);
+	}
+
 	public void calculate() {
+		editPartMap.clear();
+
 		// @formatter:off
 		final var interfaceMap = ep.getChildren().stream()
 			.filter(InterfaceEditPart.class::isInstance)
@@ -66,7 +78,13 @@ public class ExpandedInterfacePositionMap {
 		final var inputList = interfaceMap.getOrDefault(Boolean.TRUE, new ArrayList<>());
 		final var outputList = interfaceMap.getOrDefault(Boolean.FALSE, new ArrayList<>());
 
-		directPositions = calculateDirectPositions(inputList);
+		final Rectangle clientArea = getClientArea(inputList, outputList);
+		if (clientArea == null) {
+			return;
+		}
+
+		sizes = getPinSizes(inputList, outputList);
+		directPositions = calculateDirectPositions(inputList, clientArea.top());
 
 		final var inputMap = calculateInput(inputList);
 		resolveCollisions(inputMap);
@@ -83,6 +101,128 @@ public class ExpandedInterfacePositionMap {
 			outputUnconnectedStart = outputDirectEnd;
 		}
 		outputPositions = outputMap;
+
+		stackToFit(clientArea, inputPositions, true);
+		stackToFit(clientArea, outputPositions, false);
+	}
+
+	private static Map<IFigure, Integer> getPinSizes(final List<InterfaceEditPart> inputList,
+			final List<InterfaceEditPart> outputList) {
+		final var sizes = new HashMap<IFigure, Integer>();
+		for (final var pin : inputList) {
+			final var ep = (UntypedSubAppInterfaceElementEditPart) pin;
+			if (ep.isOverflow()) {
+				ep.setOverflow(false);
+				ep.refresh();
+				sizes.put(ep.getFigure(), Integer.valueOf(ep.getUncollapsedFigureHeight()));
+			} else {
+				sizes.put(ep.getFigure(), Integer.valueOf(ep.getFigure().getBounds().height));
+			}
+		}
+		for (final var pin : outputList) {
+			final var ep = (UntypedSubAppInterfaceElementEditPart) pin;
+			if (ep.isOverflow()) {
+				ep.setOverflow(false);
+				ep.refresh();
+				sizes.put(ep.getFigure(), Integer.valueOf(ep.getUncollapsedFigureHeight()));
+			} else {
+				sizes.put(ep.getFigure(), Integer.valueOf(ep.getFigure().getBounds().height));
+			}
+		}
+		return sizes;
+	}
+
+	private static Rectangle getClientArea(final List<InterfaceEditPart> inputList,
+			final List<InterfaceEditPart> outputList) {
+		if (!inputList.isEmpty()) {
+			return inputList.get(0).getFigure().getParent().getBounds();
+		}
+		if (!outputList.isEmpty()) {
+			return outputList.get(0).getFigure().getParent().getBounds();
+		}
+		return null;
+	}
+
+	private void stackToFit(final Rectangle clientArea, final Map<IFigure, Integer> positions, final boolean isInput) {
+		if (positions.isEmpty()) {
+			return;
+		}
+
+		final var entryList = positions.entrySet().stream().filter(e -> !directPositions.containsKey(e.getKey()))
+				.collect(Collectors.toList());
+		entryList.sort(Comparator.comparing(Map.Entry::getValue));
+
+		final int bottom = clientArea.bottom() - 10; // add padding to ensure no pin is drawn out of bounds
+		int i = entryList.size() - 1;
+		int totalSize = 0;
+
+		// add unconnected pins from the end
+		for (; i >= 0; i--) {
+			final var entry = entryList.get(i);
+			if (entry.getValue().intValue() != Integer.MAX_VALUE) {
+				break;
+			}
+			totalSize += sizes.get(entry.getKey()).intValue();
+		}
+
+		// all pins were unconnected
+		if (i < 0) {
+			return;
+		}
+
+		// all pins fit, no need to continue
+		if ((isInput) ? inputUnconnectedStart + totalSize < bottom : outputUnconnectedStart + totalSize < bottom) {
+			return;
+		}
+
+		int lastY = -1;
+
+		// find out when stacking is enough and collapse pins in the process
+		for (; i >= 0; i--) {
+			final var fig = entryList.get(i).getKey();
+			final var ep = (UntypedSubAppInterfaceElementEditPart) editPartMap.get(fig);
+			ep.setOverflow(true);
+			ep.refresh();
+			final int size = ep.getCollapsedFigureHeight();
+			sizes.put(fig, Integer.valueOf(size));
+
+			totalSize += size;
+
+			final int y = entryList.get(i).getValue().intValue();
+
+			final int collapsedY = y + ((ep.getUncollapsedFigureHeight() - size) / 2);
+			if (totalSize + collapsedY < bottom) {
+				lastY = collapsedY;
+				break;
+			}
+		}
+
+		int y;
+		if (i == -1) {
+			i = 0;
+			y = isInput ? inputDirectEnd : outputDirectEnd;
+		} else {
+			y = lastY;
+		}
+
+		// do the actual stacking
+		for (; i < entryList.size(); i++) {
+			// reached unconnected pins again
+			if (entryList.get(i).getValue().intValue() == Integer.MAX_VALUE) {
+				break;
+			}
+			final var fig = entryList.get(i).getKey();
+			positions.put(fig, Integer.valueOf(y));
+
+			final Integer newSize = sizes.get(fig);
+			y += (newSize != null) ? newSize.intValue() : fig.getBounds().height;
+		}
+
+		if (isInput) {
+			inputUnconnectedStart = y;
+		} else {
+			outputUnconnectedStart = y;
+		}
 	}
 
 	/**
@@ -92,7 +232,7 @@ public class ExpandedInterfacePositionMap {
 	 * would be drawn beyond the client area, where the connection cannot be drawn
 	 * straight.
 	 */
-	private Map<IFigure, Integer> calculateDirectPositions(final List<InterfaceEditPart> inputList) {
+	private Map<IFigure, Integer> calculateDirectPositions(final List<InterfaceEditPart> inputList, final int top) {
 		// @formatter:off
 		final var connections = inputList
 				.stream()
@@ -104,8 +244,7 @@ public class ExpandedInterfacePositionMap {
 
 		final var inputMap = new HashMap<IFigure, Integer>();
 		final var outputMap = new HashMap<IFigure, Integer>();
-		final var clientAreaY = (inputList.isEmpty()) ? 0 : inputList.get(0).getFigure().getParent().getBounds().y;
-		int inputY = clientAreaY;
+		int inputY = top;
 
 		for (final var conn : connections) {
 			final var inputFigure = ((GraphicalEditPart) conn.getSource()).getFigure();
@@ -117,7 +256,7 @@ public class ExpandedInterfacePositionMap {
 			if (!outputMap.containsKey(outputFigure)) {
 				final int connStart = inputMap.get(inputFigure).intValue() + (inputFigure.getBounds().height / 2);
 				final int outputY = connStart - (outputFigure.getBounds().height / 2);
-				outputMap.put(outputFigure, Integer.valueOf(Math.max(outputY, clientAreaY)));
+				outputMap.put(outputFigure, Integer.valueOf(Math.max(outputY, top)));
 			}
 		}
 
@@ -128,8 +267,9 @@ public class ExpandedInterfacePositionMap {
 		if (max.isPresent()) {
 			outputDirectEnd = max.get().getValue().intValue() + max.get().getKey().getBounds().height;
 		} else {
-			outputDirectEnd = clientAreaY;
+			outputDirectEnd = top;
 		}
+
 		inputMap.putAll(outputMap);
 		return inputMap;
 	}
@@ -138,13 +278,13 @@ public class ExpandedInterfacePositionMap {
 	 * Calculates the start position for unconnected pins which is always below the
 	 * connected pins.
 	 */
-	private static int calculateUnconnectedStartPositions(final Map<IFigure, Integer> map) {
+	private int calculateUnconnectedStartPositions(final Map<IFigure, Integer> map) {
 		final Optional<Entry<IFigure, Integer>> inputOptional = map.entrySet().stream()
 				.filter(entry -> entry.getValue().intValue() != Integer.MAX_VALUE)
 				.max((entry1, entry2) -> Integer.compare(entry1.getValue().intValue(), entry2.getValue().intValue()));
 		if (inputOptional.isPresent()) {
 			final var entry = inputOptional.get();
-			return entry.getValue().intValue() + entry.getKey().getBounds().height;
+			return entry.getValue().intValue() + sizes.get(entry.getKey()).intValue();
 		}
 		return Integer.MAX_VALUE;
 	}
@@ -160,8 +300,8 @@ public class ExpandedInterfacePositionMap {
 			if (max.isPresent()) {
 				final ConnectionEditPart connEp = (ConnectionEditPart) max.get();
 				final Point end = connEp.getConnectionFigure().getEnd();
-				final int pinHeight = ((GraphicalEditPart) max.get().getSource()).getFigure().getBounds().height;
-				final int y = end.y - (pinHeight / 2);
+				final var fig = ((GraphicalEditPart) max.get().getSource()).getFigure();
+				final int y = end.y - (sizes.get(fig).intValue() / 2);
 
 				if (!isSkipConnection(connEp)) {
 					map.put(ie.getFigure(), Integer.valueOf(Math.max(y, inputDirectEnd)));
@@ -169,6 +309,7 @@ public class ExpandedInterfacePositionMap {
 			} else {
 				map.put(ie.getFigure(), Integer.valueOf(Integer.MAX_VALUE));
 			}
+			editPartMap.put(ie.getFigure(), ie);
 		}
 		return map;
 	}
@@ -184,8 +325,8 @@ public class ExpandedInterfacePositionMap {
 			if (max.isPresent()) {
 				final ConnectionEditPart connEp = (ConnectionEditPart) max.get();
 				final Point start = connEp.getConnectionFigure().getStart();
-				final int pinHeight = ((GraphicalEditPart) max.get().getTarget()).getFigure().getBounds().height;
-				final int y = start.y - (pinHeight / 2);
+				final var fig = ((GraphicalEditPart) max.get().getTarget()).getFigure();
+				final int y = start.y - (sizes.get(fig).intValue() / 2);
 
 				if (!isSkipConnection(connEp)) {
 					map.put(ie.getFigure(), Integer.valueOf(Math.max(y, outputDirectEnd)));
@@ -193,6 +334,7 @@ public class ExpandedInterfacePositionMap {
 			} else {
 				map.put(ie.getFigure(), Integer.valueOf(Integer.MAX_VALUE));
 			}
+			editPartMap.put(ie.getFigure(), ie);
 		}
 		return map;
 	}
@@ -200,19 +342,20 @@ public class ExpandedInterfacePositionMap {
 	private static boolean isSkipConnection(final ConnectionEditPart ep) {
 		final var sourceModel = (IInterfaceElement) ep.getSource().getModel();
 		final var targetModel = (IInterfaceElement) ep.getTarget().getModel();
-		return sourceModel.getFBNetworkElement() == targetModel.getFBNetworkElement();
+		return sourceModel.eContainer().eContainer() instanceof final SubApp sourceSub
+				&& targetModel.eContainer().eContainer() instanceof final SubApp targetSub && sourceSub == targetSub;
 	}
 
-	private static void resolveCollisions(final Map<IFigure, Integer> positions) {
+	private void resolveCollisions(final Map<IFigure, Integer> positions) {
 		final var entryList = new ArrayList<>(positions.entrySet());
 		entryList.sort(Comparator.comparing(Map.Entry::getValue));
 
 		for (int i = 1; i < entryList.size(); i++) {
 			final var prevEntry = entryList.get(i - 1);
 			final var currEntry = entryList.get(i);
-			final int prevHeight = prevEntry.getKey().getBounds().height;
 			final int prev = prevEntry.getValue().intValue();
 			final int curr = currEntry.getValue().intValue();
+			final int prevHeight = sizes.get(prevEntry.getKey()).intValue();
 
 			// reached the end of connected pins
 			if (curr == Integer.MAX_VALUE) {


### PR DESCRIPTION
This commit introduces a mechanism that reduces the number of target pins by grouping them by their source/destination subapps as well as a stacking mechanism that behaves like the default toolbar layout if pins would be drawn out of bounds.