### PR TITLE
Hiding InOut pin of the not connected interface element

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractFBNElementEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractFBNElementEditPart.java
@@ -327,7 +327,6 @@ public abstract class AbstractFBNElementEditPart extends AbstractPositionableEle
 			return getTargetInputFigure(interfaceEditPart);
 		}
 		return getTargetOutputFigure(interfaceEditPart);
-
 	}
 
 	private IFigure getTargetInputFigure(final InterfaceEditPart interfaceEditPart) {

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractFBNElementEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractFBNElementEditPart.java
@@ -390,8 +390,8 @@ public abstract class AbstractFBNElementEditPart extends AbstractPositionableEle
 			if (((VarDeclaration) interfaceEditPart.getModel()).isInOutVar()) {
 				final List<VarDeclaration> visList = interfaceList.getInOutVars().stream()
 						.filter(VarDeclaration::isVisible).toList();
-				System.out.println(interfaceEditPart.getModel().getFBNetworkElement().getName() + " "
-						+ interfaceEditPart.getModel().getName() + " " + visList.indexOf(interfaceEditPart.getModel()));
+//				System.out.println(interfaceEditPart.getModel().getFBNetworkElement().getName() + " "
+//						+ interfaceEditPart.getModel().getName() + " " + visList.indexOf(interfaceEditPart.getModel()));
 				return visList.indexOf(interfaceEditPart.getModel());
 			}
 			return interfaceList.getVisibleInputVars().indexOf(interfaceEditPart.getModel());
@@ -415,8 +415,8 @@ public abstract class AbstractFBNElementEditPart extends AbstractPositionableEle
 			if (((VarDeclaration) interfaceEditPart.getModel()).isInOutVar()) {
 				final List<VarDeclaration> visList = interfaceList.getOutMappedInOutVars().stream()
 						.filter(VarDeclaration::isVisible).toList();
-				System.out.println(interfaceEditPart.getModel().getFBNetworkElement().getName() + " "
-						+ interfaceEditPart.getModel().getName() + " " + visList.indexOf(interfaceEditPart.getModel()));
+//				System.out.println(interfaceEditPart.getModel().getFBNetworkElement().getName() + " "
+//						+ interfaceEditPart.getModel().getName() + " " + visList.indexOf(interfaceEditPart.getModel()));
 				return visList.indexOf(interfaceEditPart.getModel());
 
 			}
@@ -472,10 +472,8 @@ public abstract class AbstractFBNElementEditPart extends AbstractPositionableEle
 
 		final List<VarDeclaration> inoutInConList = getModel().getInterface().getOutMappedInOutVars().stream()
 				.filter(it -> !it.getOutputConnections().isEmpty()).map(VarDeclaration::getInOutVarOpposite).toList();
-		// System.out.println("To be banned inputs: " + inoutInRemList);
 		final List<VarDeclaration> inoutOutConList = getModel().getInterface().getInOutVars().stream()
 				.filter(it -> !it.getInputConnections().isEmpty()).map(VarDeclaration::getInOutVarOpposite).toList();
-		// System.out.println("To be banned outputs: " + inoutOutRemList);
 
 		elements.removeAll(inputRemovalList);
 		elements.removeAll(outputRemovalList);

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractFBNElementEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractFBNElementEditPart.java
@@ -256,6 +256,8 @@ public abstract class AbstractFBNElementEditPart extends AbstractPositionableEle
 
 	private HiddenPinIndicator inputPinIndicator;
 	private HiddenPinIndicator outputPinIndicator;
+	private static List<VarDeclaration> inoutInConList;
+	private static List<VarDeclaration> inoutOutConList;
 
 	/**
 	 * Returns an <code>IPropertyChangeListener</code> with implemented
@@ -388,11 +390,9 @@ public abstract class AbstractFBNElementEditPart extends AbstractPositionableEle
 		}
 		if (interfaceEditPart.isVariable()) {
 			if (((VarDeclaration) interfaceEditPart.getModel()).isInOutVar()) {
-				final List<VarDeclaration> visList = interfaceList.getInOutVars().stream()
-						.filter(VarDeclaration::isVisible).toList();
-//				System.out.println(interfaceEditPart.getModel().getFBNetworkElement().getName() + " "
-//						+ interfaceEditPart.getModel().getName() + " " + visList.indexOf(interfaceEditPart.getModel()));
-				return visList.indexOf(interfaceEditPart.getModel());
+				final List<VarDeclaration> visInOutList = interfaceList.getInOutVars().stream()
+						.filter(x -> !inoutInConList.contains(x)).toList();
+				return visInOutList.indexOf(interfaceEditPart.getModel());
 			}
 			return interfaceList.getVisibleInputVars().indexOf(interfaceEditPart.getModel());
 		}
@@ -413,12 +413,9 @@ public abstract class AbstractFBNElementEditPart extends AbstractPositionableEle
 		}
 		if (interfaceEditPart.isVariable()) {
 			if (((VarDeclaration) interfaceEditPart.getModel()).isInOutVar()) {
-				final List<VarDeclaration> visList = interfaceList.getOutMappedInOutVars().stream()
-						.filter(VarDeclaration::isVisible).toList();
-//				System.out.println(interfaceEditPart.getModel().getFBNetworkElement().getName() + " "
-//						+ interfaceEditPart.getModel().getName() + " " + visList.indexOf(interfaceEditPart.getModel()));
-				return visList.indexOf(interfaceEditPart.getModel());
-
+				final List<VarDeclaration> visInOutList = interfaceList.getOutMappedInOutVars().stream()
+						.filter(x -> !inoutOutConList.contains(x)).toList();
+				return visInOutList.indexOf(interfaceEditPart.getModel());
 			}
 			return interfaceList.getVisibleOutputVars().indexOf(interfaceEditPart.getModel());
 		}
@@ -470,9 +467,9 @@ public abstract class AbstractFBNElementEditPart extends AbstractPositionableEle
 		final List<VarDeclaration> outputRemovalList = getModel().getInterface().getOutputVars().stream()
 				.filter(it -> !it.isVisible()).toList();
 
-		final List<VarDeclaration> inoutInConList = getModel().getInterface().getOutMappedInOutVars().stream()
+		inoutInConList = getModel().getInterface().getOutMappedInOutVars().stream()
 				.filter(it -> !it.getOutputConnections().isEmpty()).map(VarDeclaration::getInOutVarOpposite).toList();
-		final List<VarDeclaration> inoutOutConList = getModel().getInterface().getInOutVars().stream()
+		inoutOutConList = getModel().getInterface().getInOutVars().stream()
 				.filter(it -> !it.getInputConnections().isEmpty()).map(VarDeclaration::getInOutVarOpposite).toList();
 
 		elements.removeAll(inputRemovalList);

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractFBNElementEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractFBNElementEditPart.java
@@ -388,7 +388,11 @@ public abstract class AbstractFBNElementEditPart extends AbstractPositionableEle
 		}
 		if (interfaceEditPart.isVariable()) {
 			if (((VarDeclaration) interfaceEditPart.getModel()).isInOutVar()) {
-				return interfaceList.getInOutVars().indexOf(interfaceEditPart.getModel());
+				final List<VarDeclaration> visList = interfaceList.getInOutVars().stream()
+						.filter(VarDeclaration::isVisible).toList();
+				System.out.println(interfaceEditPart.getModel().getFBNetworkElement().getName() + " "
+						+ interfaceEditPart.getModel().getName() + " " + visList.indexOf(interfaceEditPart.getModel()));
+				return visList.indexOf(interfaceEditPart.getModel());
 			}
 			return interfaceList.getVisibleInputVars().indexOf(interfaceEditPart.getModel());
 		}
@@ -409,7 +413,12 @@ public abstract class AbstractFBNElementEditPart extends AbstractPositionableEle
 		}
 		if (interfaceEditPart.isVariable()) {
 			if (((VarDeclaration) interfaceEditPart.getModel()).isInOutVar()) {
-				return interfaceList.getOutMappedInOutVars().indexOf(interfaceEditPart.getModel());
+				final List<VarDeclaration> visList = interfaceList.getOutMappedInOutVars().stream()
+						.filter(VarDeclaration::isVisible).toList();
+				System.out.println(interfaceEditPart.getModel().getFBNetworkElement().getName() + " "
+						+ interfaceEditPart.getModel().getName() + " " + visList.indexOf(interfaceEditPart.getModel()));
+				return visList.indexOf(interfaceEditPart.getModel());
+
 			}
 			return interfaceList.getVisibleOutputVars().indexOf(interfaceEditPart.getModel());
 		}
@@ -460,8 +469,19 @@ public abstract class AbstractFBNElementEditPart extends AbstractPositionableEle
 				.filter(it -> !it.isVisible()).toList();
 		final List<VarDeclaration> outputRemovalList = getModel().getInterface().getOutputVars().stream()
 				.filter(it -> !it.isVisible()).toList();
+
+		final List<VarDeclaration> inoutInConList = getModel().getInterface().getOutMappedInOutVars().stream()
+				.filter(it -> !it.getOutputConnections().isEmpty()).map(VarDeclaration::getInOutVarOpposite).toList();
+		// System.out.println("To be banned inputs: " + inoutInRemList);
+		final List<VarDeclaration> inoutOutConList = getModel().getInterface().getInOutVars().stream()
+				.filter(it -> !it.getInputConnections().isEmpty()).map(VarDeclaration::getInOutVarOpposite).toList();
+		// System.out.println("To be banned outputs: " + inoutOutRemList);
+
 		elements.removeAll(inputRemovalList);
 		elements.removeAll(outputRemovalList);
+		elements.removeAll(inoutInConList);
+		elements.removeAll(inoutOutConList);
+		elements.addAll(getPinIndicators(!inoutInConList.isEmpty(), !inoutOutConList.isEmpty()));
 		elements.addAll(getPinIndicators(!inputRemovalList.isEmpty(), !outputRemovalList.isEmpty()));
 		return elements;
 	}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractFBNElementEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractFBNElementEditPart.java
@@ -327,6 +327,7 @@ public abstract class AbstractFBNElementEditPart extends AbstractPositionableEle
 			return getTargetInputFigure(interfaceEditPart);
 		}
 		return getTargetOutputFigure(interfaceEditPart);
+
 	}
 
 	private IFigure getTargetInputFigure(final InterfaceEditPart interfaceEditPart) {

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractFBNElementEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractFBNElementEditPart.java
@@ -378,14 +378,19 @@ public abstract class AbstractFBNElementEditPart extends AbstractPositionableEle
 
 	}
 
-	private List<VarDeclaration> getRemovedInOutConnections(final boolean isInput) {
+	private List<VarDeclaration> getRemovedVarInOutPins(final boolean isInput) {
+		List<VarDeclaration> removedVarInOutPins;
 		if (isInput) {
-			return getModel().getInterface().getOutMappedInOutVars().stream()
+			removedVarInOutPins = getModel().getInterface().getOutMappedInOutVars().stream()
 					.filter(it -> !it.getOutputConnections().isEmpty()).map(VarDeclaration::getInOutVarOpposite)
 					.toList();
+		} else {
+			removedVarInOutPins = getModel().getInterface().getInOutVars().stream()
+					.filter(it -> !it.getInputConnections().isEmpty()).map(VarDeclaration::getInOutVarOpposite)
+					.toList();
 		}
-		return getModel().getInterface().getInOutVars().stream().filter(it -> !it.getInputConnections().isEmpty())
-				.map(VarDeclaration::getInOutVarOpposite).toList();
+		removedVarInOutPins.forEach(vd -> vd.setValue(null));
+		return removedVarInOutPins;
 	}
 
 	private int getInterfaceInputElementIndex(final InterfaceEditPart interfaceEditPart,
@@ -399,7 +404,7 @@ public abstract class AbstractFBNElementEditPart extends AbstractPositionableEle
 		if (interfaceEditPart.isVariable()) {
 			if (((VarDeclaration) interfaceEditPart.getModel()).isInOutVar()) {
 				final List<VarDeclaration> visInOutList = interfaceList.getInOutVars().stream()
-						.filter(x -> !getRemovedInOutConnections(true).contains(x)).toList();
+						.filter(vd -> !getRemovedVarInOutPins(true).contains(vd)).toList();
 				return visInOutList.indexOf(interfaceEditPart.getModel());
 			}
 			return interfaceList.getVisibleInputVars().indexOf(interfaceEditPart.getModel());
@@ -422,7 +427,7 @@ public abstract class AbstractFBNElementEditPart extends AbstractPositionableEle
 		if (interfaceEditPart.isVariable()) {
 			if (((VarDeclaration) interfaceEditPart.getModel()).isInOutVar()) {
 				final List<VarDeclaration> visInOutList = interfaceList.getOutMappedInOutVars().stream()
-						.filter(x -> !getRemovedInOutConnections(false).contains(x)).toList();
+						.filter(vd -> !getRemovedVarInOutPins(false).contains(vd)).toList();
 				return visInOutList.indexOf(interfaceEditPart.getModel());
 			}
 			return interfaceList.getVisibleOutputVars().indexOf(interfaceEditPart.getModel());
@@ -474,12 +479,8 @@ public abstract class AbstractFBNElementEditPart extends AbstractPositionableEle
 				.filter(it -> !it.isVisible()).toList();
 		final List<VarDeclaration> outputRemovalList = getModel().getInterface().getOutputVars().stream()
 				.filter(it -> !it.isVisible()).toList();
-
-		final List<VarDeclaration> inoutInConList = getRemovedInOutConnections(true);
-		final List<VarDeclaration> inoutOutConList = getRemovedInOutConnections(false);
-
-		inoutInConList.stream().forEach(vd -> vd.setValue(null));
-		inoutOutConList.stream().forEach(vd -> vd.setValue(null));
+		final List<VarDeclaration> inoutInConList = getRemovedVarInOutPins(true);
+		final List<VarDeclaration> inoutOutConList = getRemovedVarInOutPins(false);
 
 		elements.removeAll(inputRemovalList);
 		elements.removeAll(outputRemovalList);


### PR DESCRIPTION
When an inout pin is connected with it's input/output, the opposite pin
will be visually removed.