### PR TITLE
DeploymenFBEvaluator syncs time

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.deployment.eval/src/org/eclipse/fordiac/ide/deployment/eval/DeploymentEvaluatorSharedState.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.eval/src/org/eclipse/fordiac/ide/deployment/eval/DeploymentEvaluatorSharedState.java
@@ -97,6 +97,10 @@ public class DeploymentEvaluatorSharedState implements Closeable {
 		deviceManagementInteractor.writeFBParameter(resource, value, deploymentData, varDeclaration);
 	}
 
+	public void writeDeviceParameter(final String name, final String value) throws DeploymentException {
+		deviceManagementInteractor.writeDeviceParameter(resource.getDevice(), name, value);
+	}
+
 	public Resource getResource() {
 		return resource;
 	}

--- a/plugins/org.eclipse.fordiac.ide.deployment.eval/src/org/eclipse/fordiac/ide/deployment/eval/fb/DeploymentFBEvaluator.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.eval/src/org/eclipse/fordiac/ide/deployment/eval/fb/DeploymentFBEvaluator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Martin Erich Jobst
+ * Copyright (c) 2023, 2024 Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -28,6 +28,7 @@ import org.eclipse.fordiac.ide.deployment.monitoringbase.MonitoringBaseElement;
 import org.eclipse.fordiac.ide.model.eval.Evaluator;
 import org.eclipse.fordiac.ide.model.eval.EvaluatorException;
 import org.eclipse.fordiac.ide.model.eval.fb.FBEvaluator;
+import org.eclipse.fordiac.ide.model.eval.function.StandardFunctions;
 import org.eclipse.fordiac.ide.model.eval.variable.Variable;
 import org.eclipse.fordiac.ide.model.libraryElement.Event;
 import org.eclipse.fordiac.ide.model.libraryElement.FB;
@@ -45,6 +46,7 @@ import org.eclipse.fordiac.ide.monitoring.MonitoringManagerUtils;
 
 public class DeploymentFBEvaluator<T extends FBType> extends FBEvaluator<T> {
 
+	private static final String FAKE_TIME_DEV_PARAM_NAME = "FakeTime"; //$NON-NLS-1$
 	private DeploymentEvaluatorSharedState sharedState;
 	private FBDeploymentData deploymentData;
 	private Map<String, MonitoringElement> monitoringElements;
@@ -118,6 +120,7 @@ public class DeploymentFBEvaluator<T extends FBType> extends FBEvaluator<T> {
 		try {
 			writeVariables(getType().getInterfaceList().getInputVars());
 			writeVariables(getType().getInterfaceList().getInOutVars());
+			sharedState.writeDeviceParameter(FAKE_TIME_DEV_PARAM_NAME, StandardFunctions.NOW_MONOTONIC().toString());
 			sharedState.triggerEvent(monitoringElements.get(event.getName()));
 			pollWatches();
 		} catch (final DeploymentException e) {


### PR DESCRIPTION
With this change the DeploymentFBEvaluator tries to set the faketime of the evaluator device so that evaluated fbs in 4diac IDE and fbs in the device share the same time base.