### PR TITLE
Correctly hide values of hidden varinout inputs

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractFBNElementEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractFBNElementEditPart.java
@@ -389,7 +389,6 @@ public abstract class AbstractFBNElementEditPart extends AbstractPositionableEle
 					.filter(it -> !it.getInputConnections().isEmpty()).map(VarDeclaration::getInOutVarOpposite)
 					.toList();
 		}
-		removedVarInOutPins.forEach(vd -> vd.setValue(null));
 		return removedVarInOutPins;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/AbstractFBNetworkEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/AbstractFBNetworkEditPart.java
@@ -117,6 +117,8 @@ public abstract class AbstractFBNetworkEditPart extends AbstractDiagramEditPart 
 			element.getInterface().getVisibleInputVars().stream().filter(di -> (di.getValue() != null))
 					.forEach(di -> valueElements.add(di.getValue()));
 			element.getInterface().getInOutVars().stream().filter(di -> (di.getValue() != null))
+					.filter(it -> !it.getInOutVarOpposite().getOutputConnections().isEmpty()) // indication that
+																								// varinout is hidden
 					.forEach(di -> valueElements.add(di.getValue()));
 			element.getInterface().getErrorMarker().stream().filter(er -> (er.getValue() != null))
 					.forEach(er -> valueElements.add(er.getValue()));


### PR DESCRIPTION
When VarInOuts inputs are hidden because of there output side beeing connected they shall not be shown. This was wrongly implemented by setting the value null.