### PR TITLE
Correctly show varinout in typed and untyped subapps

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractFBNElementEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractFBNElementEditPart.java
@@ -21,6 +21,7 @@
 package org.eclipse.fordiac.ide.application.editparts;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.core.runtime.Assert;
@@ -378,18 +379,9 @@ public abstract class AbstractFBNElementEditPart extends AbstractPositionableEle
 
 	}
 
-	private List<VarDeclaration> getRemovedVarInOutPins(final boolean isInput) {
-		List<VarDeclaration> removedVarInOutPins;
-		if (isInput) {
-			removedVarInOutPins = getModel().getInterface().getOutMappedInOutVars().stream()
-					.filter(it -> !it.getOutputConnections().isEmpty()).map(VarDeclaration::getInOutVarOpposite)
-					.toList();
-		} else {
-			removedVarInOutPins = getModel().getInterface().getInOutVars().stream()
-					.filter(it -> !it.getInputConnections().isEmpty()).map(VarDeclaration::getInOutVarOpposite)
-					.toList();
-		}
-		return removedVarInOutPins;
+	@SuppressWarnings("static-method")
+	protected List<VarDeclaration> getRemovedVarInOutPins(final boolean isInput) {
+		return Collections.emptyList();
 	}
 
 	private int getInterfaceInputElementIndex(final InterfaceEditPart interfaceEditPart,

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/EditorWithInterfaceEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/EditorWithInterfaceEditPart.java
@@ -174,6 +174,7 @@ public abstract class EditorWithInterfaceEditPart extends AbstractFBNetworkEditP
 	private Figure rightInterfaceContainer;
 	private Figure rightEventContainer;
 	private Figure rightVarContainer;
+	private Figure rightVarInOutContainer;
 	private Figure rightAdapterContainer;
 	private FreeformLayer contentContainer;
 	private ControlListener controlListener;
@@ -300,6 +301,7 @@ public abstract class EditorWithInterfaceEditPart extends AbstractFBNetworkEditP
 
 		rightEventContainer = createInterfaceElementsContainer(rightInnerContainer);
 		rightVarContainer = createInterfaceElementsContainer(rightInnerContainer);
+		rightVarInOutContainer = createInterfaceElementsContainer(rightInnerContainer);
 		rightAdapterContainer = createInterfaceElementsContainer(rightInnerContainer);
 	}
 
@@ -394,6 +396,10 @@ public abstract class EditorWithInterfaceEditPart extends AbstractFBNetworkEditP
 		return rightVarContainer;
 	}
 
+	public Figure getRightVarInOutInterfaceContainer() {
+		return rightVarInOutContainer;
+	}
+
 	public Figure getRightAdapterInterfaceContainer() {
 		return rightAdapterContainer;
 	}
@@ -442,14 +448,14 @@ public abstract class EditorWithInterfaceEditPart extends AbstractFBNetworkEditP
 
 	@Override
 	protected void addChildVisual(final EditPart childEditPart, final int index) {
-		if (childEditPart instanceof final InterfaceEditPart iep) {
-			addChildVisualInterfaceElement(iep);
-		} else if (childEditPart instanceof final InstanceCommentEditPart icep) {
+		switch (childEditPart) {
+		case final InterfaceEditPart iep -> addChildVisualInterfaceElement(iep);
+		case final InstanceCommentEditPart icep -> {
 			final Figure commentFigure = icep.getFigure();
 			commentFigure.setBorder(null);
 			commentContainer.add(commentFigure);
-		} else {
-			super.addChildVisual(childEditPart, index);
+		}
+		default -> super.addChildVisual(childEditPart, index);
 		}
 	}
 
@@ -460,12 +466,10 @@ public abstract class EditorWithInterfaceEditPart extends AbstractFBNetworkEditP
 	 */
 	@Override
 	protected void removeChildVisual(final EditPart childEditPart) {
-		if (childEditPart instanceof final InterfaceEditPart iep) {
-			removeChildVisualInterfaceElement(iep);
-		} else if (childEditPart instanceof final InstanceCommentEditPart icep) {
-			commentContainer.remove(icep.getFigure());
-		} else {
-			super.removeChildVisual(childEditPart);
+		switch (childEditPart) {
+		case final InterfaceEditPart iep -> removeChildVisualInterfaceElement(iep);
+		case final InstanceCommentEditPart icep -> commentContainer.remove(icep.getFigure());
+		default -> super.removeChildVisual(childEditPart);
 		}
 	}
 
@@ -496,10 +500,11 @@ public abstract class EditorWithInterfaceEditPart extends AbstractFBNetworkEditP
 	}
 
 	private Figure getVarVisualContainer(final InterfaceEditPart childEditPart) {
-		if (childEditPart.getModel() instanceof final VarDeclaration varDecl && varDecl.isInOutVar()) {
-			return getLeftVarInOutInterfaceContainer();
+		final IInterfaceElement model = childEditPart.getModel();
+		if (model instanceof final VarDeclaration varDecl && varDecl.isInOutVar()) {
+			return model.isIsInput() ? getLeftVarInOutInterfaceContainer() : getRightVarInOutInterfaceContainer();
 		}
-		return childEditPart.getModel().isIsInput() ? getLeftVarInterfaceContainer() : getRightVarInterfaceContainer();
+		return model.isIsInput() ? getLeftVarInterfaceContainer() : getRightVarInterfaceContainer();
 	}
 
 	private Figure getAdapterVisualContainer(final InterfaceEditPart childEditPart) {

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/UISubAppNetworkEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/UISubAppNetworkEditPart.java
@@ -1,6 +1,7 @@
 /*******************************************************************************
  * Copyright (c) 2008, 2024 Profactor GmbH, AIT, fortiss GmbH,
- *                          Johannes Kepler University Linz
+ *                          Johannes Kepler University Linz,
+ *                          Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,6 +18,8 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.application.editparts;
 
+import java.util.List;
+
 import org.eclipse.fordiac.ide.application.policies.FBNetworkXYLayoutEditPolicy;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
@@ -27,6 +30,18 @@ public class UISubAppNetworkEditPart extends EditorWithInterfaceEditPart {
 
 	public SubApp getSubApp() {
 		return (SubApp) getModel().eContainer();
+	}
+
+	@Override
+	protected List<?> getModelChildren() {
+		@SuppressWarnings("unchecked")
+		final List<Object> modelChildren = (List<Object>) super.getModelChildren();
+		if (getModel() != null) {
+			final InterfaceList ifList = getInterfaceList();
+			modelChildren.addAll(ifList.getInOutVars());
+			modelChildren.addAll(ifList.getOutMappedInOutVars());
+		}
+		return modelChildren;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.subapptypeeditor/src/org/eclipse/fordiac/ide/subapptypeeditor/editparts/TypedSubAppNetworkEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.subapptypeeditor/src/org/eclipse/fordiac/ide/subapptypeeditor/editparts/TypedSubAppNetworkEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 fortiss GmbH
+ * Copyright (c) 2019, 2024 fortiss GmbH, Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.subapptypeeditor.editparts;
 
+import java.util.List;
+
 import org.eclipse.fordiac.ide.fbtypeeditor.network.editparts.CompositeNetworkEditPart;
 import org.eclipse.fordiac.ide.subapptypeeditor.policies.SubAppTypeFBNetworkLayoutEditPolicy;
 import org.eclipse.gef.EditPart;
@@ -20,6 +22,16 @@ import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.editpolicies.RootComponentEditPolicy;
 
 public class TypedSubAppNetworkEditPart extends CompositeNetworkEditPart {
+
+	@Override
+	protected List<?> getModelChildren() {
+		@SuppressWarnings("unchecked")
+		final List<Object> modelChildren = (List<Object>) super.getModelChildren();
+		if (getModel() != null) {
+			modelChildren.addAll(getInterfaceList().getOutMappedInOutVars());
+		}
+		return modelChildren;
+	}
 
 	@Override
 	protected boolean isVarVisible(final EditPart childEditPart) {


### PR DESCRIPTION
With this change the interface bar of typed or untyped subapps shows on both sides var inouts.

Furthermore the filtering of varinouts now reflects the internal connection state of subapps and only for subapps.