### PR TITLE
Follow Connection Didn't Handle Grouped Target Pins

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/TargetInterfaceElement.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/TargetInterfaceElement.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.application.editparts;
 
+import java.util.List;
+
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
@@ -95,18 +97,22 @@ public class TargetInterfaceElement implements Comparable<TargetInterfaceElement
 
 	public static class GroupTargetInterfaceElement extends SubappTargetInterfaceElement {
 		final SubApp subapp;
-		final int numConns;
+		final List<IInterfaceElement> refElements;
 
-		public GroupTargetInterfaceElement(final IInterfaceElement host, final IInterfaceElement refElement,
-				final SubApp subapp, final int numConns) {
-			super(host, refElement);
+		public GroupTargetInterfaceElement(final IInterfaceElement host, final List<IInterfaceElement> refElements,
+				final SubApp subapp) {
+			super(host, refElements.getFirst());
 			this.subapp = subapp;
-			this.numConns = numConns;
+			this.refElements = refElements;
 		}
 
 		@Override
 		public String getRefPinFullName() {
-			return subapp.getName() + ": " + numConns; //$NON-NLS-1$
+			return subapp.getName() + ": " + refElements.size(); //$NON-NLS-1$
+		}
+
+		public List<IInterfaceElement> getRefElements() {
+			return refElements;
 		}
 
 	}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/TargetPinManager.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/TargetPinManager.java
@@ -62,8 +62,8 @@ public class TargetPinManager {
 						if(e.getValue().size() == 1) {
 							return  TargetInterfaceElement.createFor(getModel(), e.getValue().get(0), parentNW);
 						}
-						return (TargetInterfaceElement) new GroupTargetInterfaceElement(getModel(), e.getValue().get(0),
-							e.getKey(), e.getValue().size());
+						return (TargetInterfaceElement) new GroupTargetInterfaceElement(getModel(), e.getValue(),
+								e.getKey());
 					})
 					.collect(Collectors.toList());
 

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/FollowConnectionHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/FollowConnectionHandler.java
@@ -22,6 +22,8 @@ import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.emf.common.util.EList;
+import org.eclipse.fordiac.ide.application.editparts.TargetInterfaceElement;
+import org.eclipse.fordiac.ide.application.editparts.TargetInterfaceElement.GroupTargetInterfaceElement;
 import org.eclipse.fordiac.ide.application.editparts.TargetInterfaceElementEditPart;
 import org.eclipse.fordiac.ide.application.widgets.OppositeSelectionDialog;
 import org.eclipse.fordiac.ide.gef.editparts.InterfaceEditPart;
@@ -122,8 +124,17 @@ public abstract class FollowConnectionHandler extends AbstractHandler {
 	protected abstract EList<Connection> getConnectionList(final IInterfaceElement ie);
 
 	private static List<IInterfaceElement> getTargetPins(final InterfaceEditPart iep) {
-		return iep.getChildren().stream().filter(TargetInterfaceElementEditPart.class::isInstance)
-				.map(ep -> (TargetInterfaceElementEditPart) ep).map(ep -> ep.getModel().getRefElement()).toList();
+		final List<IInterfaceElement> result = new ArrayList<>();
+		for (final EditPart ep : iep.getChildren()) {
+			switch (ep.getModel()) {
+			case final GroupTargetInterfaceElement gtIE -> result.addAll(gtIE.getRefElements());
+			case final TargetInterfaceElement targetIE -> result.add(targetIE.getRefElement());
+			default -> {
+				// we should never get here, even if we do we don't want to do anything
+			}
+			}
+		}
+		return result;
 	}
 
 	protected static boolean isInsideSubappOrViewer(final IInterfaceElement ie, final FBNetwork fbNetwork) {


### PR DESCRIPTION
Follow connection only considered a single target pin for grouped target pins. This change adds now all target pins to the
GroupTargetInterfaceElement model. Will also be needed for any tooltips.