### PR TITLE
Correctly create array for struct members

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/ConfigurableFBManagement.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/ConfigurableFBManagement.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.eclipse.emf.common.util.ECollections;
 import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.model.LibraryElementTags;
 import org.eclipse.fordiac.ide.model.data.DataType;
 import org.eclipse.fordiac.ide.model.data.StructuredType;
@@ -145,7 +146,8 @@ public final class ConfigurableFBManagement {
 			if (!isInDefaultConfiguration(fb, attr.getValue(), fb.getDataType())) {
 				return ECollections.asEList(structTypeAttr.get(0), attr);
 			}
-			// Until the configured state is updated automatically in the commands, save result here:
+			// Until the configured state is updated automatically in the commands, save
+			// result here:
 			fb.setIsConfigured(false);
 		}
 		return structTypeAttr;
@@ -233,6 +235,7 @@ public final class ConfigurableFBManagement {
 		copy.setType(memberVar.getType());
 		copy.setValue(LibraryElementFactory.eINSTANCE.createValue());
 		copy.setIsInput(isInput);
+		copy.setArraySize(EcoreUtil.copy(memberVar.getArraySize()));
 		return copy;
 	}
 


### PR DESCRIPTION
When creating the interface pins of a mux/demux, the array size was not correctly initialized. This was added in the code for creating a membervardeclaration from a given struct member vardeclaration. Note that an array size is nowadays a model object with containment, so a simple setArraySize(arraySizeObj) will break the containment of the model. Hence, ECoreUtil.copy is used.