### PR TITLE
CompositeNetworkEditPart wrongly uses EContentAdapter

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/UISubAppNetworkEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/UISubAppNetworkEditPart.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008 - 2017 Profactor GmbH, AIT, fortiss GmbH
- * 				 2019 - 2020 Johannes Kepler University Linz
+ * Copyright (c) 2008, 2024 Profactor GmbH, AIT, fortiss GmbH,
+ *                          Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,78 +17,13 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.application.editparts;
 
-import org.eclipse.emf.common.notify.Adapter;
-import org.eclipse.emf.common.notify.Notification;
-import org.eclipse.emf.common.notify.impl.AdapterImpl;
-import org.eclipse.emf.ecore.util.EContentAdapter;
 import org.eclipse.fordiac.ide.application.policies.FBNetworkXYLayoutEditPolicy;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
-import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.editpolicies.RootComponentEditPolicy;
 
 public class UISubAppNetworkEditPart extends EditorWithInterfaceEditPart {
-	private final Adapter contentAdapter = new AdapterImpl() {
-		@Override
-		public void notifyChanged(final Notification notification) {
-			super.notifyChanged(notification);
-			switch (notification.getEventType()) {
-			case Notification.ADD, Notification.ADD_MANY, Notification.MOVE, Notification.REMOVE,
-					Notification.REMOVE_MANY:
-				refreshChildren();
-				break;
-			case Notification.SET:
-				refreshVisuals();
-				break;
-			default:
-				break;
-			}
-		}
-	};
-
-	private final Adapter subAppInterfaceAdapter = new EContentAdapter() {
-		@Override
-		public void notifyChanged(final Notification notification) {
-			super.notifyChanged(notification);
-			switch (notification.getEventType()) {
-			case Notification.ADD:
-				if (LibraryElementPackage.eINSTANCE.getConfigurableObject_Attributes()
-						.equals(notification.getFeature())) {
-					refreshVisuals();
-					break;
-				}
-				//$FALL-THROUGH$
-			case Notification.ADD_MANY, Notification.MOVE, Notification.REMOVE, Notification.REMOVE_MANY:
-				refreshChildren();
-				break;
-			default:
-				break;
-			}
-		}
-	};
-
-	@Override
-	public void activate() {
-		super.activate();
-		if ((null != getModel()) && !getModel().eAdapters().contains(contentAdapter)) {
-			getModel().eAdapters().add(contentAdapter);
-			if ((null != getSubApp()) && !getSubApp().getInterface().eAdapters().contains(subAppInterfaceAdapter)) {
-				getSubApp().getInterface().eAdapters().add(subAppInterfaceAdapter);
-			}
-		}
-	}
-
-	@Override
-	public void deactivate() {
-		super.deactivate();
-		if (null != getModel()) {
-			getModel().eAdapters().remove(contentAdapter);
-			if (null != getSubApp()) {
-				getSubApp().getInterface().eAdapters().remove(subAppInterfaceAdapter);
-			}
-		}
-	}
 
 	public SubApp getSubApp() {
 		return (SubApp) getModel().eContainer();

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.network/src/org/eclipse/fordiac/ide/fbtypeeditor/network/editparts/CompositeNetworkEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.network/src/org/eclipse/fordiac/ide/fbtypeeditor/network/editparts/CompositeNetworkEditPart.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008 - 2012, 2014, 2016, 2017  Profactor GmbH, fortiss GmbH
- * 				 2020 Johannes Kepler University Linz
+ * Copyright (c) 2008, 2024  Profactor GmbH, fortiss GmbH,
+ *                           Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,15 +17,10 @@ package org.eclipse.fordiac.ide.fbtypeeditor.network.editparts;
 
 import java.util.List;
 
-import org.eclipse.emf.common.notify.Adapter;
-import org.eclipse.emf.common.notify.Notification;
-import org.eclipse.emf.ecore.util.EContentAdapter;
 import org.eclipse.fordiac.ide.application.editparts.EditorWithInterfaceEditPart;
 import org.eclipse.fordiac.ide.model.libraryElement.AdapterDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.CompositeFBType;
-import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
-import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.editpolicies.RootComponentEditPolicy;
@@ -34,74 +29,6 @@ import org.eclipse.gef.editpolicies.RootComponentEditPolicy;
  * Edit Part for the visualization of Composite Networks.
  */
 public class CompositeNetworkEditPart extends EditorWithInterfaceEditPart {
-
-	/** The adapter. */
-	private Adapter adapter;
-
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.eclipse.gef.editparts.AbstractGraphicalEditPart#activate()
-	 */
-	@Override
-	public void activate() {
-		if (!isActive()) {
-			super.activate();
-			getModel().eAdapters().add(getContentAdapter());
-			getModel().eContainer().eAdapters().add(getContentAdapter());
-		}
-	}
-
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.eclipse.gef.editparts.AbstractGraphicalEditPart#deactivate()
-	 */
-	@Override
-	public void deactivate() {
-		if (isActive()) {
-			super.deactivate();
-			getModel().eAdapters().remove(getContentAdapter());
-			getModel().eContainer().eAdapters().remove(getContentAdapter());
-		}
-	}
-
-	/**
-	 * Gets the content adapter.
-	 *
-	 * @return the content adapter
-	 */
-	public Adapter getContentAdapter() {
-		if (null == adapter) {
-			adapter = new EContentAdapter() {
-				@Override
-				public void notifyChanged(final Notification notification) {
-					super.notifyChanged(notification);
-					// if the notification is from the out_mapped In Out vars we are in the middle
-					// of an in out var change, ignore it!
-					if (notification.getFeatureID(
-							InterfaceList.class) != LibraryElementPackage.INTERFACE_LIST__OUT_MAPPED_IN_OUT_VARS) {
-						switch (notification.getEventType()) {
-						case Notification.ADD, Notification.ADD_MANY:
-							refreshChildren();
-							break;
-						case Notification.MOVE:
-							if (notification.getNewValue() instanceof IInterfaceElement) {
-								refreshChildren();
-							}
-							break;
-						case Notification.REMOVE, Notification.REMOVE_MANY:
-							refreshChildren();
-							break;
-						default:
-							break;
-						}
-					}
-				}
-			};
-		}
-		return adapter;
-	}
 
 	@SuppressWarnings("unchecked")
 	@Override


### PR DESCRIPTION
The CompositeNetworkEditPart was attaching an EContentAdapter to all its contained elements. As this class is also used for typed Subapps this could lead to major performance issues.

With this commit the code that is used for untyped subapps is also used for CompositeNetworkEditParts.