### PR TITLE
Deletion of InternalFBs didn't correctly use table selection

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/InternalFbsSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/InternalFbsSection.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Primetals Technologies Germany GmbH
- * 				 2023 Johannes Kepler University, Linz
+ * Copyright (c) 2021, 2024 Primetals Technologies Germany GmbH,
+ *                          Johannes Kepler University, Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -99,7 +99,7 @@ public class InternalFbsSection extends AbstractSection implements I4diacNatTabl
 
 		buttons.bindToTableViewer(table, this,
 				ref -> new CreateInternalFBCommand(getType(), getInsertionIndex(), getName(), getFBTypeEntry()),
-				ref -> new DeleteInternalFBCommand(getType(), getLastSelectedFB()),
+				ref -> new DeleteInternalFBCommand((FB) ref),
 				ref -> new ChangeInternalFBOrderCommand(getType(), (FB) ref, IndexUpDown.UP),
 				ref -> new ChangeInternalFBOrderCommand(getType(), (FB) ref, IndexUpDown.DOWN));
 
@@ -186,7 +186,7 @@ public class InternalFbsSection extends AbstractSection implements I4diacNatTabl
 	@Override
 	public void removeEntry(final Object entry, final CompoundCommand cmd) {
 		if (entry instanceof final FB fb) {
-			cmd.add(new DeleteInternalFBCommand(getType(), fb));
+			cmd.add(new DeleteInternalFBCommand(fb));
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/delete/DeleteInternalFBCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/delete/DeleteInternalFBCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Primetals Technologies Germany GmbH
+ * Copyright (c) 2021, 2024 Primetals Technologies Germany GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -36,24 +36,23 @@ public class DeleteInternalFBCommand extends Command implements ScopedCommand {
 	/** The old index. */
 	private int oldIndex;
 
-	public DeleteInternalFBCommand(final BaseFBType baseFbtype, final FB fb) {
-		this.baseFbtype = Objects.requireNonNull(baseFbtype);
+	public DeleteInternalFBCommand(final FB fb) {
 		this.fbToDelete = Objects.requireNonNull(fb);
-	}
-
-	private EList<FB> getInteralFBList() {
-		return baseFbtype.getInternalFbs();
+		if (!(fb.eContainer() instanceof final BaseFBType baseFBtype)) {
+			throw new IllegalArgumentException("FB to delete is not contained in BaseFBType!"); //$NON-NLS-1$
+		}
+		this.baseFbtype = baseFBtype;
 	}
 
 	@Override
 	public void execute() {
 		oldIndex = getIndexOfFBtoDelete();
-		redo();
+		removeFB();
 	}
 
 	@Override
 	public void redo() {
-		getInteralFBList().remove(oldIndex);
+		removeFB();
 	}
 
 	@Override
@@ -61,13 +60,20 @@ public class DeleteInternalFBCommand extends Command implements ScopedCommand {
 		getInteralFBList().add(oldIndex, fbToDelete);
 	}
 
-	private int getIndexOfFBtoDelete() {
-		return getInteralFBList().indexOf(getInteralFBList().stream()
-				.filter(fb -> fb.getName().equals(fbToDelete.getName())).findFirst().orElse(fbToDelete));
-	}
-
 	@Override
 	public Set<EObject> getAffectedObjects() {
 		return Set.of(baseFbtype);
+	}
+
+	private int getIndexOfFBtoDelete() {
+		return getInteralFBList().indexOf(fbToDelete);
+	}
+
+	private EList<FB> getInteralFBList() {
+		return baseFbtype.getInternalFbs();
+	}
+
+	private void removeFB() {
+		getInteralFBList().remove(fbToDelete);
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/SafeFBTypeDeletionChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/SafeFBTypeDeletionChange.java
@@ -29,7 +29,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.search.AbstractLiveSearchContext;
 import org.eclipse.fordiac.ide.model.search.types.BlockTypeInstanceSearch;
 import org.eclipse.fordiac.ide.model.typelibrary.FBTypeEntry;
-import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
 import org.eclipse.fordiac.ide.typemanagement.Messages;
 import org.eclipse.gef.commands.Command;
@@ -100,10 +99,9 @@ public class SafeFBTypeDeletionChange extends CompositeChange {
 
 		@Override
 		public Change perform(final IProgressMonitor pm) throws CoreException {
-			final TypeEntry typeEntry = baseFb.getTypeEntry();
 			Command cmd = null;
 			if (state.contains(ChangeState.DELETE)) {
-				cmd = new DeleteInternalFBCommand((BaseFBType) typeEntry.getTypeEditable(), internalFb);
+				cmd = new DeleteInternalFBCommand(internalFb);
 			} else if (state.contains(ChangeState.REPLACE_WITH_MARKER)) {
 				// use empty string to force errormarker
 				cmd = new ChangeFbTypeCommand(internalFb, getErrorMarkerEntry(internalFb));

--- a/plugins/org.eclipse.fordiac.ide.ui/src/org/eclipse/fordiac/ide/ui/widget/AddDeleteWidget.java
+++ b/plugins/org.eclipse.fordiac.ide.ui/src/org/eclipse/fordiac/ide/ui/widget/AddDeleteWidget.java
@@ -240,7 +240,7 @@ public class AddDeleteWidget {
 	protected static void executeCompoundCommandForList(final NatTable table, final List<Object> selection,
 			final CommandExecutor executor, final CommandProvider commandProvider) {
 		final CompoundCommand cmd = new CompoundCommand();
-		selection.stream().forEach(elem -> cmd.add(commandProvider.getCommand(elem)));
+		selection.forEach(elem -> cmd.add(commandProvider.getCommand(elem)));
 		executor.executeCommand(cmd);
 		table.refresh();
 	}


### PR DESCRIPTION
When more then one FB was selected the InternalFBsSection always used the last selected element. This lead to exceptions as the same element was deleted multiple times.

Furthermore the DeleteInternalFBCommand was cleaned.