### PR TITLE
Provide progress feedback when deploying #272

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/DeploymentStreamsProxy.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/DeploymentStreamsProxy.java
@@ -15,6 +15,7 @@ package org.eclipse.fordiac.ide.deployment.debug;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.text.MessageFormat;
 
 import javax.xml.XMLConstants;
 import javax.xml.transform.OutputKeys;
@@ -41,7 +42,6 @@ public class DeploymentStreamsProxy implements IStreamsProxy, IDeploymentListene
 	private final DeploymentStreamMonitor outputStreamMonitor = new DeploymentStreamMonitor();
 	private final DeploymentStreamMonitor errorStreamMonitor = new DeploymentStreamMonitor();
 	private final Transformer transformer;
-	// private final HashMap<String, Integer> resources = new HashMap<>();
 
 	private String currentDest;
 	private int count;
@@ -75,7 +75,7 @@ public class DeploymentStreamsProxy implements IStreamsProxy, IDeploymentListene
 	@Override
 	public void connectionOpened(final Device dev) {
 		currentDest = null;
-		outputStreamMonitor.message("<!--  Connected to device: " + dev.getName() + " -->\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+		outputStreamMonitor.message(MessageFormat.format(Messages.DeploymentStreamsProxy_ConnectedToDevice, dev.getName()));
 	}
 
 	@Override
@@ -95,12 +95,11 @@ public class DeploymentStreamsProxy implements IStreamsProxy, IDeploymentListene
 	}
 
 	private void printDeployStatistics() {
-		outputStreamMonitor.message("Deployed: " + currentDest + " with " + count + " elements\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-																									// }
+		outputStreamMonitor.message(MessageFormat.format(Messages.DeploymentStreamsProxy_DeployedElements, currentDest, count));
 	}
 
 	private void printDeployingResource(final String destination) {
-		outputStreamMonitor.message("Deploying: " + destination + "\n"); //$NON-NLS-1$ //$NON-NLS-2$
+		outputStreamMonitor.message(MessageFormat.format(Messages.DeploymentStreamsProxy_Deploying, destination));
 	}
 
 	@Override
@@ -131,8 +130,7 @@ public class DeploymentStreamsProxy implements IStreamsProxy, IDeploymentListene
 		if (currentDest != null && !currentDest.isBlank()) {
 			printDeployStatistics();
 		}
-
-		outputStreamMonitor.message("<!--  Disconnected from device: " + dev.getName() + " -->\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+		outputStreamMonitor.message(MessageFormat.format(Messages.DeploymentStreamsProxy_DisconnectedFromDevice, dev.getName()));
 	}
 
 	private String getFormattedXML(final String input) throws TransformerFactoryConfigurationError {

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/Messages.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Johannes Kepler University Linz
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Alois Zoitl - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.deployment.debug;
+
+import org.eclipse.osgi.util.NLS;
+
+@SuppressWarnings("squid:S3008") // tell sonar the java naming convention does not make sense for this class
+public class Messages extends NLS {
+	private static final String BUNDLE_NAME = Messages.class.getPackageName() + ".messages"; //$NON-NLS-1$
+
+	public static String DeploymentProcess_ExeceptionOccured;
+	public static String DeploymentProcess_Terminated;
+
+	public static String DeploymentStreamsProxy_ConnectedToDevice;
+
+	public static String DeploymentStreamsProxy_DeployedElements;
+
+	public static String DeploymentStreamsProxy_Deploying;
+
+	public static String DeploymentStreamsProxy_DisconnectedFromDevice;
+
+	static {
+		// initialize resource bundle
+		NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+	}
+
+	private Messages() {
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/messages.properties
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/messages.properties
@@ -1,0 +1,6 @@
+DeploymentProcess_ExeceptionOccured=Exception occurred: {0}
+DeploymentProcess_Terminated=Terminated\n
+DeploymentStreamsProxy_ConnectedToDevice=<\!--  Connected to device: {0} -->\n\n
+DeploymentStreamsProxy_DeployedElements=Deployed: {0} with {1} elements\n
+DeploymentStreamsProxy_Deploying=Deploying: {0}\n
+DeploymentStreamsProxy_DisconnectedFromDevice=<\!--  Disconnected from device: {0} -->\n\n


### PR DESCRIPTION
The DeploymentProcess uses now a user Job to show progress of deployment to the user.

Furthermore some clean-up around the deployment regarding translateable strings was done.

Fixes https://github.com/eclipse-4diac/4diac-ide/issues/272