### PR TITLE
Set Correct Segment Size on Segment Creation #271

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/commands/SegmentCreateCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/commands/SegmentCreateCommand.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2009, 2011 - 2017 Profactor GbmH, TU Wien ACIN, fortiss GmbH
- * 				 2019 Johannes Keppler University Linz
+ * Copyright (c) 2008, 2024 Profactor GbmH, TU Wien ACIN, fortiss GmbH,
+ *                          Johannes Keppler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -61,7 +61,7 @@ public class SegmentCreateCommand extends Command {
 		}
 		segment.getVarDeclarations().addAll(EcoreUtil.copyAll(type.getType().getVarDeclaration()));
 		segment.setPosition(pos);
-		segment.setWidth(width);
+		segment.setWidth(CoordinateConverter.INSTANCE.screenToIEC61499(width));
 		redo();
 		segment.setName(NameRepository.createUniqueName(segment, type.getType().getName()));
 	}


### PR DESCRIPTION
With the change of using the IEC 61499 coordinate system in the model the initial value for Segments sizes was not correctly transfered from screen coordinates to IEC 61499 coordinates.

Fixes https://github.com/eclipse-4diac/4diac-ide/issues/271