### PR TITLE
improve search and update for structmanipulators

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeStructCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeStructCommand.java
@@ -21,7 +21,6 @@ package org.eclipse.fordiac.ide.model.commands.change;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.model.LibraryElementTags;
 import org.eclipse.fordiac.ide.model.data.DataType;
-import org.eclipse.fordiac.ide.model.data.StructuredType;
 import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes;
 import org.eclipse.fordiac.ide.model.libraryElement.Demultiplexer;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
@@ -37,13 +36,19 @@ public class ChangeStructCommand extends AbstractUpdateFBNElementCommand {
 
 	private final TypeEntry newStructTypeEntry;
 	private final String newVisibleChildren;
+	private boolean reloadDatatype = true;
 
 	public ChangeStructCommand(final StructManipulator mux) {
 		this(mux, mux.getDataType(), getOldVisibleChildren(mux));
 	}
 
-	public ChangeStructCommand(final StructManipulator mux, final StructuredType newStruct) {
+	public ChangeStructCommand(final StructManipulator mux, final DataType newStruct) {
 		this(mux, newStruct, getOldVisibleChildren(mux));
+	}
+
+	public ChangeStructCommand(final StructManipulator mux, final DataType newStruct, final boolean doNotReload) {
+		this(mux, newStruct, getOldVisibleChildren(mux));
+		reloadDatatype = !doNotReload;
 	}
 
 	public ChangeStructCommand(final Demultiplexer demux, final String newVisibleChildren) {
@@ -124,19 +129,19 @@ public class ChangeStructCommand extends AbstractUpdateFBNElementCommand {
 		}
 
 		LibraryElement type = newStructTypeEntry.getType();
-		final DataTypeLibrary datatypeLib = entry.getTypeLibrary().getDataTypeLibrary();
-		final TypeEntry reloadedTypeEntry = datatypeLib.getDerivedTypeEntry(newStructTypeEntry.getFullTypeName());
-		if (newStructTypeEntry instanceof ErrorDataTypeEntry) {
-			if (reloadedTypeEntry != null && reloadedTypeEntry != newStructTypeEntry) {
-				// type exists now
-				type = reloadedTypeEntry.getType();
+		if (reloadDatatype) {
+			final DataTypeLibrary datatypeLib = entry.getTypeLibrary().getDataTypeLibrary();
+			final TypeEntry reloadedTypeEntry = datatypeLib.getDerivedTypeEntry(newStructTypeEntry.getFullTypeName());
+			if (newStructTypeEntry instanceof ErrorDataTypeEntry) {
+				if (reloadedTypeEntry != null && reloadedTypeEntry != newStructTypeEntry) {
+					// type exists now
+					type = reloadedTypeEntry.getType();
+				}
+			} else if (reloadedTypeEntry == null) {
+				// type was deleted, create error marker
+				type = datatypeLib.getType(newStructTypeEntry.getFullTypeName());
 			}
-		} else // does the type entry still exist?
-		if (reloadedTypeEntry == null) {
-			// type was deleted, create error marker
-			type = datatypeLib.getType(newStructTypeEntry.getFullTypeName());
 		}
 		return (type instanceof final DataType dt) ? dt : IecTypes.GenericTypes.ANY_STRUCT;
 	}
-
 }

--- a/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/types/DataTypeInstanceSearch.java
+++ b/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/types/DataTypeInstanceSearch.java
@@ -21,6 +21,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.AttributeDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
 import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableFB;
+import org.eclipse.fordiac.ide.model.libraryElement.ErrorMarkerDataType;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
@@ -47,10 +48,20 @@ public class DataTypeInstanceSearch extends IEC61499ElementSearch {
 	}
 
 	private static IEC61499SearchFilter createSearchFilter(final DataTypeEntry dtEntry) {
-		return searchCanditate -> (searchCanditate instanceof final VarDeclaration varDecl
+		return searchCandidate -> (searchCandidate instanceof final VarDeclaration varDecl
 				&& dtEntry == varDecl.getType().getTypeEntry())
-				|| (searchCanditate instanceof final ConfigurableFB confFB
-						&& dtEntry == confFB.getDataType().getTypeEntry());
+				|| (searchCandidate instanceof final ConfigurableFB configFb
+						&& isConfiguredWithDataType(configFb, dtEntry));
+	}
+
+	private static boolean isConfiguredWithDataType(final ConfigurableFB confFB, final DataTypeEntry dtEntry) {
+		if (confFB.getDataType() == null) {
+			return false; // unconfigured FB, corresponds to ANY_STRUCT
+		}
+		if (confFB.getDataType() instanceof ErrorMarkerDataType || dtEntry.getType() instanceof ErrorMarkerDataType) {
+			return confFB.getDataType().getTypeEntry().getFullTypeName().equals(dtEntry.getFullTypeName());
+		}
+		return dtEntry == confFB.getDataType().getTypeEntry();
 	}
 
 	private static final class DataTypeInstanceSearchChildrenProivder implements ISearchChildrenProvider {

--- a/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/types/IEC61499SearchFilter.java
+++ b/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/types/IEC61499SearchFilter.java
@@ -16,5 +16,5 @@ import org.eclipse.emf.ecore.EObject;
 
 @FunctionalInterface
 public interface IEC61499SearchFilter {
-	boolean apply(EObject searchCanditate);
+	boolean apply(EObject searchCandidate);
 }

--- a/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/types/StructDataTypeSearch.java
+++ b/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/types/StructDataTypeSearch.java
@@ -13,6 +13,7 @@
 package org.eclipse.fordiac.ide.model.search.types;
 
 import org.eclipse.fordiac.ide.model.data.StructuredType;
+import org.eclipse.fordiac.ide.model.libraryElement.ErrorMarkerDataType;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.StructManipulator;
@@ -92,6 +93,13 @@ public class StructDataTypeSearch extends InstanceSearch {
 		@Override
 		public boolean apply(final INamedElement searchCandidate) {
 			if (searchCandidate instanceof final StructManipulator mux) {
+				if (mux.getDataType() == null) {
+					return false;
+				}
+
+				if (mux.getDataType() instanceof ErrorMarkerDataType) {
+					return mux.getDataType().getTypeEntry().getFullTypeName().equals(searchCandidate.getName());
+				}
 				return mux.getDataType().getName().equals(entry.getName());
 			}
 			return false;

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/DataTypeLibrary.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/DataTypeLibrary.java
@@ -204,7 +204,7 @@ public final class DataTypeLibrary {
 		return null;
 	}
 
-	private ErrorMarkerDataType createErrorMarkerType(final String typeName, final String message) {
+	public ErrorMarkerDataType createErrorMarkerType(final String typeName, final String message) {
 		return errorTypes.computeIfAbsent(typeName.toUpperCase(), name -> {
 			FordiacLogHelper.logInfo(message);
 			final ErrorMarkerDataType type = LibraryElementFactory.eINSTANCE.createErrorMarkerDataType();


### PR DESCRIPTION
The search of struct manipulators caused NPEs when dealing with unconfigured mux/demux and also with error markers in mux/demux. Also not all instances were found, especially in the aforementioned cases: if an unconfigured mux was encountered, the search crashed and did not necessarily find all elements. This patch also fixes the update struct command for deleting structs, because the datatype entry is still present in the library in these cases. An introduced label ensures that the datatype entry is not reloaded, but the newly created error marker is used instead.