### PR TITLE
Improve Loading of TypeEditable

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
@@ -231,9 +231,17 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 			return typeEditable;
 		}
 
-		// we need to get a fresh type editable in order to ensure consistency take a
-		// copy of the none editable type
-		final LibraryElement loadType = EcoreUtil.copy(getType());
+		// we need to get a fresh type editable
+		LibraryElement loadType = null;
+		if (typeRef != null && typeRef.get() != null) {
+			// only copy if the none editable type is already loaded, copying takes about
+			// the same time then loading
+			loadType = EcoreUtil.copy(getType());
+		} else {
+			lastModificationTimestamp = getFile().getModificationStamp();
+			loadType = loadType();
+		}
+
 		setTypeEditable(loadType);
 		return loadType;
 	}


### PR DESCRIPTION
Loading the typeeditable sofar copied the type model. However copying takes for larger types app the same amount of time then loading from xml. So if the type was not loaded, loading type editable costed twice the time.

This fix now only copies if the type is loaded and in the other case loads it from the file.