### PR TITLE
Generate mangled C++ name correctly

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/util/ForteNgExportUtil.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/util/ForteNgExportUtil.xtend
@@ -188,6 +188,11 @@ final class ForteNgExportUtil {
 		}
 	}
 
+	def static String generateMangledPackageName(LibraryElement type) {
+		val packageName = type.compilerInfo?.packageName?.replace(":", "_")
+		packageName.nullOrEmpty ? "" : packageName + "__"
+	}
+
 	def static String generateTypeNamePlain(INamedElement type) {
 		switch (type) {
 			TimeType:
@@ -212,7 +217,7 @@ final class ForteNgExportUtil {
 				"STRING"
 			WstringType:
 				"WSTRING"
-			LibraryElement: '''«type.generateTypePath?.concat(type.generateTypePath.blank ? "" : "__")»«type.name»'''
+			LibraryElement: '''«type.generateMangledPackageName»«type.name»'''
 			default:
 				type.name
 		}


### PR DESCRIPTION
The fix in #178 tried to avoid duplicating code but used the wrong static method. This led to invalid mangled names being generated