### PR TITLE
fix indentation for generated source to be used with FORTE

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteFBTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteFBTemplate.xtend
@@ -394,7 +394,7 @@ abstract class ForteFBTemplate<T extends FBType> extends ForteLibraryElementTemp
 	def protected generateSetInitialValuesDefinition(Iterable<VarDeclaration> variables) '''
 		«IF (containsNonRetainedVariable(variables))»
 			void «className»::setInitialValues() {
-				«generateVariableDefaultAssignment(variables.filter[!isRetainedVariable(it)])»
+			  «generateVariableDefaultAssignment(variables.filter[!isRetainedVariable(it)])»
 			}
 			
 		«ENDIF»	


### PR DESCRIPTION
code generation for setInitialValues used tab instead of spaces for indentation