### PR TITLE
Only configure Unconfigured Struct Manipulators

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/VariableNodeEditPolicy.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/VariableNodeEditPolicy.java
@@ -42,6 +42,11 @@ public class VariableNodeEditPolicy extends InterfaceElementEditPolicy {
 			return null;
 		}
 
+		if (getHost().getRoot() == null) {
+			// we are in an intermediate configuration stage
+			return null;
+		}
+
 		return (AbstractConnectionCreateCommand.isStructManipulatorDefPin(pin))
 				? new StructDataConnectionCreateCommand(getParentNetwork())
 				: new DataConnectionCreateCommand(getParentNetwork());

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/data/impl/DataTypeAnnotations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/data/impl/DataTypeAnnotations.java
@@ -63,6 +63,7 @@ import org.eclipse.fordiac.ide.model.data.UsintType;
 import org.eclipse.fordiac.ide.model.data.WcharType;
 import org.eclipse.fordiac.ide.model.data.WordType;
 import org.eclipse.fordiac.ide.model.data.WstringType;
+import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes.GenericTypes;
 import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 
 final class DataTypeAnnotations {
@@ -104,8 +105,9 @@ final class DataTypeAnnotations {
 	}
 
 	static boolean isAssignableFrom(final StructuredType type, final DataType other) {
-		// only strict name equality for structs
-		return PackageNameHelper.getFullTypeName(type).equalsIgnoreCase(PackageNameHelper.getFullTypeName(other));
+		// only strict name equality for structs or assignment to any_struct
+		return PackageNameHelper.getFullTypeName(type).equalsIgnoreCase(PackageNameHelper.getFullTypeName(other))
+				|| (GenericTypes.ANY_STRUCT == type && other instanceof StructuredType);
 	}
 
 	static boolean isAssignableFrom(final AnyElementaryType type, final DataType other) {


### PR DESCRIPTION
With this fix only unconfigured struct manipulators will be configured on connecting their struct defining pin to a typed struct pin.

Furthermore an NPE resulting from a transient state during connection creation (configuring the struct manipulator) is fixed.