### PR TITLE
TypeEditor put an EContentAdapter on the whole type

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editparts/FBTypeRootEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editparts/FBTypeRootEditPart.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2011 - 2017 Profactor GmbH, fortiss GmbH
- * 				 2019 Johannes Kepler University Linz
+ * Copyright (c) 2011, 2024 Profactor GmbH, fortiss GmbH,
+ *                          Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -25,9 +25,9 @@ import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.ShortestPathConnectionRouter;
 import org.eclipse.emf.common.notify.Adapter;
 import org.eclipse.emf.common.notify.Notification;
-import org.eclipse.emf.ecore.util.EContentAdapter;
 import org.eclipse.fordiac.ide.gef.editparts.AbstractDiagramEditPart;
 import org.eclipse.fordiac.ide.gef.policies.EmptyXYLayoutEditPolicy;
+import org.eclipse.fordiac.ide.model.emf.SingleRecursiveContentAdapter;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.gef.EditPolicy;
@@ -36,7 +36,7 @@ import org.eclipse.swt.widgets.Display;
 
 public class FBTypeRootEditPart extends AbstractDiagramEditPart {
 
-	private Adapter adapter;
+	private Adapter interfaceAdapter;
 	private final Map<IInterfaceElement, CommentTypeField> commentTypeFieldCache = new HashMap<>();
 
 	@Override
@@ -48,7 +48,7 @@ public class FBTypeRootEditPart extends AbstractDiagramEditPart {
 	public void activate() {
 		if (!isActive()) {
 			super.activate();
-			getModel().eAdapters().add(getContentAdapter());
+			getModel().getInterfaceList().eAdapters().add(getInterfaceAdapter());
 		}
 	}
 
@@ -56,13 +56,13 @@ public class FBTypeRootEditPart extends AbstractDiagramEditPart {
 	public void deactivate() {
 		if (isActive()) {
 			super.deactivate();
-			getModel().eAdapters().remove(getContentAdapter());
+			getModel().getInterfaceList().eAdapters().remove(getInterfaceAdapter());
 		}
 	}
 
-	public Adapter getContentAdapter() {
-		if (null == adapter) {
-			adapter = new EContentAdapter() {
+	public Adapter getInterfaceAdapter() {
+		if (null == interfaceAdapter) {
+			interfaceAdapter = new SingleRecursiveContentAdapter() {
 				@Override
 				public void notifyChanged(final Notification notification) {
 					super.notifyChanged(notification);
@@ -79,7 +79,7 @@ public class FBTypeRootEditPart extends AbstractDiagramEditPart {
 				}
 			};
 		}
-		return adapter;
+		return interfaceAdapter;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editparts/InterfaceContainerEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editparts/InterfaceContainerEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 - 2017 Profactor GmbH, TU Wien ACIN, fortiss GmbH
+ * Copyright (c) 2011, 2024 Profactor GmbH, TU Wien ACIN, fortiss GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -22,7 +22,6 @@ import org.eclipse.draw2d.ToolbarLayout;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.emf.common.notify.Adapter;
 import org.eclipse.emf.common.notify.Notification;
-import org.eclipse.emf.ecore.util.EContentAdapter;
 import org.eclipse.fordiac.ide.fbtypeeditor.policies.EventInputContainerLayoutEditPolicy;
 import org.eclipse.fordiac.ide.fbtypeeditor.policies.EventOutputContainerLayoutEditPolicy;
 import org.eclipse.fordiac.ide.fbtypeeditor.policies.PlugContainerLayoutEditPolicy;
@@ -31,6 +30,7 @@ import org.eclipse.fordiac.ide.fbtypeeditor.policies.VarInOutInputContainerLayou
 import org.eclipse.fordiac.ide.fbtypeeditor.policies.VarInOutOutputContainerLayoutEditPolicy;
 import org.eclipse.fordiac.ide.fbtypeeditor.policies.VariableInputContainerLayoutEditPolicy;
 import org.eclipse.fordiac.ide.fbtypeeditor.policies.VariableOutputContainerLayoutEditPolicy;
+import org.eclipse.fordiac.ide.model.emf.SingleRecursiveContentAdapter;
 import org.eclipse.fordiac.ide.model.libraryElement.FunctionFBType;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPolicy;
@@ -49,7 +49,7 @@ public class InterfaceContainerEditPart extends AbstractGraphicalEditPart {
 		}
 	}
 
-	private final Adapter econtentAdapter = new EContentAdapter() {
+	private final Adapter econtentAdapter = new SingleRecursiveContentAdapter() {
 		@Override
 		public void notifyChanged(final Notification notification) {
 			refresh();

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editparts/TypeEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editparts/TypeEditPart.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2011 - 2017 Profactor GmbH, TU Wien ACIN, fortiss GmbH
- * 				 2019 Johannes Kepler University
+ * Copyright (c) 2011, 2024 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
+ *                          Johannes Kepler University
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -23,7 +23,7 @@ import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.Label;
 import org.eclipse.emf.common.notify.Adapter;
 import org.eclipse.emf.common.notify.Notification;
-import org.eclipse.emf.ecore.util.EContentAdapter;
+import org.eclipse.emf.common.notify.impl.AdapterImpl;
 import org.eclipse.fordiac.ide.gef.annotation.AnnotableGraphicalEditPart;
 import org.eclipse.fordiac.ide.gef.annotation.FordiacAnnotationUtil;
 import org.eclipse.fordiac.ide.gef.annotation.GraphicalAnnotationModelEvent;
@@ -82,7 +82,7 @@ public class TypeEditPart extends AbstractInterfaceElementEditPart implements An
 
 	@Override
 	protected Adapter createAdapter() {
-		return new EContentAdapter() {
+		return new AdapterImpl() {
 			@Override
 			public void notifyChanged(final Notification notification) {
 				super.notifyChanged(notification);


### PR DESCRIPTION
In several places the interface editor used an EContentAdapter either on the whole type or at least on the InterfaceList. This was partly not needed or costed a lot of performance. This fix reduces the number of adapters and uses less heavy adapters where possible.