### PR TITLE
Caching connection anchors for InterfaceEditParts

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/InterfaceEditPartForFBNetwork.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/InterfaceEditPartForFBNetwork.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.draw2d.Border;
-import org.eclipse.draw2d.ConnectionAnchor;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -41,7 +40,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.impl.ErrorMarkerDataTypeImpl;
 import org.eclipse.fordiac.ide.model.ui.actions.OpenListenerManager;
 import org.eclipse.fordiac.ide.model.ui.editors.HandlerHelper;
-import org.eclipse.gef.ConnectionEditPart;
 import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.GraphicalViewer;
 import org.eclipse.gef.Request;
@@ -183,11 +181,11 @@ public class InterfaceEditPartForFBNetwork extends InterfaceEditPart {
 	}
 
 	@Override
-	public ConnectionAnchor getTargetConnectionAnchor(final ConnectionEditPart connection) {
+	protected FixedAnchor createTargetConAnchor() {
 		if (getModel() instanceof VarDeclaration && getModel().isIsInput()) {
 			return new VarInputConnAnchor(this);
 		}
-		return super.getTargetConnectionAnchor(connection);
+		return super.createTargetConAnchor();
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/SubAppInternalInterfaceEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/SubAppInternalInterfaceEditPart.java
@@ -16,7 +16,6 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.application.editparts;
 
-import org.eclipse.draw2d.ConnectionAnchor;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.emf.common.notify.Adapter;
 import org.eclipse.emf.common.notify.Notification;
@@ -27,7 +26,6 @@ import org.eclipse.fordiac.ide.gef.draw2d.ConnectorBorder;
 import org.eclipse.fordiac.ide.gef.figures.ToolTipFigure;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.ui.editors.HandlerHelper;
-import org.eclipse.gef.ConnectionEditPart;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.GraphicalViewer;
 import org.eclipse.gef.Request;
@@ -122,12 +120,12 @@ public class SubAppInternalInterfaceEditPart extends UntypedSubAppInterfaceEleme
 	}
 
 	@Override
-	public ConnectionAnchor getSourceConnectionAnchor(final ConnectionEditPart connection) {
+	protected FixedAnchor createSourceConAnchor() {
 		return new FixedAnchor(getFigure(), isInput());
 	}
 
 	@Override
-	public ConnectionAnchor getTargetConnectionAnchor(final ConnectionEditPart connection) {
+	protected FixedAnchor createTargetConAnchor() {
 		return new FixedAnchor(getFigure(), isInput());
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/UntypedSubAppInterfaceElementEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/UntypedSubAppInterfaceElementEditPart.java
@@ -22,7 +22,6 @@ import java.util.List;
 import org.eclipse.draw2d.Border;
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.CompoundBorder;
-import org.eclipse.draw2d.ConnectionAnchor;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.GridData;
 import org.eclipse.draw2d.GridLayout;
@@ -50,7 +49,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.impl.ErrorMarkerDataTypeImpl;
-import org.eclipse.gef.ConnectionEditPart;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.GraphicalEditPart;
@@ -215,21 +213,21 @@ public class UntypedSubAppInterfaceElementEditPart extends InterfaceEditPartForF
 	}
 
 	@Override
-	public ConnectionAnchor getSourceConnectionAnchor(final ConnectionEditPart connection) {
+	protected FixedAnchor createSourceConAnchor() {
 		if (isInput()) {
 			// we are unfolded and this is an internal connection
 			return new SubappInternalConnAnchor(getFigure(), !isInput());
 		}
-		return new FixedAnchor(getFigure(), isInput());
+		return super.createTargetConAnchor();
 	}
 
 	@Override
-	public ConnectionAnchor getTargetConnectionAnchor(final ConnectionEditPart connection) {
+	protected FixedAnchor createTargetConAnchor() {
 		if (!isInput()) {
 			// we are unfolded and this is an internal connection
 			return new SubappInternalConnAnchor(getFigure(), !isInput());
 		}
-		return super.getTargetConnectionAnchor(connection);
+		return super.createTargetConAnchor();
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/InterfaceEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/InterfaceEditPart.java
@@ -438,23 +438,46 @@ public abstract class InterfaceEditPart extends AbstractConnectableEditPart
 		}
 	}
 
+	private ConnectionAnchor sourceConAnchor = null;
+	private ConnectionAnchor destinationConAnchor = null;
+
 	@Override
-	public ConnectionAnchor getSourceConnectionAnchor(final ConnectionEditPart connection) {
-		return new FixedAnchor(getFigure(), isInput());
+	public final ConnectionAnchor getSourceConnectionAnchor(final ConnectionEditPart connection) {
+		if (sourceConAnchor == null) {
+			sourceConAnchor = createSourceConAnchor();
+		}
+		return sourceConAnchor;
 	}
 
 	@Override
-	public ConnectionAnchor getSourceConnectionAnchor(final Request request) {
-		return new FixedAnchor(getFigure(), isInput());
+	public final ConnectionAnchor getSourceConnectionAnchor(final Request request) {
+		if (sourceConAnchor == null) {
+			sourceConAnchor = createSourceConAnchor();
+		}
+		return sourceConAnchor;
 	}
 
 	@Override
-	public ConnectionAnchor getTargetConnectionAnchor(final ConnectionEditPart connection) {
-		return new FixedAnchor(getFigure(), isInput());
+	public final ConnectionAnchor getTargetConnectionAnchor(final ConnectionEditPart connection) {
+		if (destinationConAnchor == null) {
+			destinationConAnchor = createTargetConAnchor();
+		}
+		return destinationConAnchor;
 	}
 
 	@Override
-	public ConnectionAnchor getTargetConnectionAnchor(final Request request) {
+	public final ConnectionAnchor getTargetConnectionAnchor(final Request request) {
+		if (destinationConAnchor == null) {
+			destinationConAnchor = createTargetConAnchor();
+		}
+		return destinationConAnchor;
+	}
+
+	protected FixedAnchor createSourceConAnchor() {
+		return new FixedAnchor(getFigure(), isInput());
+	}
+
+	protected FixedAnchor createTargetConAnchor() {
 		return new FixedAnchor(getFigure(), isInput());
 	}
 


### PR DESCRIPTION
Recreating connection anchors on each request can especially for larger applications mean a long startup time (old anchors need to be detached new added). This commit caches the anchors in the source and target editparts reducing editor startup time.