### PR TITLE
Ensure that Property Sheet Refresh Does not Result in Changes #293

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/CommentPropertySection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/CommentPropertySection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Primetals Technologies Austria GmbH
+ * Copyright (c) 2023, 2024 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,7 +16,6 @@ package org.eclipse.fordiac.ide.application.properties;
 import org.eclipse.fordiac.ide.gef.properties.AbstractSection;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeCommentCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.Comment;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.swt.SWT;
@@ -36,13 +35,8 @@ public class CommentPropertySection extends AbstractSection {
 	}
 
 	@Override
-	public void refresh() {
-		if ((getType() != null)) {
-			final CommandStack commandStackBuffer = commandStack;
-			commandStack = null;
-			commentText.setText(getType().getComment() != null ? getType().getComment() : ""); //$NON-NLS-1$
-			commandStack = commandStackBuffer;
-		}
+	protected void performRefresh() {
+		commentText.setText(getType().getComment() != null ? getType().getComment() : ""); //$NON-NLS-1$
 	}
 
 	protected Composite createFBInfoContainer(final Composite parent) {

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/ConfigurableMoveFBSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/ConfigurableMoveFBSection.java
@@ -84,7 +84,7 @@ public class ConfigurableMoveFBSection extends AbstractSection implements Comman
 		if (null != getType() && newDataTypeSelected(newTypeName)) {
 			final DataType newDtp = getDataTypeLib().getTypeIfExists(newTypeName);
 			final ConfigureFBCommand cmd = new ConfigureFBCommand(getType(), newDtp);
-			commandStack.execute(cmd);
+			executeCommand(cmd);
 			updateFB(cmd.getNewElement());
 		}
 	}
@@ -113,14 +113,14 @@ public class ConfigurableMoveFBSection extends AbstractSection implements Comman
 
 	@Override
 	public void setInput(final IWorkbenchPart part, final ISelection selection) {
-		if (commandStack != null) {
-			commandStack.removeCommandStackEventListener(this);
+		if (getCurrentCommandStack() != null) {
+			getCurrentCommandStack().removeCommandStackEventListener(this);
 		}
 		Assert.isTrue(selection instanceof IStructuredSelection);
 		final Object input = ((IStructuredSelection) selection).getFirstElement();
 
-		commandStack = getCommandStack(part, input);
-		if (null == commandStack) { // disable all fields
+		setCurrentCommandStack(part, input);
+		if (null == getCurrentCommandStack()) { // disable all fields
 			configurableFbLabel.setEnabled(false);
 		}
 
@@ -129,16 +129,16 @@ public class ConfigurableMoveFBSection extends AbstractSection implements Comman
 		typeSelectionWidget.initialize(getType(), DataTypeSelectionContentProvider.INSTANCE,
 				DataTypeSelectionTreeContentProvider.INSTANCE);
 
-		if (commandStack != null) {
-			commandStack.addCommandStackEventListener(this);
+		if (getCurrentCommandStack() != null) {
+			getCurrentCommandStack().addCommandStackEventListener(this);
 		}
 	}
 
 	@Override
 	public void dispose() {
 		super.dispose();
-		if (commandStack != null) {
-			commandStack.removeCommandStackEventListener(this);
+		if (getCurrentCommandStack() != null) {
+			getCurrentCommandStack().removeCommandStackEventListener(this);
 		}
 	}
 
@@ -169,6 +169,11 @@ public class ConfigurableMoveFBSection extends AbstractSection implements Comman
 
 	@Override
 	protected void setInputInit() {
+		// Currently nothing needs to be done here
+	}
+
+	@Override
+	protected void performRefresh() {
 		// Currently nothing needs to be done here
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/CreateConnectionSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/CreateConnectionSection.java
@@ -1,6 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 fortiss GmbH
- * 				 2019 Johannes Kepler University Linz
+ * Copyright (c) 2017, 2024 fortiss GmbH, Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -35,7 +34,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
 import org.eclipse.gef.EditPart;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.swt.SWT;
@@ -102,7 +100,7 @@ public class CreateConnectionSection extends AbstractSection {
 				Messages.CreateConnectionSection_CreateConnection, SWT.PUSH);
 		createConnectionButton.setLayoutData(new GridData(SWT.NONE, SWT.FILL, false, true));
 		createConnectionButton
-		.setImage(PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_OBJ_ADD));
+				.setImage(PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_OBJ_ADD));
 		createConnectionButton.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(final SelectionEvent event) {
@@ -128,7 +126,8 @@ public class CreateConnectionSection extends AbstractSection {
 	private static FBNetwork getFBNetwork(final IInterfaceElement source, final IInterfaceElement dest) {
 		if (source.eContainer().eContainer() instanceof final CompositeFBType cfbt) {
 			return cfbt.getFBNetwork();
-		} else if ((source.getFBNetworkElement().getFbNetwork() != dest.getFBNetworkElement().getFbNetwork())
+		}
+		if ((source.getFBNetworkElement().getFbNetwork() != dest.getFBNetworkElement().getFbNetwork())
 				&& (source.getFBNetworkElement() instanceof final SubApp subApp)) {
 			// one of the both is a untyped subapp interface element
 			if (subApp.getSubAppNetwork() == dest.getFBNetworkElement().getFbNetwork()) {
@@ -142,8 +141,8 @@ public class CreateConnectionSection extends AbstractSection {
 	@Override
 	public void setInput(final IWorkbenchPart part, final ISelection selection) {
 		Assert.isTrue(selection instanceof IStructuredSelection);
-		commandStack = getCommandStack(part, selection);
-		if (null == commandStack) { // disable all fields
+		setCurrentCommandStack(part, selection);
+		if (null == getCurrentCommandStack()) { // disable all fields
 			commentText.setEnabled(false);
 			sourceText.setEnabled(false);
 			targetText.setEnabled(false);
@@ -152,14 +151,9 @@ public class CreateConnectionSection extends AbstractSection {
 	}
 
 	@Override
-	public void refresh() {
-		final CommandStack commandStackBuffer = commandStack;
-		commandStack = null;
-		if (null != type) {
-			sourceText.setText(getInterfaceName(true));
-			targetText.setText(getInterfaceName(false));
-		}
-		commandStack = commandStackBuffer;
+	protected void performRefresh() {
+		sourceText.setText(getInterfaceName(true));
+		targetText.setText(getInterfaceName(false));
 	}
 
 	private IInterfaceElement getInterfaceElement(final boolean source) {

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/GroupPropertySection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/GroupPropertySection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Primetals Technologies Austria GmbH
+ * Copyright (c) 2022, 2024 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -23,7 +23,6 @@ import org.eclipse.fordiac.ide.model.commands.change.ChangeNameCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.Group;
 import org.eclipse.fordiac.ide.ui.FordiacMessages;
 import org.eclipse.fordiac.ide.ui.editors.EditorUtils;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.swt.SWT;
@@ -62,16 +61,13 @@ public class GroupPropertySection extends AbstractDoubleColumnSection {
 	}
 
 	@Override
-	public void refresh() {
-		if ((getType() != null) && !nameText.isDisposed() && !nameText.getParent().isDisposed()) {
-			final CommandStack commandStackBuffer = commandStack;
-			commandStack = null;
+	protected void performRefresh() {
+		if (!nameText.isDisposed() && !nameText.getParent().isDisposed()) {
 			nameText.setText(getType().getName() != null ? getType().getName() : ""); //$NON-NLS-1$
 			commentText.setText(getType().getComment() != null ? getType().getComment() : ""); //$NON-NLS-1$
 			heightText.setText(Integer.toString(CoordinateConverter.INSTANCE.iec61499ToScreen(getType().getHeight())));
 			widthText.setText(Integer.toString(CoordinateConverter.INSTANCE.iec61499ToScreen(getType().getWidth())));
 			lockCheckbox.setSelection(getType().isLocked());
-			commandStack = commandStackBuffer;
 		}
 	}
 
@@ -179,7 +175,7 @@ public class GroupPropertySection extends AbstractDoubleColumnSection {
 		commentText.addModifyListener(e -> {
 			removeContentAdapter();
 
-			if (EditorUtils.getGraphicalViewerFromCurrentActiveEditor() != null && getType() instanceof Group) {
+			if (EditorUtils.getGraphicalViewerFromCurrentActiveEditor() != null && getType() != null) {
 				final Object groupforFBNetowrkEditPart = EditorUtils.getGraphicalViewerFromCurrentActiveEditor()
 						.getEditPartRegistry().get(getType());
 				if (groupforFBNetowrkEditPart instanceof final GroupEditPart gep && gep.getContentEP() != null) {

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/InstancePropertySection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/InstancePropertySection.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2022 Primetals Technologies Austria GmbH
- *               2023 Martin Erich Jobst
+ * Copyright (c) 2022, 2024 Primetals Technologies Austria GmbH,
+ *                          Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -45,7 +45,6 @@ import org.eclipse.fordiac.ide.ui.widget.NatTableColumnEditableRule;
 import org.eclipse.fordiac.ide.ui.widget.NatTableColumnProvider;
 import org.eclipse.fordiac.ide.ui.widget.NatTableWidgetFactory;
 import org.eclipse.gef.commands.Command;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
@@ -117,13 +116,10 @@ public class InstancePropertySection extends AbstractSection {
 	}
 
 	@Override
-	public void refresh() {
-		if ((getType() != null) && !nameText.isDisposed() && !nameText.getParent().isDisposed()) {
-			final CommandStack commandStackBuffer = commandStack;
-			commandStack = null;
+	protected void performRefresh() {
+		if (!nameText.isDisposed() && !nameText.getParent().isDisposed()) {
 			nameText.setText(getType().getName() != null ? getType().getName() : ""); //$NON-NLS-1$
 			commentText.setText(getType().getComment() != null ? getType().getComment() : ""); //$NON-NLS-1$
-			commandStack = commandStackBuffer;
 			outputTable.refresh();
 			inputTable.refresh();
 		}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/InterfaceElementSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/InterfaceElementSection.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 fortiss GmbH, Johannes Kepler University Linz,
- * 							Primetals Technologies Austria GmbH
- *               2023 Martin Erich Jobst
+ * Copyright (c) 2016, 2024 fortiss GmbH, Johannes Kepler University Linz,
+ * 							Primetals Technologies Austria GmbH,
+ *                          Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -44,7 +44,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.ui.widgets.OpenStructMenu;
 import org.eclipse.fordiac.ide.ui.FordiacMessages;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.swt.SWT;
@@ -161,44 +160,37 @@ public class InterfaceElementSection extends AbstractDoubleColumnSection {
 	}
 
 	@Override
-	public void refresh() {
-		final CommandStack commandStackBuffer = commandStack;
-		commandStack = null;
+	protected void performRefresh() {
+		refreshParameterVisibility();
+		final FBNetworkElement fb = getType().getFBNetworkElement();
+		if (fb != null) {
+			infoSection.setText(
+					MessageFormat.format(Messages.InterfaceElementSection_Instance, fb.getName(), getPinName()));
+		} else { // e.g., IP address of device
+			infoSection.setText(Messages.InterfaceElementSection_InterfaceElement);
+		}
+		typeCommentText.setText(CommentHelper.getTypeComment(getType()));
 
-		if (null != type) {
-			refreshParameterVisibility();
-			final FBNetworkElement fb = getType().getFBNetworkElement();
-			if (fb != null) {
-				infoSection.setText(
-						MessageFormat.format(Messages.InterfaceElementSection_Instance, fb.getName(), getPinName()));
-			} else { // e.g., IP address of device
-				infoSection.setText(Messages.InterfaceElementSection_InterfaceElement);
-			}
-			typeCommentText.setText(CommentHelper.getTypeComment(getType()));
+		configureOpenEditorButton();
 
-			configureOpenEditorButton();
+		instanceCommentText.setText(CommentHelper.getInstanceComment(getType()));
+		instanceCommentText.setForeground(getForegroundColor());
 
-			instanceCommentText.setText(CommentHelper.getInstanceComment(getType()));
-			instanceCommentText.setForeground(getForegroundColor());
+		refreshTypeInitialValue();
+		currentParameterEditor.setInterfaceElement(getType());
+		currentParameterEditor.refresh();
 
-			refreshTypeInitialValue();
-			currentParameterEditor.setInterfaceElement(getType());
-			currentParameterEditor.refresh();
+		typeText.setText(getPinTypeName());
 
-			typeText.setText(getPinTypeName());
+		connectionDisplayWidget.refreshConnectionsViewer(getType());
 
-			connectionDisplayWidget.refreshConnectionsViewer(getType());
-
-			if (getType() instanceof final VarDeclaration verDeclaration) {
-				currentVarConfigCheckBox.setSelection(verDeclaration.isVarConfig());
-			}
-
-			if (fb != null) {
-				setEditable(!fb.isContainedInTypedInstance());
-			}
+		if (getType() instanceof final VarDeclaration verDeclaration) {
+			currentVarConfigCheckBox.setSelection(verDeclaration.isVarConfig());
 		}
 
-		commandStack = commandStackBuffer;
+		if (fb != null) {
+			setEditable(!fb.isContainedInTypedInstance());
+		}
 	}
 
 	private void configureOpenEditorButton() {

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/PinEventInfoSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/PinEventInfoSection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Primetals Technologies Austria GmbH
+ * Copyright (c) 2022, 2024 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -27,7 +27,6 @@ import org.eclipse.fordiac.ide.model.ui.nat.EventTypeSelectionTreeContentProvide
 import org.eclipse.fordiac.ide.model.ui.widgets.EventTypeSelectionContentProvider;
 import org.eclipse.fordiac.ide.model.ui.widgets.ITypeSelectionContentProvider;
 import org.eclipse.gef.EditPart;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -87,17 +86,15 @@ public class PinEventInfoSection extends AbstractDoubleColumnSection {
 	@Override
 	protected EObject getInputType(final Object input) {
 		Object refType = input;
-		if (input instanceof EditPart) {
-			refType = ((EditPart) input).getModel();
+		if (input instanceof final EditPart ep) {
+			refType = ep.getModel();
 		}
-		return (refType instanceof IInterfaceElement) ? (IInterfaceElement) refType : null;
+		return (refType instanceof final IInterfaceElement ie) ? ie : null;
 	}
 
 	@Override
-	public void refresh() {
-		final CommandStack commandStackBuffer = commandStack;
-		commandStack = null;
-		if (null != pinInfo && null != inConnections && null != outConnections && null != getType()) {
+	protected void performRefresh() {
+		if (null != pinInfo && null != inConnections && null != outConnections) {
 			pinInfo.refresh();
 			inConnections.refreshConnectionsViewer(getType());
 			outConnections.refreshConnectionsViewer(getType());
@@ -107,7 +104,6 @@ public class PinEventInfoSection extends AbstractDoubleColumnSection {
 				outConnections.setEditable(true);
 			}
 		}
-		commandStack = commandStackBuffer;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/StructManipulatorSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/StructManipulatorSection.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Johannes Kepler University Linz
- *                          Primetals Technologies Austria GmbH
+ * Copyright (c) 2020, 2024 Johannes Kepler University Linz,
+ *                          Primetals Technologies Austria GmbH,
  *                          Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
@@ -137,7 +137,7 @@ public class StructManipulatorSection extends AbstractSection implements Command
 			}
 
 			final ChangeStructCommand cmd = new ChangeStructCommand(getType(), newStruct);
-			commandStack.execute(cmd.chain(importCommand));
+			executeCommand(cmd.chain(importCommand));
 			updateStructManipulatorFB(cmd.getNewMux());
 		}
 	}
@@ -252,22 +252,22 @@ public class StructManipulatorSection extends AbstractSection implements Command
 	}
 
 	@Override
-	public void refresh() {
-		if ((null != getType()) && (null != getType().getFbNetwork()) && !blockRefresh) {
+	protected void performRefresh() {
+		if ((null != getType().getFbNetwork()) && !blockRefresh) {
 			refreshStructTypeTable();
 		}
 	}
 
 	@Override
 	public void setInput(final IWorkbenchPart part, final ISelection selection) {
-		if (commandStack != null) {
-			commandStack.removeCommandStackEventListener(this);
+		if (getCurrentCommandStack() != null) {
+			getCurrentCommandStack().removeCommandStackEventListener(this);
 		}
 		Assert.isTrue(selection instanceof IStructuredSelection);
 		final Object input = ((IStructuredSelection) selection).getFirstElement();
 
-		commandStack = getCommandStack(part, input);
-		if (null == commandStack) { // disable all fields
+		setCurrentCommandStack(part, input);
+		if (null == getCurrentCommandStack()) { // disable all fields
 			muxLabel.setEnabled(false);
 			memberVarViewer.setInput(null);
 		}
@@ -280,8 +280,8 @@ public class StructManipulatorSection extends AbstractSection implements Command
 		typeSelectionWidget.initialize(getType(), StructuredTypeSelectionContentProvider.INSTANCE,
 				StructuredTypeSelectionTreeContentProvider.INSTANCE);
 
-		if (commandStack != null) {
-			commandStack.addCommandStackEventListener(this);
+		if (getCurrentCommandStack() != null) {
+			getCurrentCommandStack().addCommandStackEventListener(this);
 		}
 	}
 
@@ -302,8 +302,8 @@ public class StructManipulatorSection extends AbstractSection implements Command
 	@Override
 	public void dispose() {
 		super.dispose();
-		if (commandStack != null) {
-			commandStack.removeCommandStackEventListener(this);
+		if (getCurrentCommandStack() != null) {
+			getCurrentCommandStack().removeCommandStackEventListener(this);
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/SubAppPropertySection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/SubAppPropertySection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Primetals Technologies Austria GmbH
+ * Copyright (c) 2023, 2024 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,7 +18,6 @@ import org.eclipse.fordiac.ide.model.commands.change.ChangeSubAppBoundsCommand;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeSubAppSizeLockCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
 import org.eclipse.fordiac.ide.ui.FordiacMessages;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.swt.SWT;
@@ -114,16 +113,11 @@ public class SubAppPropertySection extends InstancePropertySection {
 	}
 
 	@Override
-	public void refresh() {
-		super.refresh();
-		if ((getType() != null)) {
-			final CommandStack commandStackBuffer = commandStack;
-			commandStack = null;
-			heightText.setText(Integer.toString(CoordinateConverter.INSTANCE.iec61499ToScreen(getType().getHeight())));
-			widthText.setText(Integer.toString(CoordinateConverter.INSTANCE.iec61499ToScreen(getType().getWidth())));
-			lockCheckbox.setSelection(getType().isLocked());
-			commandStack = commandStackBuffer;
-		}
+	protected void performRefresh() {
+		super.performRefresh();
+		heightText.setText(Integer.toString(CoordinateConverter.INSTANCE.iec61499ToScreen(getType().getHeight())));
+		widthText.setText(Integer.toString(CoordinateConverter.INSTANCE.iec61499ToScreen(getType().getWidth())));
+		lockCheckbox.setSelection(getType().isLocked());
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/VarConfigurationSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/VarConfigurationSection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2023 Primetals Technologies Austria GmbH
+ * Copyright (c) 2022, 2024 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -143,7 +143,11 @@ public class VarConfigurationSection extends AbstractSection {
 	protected void setInputInit() {
 		inputDataProvider.setInput(collectVarConfigs());
 		inputTable.refresh();
+	}
 
+	@Override
+	protected void performRefresh() {
+		// currently nothing to do
 	}
 
 	private List<VarDeclaration> collectVarConfigs() {

--- a/plugins/org.eclipse.fordiac.ide.datatypeeditor/src/org/eclipse/fordiac/ide/datatypeeditor/properties/DataTypeInfoSection.java
+++ b/plugins/org.eclipse.fordiac.ide.datatypeeditor/src/org/eclipse/fordiac/ide/datatypeeditor/properties/DataTypeInfoSection.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2020 Johannes Kepler University, Linz
- * 				 2021 Primetals Technologies Austria GmbH
+ * Copyright (c) 2020, 2024 Johannes Kepler University, Linz,
+ *                          Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -94,11 +94,9 @@ public class DataTypeInfoSection extends AbstractSection {
 	}
 
 	@Override
-	public void refresh() {
-		if (null != getType()) {
-			commentText.setText((null != getType().getComment()) ? getType().getComment() : ""); //$NON-NLS-1$
-			typeInfoWidget.refresh();
-		}
+	protected void performRefresh() {
+		commentText.setText((null != getType().getComment()) ? getType().getComment() : ""); //$NON-NLS-1$
+		typeInfoWidget.refresh();
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/properties/ActionSection.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/properties/ActionSection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2023 fortiss GmbH, Johannes Kepler University Linz (JKU)
+ * Copyright (c) 2015, 2024 fortiss GmbH, Johannes Kepler University Linz (JKU)
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -33,7 +33,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.BasicFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.ECAction;
 import org.eclipse.fordiac.ide.model.libraryElement.Event;
 import org.eclipse.fordiac.ide.ui.widget.ComboBoxWidgetFactory;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.swt.SWT;
@@ -73,17 +72,17 @@ public class ActionSection extends AbstractSection {
 
 	@Override
 	protected Object getInputType(final Object input) {
-		if (input instanceof ECActionAlgorithmEditPart) {
-			return ((ECActionAlgorithmEditPart) input).getAction();
+		if (input instanceof final ECActionAlgorithmEditPart aaEP) {
+			return aaEP.getAction();
 		}
-		if (input instanceof ECActionAlgorithm) {
-			return ((ECActionAlgorithm) input).getAction();
+		if (input instanceof final ECActionAlgorithm aa) {
+			return aa.getAction();
 		}
-		if (input instanceof ECActionOutputEventEditPart) {
-			return ((ECActionOutputEventEditPart) input).getAction();
+		if (input instanceof final ECActionOutputEventEditPart oeEP) {
+			return oeEP.getAction();
 		}
-		if (input instanceof ECActionOutputEvent) {
-			return ((ECActionOutputEvent) input).getAction();
+		if (input instanceof final ECActionOutputEvent oe) {
+			return oe.getAction();
 		}
 		if (input instanceof ECAction) {
 			return input;
@@ -144,8 +143,8 @@ public class ActionSection extends AbstractSection {
 	public void setInput(final IWorkbenchPart part, final ISelection selection) {
 		Assert.isTrue(selection instanceof IStructuredSelection);
 		final Object input = ((IStructuredSelection) selection).getFirstElement();
-		commandStack = getCommandStack(part, input);
-		if (null == commandStack) { // disable all fields
+		setCurrentCommandStack(part, input);
+		if (null == getCurrentCommandStack()) { // disable all fields
 			outputEventCombo.removeAll();
 			outputEventCombo.setEnabled(false);
 			algorithmCombo.removeAll();
@@ -160,10 +159,8 @@ public class ActionSection extends AbstractSection {
 	}
 
 	@Override
-	public void refresh() {
-		final CommandStack commandStackBuffer = commandStack;
-		commandStack = null;
-		if ((null != type) && (null != getFBType())) {
+	protected void performRefresh() {
+		if (getFBType() != null) {
 			// during delete phases it can be that the input (i.e., Action) is not attached
 			// to its type anymore. Therefore also the check if getFBType() is not null
 			updateDropdown(outputEventCombo, ECCContentAndLabelProvider.getOutputEventNames(getFBType()));
@@ -177,7 +174,6 @@ public class ActionSection extends AbstractSection {
 			algorithmGroup.setAlgorithm(getAlgorithm());
 			algorithmList.refresh();
 		}
-		commandStack = commandStackBuffer;
 	}
 
 	private static void updateDropdown(final CCombo comboBox, final List<String> names) {
@@ -192,7 +188,7 @@ public class ActionSection extends AbstractSection {
 
 	private void selectAlgorithm(final Algorithm alg) {
 		algorithmCombo
-		.select((null == alg) ? algorithmCombo.getItemCount() - 1 : algorithmCombo.indexOf(alg.getName()));
+				.select((null == alg) ? algorithmCombo.getItemCount() - 1 : algorithmCombo.indexOf(alg.getName()));
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/properties/AlgorithmsSection.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/properties/AlgorithmsSection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2022 fortiss GmbH, Johannes Kepler University Linz (JKU)
+ * Copyright (c) 2015, 2024 fortiss GmbH, Johannes Kepler University Linz (JKU)
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -54,7 +54,8 @@ public class AlgorithmsSection extends AbstractSection {
 		algorithmList = new AlgorithmList(view, getWidgetFactory());
 
 		getAlgorithmList().getViewer().addSelectionChangedListener(event -> {
-			final Object selection = ((IStructuredSelection) getAlgorithmList().getViewer().getSelection()).getFirstElement();
+			final Object selection = ((IStructuredSelection) getAlgorithmList().getViewer().getSelection())
+					.getFirstElement();
 			algorithmGroup.setAlgorithm((selection instanceof final Algorithm alg) ? alg : null);
 		});
 
@@ -81,12 +82,8 @@ public class AlgorithmsSection extends AbstractSection {
 	}
 
 	@Override
-	public void refresh() {
+	protected void performRefresh() {
 		getAlgorithmList().refresh();
 	}
-
-
-
-
 
 }

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/properties/StateSection.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/properties/StateSection.java
@@ -1,6 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 - 2017 fortiss GmbH
- * 				 2019 Johannes Kepler University Linz
+ * Copyright (c) 2015, 2024 fortiss GmbH, Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -29,7 +28,6 @@ import org.eclipse.fordiac.ide.model.commands.change.ChangeCommentCommand;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeNameCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.ECState;
 import org.eclipse.gef.EditPart;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -101,22 +99,17 @@ public class StateSection extends AbstractSection {
 	}
 
 	@Override
-	public void refresh() {
+	protected void performRefresh() {
 		actionGroup.refresh();
 		transitionGroup.refresh();
-		final CommandStack commandStackBuffer = commandStack;
-		commandStack = null;
-		if (null != type) {
-			stateCommentText.setText(getType().getComment() != null ? getType().getComment() : ""); //$NON-NLS-1$
-			stateNameText.setText(getType().getName() != null ? getType().getName() : ""); //$NON-NLS-1$
-		}
-		commandStack = commandStackBuffer;
+		stateCommentText.setText(getType().getComment() != null ? getType().getComment() : ""); //$NON-NLS-1$
+		stateNameText.setText(getType().getName() != null ? getType().getName() : ""); //$NON-NLS-1$
 	}
 
 	@Override
 	protected void setInputInit() {
 		// we have to do this here because at this point in time we have a valid type
-		actionGroup.setTypeAndCommandStack(getType(), commandStack);
-		transitionGroup.setTypeAndCommandStack(getType(), commandStack);
+		actionGroup.setTypeAndCommandStack(getType(), getCurrentCommandStack());
+		transitionGroup.setTypeAndCommandStack(getType(), getCurrentCommandStack());
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/properties/TransitionSection.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/properties/TransitionSection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2023 fortiss GmbH, Johannes Kepler University Linz,
+ * Copyright (c) 2015, 2024 fortiss GmbH, Johannes Kepler University Linz,
  *                          Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
@@ -37,7 +37,6 @@ import org.eclipse.fordiac.ide.structuredtextalgorithm.ui.editor.embedded.STAlgo
 import org.eclipse.fordiac.ide.ui.providers.SourceViewerColorProvider;
 import org.eclipse.fordiac.ide.ui.widget.ComboBoxWidgetFactory;
 import org.eclipse.gef.EditPart;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.jface.text.DocumentEvent;
@@ -51,7 +50,10 @@ import org.eclipse.xtext.ui.editor.embedded.EmbeddedEditor;
 import org.eclipse.xtext.ui.editor.embedded.EmbeddedEditorModelAccess;
 import org.eclipse.xtext.ui.editor.embedded.IEditedResourceProvider;
 
-/** Section that appears in the Properties view, when a Transition is selected in the ECC */
+/**
+ * Section that appears in the Properties view, when a Transition is selected in
+ * the ECC
+ */
 @SuppressWarnings("restriction")
 public class TransitionSection extends AbstractSection {
 	private Text commentText;
@@ -179,10 +181,8 @@ public class TransitionSection extends AbstractSection {
 	}
 
 	@Override
-	public void refresh() {
-		final CommandStack commandStackBuffer = commandStack;
-		commandStack = null;
-		if ((null != type) && (null != getBasicFBType())) {
+	protected void performRefresh() {
+		if (null != getBasicFBType()) {
 			fillEventConditionDropdown();
 			commentText.setText(getType().getComment() != null ? getType().getComment() : ""); //$NON-NLS-1$
 			if ((getType().getConditionExpression() != null)
@@ -195,7 +195,6 @@ public class TransitionSection extends AbstractSection {
 			}
 			updateConditionEditor();
 		}
-		commandStack = commandStackBuffer;
 	}
 
 	private int getEventIndex(final Event conditionEvent) {
@@ -205,6 +204,6 @@ public class TransitionSection extends AbstractSection {
 	public void fillEventConditionDropdown() {
 		eventCombo.removeAll();
 		ECCContentAndLabelProvider.getTransitionConditionEventNames(getBasicFBType()).stream()
-		.forEach(name -> eventCombo.add(name));
+				.forEach(name -> eventCombo.add(name));
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/properties/AbstractPrimitiveSection.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/properties/AbstractPrimitiveSection.java
@@ -1,6 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 - 2017 fortiss GmbH
- *               2019, 2021 Johannes Kepler University Linz
+ * Copyright (c) 2014, 2024 fortiss GmbH, Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -34,7 +33,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.InputPrimitive;
 import org.eclipse.fordiac.ide.model.libraryElement.OutputPrimitive;
 import org.eclipse.fordiac.ide.model.libraryElement.Primitive;
 import org.eclipse.fordiac.ide.ui.widget.ComboBoxWidgetFactory;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CCombo;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -48,7 +46,6 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.views.properties.tabbed.TabbedPropertySheetPage;
 
 public abstract class AbstractPrimitiveSection extends AbstractDoubleColumnSection {
-
 
 	private Text parametersText;
 	private CCombo eventCombo;
@@ -71,7 +68,6 @@ public abstract class AbstractPrimitiveSection extends AbstractDoubleColumnSecti
 		fillDataQualifyingDropdown();
 		dataQualifyingCombo.setToolTipText(Messages.PrimitiveSection_DataQualifyingToolTip);
 	}
-
 
 	protected void createEventSection(final Group parent) {
 		final Composite composite = getWidgetFactory().createComposite(parent);
@@ -192,23 +188,18 @@ public abstract class AbstractPrimitiveSection extends AbstractDoubleColumnSecti
 	}
 
 	@Override
-	public void refresh() {
-		final CommandStack commandStackBuffer = commandStack;
-		commandStack = null;
-		if (null != type) {
-			parametersText.setText(getType().getParameters() != null ? getType().getParameters() : ""); //$NON-NLS-1$
-			interfaceSelector.setType(getType());
-			setEventDropdown();
-			setDataQualifyingDropdown();
+	protected void performRefresh() {
+		parametersText.setText(getType().getParameters() != null ? getType().getParameters() : ""); //$NON-NLS-1$
+		interfaceSelector.setType(getType());
+		setEventDropdown();
+		setDataQualifyingDropdown();
 
-			final IInterfaceElement qiData = getType().getService().getFBType().getInterfaceList()
-					.getInterfaceElement("QI"); //$NON-NLS-1$
+		final IInterfaceElement qiData = getType().getService().getFBType().getInterfaceList()
+				.getInterfaceElement("QI"); //$NON-NLS-1$
 
-			dataQualifyingCombo.setEnabled(qiData != null && !checkBox.getSelection());
-			customEventText.setEnabled(checkBox.getSelection());
-			eventCombo.setEnabled(!checkBox.getSelection());
-		}
-		commandStack = commandStackBuffer;
+		dataQualifyingCombo.setEnabled(qiData != null && !checkBox.getSelection());
+		customEventText.setEnabled(checkBox.getSelection());
+		eventCombo.setEnabled(!checkBox.getSelection());
 	}
 
 	protected abstract EList<Event> getRelevantEvents(final FBType fb);
@@ -258,10 +249,10 @@ public abstract class AbstractPrimitiveSection extends AbstractDoubleColumnSecti
 		String currentEvent = getType().getEvent();
 
 		// handle qualifier QI
-		if(!currentEvent.isEmpty()) {
+		if (!currentEvent.isEmpty()) {
 			final char lastChar = currentEvent.charAt(currentEvent.length() - 1);
 			if (!(Character.isLetterOrDigit(lastChar) || (lastChar == ASCII_UNDERSCORE))) {
-				currentEvent = currentEvent.substring(0, currentEvent.length()-1);
+				currentEvent = currentEvent.substring(0, currentEvent.length() - 1);
 			}
 		}
 

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/properties/ServiceSection.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/properties/ServiceSection.java
@@ -1,6 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 - 2016 fortiss GmbH
- * 				 2019, 2021 Johannes Kepler University Linz
+ * Copyright (c) 2014, 2024 fortiss GmbH, Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -37,7 +36,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.OutputPrimitive;
 import org.eclipse.fordiac.ide.model.libraryElement.Service;
 import org.eclipse.fordiac.ide.model.libraryElement.ServiceSequence;
 import org.eclipse.fordiac.ide.model.libraryElement.ServiceTransaction;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.viewers.TreeSelection;
 import org.eclipse.jface.viewers.TreeViewer;
@@ -197,13 +195,12 @@ public class ServiceSection extends AbstractSection {
 
 	private void executeCreateCommand() {
 		final Object selection = ((TreeSelection) sequencesViewer.getSelection()).getFirstElement();
-		if (selection instanceof ServiceSequence) {
-			executeCommand(new CreateServiceSequenceCommand(getType().getService(), (ServiceSequence) selection));
-		} else if (selection instanceof ServiceTransaction) {
-			executeCommand(new CreateTransactionCommand(((ServiceTransaction) selection).getServiceSequence()));
-		} else if (selection instanceof OutputPrimitive) {
-			executeCommand(new CreateOutputPrimitiveCommand(((OutputPrimitive) selection).getServiceTransaction(), null,
-					true));
+		if (selection instanceof final ServiceSequence serSeq) {
+			executeCommand(new CreateServiceSequenceCommand(getType().getService(), serSeq));
+		} else if (selection instanceof final ServiceTransaction serTran) {
+			executeCommand(new CreateTransactionCommand(serTran.getServiceSequence()));
+		} else if (selection instanceof final OutputPrimitive op) {
+			executeCommand(new CreateOutputPrimitiveCommand(op.getServiceTransaction(), null, true));
 		} else if (selection == null) {
 			executeCommand(new CreateServiceSequenceCommand(getType().getService()));
 		}
@@ -212,50 +209,45 @@ public class ServiceSection extends AbstractSection {
 
 	private void executeMoveCommand(final boolean moveUp) {
 		final Object selection = ((TreeSelection) sequencesViewer.getSelection()).getFirstElement();
-		if (selection instanceof ServiceSequence) {
-			executeCommand(new ChangeServiceSequenceOrderCommand((ServiceSequence) selection, moveUp));
-		} else if (selection instanceof ServiceTransaction) {
-			executeCommand(new ChangeTransactionOrderCommand((ServiceTransaction) selection, moveUp));
-		} else if (selection instanceof OutputPrimitive) {
-			executeCommand(new ChangeOutputPrimitiveOrderCommand((OutputPrimitive) selection, moveUp));
+		if (selection instanceof final ServiceSequence serSeq) {
+			executeCommand(new ChangeServiceSequenceOrderCommand(serSeq, moveUp));
+		} else if (selection instanceof final ServiceTransaction serTran) {
+			executeCommand(new ChangeTransactionOrderCommand(serTran, moveUp));
+		} else if (selection instanceof final OutputPrimitive op) {
+			executeCommand(new ChangeOutputPrimitiveOrderCommand(op, moveUp));
 		}
 		sequencesViewer.refresh();
 	}
 
 	private void executeDeleteCommand() {
 		final Object selection = ((TreeSelection) sequencesViewer.getSelection()).getFirstElement();
-		if (selection instanceof ServiceSequence) {
-			executeCommand(new DeleteServiceSequenceCommand(getType(), (ServiceSequence) selection));
-		} else if (selection instanceof ServiceTransaction) {
-			executeCommand(new DeleteTransactionCommand((ServiceTransaction) selection));
-		} else if (selection instanceof OutputPrimitive) {
-			executeCommand(new DeleteOutputPrimitiveCommand((OutputPrimitive) selection));
+		if (selection instanceof final ServiceSequence serSeq) {
+			executeCommand(new DeleteServiceSequenceCommand(getType(), serSeq));
+		} else if (selection instanceof final ServiceTransaction serTran) {
+			executeCommand(new DeleteTransactionCommand(serTran));
+		} else if (selection instanceof final OutputPrimitive op) {
+			executeCommand(new DeleteOutputPrimitiveCommand(op));
 		}
 		sequencesViewer.refresh();
 	}
 
 	@Override
-	public void refresh() {
-		final CommandStack commandStackBuffer = commandStack;
-		commandStack = null;
-		if (null != type) {
-			leftNameInput.setText(null != getType().getService().getLeftInterface()
-					? getType().getService().getLeftInterface().getName()
-							: ""); //$NON-NLS-1$
-			leftCommentInput.setText(null != getType().getService().getLeftInterface()
-					&& null != getType().getService().getLeftInterface().getComment()
-					? getType().getService().getLeftInterface().getComment()
-							: ""); //$NON-NLS-1$
-			rightNameInput.setText(null != getType().getService().getRightInterface()
-					? getType().getService().getRightInterface().getName()
-							: ""); //$NON-NLS-1$
-			rightCommentInput.setText(null != getType().getService().getRightInterface()
-					&& null != getType().getService().getRightInterface().getComment()
-					? getType().getService().getRightInterface().getComment()
-							: ""); //$NON-NLS-1$
-			sequencesViewer.setInput(getType().getService());
-		}
-		commandStack = commandStackBuffer;
+	protected void performRefresh() {
+		leftNameInput.setText(
+				null != getType().getService().getLeftInterface() ? getType().getService().getLeftInterface().getName()
+						: ""); //$NON-NLS-1$
+		leftCommentInput.setText(null != getType().getService().getLeftInterface()
+				&& null != getType().getService().getLeftInterface().getComment()
+						? getType().getService().getLeftInterface().getComment()
+						: ""); //$NON-NLS-1$
+		rightNameInput.setText(null != getType().getService().getRightInterface()
+				? getType().getService().getRightInterface().getName()
+				: ""); //$NON-NLS-1$
+		rightCommentInput.setText(null != getType().getService().getRightInterface()
+				&& null != getType().getService().getRightInterface().getComment()
+						? getType().getService().getRightInterface().getComment()
+						: ""); //$NON-NLS-1$
+		sequencesViewer.setInput(getType().getService());
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/properties/ServiceSequenceSection.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/properties/ServiceSequenceSection.java
@@ -1,6 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 - 2016 fortiss GmbH
- *               2019, 2021 Johannes Kepler University Linz
+ * Copyright (c) 2014, 2024 fortiss GmbH, Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -41,7 +40,6 @@ import org.eclipse.fordiac.ide.ui.widget.AddDeleteReorderListWidget;
 import org.eclipse.fordiac.ide.ui.widget.ComboBoxWidgetFactory;
 import org.eclipse.fordiac.ide.ui.widget.TableWidgetFactory;
 import org.eclipse.gef.commands.Command;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.jface.viewers.ColumnPixelData;
 import org.eclipse.jface.viewers.ITableLabelProvider;
 import org.eclipse.jface.viewers.LabelProvider;
@@ -79,11 +77,11 @@ public class ServiceSequenceSection extends AbstractSection {
 
 	@Override
 	protected ServiceSequence getInputType(final Object input) {
-		if (input instanceof ServiceSequenceEditPart) {
-			return ((ServiceSequenceEditPart) input).getModel();
+		if (input instanceof final ServiceSequenceEditPart serSeqEP) {
+			return serSeqEP.getModel();
 		}
-		if (input instanceof ServiceSequence) {
-			return (ServiceSequence) input;
+		if (input instanceof final ServiceSequence serSeq) {
+			return serSeq;
 		}
 		return null;
 	}
@@ -146,7 +144,8 @@ public class ServiceSequenceSection extends AbstractSection {
 	}
 
 	private void createTransactionSection(final Composite parent) {
-		final Group transactionGroup = getWidgetFactory().createGroup(parent, Messages.ServiceSequenceSection_Transaction);
+		final Group transactionGroup = getWidgetFactory().createGroup(parent,
+				Messages.ServiceSequenceSection_Transaction);
 		transactionGroup.setLayout(new GridLayout(2, false));
 		transactionGroup.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
@@ -163,7 +162,7 @@ public class ServiceSequenceSection extends AbstractSection {
 		return combo;
 	}
 
-	private CCombo createStartStateSelector(final Group parent) {
+	private static CCombo createStartStateSelector(final Group parent) {
 		return ComboBoxWidgetFactory.createCombo(parent);
 	}
 
@@ -217,21 +216,14 @@ public class ServiceSequenceSection extends AbstractSection {
 	}
 
 	@Override
-	public void refresh() {
-		final CommandStack commandStackBuffer = commandStack;
-		commandStack = null;
-		if (null != type) {
-			nameText.setText(getType().getName() != null ? getType().getName() : ""); //$NON-NLS-1$
-			commentText.setText(getType().getComment() != null ? getType().getComment() : ""); //$NON-NLS-1$
-			final int i = Arrays.asList(serviceSequencetype.getItems()).indexOf(getType().getServiceSequenceType());
-			serviceSequencetype.select(i >= 0 ? i : 0);
-			final FBType fbtype = getType().getService().getFBType();
-			StateComboHelper.setup(fbtype, getType(), startState);
-
-			transactionsViewer.setInput(getType());
-
-		}
-		commandStack = commandStackBuffer;
+	protected void performRefresh() {
+		nameText.setText(getType().getName() != null ? getType().getName() : ""); //$NON-NLS-1$
+		commentText.setText(getType().getComment() != null ? getType().getComment() : ""); //$NON-NLS-1$
+		final int i = Arrays.asList(serviceSequencetype.getItems()).indexOf(getType().getServiceSequenceType());
+		serviceSequencetype.select(i >= 0 ? i : 0);
+		final FBType fbtype = getType().getService().getFBType();
+		StateComboHelper.setup(fbtype, getType(), startState);
+		transactionsViewer.setInput(getType());
 	}
 
 	@Override
@@ -259,13 +251,11 @@ public class ServiceSequenceSection extends AbstractSection {
 
 		@Override
 		public String getColumnText(final Object element, final int columnIndex) {
-			if (element instanceof ServiceTransaction) {
-				final ServiceTransaction transaction = (ServiceTransaction) element;
+			if (element instanceof final ServiceTransaction transaction) {
 				switch (columnIndex) {
 				case INDEX_COL_INDEX:
 					return String
-							.valueOf(transaction.getServiceSequence().getServiceTransaction()
-									.indexOf(transaction) + 1);
+							.valueOf(transaction.getServiceSequence().getServiceTransaction().indexOf(transaction) + 1);
 				case INPUT_PRIMITIVE_COL_INDEX:
 					return transaction.getInputPrimitive().getEvent();
 				case OUTPUT_PRIMITIVE_COL_INDEX:
@@ -279,7 +269,7 @@ public class ServiceSequenceSection extends AbstractSection {
 
 		private static String getOutputPrimitives(final ServiceTransaction transaction) {
 			final StringBuilder sb = new StringBuilder();
-			for(final OutputPrimitive outputPrimitive : transaction.getOutputPrimitive()) {
+			for (final OutputPrimitive outputPrimitive : transaction.getOutputPrimitive()) {
 				sb.append(outputPrimitive.getEvent());
 				sb.append("; "); //$NON-NLS-1$
 			}

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/properties/TransactionSection.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/properties/TransactionSection.java
@@ -1,6 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2017 fortiss GmbH
- * 		         2019, 2021 Johannes Kepler University Linz
+ * Copyright (c) 2014, 2024 fortiss GmbH, Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -39,7 +38,6 @@ import org.eclipse.fordiac.ide.ui.widget.AddDeleteReorderListWidget;
 import org.eclipse.fordiac.ide.ui.widget.ComboBoxWidgetFactory;
 import org.eclipse.fordiac.ide.ui.widget.TableWidgetFactory;
 import org.eclipse.gef.commands.Command;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.CellEditor;
 import org.eclipse.jface.viewers.CheckboxCellEditor;
@@ -77,7 +75,7 @@ public class TransactionSection extends AbstractSection {
 	private CCombo eventNameInput;
 	private Text parameterNameInput;
 
-	private static final String INTERFACE = "";  //$NON-NLS-1$
+	private static final String INTERFACE = ""; //$NON-NLS-1$
 	private static final String INDEX = "index"; //$NON-NLS-1$
 	private static final String NAME = "name"; //$NON-NLS-1$
 	private static final String PARAM = "parameter"; //$NON-NLS-1$
@@ -115,7 +113,6 @@ public class TransactionSection extends AbstractSection {
 			executeCommand(cmd);
 			refresh();
 		});
-
 
 		getWidgetFactory().createCLabel(composite, Messages.ServiceSection_Name);
 
@@ -160,8 +157,8 @@ public class TransactionSection extends AbstractSection {
 	}
 
 	private String[] getOutputEventNames() {
-		return (getType().getServiceSequence().getService().getFBType()).getInterfaceList().getEventOutputs()
-				.stream().map(Event::getName).toArray(String[]::new);
+		return (getType().getServiceSequence().getService().getFBType()).getInterfaceList().getEventOutputs().stream()
+				.map(Event::getName).toArray(String[]::new);
 	}
 
 	private static String[] getColumnProperties() {
@@ -184,7 +181,6 @@ public class TransactionSection extends AbstractSection {
 		layout.addColumnData(new ColumnPixelData(PARAMETER_COL_WIDTH));
 		return layout;
 	}
-
 
 	private void configureButtonList(final AddDeleteReorderListWidget buttons, final TableViewer primitiveViewer) {
 		buttons.bindToTableViewer(primitiveViewer, this, ref -> newCreateCommand((OutputPrimitive) ref, true),
@@ -257,23 +253,17 @@ public class TransactionSection extends AbstractSection {
 	}
 
 	@Override
-	public void refresh() {
-		super.refresh();
-		final CommandStack commandStackBuffer = commandStack;
-		commandStack = null;
-		if (null != type) {
-			interfaceSelector.setType(getType().getInputPrimitive());
-			outputPrimitivesViewer.setInput(getType());
-			outputsGroup.setText(getInterfaceNames());
-			fillEventNameInputDropdown();
-			eventNameInput.setText(getType().getInputPrimitive().getEvent());
-			if (getType().getInputPrimitive().getParameters() == null) {
-				parameterNameInput.setText(""); //$NON-NLS-1$
-			} else {
-				parameterNameInput.setText(getType().getInputPrimitive().getParameters());
-			}
+	protected void performRefresh() {
+		interfaceSelector.setType(getType().getInputPrimitive());
+		outputPrimitivesViewer.setInput(getType());
+		outputsGroup.setText(getInterfaceNames());
+		fillEventNameInputDropdown();
+		eventNameInput.setText(getType().getInputPrimitive().getEvent());
+		if (getType().getInputPrimitive().getParameters() == null) {
+			parameterNameInput.setText(""); //$NON-NLS-1$
+		} else {
+			parameterNameInput.setText(getType().getInputPrimitive().getParameters());
 		}
-		commandStack = commandStackBuffer;
 	}
 
 	private void fillEventNameInputDropdown() {
@@ -288,8 +278,8 @@ public class TransactionSection extends AbstractSection {
 
 	@Override
 	protected Object getInputType(final Object input) {
-		if (input instanceof TransactionEditPart) {
-			return ((TransactionEditPart) input).getModel();
+		if (input instanceof final TransactionEditPart transEP) {
+			return transEP.getModel();
 		}
 		if (input instanceof ServiceTransaction) {
 			return input;
@@ -316,8 +306,7 @@ public class TransactionSection extends AbstractSection {
 
 		@Override
 		public String getColumnText(final Object element, final int columnIndex) {
-			if (element instanceof Primitive) {
-				final Primitive primitive = (Primitive) element;
+			if (element instanceof final Primitive primitive) {
 				switch (columnIndex) {
 				case INTERFACE_COL_INDEX:
 					return ""; //$NON-NLS-1$
@@ -328,7 +317,7 @@ public class TransactionSection extends AbstractSection {
 					return primitive.getEvent();
 				case PARAM_COL_INDEX:
 					if (primitive.getParameters() == null) {
-						return "";  //$NON-NLS-1$
+						return ""; //$NON-NLS-1$
 					}
 					return primitive.getParameters();
 				default:
@@ -340,8 +329,7 @@ public class TransactionSection extends AbstractSection {
 
 		@Override
 		public Image getColumnImage(final Object object, final int columnIndex) {
-			if ((object instanceof Primitive) && (columnIndex == INTERFACE_COL_INDEX)) {
-				final Primitive primitive = (Primitive) object;
+			if ((object instanceof final Primitive primitive) && (columnIndex == INTERFACE_COL_INDEX)) {
 				if (primitive.getInterface().isLeftInterface()) {
 					return FordiacImage.ICON_LEFT_INPUT_PRIMITIVE.getImage();
 				}
@@ -351,7 +339,6 @@ public class TransactionSection extends AbstractSection {
 		}
 	}
 
-
 	private class TransactionCellModifier implements ICellModifier {
 		@Override
 		public boolean canModify(final Object element, final String property) {
@@ -360,8 +347,7 @@ public class TransactionSection extends AbstractSection {
 
 		@Override
 		public Object getValue(final Object element, final String property) {
-			if (element instanceof Primitive) {
-				final Primitive primitive = (Primitive) element;
+			if (element instanceof final Primitive primitive) {
 				switch (property) {
 				case INDEX:
 					return String
@@ -370,7 +356,7 @@ public class TransactionSection extends AbstractSection {
 					return getNameOfCurrentEvent(primitive);
 				case PARAM:
 					if (primitive.getParameters() == null) {
-						return "";  //$NON-NLS-1$
+						return ""; //$NON-NLS-1$
 					}
 					return primitive.getParameters();
 				case INTERFACE:
@@ -381,7 +367,6 @@ public class TransactionSection extends AbstractSection {
 			}
 			return element;
 		}
-
 
 		@Override
 		public void modify(final Object element, final String property, final Object value) {

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/properties/AdapterInterfaceElementSection.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/properties/AdapterInterfaceElementSection.java
@@ -1,6 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 - 2017 fortiss GmbH
- * 				 2019 Johannes Kepler University
+ * Copyright (c) 2014, 2024 fortiss GmbH, Johannes Kepler University
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -26,7 +25,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.ui.nat.AdapterTypeSelectionTreeContentProvider;
 import org.eclipse.fordiac.ide.model.ui.widgets.AdapterTypeSelectionContentProvider;
 import org.eclipse.fordiac.ide.model.ui.widgets.ITypeSelectionContentProvider;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.views.properties.tabbed.TabbedPropertySheetPage;
@@ -56,13 +54,10 @@ public class AdapterInterfaceElementSection extends AbstractDoubleColumnSection 
 	}
 
 	@Override
-	public void refresh() {
-		final CommandStack commandStackBuffer = commandStack;
-		commandStack = null;
-		if (null != type && pinInfoBasicWidget != null) {
+	protected void performRefresh() {
+		if (pinInfoBasicWidget != null) {
 			pinInfoBasicWidget.refresh();
 		}
-		commandStack = commandStackBuffer;
 	}
 
 	public boolean isEditable() {

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/properties/DataInterfaceElementSection.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/properties/DataInterfaceElementSection.java
@@ -1,6 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 - 2017 fortiss GmbH
- *               2019 - 2020 Johannes Kepler University Linz
+ * Copyright (c) 2014, 2024 fortiss GmbH, Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -36,7 +35,6 @@ import org.eclipse.fordiac.ide.model.ui.widgets.DataTypeSelectionContentProvider
 import org.eclipse.fordiac.ide.model.ui.widgets.ITypeSelectionContentProvider;
 import org.eclipse.fordiac.ide.ui.FordiacMessages;
 import org.eclipse.fordiac.ide.ui.widget.TableWidgetFactory;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.jface.viewers.ColumnWeightData;
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.TableLayout;
@@ -114,23 +112,18 @@ public class DataInterfaceElementSection extends AdapterInterfaceElementSection 
 	}
 
 	@Override
-	public void refresh() {
-		super.refresh();
-		final CommandStack commandStackBuffer = commandStack;
-		commandStack = null;
-		if (null != type) {
-			if (getType().eContainer().eContainer() instanceof FBType) {
-				eventComposite.setVisible(true);
-				withEventsViewer.setInput(getType());
-				withEventsViewer.getTable().setEnabled(isEditable());
-				Arrays.stream(withEventsViewer.getTable().getItems()).forEach(item -> item.setChecked(false));
-				getType().getWiths().stream().map(with -> withEventsViewer.testFindItem(with.eContainer()))
-						.filter(TableItem.class::isInstance).forEach(item -> ((TableItem) item).setChecked(true));
-			} else {
-				eventComposite.setVisible(false);
-			}
+	protected void performRefresh() {
+		super.performRefresh();
+		if (getType().eContainer().eContainer() instanceof FBType) {
+			eventComposite.setVisible(true);
+			withEventsViewer.setInput(getType());
+			withEventsViewer.getTable().setEnabled(isEditable());
+			Arrays.stream(withEventsViewer.getTable().getItems()).forEach(item -> item.setChecked(false));
+			getType().getWiths().stream().map(with -> withEventsViewer.testFindItem(with.eContainer()))
+					.filter(TableItem.class::isInstance).forEach(item -> ((TableItem) item).setChecked(true));
+		} else {
+			eventComposite.setVisible(false);
 		}
-		commandStack = commandStackBuffer;
 	}
 
 	@Override
@@ -144,7 +137,7 @@ public class DataInterfaceElementSection extends AdapterInterfaceElementSection 
 
 			eventComposite.setVisible(!(getType().eContainer().eContainer() instanceof SubAppType));
 		}
-		if (null == commandStack) { // disable all fields
+		if (null == getCurrentCommandStack()) { // disable all fields
 			withEventsViewer.setInput(null);
 			Arrays.stream(withEventsViewer.getTable().getItems()).forEach(item -> item.setGrayed(true));
 		}

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/properties/EventInterfaceElementSection.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/properties/EventInterfaceElementSection.java
@@ -1,6 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 - 2017 fortiss GmbH
- *               2019 Johannes Kepler University Linz
+ * Copyright (c) 2014, 2024 fortiss GmbH, Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -31,7 +30,6 @@ import org.eclipse.fordiac.ide.model.ui.widgets.EventTypeSelectionContentProvide
 import org.eclipse.fordiac.ide.model.ui.widgets.ITypeSelectionContentProvider;
 import org.eclipse.fordiac.ide.ui.FordiacMessages;
 import org.eclipse.fordiac.ide.ui.widget.TableWidgetFactory;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.jface.viewers.ColumnWeightData;
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.TableLayout;
@@ -104,26 +102,21 @@ public class EventInterfaceElementSection extends AdapterInterfaceElementSection
 		if (getType() != null) {
 			eventComposite.setVisible(!(getType().eContainer().eContainer() instanceof SubAppType));
 		}
-		if (null == commandStack) { // disable all fields
+		if (null == getCurrentCommandStack()) { // disable all fields
 			withEventsViewer.setInput(null);
 			Arrays.stream(withEventsViewer.getTable().getItems()).forEach(item -> item.setGrayed(true));
 		}
 	}
 
 	@Override
-	public void refresh() {
-		super.refresh();
-		final CommandStack commandStackBuffer = commandStack;
-		commandStack = null;
-		if (null != getType()) {
-			withEventsViewer.setInput(getType());
-			withEventsViewer.getTable().setEnabled(isEditable());
-			Arrays.stream(withEventsViewer.getTable().getItems()).forEach(item -> item.setChecked(false));
-			getType().getWith().stream().filter(with -> (with.getVariables() != null))
-					.map(with -> withEventsViewer.testFindItem(with.getVariables())).filter(TableItem.class::isInstance)
-					.forEach(item -> ((TableItem) item).setChecked(true));
-		}
-		commandStack = commandStackBuffer;
+	protected void performRefresh() {
+		super.performRefresh();
+		withEventsViewer.setInput(getType());
+		withEventsViewer.getTable().setEnabled(isEditable());
+		Arrays.stream(withEventsViewer.getTable().getItems()).forEach(item -> item.setChecked(false));
+		getType().getWith().stream().filter(with -> (with.getVariables() != null))
+				.map(with -> withEventsViewer.testFindItem(with.getVariables())).filter(TableItem.class::isInstance)
+				.forEach(item -> ((TableItem) item).setChecked(true));
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AbstractEditInterfaceSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AbstractEditInterfaceSection.java
@@ -1,7 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 fortiss GmbH
- * 				 2018, 2019, 2020 Johannes Kepler University Linz
- *               2023 Martin Erich Jobst
+ * Copyright (c) 2017, 2024 fortiss GmbH, Johannes Kepler University Linz,
+ *                          Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -44,7 +43,6 @@ import org.eclipse.fordiac.ide.ui.widget.ISelectionProviderSection;
 import org.eclipse.fordiac.ide.ui.widget.NatTableWidgetFactory;
 import org.eclipse.fordiac.ide.ui.widget.SelectionProviderProxy;
 import org.eclipse.gef.commands.Command;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.gef.commands.CompoundCommand;
 import org.eclipse.nebula.widgets.nattable.NatTable;
 import org.eclipse.nebula.widgets.nattable.config.IConfigRegistry;
@@ -160,13 +158,8 @@ public abstract class AbstractEditInterfaceSection<T extends IInterfaceElement> 
 	}
 
 	@Override
-	public void refresh() {
-		final CommandStack commandStackBuffer = commandStack;
-		commandStack = null;
-		if (null != type) {
-			setTableInput();
-		}
-		commandStack = commandStackBuffer;
+	protected void performRefresh() {
+		setTableInput();
 		inputTable.refresh();
 		outputTable.refresh();
 	}

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AbstractEditVarInOutSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AbstractEditVarInOutSection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Primetals Technologies Austria GmbH
+ * Copyright (c) 2023, 2024 Primetals Technologies Austria GmbH
  *                    Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
@@ -41,7 +41,6 @@ import org.eclipse.fordiac.ide.ui.widget.IChangeableRowDataProvider;
 import org.eclipse.fordiac.ide.ui.widget.ISelectionProviderSection;
 import org.eclipse.fordiac.ide.ui.widget.NatTableColumnProvider;
 import org.eclipse.fordiac.ide.ui.widget.NatTableWidgetFactory;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.gef.commands.CompoundCommand;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.nebula.widgets.nattable.NatTable;
@@ -129,13 +128,8 @@ public abstract class AbstractEditVarInOutSection extends AbstractSection
 	}
 
 	@Override
-	public void refresh() {
-		final CommandStack commandStackBuffer = commandStack;
-		commandStack = null;
-		if (null != type) {
-			setTableInput();
-		}
-		commandStack = commandStackBuffer;
+	protected void performRefresh() {
+		setTableInput();
 		inputTable.refresh();
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AbstractInternalVarsSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AbstractInternalVarsSection.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
- * Copyright (c) 2015 - 2024 fortiss GmbH, Johannes Kepler University Linz,
- * 							 Primetals Technologies Germany GmbH,
- * 							 Martin Erich Jobst
+ * Copyright (c) 2015, 2024 fortiss GmbH, Johannes Kepler University Linz,
+ * 							Primetals Technologies Germany GmbH,
+ * 							Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -188,7 +188,7 @@ public abstract class AbstractInternalVarsSection extends AbstractSection
 	}
 
 	@Override
-	public void refresh() {
+	protected void performRefresh() {
 		table.refresh();
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AttributeSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AttributeSection.java
@@ -1,6 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 fortiss GmbH
- *                          Johannes Kepler University Linz
+ * Copyright (c) 2017, 2024 fortiss GmbH, Johannes Kepler University Linz,
  *                          Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
@@ -52,7 +51,6 @@ import org.eclipse.fordiac.ide.ui.widget.IChangeableRowDataProvider;
 import org.eclipse.fordiac.ide.ui.widget.NatTableColumnProvider;
 import org.eclipse.fordiac.ide.ui.widget.NatTableWidgetFactory;
 import org.eclipse.gef.commands.Command;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.gef.commands.CompoundCommand;
 import org.eclipse.jface.bindings.keys.KeyStroke;
 import org.eclipse.jface.fieldassist.ContentProposalAdapter;
@@ -167,11 +165,8 @@ public class AttributeSection extends AbstractSection implements I4diacNatTableU
 	}
 
 	@Override
-	public void refresh() {
-		final CommandStack commandStackBuffer = commandStack;
-		commandStack = null;
+	protected void performRefresh() {
 		provider.setInput(getFilteredAttributeList());
-		commandStack = commandStackBuffer;
 		table.refresh();
 	}
 
@@ -237,7 +232,7 @@ public class AttributeSection extends AbstractSection implements I4diacNatTableU
 
 			if (packageEntry == null
 					&& EcoreUtil.getRootContainer(getType()) instanceof final LibraryElement libraryElement) {
-				commandStack.execute(new AddNewImportCommand(libraryElement, proposal.getContent()));
+				executeCommand(new AddNewImportCommand(libraryElement, proposal.getContent()));
 			}
 		}
 	}

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/CompilableTypeInfoSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/CompilableTypeInfoSection.java
@@ -1,6 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 - 2016 fortiss GmbH
- * 				 2019 Johannes Kepler University Linz
+ * Copyright (c) 2014, 2024 fortiss GmbH, Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -35,7 +34,6 @@ import org.eclipse.fordiac.ide.ui.widget.AddDeleteWidget;
 import org.eclipse.fordiac.ide.ui.widget.ComboBoxWidgetFactory;
 import org.eclipse.fordiac.ide.ui.widget.TableWidgetFactory;
 import org.eclipse.gef.commands.Command;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.jface.viewers.CellEditor;
 import org.eclipse.jface.viewers.ColumnWeightData;
 import org.eclipse.jface.viewers.ICellModifier;
@@ -207,20 +205,17 @@ public abstract class CompilableTypeInfoSection extends TypeInfoSection {
 	@Override
 	public void setInput(final IWorkbenchPart part, final ISelection selection) {
 		super.setInput(part, selection);
-		if (null == commandStack) { // disable all field
+		if (null == getCurrentCommandStack()) { // disable all field
 			compilerViewer.setCellModifier(null);
 		}
 	}
 
 	@Override
-	public void refresh() {
-		super.refresh();
-		final CommandStack commandStackBuffer = commandStack;
-		commandStack = null;
-		if ((getType() != null) && (null != getType().getCompilerInfo())) {
+	protected void performRefresh() {
+		super.performRefresh();
+		if (getType().getCompilerInfo() != null) {
 			compilerViewer.setInput(type);
 		}
-		commandStack = commandStackBuffer;
 	}
 
 	private final Adapter typeInfoAdapter = new EContentAdapter() {

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/ConnectionSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/ConnectionSection.java
@@ -1,7 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2017 fortiss GmbH
- *               2019 Johannes Kepler University Linz
- *               2021 Primetals Technologies Austria GmbH
+ * Copyright (c) 2017, 2024 fortiss GmbH, Johannes Kepler University Linz,
+ *                          Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -28,7 +27,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.Connection;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.gef.EditPart;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
@@ -44,6 +42,7 @@ public class ConnectionSection extends AbstractSection {
 	private Text sourceText;
 	private Text targetText;
 	private Button showConnectionButton;
+
 	@Override
 	protected Connection getType() {
 		return (Connection) type;
@@ -85,31 +84,25 @@ public class ConnectionSection extends AbstractSection {
 	}
 
 	@Override
-	public void refresh() {
-		final CommandStack commandStackBuffer = commandStack;
-		commandStack = null;
-		if (null != type) {
-			commentText.setText(getType().getComment() != null ? getType().getComment() : ""); //$NON-NLS-1$
-			if (null != getType().getSource()) {
-				sourceText.setText(
-						getFBNameFromIInterfaceElement(getType().getSource()) + "." + getType().getSource().getName()); //$NON-NLS-1$
-				if (isViewer()) {
-					commentText.setEditable(false);
-					commentText.setEnabled(false);
-				} else {
-					commentText.setEditable(true);
-					commentText.setEnabled(true);
-				}
+	protected void performRefresh() {
+		commentText.setText(getType().getComment() != null ? getType().getComment() : ""); //$NON-NLS-1$
+		if (null != getType().getSource()) {
+			sourceText.setText(
+					getFBNameFromIInterfaceElement(getType().getSource()) + "." + getType().getSource().getName()); //$NON-NLS-1$
+			if (isViewer()) {
+				commentText.setEditable(false);
+				commentText.setEnabled(false);
+			} else {
+				commentText.setEditable(true);
+				commentText.setEnabled(true);
 			}
-			if (null != getType().getDestination()) {
-				targetText.setText(getFBNameFromIInterfaceElement(getType().getDestination()) + "." //$NON-NLS-1$
-						+ getType().getDestination().getName());
-			}
-
-			showConnectionButton.setSelection(getConnection().isVisible());
-
 		}
-		commandStack = commandStackBuffer;
+		if (null != getType().getDestination()) {
+			targetText.setText(getFBNameFromIInterfaceElement(getType().getDestination()) + "." //$NON-NLS-1$
+					+ getType().getDestination().getName());
+		}
+
+		showConnectionButton.setSelection(getConnection().isVisible());
 	}
 
 	private boolean isViewer() {
@@ -128,8 +121,10 @@ public class ConnectionSection extends AbstractSection {
 	}
 
 	private static boolean isValidConnection(final Connection con) {
-		// only allow connections that are fully included in the model. In rare cases it can be that during command
-		// execution we may get half updated connections. This should protect against it.
+		// only allow connections that are fully included in the model. In rare cases it
+		// can be that during command
+		// execution we may get half updated connections. This should protect against
+		// it.
 		return con.eContainer() != null && con.getSource() != null && con.getDestination() != null
 				&& con.getSource().eContainer() != null && con.getDestination().eContainer() != null;
 	}

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/InterfaceElementSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/InterfaceElementSection.java
@@ -1,6 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 fortiss GmbH
- * 				 2019 Johannes Kepler Unviersity
+ * Copyright (c) 2017, 2024 fortiss GmbH, Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -32,7 +31,6 @@ import org.eclipse.fordiac.ide.ui.FordiacMessages;
 import org.eclipse.fordiac.ide.ui.widget.ComboBoxWidgetFactory;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.commands.Command;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CCombo;
 import org.eclipse.swt.custom.CLabel;
@@ -116,37 +114,34 @@ public class InterfaceElementSection extends AbstractSection {
 	}
 
 	@Override
-	public void refresh() {
-		final CommandStack commandStackBuffer = commandStack;
-		commandStack = null;
-		if (null != type) {
-			setEditableFields(getType().getFBNetworkElement() instanceof SubApp);
-			nameText.setText(getType().getName() != null ? getType().getName() : ""); //$NON-NLS-1$
-			commentText.setText(getType().getComment() != null ? getType().getComment() : ""); //$NON-NLS-1$
-			String itype = ""; //$NON-NLS-1$
-			if (getType() instanceof final VarDeclaration varDecl) {
-				itype = varDecl.getType() != null ? varDecl.getTypeName() : ""; //$NON-NLS-1$
-				if (getType().isIsInput()) {
-					parameterText.setVisible(true);
-					valueCLabel.setVisible(true);
-					parameterText.setText((varDecl.getValue() != null) ? varDecl.getValue().getValue() : ""); //$NON-NLS-1$
-				} else {
-					valueCLabel.setVisible(false);
-					parameterText.setVisible(false);
-				}
+	protected void performRefresh() {
+		setEditableFields(getType().getFBNetworkElement() instanceof SubApp);
+		nameText.setText(getType().getName() != null ? getType().getName() : ""); //$NON-NLS-1$
+		commentText.setText(getType().getComment() != null ? getType().getComment() : ""); //$NON-NLS-1$
+		String itype = ""; //$NON-NLS-1$
+		if (getType() instanceof final VarDeclaration varDecl) {
+			itype = varDecl.getType() != null ? varDecl.getTypeName() : ""; //$NON-NLS-1$
+			if (getType().isIsInput()) {
+				parameterText.setVisible(true);
+				valueCLabel.setVisible(true);
+				parameterText.setText((varDecl.getValue() != null) ? varDecl.getValue().getValue() : ""); //$NON-NLS-1$
 			} else {
-				itype = FordiacMessages.Event;
 				valueCLabel.setVisible(false);
 				parameterText.setVisible(false);
 			}
-			fillTypeCombo(itype);
+		} else {
+			itype = FordiacMessages.Event;
+			valueCLabel.setVisible(false);
+			parameterText.setVisible(false);
 		}
-		commandStack = commandStackBuffer;
+		fillTypeCombo(itype);
 	}
 
-	/** Set the input fields edit able or not
+	/**
+	 * Set the input fields edit able or not
 	 *
-	 * @param editAble flag indicating if the fields should be editable */
+	 * @param editAble flag indicating if the fields should be editable
+	 */
 	private void setEditableFields(final boolean editAble) {
 		nameText.setEditable(editAble);
 		nameText.setEnabled(editAble);

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/InternalFbsSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/InternalFbsSection.java
@@ -47,7 +47,6 @@ import org.eclipse.fordiac.ide.ui.widget.IChangeableRowDataProvider;
 import org.eclipse.fordiac.ide.ui.widget.ISelectionProviderSection;
 import org.eclipse.fordiac.ide.ui.widget.NatTableColumnProvider;
 import org.eclipse.fordiac.ide.ui.widget.NatTableWidgetFactory;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.gef.commands.CompoundCommand;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.nebula.widgets.nattable.NatTable;
@@ -138,11 +137,8 @@ public class InternalFbsSection extends AbstractSection implements I4diacNatTabl
 	}
 
 	@Override
-	public void refresh() {
-		final CommandStack commandStackBuffer = commandStack;
-		commandStack = null;
+	protected void performRefresh() {
 		provider.setInput(getType() != null ? getType().getInternalFbs() : Collections.emptyList());
-		commandStack = commandStackBuffer;
 		table.refresh();
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/TypeInfoSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/TypeInfoSection.java
@@ -1,6 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 - 2016 fortiss GmbH
- * 				 2020 Johannes Kepler Universiy Linz
+ * Copyright (c) 2014, 2024 fortiss GmbH, Johannes Kepler Universiy Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -24,7 +23,6 @@ import org.eclipse.fordiac.ide.model.commands.change.ChangeCommentCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.FunctionFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.ui.FordiacMessages;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -84,16 +82,11 @@ public abstract class TypeInfoSection extends AbstractDoubleColumnSection {
 	}
 
 	@Override
-	public void refresh() {
-		final CommandStack commandStackBuffer = commandStack;
-		commandStack = null;
-		if (null != type) {
-			fbTypeNameText.setText(getType().getName() != null ? getType().getName() : ""); //$NON-NLS-1$
-			commentText.setText(getType().getComment() != null ? getType().getComment() : ""); //$NON-NLS-1$
-			commentText.setEditable(!(getType() instanceof FunctionFBType));
-			typeInfo.refresh();
-		}
-		commandStack = commandStackBuffer;
+	protected void performRefresh() {
+		fbTypeNameText.setText(getType().getName() != null ? getType().getName() : ""); //$NON-NLS-1$
+		commentText.setText(getType().getComment() != null ? getType().getComment() : ""); //$NON-NLS-1$
+		commentText.setEditable(!(getType() instanceof FunctionFBType));
+		typeInfo.refresh();
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/src/org/eclipse/fordiac/ide/globalconstantseditor/ui/properties/GlobalConstantsAttributeSection.java
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/src/org/eclipse/fordiac/ide/globalconstantseditor/ui/properties/GlobalConstantsAttributeSection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Johannes Kepler University
+ * Copyright (c) 2023, 2024 Johannes Kepler University
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -32,8 +32,8 @@ public class GlobalConstantsAttributeSection extends AttributeSection {
 
 	@Override
 	public void setInput(final IWorkbenchPart part, final ISelection selection) {
-		commandStack = getCommandStack(part, null);
-		if (null == commandStack) {
+		setCurrentCommandStack(part, null);
+		if (null == getCurrentCommandStack()) {
 			setInputCode();
 		}
 		setType(part);

--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/src/org/eclipse/fordiac/ide/globalconstantseditor/ui/properties/GlobalConstantsTypeInfoSection.java
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/src/org/eclipse/fordiac/ide/globalconstantseditor/ui/properties/GlobalConstantsTypeInfoSection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Johannes Kepler University, Linz
+ * Copyright (c) 2020, 2024 Johannes Kepler University, Linz
  *                          Primetals Technologies Austria GmbH
  *                          Martin Erich Jobst
  *
@@ -80,8 +80,8 @@ public class GlobalConstantsTypeInfoSection extends AbstractSection {
 
 	@Override
 	public void setInput(final IWorkbenchPart part, final ISelection selection) {
-		commandStack = getCommandStack(part, null);
-		if (null == commandStack) { // disable all fields
+		setCurrentCommandStack(part, null);
+		if (null == getCurrentCommandStack()) { // disable all fields
 			setInputCode();
 		}
 		setType(part);
@@ -109,11 +109,9 @@ public class GlobalConstantsTypeInfoSection extends AbstractSection {
 	}
 
 	@Override
-	public void refresh() {
-		if (null != getType()) {
-			commentText.setText((null != getType().getComment()) ? getType().getComment() : ""); //$NON-NLS-1$
-			typeInfoWidget.refresh();
-		}
+	protected void performRefresh() {
+		commentText.setText((null != getType().getComment()) ? getType().getComment() : ""); //$NON-NLS-1$
+		typeInfoWidget.refresh();
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/properties/DeviceSection.java
+++ b/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/properties/DeviceSection.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2017 -2019 fortiss GmbH, Johannes Kepler University
+ * Copyright (c) 2017, 2024 fortiss GmbH, Johannes Kepler University
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -37,8 +38,8 @@ public class DeviceSection extends AbstractInterfaceSection {
 	private CCombo profile;
 
 	@Override
-	protected CommandStack getCommandStack(IWorkbenchPart part, Object input) {
-		Device helper = getInputType(input);
+	protected CommandStack getCommandStack(final IWorkbenchPart part, final Object input) {
+		final Device helper = getInputType(input);
 		if (null != helper) {
 			return helper.getAutomationSystem().getCommandStack();
 		}
@@ -46,16 +47,14 @@ public class DeviceSection extends AbstractInterfaceSection {
 	}
 
 	@Override
-	public void refresh() {
-		super.refresh();
-		if (null != type) {
-			setProfile();
-		}
+	protected void performRefresh() {
+		super.performRefresh();
+		setProfile();
 	}
 
 	private void setProfile() {
 		int i = 0;
-		for (String p : profile.getItems()) {
+		for (final String p : profile.getItems()) {
 			if (p.equals(((Device) getType()).getProfile())) {
 				profile.select(i);
 				break;
@@ -66,18 +65,18 @@ public class DeviceSection extends AbstractInterfaceSection {
 
 	@Override
 	protected Device getInputType(Object input) {
-		if (input instanceof EditPart) {
-			input = ((EditPart) input).getModel();
+		if (input instanceof final EditPart ep) {
+			input = ep.getModel();
 		}
-		if (input instanceof Device) {
-			return ((Device) input);
+		if (input instanceof final Device dev) {
+			return dev;
 		}
 		return null;
 	}
 
 	@Override
-	protected void createFBInfoGroup(Composite parent) {
-		Composite composite = getWidgetFactory().createComposite(parent);
+	protected void createFBInfoGroup(final Composite parent) {
+		final Composite composite = getWidgetFactory().createComposite(parent);
 		composite.setLayout(new GridLayout(2, false));
 		composite.setLayoutData(new GridData(SWT.FILL, 0, true, false));
 		getWidgetFactory().createCLabel(composite, "Instance Name:");
@@ -90,7 +89,7 @@ public class DeviceSection extends AbstractInterfaceSection {
 
 		getWidgetFactory().createCLabel(composite, "Instance Comment:");
 		commentText = createGroupText(composite, true);
-		GridData gridData = new GridData(SWT.FILL, 0, true, false);
+		final GridData gridData = new GridData(SWT.FILL, 0, true, false);
 		commentText.setLayoutData(gridData);
 		commentText.addModifyListener(event -> {
 			removeContentAdapter();
@@ -111,7 +110,7 @@ public class DeviceSection extends AbstractInterfaceSection {
 
 	protected static String[] getAvailableProfileNames() {
 		if (null == profileNames) {
-			List<String> newProfileNames = DeviceManagementInteractorFactory.INSTANCE.getAvailableProfileNames();
+			final List<String> newProfileNames = DeviceManagementInteractorFactory.INSTANCE.getAvailableProfileNames();
 			profileNames = newProfileNames.toArray(new String[newProfileNames.size()]);
 		}
 		return profileNames;

--- a/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/properties/SegmentSection.java
+++ b/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/properties/SegmentSection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Johannes Kepler University
+ * Copyright (c) 2022, 2024 Johannes Kepler University
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -50,11 +50,11 @@ public class SegmentSection extends AbstractDoubleColumnSection {
 
 	@Override
 	protected Segment getInputType(Object input) {
-		if (input instanceof EditPart) {
-			input = ((EditPart) input).getModel();
+		if (input instanceof final EditPart ep) {
+			input = ep.getModel();
 		}
-		if (input instanceof Segment) {
-			return ((Segment) input);
+		if (input instanceof final Segment segment) {
+			return segment;
 		}
 		return null;
 	}
@@ -102,8 +102,8 @@ public class SegmentSection extends AbstractDoubleColumnSection {
 
 	@Override
 	protected Segment getType() {
-		if (type instanceof Segment) {
-			return (Segment) type;
+		if (type instanceof final Segment segment) {
+			return segment;
 		}
 		return null;
 	}
@@ -119,27 +119,24 @@ public class SegmentSection extends AbstractDoubleColumnSection {
 	}
 
 	@Override
-	public void refresh() {
-		super.refresh();
-
-		if (null != getType()) {
-			nameText.setText(getType().getName());
-			commentText.setText(getType().getComment());
-			// TODO this works, but it's a bit shit as it relies on the id of the extension never being changed.
-			// Maybe find a way to make it nicer eventually
-			getRightComposite().setVisible(!"Ethernet".equals(getCommunicationType())); //$NON-NLS-1$
-			final CommunicationConfigurationDetails commConfig = CommunicationConfigurationDetails
-					.getCommConfigUiFromExtensionPoint(getCommunicationType(),
-							CommunicationConfigurationDetails.COMM_EXT_ATT_ID);
-			if (commConfig == null) {
-				ErrorMessenger.popUpErrorMessage(Messages.Segment_NoConfigErrorMessage);
-				return;
-			}
-			commConfigContents.dispose();
-			commConfigContents = commConfig.createUi(commConfigGroup, getType().getCommunication(), getSection(),
-					getWidgetFactory());
-			commConfigContents.pack();
+	protected void performRefresh() {
+		nameText.setText(getType().getName());
+		commentText.setText(getType().getComment());
+		// TODO this works, but it's a bit shit as it relies on the id of the extension
+		// never being changed.
+		// Maybe find a way to make it nicer eventually
+		getRightComposite().setVisible(!"Ethernet".equals(getCommunicationType())); //$NON-NLS-1$
+		final CommunicationConfigurationDetails commConfig = CommunicationConfigurationDetails
+				.getCommConfigUiFromExtensionPoint(getCommunicationType(),
+						CommunicationConfigurationDetails.COMM_EXT_ATT_ID);
+		if (commConfig == null) {
+			ErrorMessenger.popUpErrorMessage(Messages.Segment_NoConfigErrorMessage);
+			return;
 		}
+		commConfigContents.dispose();
+		commConfigContents = commConfig.createUi(commConfigGroup, getType().getCommunication(), getSection(),
+				getWidgetFactory());
+		commConfigContents.pack();
 	}
 
 	private String getCommunicationType() {


### PR DESCRIPTION
Refreshing a property sheet my result in the triggering of modify listeners of our widgets. We ensure that according commands are not executed by caching the command stack. This had to be done by each property sheet individually, and if forgotten led to update issues (e.g., segment property sheet).

With this fix this is handled in a common infrastructure in AbstractSection.

https://github.com/eclipse-4diac/4diac-ide/issues/293