### PR TITLE
Add call to prepare before setting inputs and inouts

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.eval.st/src/org/eclipse/fordiac/ide/model/eval/st/StructuredTextEvaluator.xtend
+++ b/plugins/org.eclipse.fordiac.ide.model.eval.st/src/org/eclipse/fordiac/ide/model/eval/st/StructuredTextEvaluator.xtend
@@ -664,6 +664,7 @@ abstract class StructuredTextEvaluator extends AbstractEvaluator {
 			error('''Cannot create evaluator for callable «receiver.type.eClass.name»''')
 			throw new UnsupportedOperationException('''Cannot create evaluator for callable «receiver.type.eClass.name»''')
 		}
+		eval.prepare
 		inputs.forEach [ parameter, argument |
 			if(argument !== null) eval.variables.get(parameter.name).value = argument.argument.evaluateExpression
 		]


### PR DESCRIPTION
In some cases the input values were lost when running internal FBs via the DeploymentEvaluator