### PR TITLE
do not save visible children attribute unnecessarily

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeStructCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeStructCommand.java
@@ -29,6 +29,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.Multiplexer;
 import org.eclipse.fordiac.ide.model.libraryElement.StructManipulator;
 import org.eclipse.fordiac.ide.model.libraryElement.impl.ConfigurableFBManagement;
+import org.eclipse.fordiac.ide.model.typelibrary.DataTypeLibrary;
 import org.eclipse.fordiac.ide.model.typelibrary.ErrorDataTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 
@@ -117,19 +118,25 @@ public class ChangeStructCommand extends AbstractUpdateFBNElementCommand {
 		return (StructManipulator) oldElement;
 	}
 
-	private StructuredType getDataTypeFromTypeEntry() {
+	private DataType getDataTypeFromTypeEntry() {
 		if (newStructTypeEntry == null) {
 			return IecTypes.GenericTypes.ANY_STRUCT;
 		}
 
 		LibraryElement type = newStructTypeEntry.getType();
-
+		final DataTypeLibrary datatypeLib = entry.getTypeLibrary().getDataTypeLibrary();
+		final TypeEntry reloadedTypeEntry = datatypeLib.getDerivedTypeEntry(newStructTypeEntry.getFullTypeName());
 		if (newStructTypeEntry instanceof ErrorDataTypeEntry) {
-			final TypeEntry reloadedTypeEntry = newStructTypeEntry.getTypeLibrary().find(entry.getFullTypeName());
-			type = reloadedTypeEntry.getType();
+			if (reloadedTypeEntry != null && reloadedTypeEntry != newStructTypeEntry) {
+				// type exists now
+				type = reloadedTypeEntry.getType();
+			}
+		} else // does the type entry still exist?
+		if (reloadedTypeEntry == null) {
+			// type was deleted, create error marker
+			type = datatypeLib.getType(newStructTypeEntry.getFullTypeName());
 		}
-
-		return (type instanceof final StructuredType dt) ? dt : IecTypes.GenericTypes.ANY_STRUCT;
+		return (type instanceof final DataType dt) ? dt : IecTypes.GenericTypes.ANY_STRUCT;
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeStructCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeStructCommand.java
@@ -62,7 +62,7 @@ public class ChangeStructCommand extends AbstractUpdateFBNElementCommand {
 
 	private static String getOldVisibleChildren(final StructManipulator mux) {
 		if (mux instanceof final Demultiplexer demux && demux.isIsConfigured()) {
-			return ConfigurableFBManagement.buildVisibleChildrenString(demux);
+			return ConfigurableFBManagement.buildVisibleChildrenString(demux.getMemberVars());
 		}
 		return null;
 	}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/ConfigurableFBManagement.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/ConfigurableFBManagement.java
@@ -145,7 +145,7 @@ public final class ConfigurableFBManagement {
 			if (!isInDefaultConfiguration(fb, attr.getValue(), fb.getDataType())) {
 				return ECollections.asEList(structTypeAttr.get(0), attr);
 			}
-			// Until the
+			// Until the configured state is updated automatically in the commands, save result here:
 			fb.setIsConfigured(false);
 		}
 		return structTypeAttr;

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/ConfigurableFBManagement.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/ConfigurableFBManagement.java
@@ -136,19 +136,40 @@ public final class ConfigurableFBManagement {
 	}
 
 	private static EList<Attribute> getConfigurableDemuxAttributes(final Demultiplexer fb) {
-		final Attribute attr = LibraryElementFactory.eINSTANCE.createAttribute();
-		attr.setName(LibraryElementTags.DEMUX_VISIBLE_CHILDREN);
-		attr.setType(ElementaryTypes.STRING);
-		attr.setValue(buildVisibleChildrenString(fb));
-		return ECollections.asEList(getStructManipulatorAttributes(fb).get(0), attr);
+		final EList<Attribute> structTypeAttr = getStructManipulatorAttributes(fb);
+		if (fb.isIsConfigured()) {
+			final Attribute attr = LibraryElementFactory.eINSTANCE.createAttribute();
+			attr.setName(LibraryElementTags.DEMUX_VISIBLE_CHILDREN);
+			attr.setType(ElementaryTypes.STRING);
+			attr.setValue(buildVisibleChildrenString(fb.getMemberVars()));
+			if (!isInDefaultConfiguration(fb, attr.getValue(), fb.getDataType())) {
+				return ECollections.asEList(structTypeAttr.get(0), attr);
+			}
+			// Until the
+			fb.setIsConfigured(false);
+		}
+		return structTypeAttr;
 	}
 
-	public static String buildVisibleChildrenString(final StructManipulator fb) {
-		if (fb.getMemberVars().isEmpty()) {
+	private static boolean isInDefaultConfiguration(final Demultiplexer demux, final String visibleChildrenString,
+			final DataType dataType) {
+		if (!(dataType instanceof StructuredType)) { // could be error marker
+			return true;
+		}
+		final EList<VarDeclaration> possibleChildren = ((StructuredType) dataType).getMemberVariables();
+		if (demux.getMemberVars().size() != possibleChildren.size()) {
+			return false;
+		}
+		final String unconfiguredVarList = buildVisibleChildrenString(possibleChildren);
+		return unconfiguredVarList.equals(visibleChildrenString);
+	}
+
+	public static String buildVisibleChildrenString(final EList<VarDeclaration> memberVars) {
+		if (memberVars.isEmpty()) {
 			return ""; //$NON-NLS-1$
 		}
 		final StringBuilder sb = new StringBuilder();
-		fb.getMemberVars().forEach(varDecl -> sb.append(varDecl.getName() + ",")); //$NON-NLS-1$
+		memberVars.forEach(varDecl -> sb.append(varDecl.getName() + ",")); //$NON-NLS-1$
 		return sb.substring(0, sb.length() - 1); // avoid adding "," in the end
 	}
 
@@ -166,7 +187,7 @@ public final class ConfigurableFBManagement {
 			getEventWithPins(muxer).getWith().clear();
 		} else if (muxer instanceof final Demultiplexer demux && demux.isIsConfigured()) {
 			// updating requires finding all elements again - struct may have changed!
-			updateConfiguredDemuxConfiguration(demux, buildVisibleChildrenString(muxer));
+			updateConfiguredDemuxConfiguration(demux, buildVisibleChildrenString(muxer.getMemberVars()));
 		} else {
 			// create member variables of struct as data input ports
 			final boolean createAsInputs = muxer instanceof Multiplexer;

--- a/tests/org.eclipse.fordiac.ide.test.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/AddDeleteDemuxPortCommandTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/AddDeleteDemuxPortCommandTest.java
@@ -169,15 +169,19 @@ public class AddDeleteDemuxPortCommandTest extends CommandTestBase<State> {
 		t.test(state.getDemultiplexer());
 		t.test(state.getStruct().getMemberVariables().size(),
 				state.getDemultiplexer().getInterface().getOutputVars().size());
+		t.test(!state.getDemultiplexer().isIsConfigured());
 	}
 
 	protected static void verifyAdded(final State state, final TestFunction t, final String name) {
 		t.test(state.getDemultiplexer());
 		t.test(!state.getDemultiplexer().getMemberVars().stream().filter(MemberVarDeclaration.class::isInstance)
 				.filter(out -> ((MemberVarDeclaration) out).getName().equals(name)).findAny().isEmpty());
-		final String attributeValue = getVisibleChildrenAttribute(state.getDemultiplexer()).getValue();
-		t.test(Arrays.asList(attributeValue.split(",")) //$NON-NLS-1$
-				.contains(name));
+		final Attribute attribute = getVisibleChildrenAttribute(state.getDemultiplexer());
+		if (state.getDemultiplexer().isIsConfigured()) {
+			t.test(Arrays.asList(attribute.getValue().split(",")) //$NON-NLS-1$
+					.contains(name));
+		}
+		t.test(state.getDemultiplexer().getMemberVars().stream().anyMatch(var -> var.getName().equals(name)));
 	}
 
 	private static Attribute getVisibleChildrenAttribute(final Demultiplexer demux) {
@@ -190,8 +194,12 @@ public class AddDeleteDemuxPortCommandTest extends CommandTestBase<State> {
 		t.test(state.getDemultiplexer());
 		t.test(state.getDemultiplexer().getInterface().getOutputVars().stream()
 				.filter(out -> out.getName().equals(name)).findAny().isEmpty());
-		t.test(!Arrays.asList(getVisibleChildrenAttribute(state.getDemultiplexer()).getValue().split(",")) //$NON-NLS-1$
-				.contains(name));
+		final Attribute attribute = getVisibleChildrenAttribute(state.getDemultiplexer());
+		if (state.getDemultiplexer().isIsConfigured()) {
+			t.test(!Arrays.asList(attribute.getValue().split(",")) //$NON-NLS-1$
+					.contains(name));
+		}
+		t.test(state.getDemultiplexer().getMemberVars().stream().noneMatch(var -> var.getName().equals(name)));
 	}
 
 	private static State executeDeleteCommand(final State state, final String name) {


### PR DESCRIPTION
With recent changes, there was a problem that the visible children attribute was saved even when the demux was not configured. The current change tries to fix this problem by checking first whether the attribute is the default attribute - in which case the attribute is not exported. Additionally, the visible children attribute is not stored for new FBs anymore (check for isIsConfigured). Hence, also the string comparison is only done for configured FBs