### PR TITLE
Fixed moving of expanded Subapp into Subapp

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/BorderCrossingReconnectCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/BorderCrossingReconnectCommand.java
@@ -49,18 +49,17 @@ public class BorderCrossingReconnectCommand extends CompoundCommand {
 	}
 
 	private void init() {
-		final var sinks = new ArrayList<IInterfaceElement>();
-		final var sources = new ArrayList<IInterfaceElement>();
-		collectSinksRec(connection, this, sinks);
-		collectSourcesRec(connection, this, sources);
-
 		if (isSourceReconnect) {
+			final var sinks = new ArrayList<IInterfaceElement>();
+			collectSinksRec(connection, this, sinks);
 			for (final var sink : sinks) {
 				add(CreateSubAppCrossingConnectionsCommand.createProcessBorderCrossingConnection(source, sink));
 			}
 		} else {
-			for (final var source : sources) {
-				add(CreateSubAppCrossingConnectionsCommand.createProcessBorderCrossingConnection(source, target));
+			final var sources = new ArrayList<IInterfaceElement>();
+			collectSourcesRec(connection, this, sources);
+			for (final var src : sources) {
+				add(CreateSubAppCrossingConnectionsCommand.createProcessBorderCrossingConnection(src, target));
 			}
 		}
 	}
@@ -83,13 +82,14 @@ public class BorderCrossingReconnectCommand extends CompoundCommand {
 
 	private static void collectSourcesRec(final Connection conn, final CompoundCommand cmd,
 			final List<IInterfaceElement> sources) {
+		cmd.add(new DeleteConnectionCommand(conn));
 		if (!conn.getSource().getInputConnections().isEmpty()) {
-			final var source = conn.getSource();
-			for (final var outConn : source.getInputConnections()) {
+			final var src = conn.getSource();
+			for (final var outConn : src.getInputConnections()) {
 				collectSourcesRec(outConn, cmd, sources);
 			}
-			if (source.getOutputConnections().size() == 1) {
-				cmd.add(new DeleteInterfaceCommand(source));
+			if (src.getOutputConnections().size() == 1) {
+				cmd.add(new DeleteInterfaceCommand(src));
 			}
 		} else {
 			sources.add(conn.getSource());

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/utilities/ExpandedInterfacePositionMap.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/utilities/ExpandedInterfacePositionMap.java
@@ -383,12 +383,14 @@ public class ExpandedInterfacePositionMap {
 							((ConnectionEditPart) conn2).getConnectionFigure().getEnd().y));
 			if (max.isPresent()) {
 				final ConnectionEditPart connEp = (ConnectionEditPart) max.get();
-				final Point end = connEp.getConnectionFigure().getEnd();
-				final var fig = ((GraphicalEditPart) max.get().getSource()).getFigure();
-				final int y = end.y - (sizes.get(fig).intValue() / 2);
+				if (connEp.getSource() instanceof final GraphicalEditPart graphicalEditPart) {
+					final Point end = connEp.getConnectionFigure().getEnd();
 
-				if (!isSkipConnection(connEp)) {
-					map.put(ie.getFigure(), Integer.valueOf(Math.max(y, inputDirectEnd)));
+					final int y = end.y - (sizes.get(graphicalEditPart.getFigure()).intValue() / 2);
+
+					if (!isSkipConnection(connEp)) {
+						map.put(ie.getFigure(), Integer.valueOf(Math.max(y, inputDirectEnd)));
+					}
 				}
 			} else {
 				map.put(ie.getFigure(), Integer.valueOf(Integer.MAX_VALUE));
@@ -408,12 +410,13 @@ public class ExpandedInterfacePositionMap {
 							((ConnectionEditPart) conn2).getConnectionFigure().getStart().y));
 			if (max.isPresent()) {
 				final ConnectionEditPart connEp = (ConnectionEditPart) max.get();
-				final Point start = connEp.getConnectionFigure().getStart();
-				final var fig = ((GraphicalEditPart) max.get().getTarget()).getFigure();
-				final int y = start.y - (sizes.get(fig).intValue() / 2);
+				if (connEp.getTarget() instanceof final GraphicalEditPart graphicalEditPart) {
+					final Point start = connEp.getConnectionFigure().getStart();
+					final int y = start.y - (sizes.get(graphicalEditPart.getFigure()).intValue() / 2);
 
-				if (!isSkipConnection(connEp)) {
-					map.put(ie.getFigure(), Integer.valueOf(Math.max(y, outputDirectEnd)));
+					if (!isSkipConnection(connEp)) {
+						map.put(ie.getFigure(), Integer.valueOf(Math.max(y, outputDirectEnd)));
+					}
 				}
 			} else {
 				map.put(ie.getFigure(), Integer.valueOf(Integer.MAX_VALUE));
@@ -424,10 +427,14 @@ public class ExpandedInterfacePositionMap {
 	}
 
 	private static boolean isSkipConnection(final ConnectionEditPart ep) {
-		final var sourceModel = (IInterfaceElement) ep.getSource().getModel();
-		final var targetModel = (IInterfaceElement) ep.getTarget().getModel();
-		return sourceModel.eContainer().eContainer() instanceof final SubApp sourceSub
-				&& targetModel.eContainer().eContainer() instanceof final SubApp targetSub && sourceSub == targetSub;
+		if (ep.getSource() != null && ep.getTarget() != null) {
+			final var sourceModel = (IInterfaceElement) ep.getSource().getModel();
+			final var targetModel = (IInterfaceElement) ep.getTarget().getModel();
+			return sourceModel.eContainer().eContainer() instanceof final SubApp sourceSub
+					&& targetModel.eContainer().eContainer() instanceof final SubApp targetSub
+					&& sourceSub == targetSub;
+		}
+		return false;
 	}
 
 	private void resolveCollisions(final Map<IFigure, Integer> positions) {


### PR DESCRIPTION
Moving expanded SubApps throws error causes by not correctly creating/deleting ConnectionEditPart