### PR TITLE
fix export of empty package names

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/util/ForteNgExportUtil.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/util/ForteNgExportUtil.xtend
@@ -210,7 +210,7 @@ final class ForteNgExportUtil {
 				"STRING"
 			WstringType:
 				"WSTRING"
-			LibraryElement: '''«type.compilerInfo?.packageName?.replace(':', '_')?.concat("__")»«type.name»'''
+			LibraryElement: '''«type.generateTypePath?.concat(type.generateTypePath.blank ? "" : "__")»«type.name»'''
 			default:
 				type.name
 		}


### PR DESCRIPTION
if a package name is fully removed and the library element is exported without reload, the separator between package and type name was still exported