### PR TITLE
Optimize export of blocks with arrays and methods

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.export.forte_lua.st/src/org/eclipse/fordiac/ide/export/forte_lua/st/ECTransitionSupport.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_lua.st/src/org/eclipse/fordiac/ide/export/forte_lua/st/ECTransitionSupport.xtend
@@ -30,7 +30,7 @@ class ECTransitionSupport extends StructuredTextSupport {
 
 	STExpressionSource parseResult
 
-	override prepare(Map<?, ?> options) {
+	override prepare() {
 		if (parseResult === null && errors.empty) {
 			parseResult = transition.conditionExpression.parse(
 				ElementaryTypes.BOOL,
@@ -42,12 +42,12 @@ class ECTransitionSupport extends StructuredTextSupport {
 	}
 
 	override generate(Map<?, ?> options) throws ExportException {
-		prepare(options)
+		prepare()
 		parseResult?.expression?.generateExpression
 	}
 
 	override getDependencies(Map<?, ?> options) {
-		prepare(options)
+		prepare()
 		parseResult?.containedDependencies ?: emptySet
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.export.forte_lua.st/src/org/eclipse/fordiac/ide/export/forte_lua/st/STAlgorithmSupport.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_lua.st/src/org/eclipse/fordiac/ide/export/forte_lua/st/STAlgorithmSupport.xtend
@@ -28,7 +28,7 @@ class STAlgorithmSupport extends StructuredTextSupport {
 
 	STAlgorithm parseResult
 
-	override prepare(Map<?, ?> options) {
+	override prepare() {
 		if (parseResult === null && errors.empty) {
 			parseResult = algorithm.parse(errors, warnings, infos)
 		}
@@ -36,7 +36,7 @@ class STAlgorithmSupport extends StructuredTextSupport {
 	}
 
 	override generate(Map<?, ?> options) throws ExportException {
-		prepare(options)
+		prepare()
 		parseResult?.generateStructuredTextAlgorithm
 	}
 
@@ -64,7 +64,7 @@ class STAlgorithmSupport extends StructuredTextSupport {
 	}
 
 	override getDependencies(Map<?, ?> options) {
-		prepare(options)
+		prepare()
 		parseResult?.containedDependencies ?: emptySet
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.export.forte_lua.st/src/org/eclipse/fordiac/ide/export/forte_lua/st/STFunctionSupport.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_lua.st/src/org/eclipse/fordiac/ide/export/forte_lua/st/STFunctionSupport.xtend
@@ -34,12 +34,12 @@ class STFunctionSupport extends StructuredTextSupport {
 	STFunction currentFunction
 	CharSequence outReturn
 
-	override prepare(Map<?, ?> options) {
+	override prepare() {
 		return true
 	}
 
 	override generate(Map<?, ?> options) throws ExportException {
-		prepare(options)
+		prepare()
 		source.generateStructuredTextFunctionSource
 	}
 
@@ -133,7 +133,7 @@ class STFunctionSupport extends StructuredTextSupport {
 	'''
 
 	override getDependencies(Map<?, ?> options) {
-		prepare(options)
+		prepare()
 //		if (options.get(ForteNgExportFilter.OPTION_HEADER) == Boolean.TRUE)
 //			(source.functions.map[returnType].filterNull + source.functions.flatMap [
 //				varDeclarations.filter [

--- a/plugins/org.eclipse.fordiac.ide.export.forte_lua.st/src/org/eclipse/fordiac/ide/export/forte_lua/st/STMethodSupport.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_lua.st/src/org/eclipse/fordiac/ide/export/forte_lua/st/STMethodSupport.xtend
@@ -37,7 +37,7 @@ class STMethodSupport extends StructuredTextSupport {
 	STMethod parseResult
 	CharSequence outReturn
 
-	override prepare(Map<?, ?> options) {
+	override prepare() {
 		if (parseResult === null && errors.empty) {
 			parseResult = method.parse(errors, warnings, infos)
 		}
@@ -45,7 +45,7 @@ class STMethodSupport extends StructuredTextSupport {
 	}
 
 	override generate(Map<?, ?> options) throws ExportException {
-		prepare(options)
+		prepare()
 		parseResult?.generateStructuredTextMethod
 	}
 
@@ -151,7 +151,7 @@ class STMethodSupport extends StructuredTextSupport {
 	def private getFBType() { switch (root : method.rootContainer) { BaseFBType: root } }
 
 	override getDependencies(Map<?, ?> options) {
-		prepare(options)
+		prepare()
 		if (parseResult !== null) {
 //			if (options.get(ForteNgExportFilter.OPTION_HEADER) == Boolean.TRUE)
 //				(#[parseResult.returnType].filterNull + parseResult.body.varDeclarations.filter [

--- a/plugins/org.eclipse.fordiac.ide.export.forte_lua.st/src/org/eclipse/fordiac/ide/export/forte_lua/st/StructuredTextSupportFactory.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_lua.st/src/org/eclipse/fordiac/ide/export/forte_lua/st/StructuredTextSupportFactory.xtend
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.export.forte_lua.st
 
+import java.util.Map
 import org.eclipse.fordiac.ide.export.language.ILanguageSupportFactory
 import org.eclipse.fordiac.ide.model.libraryElement.ECTransition
 import org.eclipse.fordiac.ide.model.libraryElement.STAlgorithm
@@ -21,7 +22,7 @@ import org.eclipse.fordiac.ide.structuredtextfunctioneditor.stfunction.STFunctio
 
 class StructuredTextSupportFactory implements ILanguageSupportFactory {
 
-	override createLanguageSupport(Object source) {
+	override createLanguageSupport(Object source, Map<?,?> options) {
 		if (source instanceof STAlgorithm) {
 			new STAlgorithmSupport(source)
 		} else if (source instanceof ECTransition) {

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/ECTransitionSupport.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/ECTransitionSupport.xtend
@@ -29,7 +29,7 @@ class ECTransitionSupport extends StructuredTextSupport {
 
 	STExpressionSource parseResult
 
-	override prepare(Map<?, ?> options) {
+	override prepare() {
 		if (parseResult === null && errors.empty) {
 			parseResult = transition.conditionExpression.parse(
 				ElementaryTypes.BOOL,
@@ -41,12 +41,12 @@ class ECTransitionSupport extends StructuredTextSupport {
 	}
 
 	override generate(Map<?, ?> options) throws ExportException {
-		prepare(options)
+		prepare()
 		parseResult?.expression?.generateExpression
 	}
 
 	override getDependencies(Map<?, ?> options) {
-		prepare(options)
+		prepare()
 		parseResult?.containedDependencies ?: emptySet
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/STAlgorithmSupport.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/STAlgorithmSupport.xtend
@@ -25,7 +25,7 @@ class STAlgorithmSupport extends StructuredTextSupport {
 
 	STAlgorithm parseResult
 
-	override prepare(Map<?, ?> options) {
+	override prepare() {
 		if (parseResult === null && errors.empty) {
 			parseResult = algorithm.parse(errors, warnings, infos)
 		}
@@ -33,7 +33,7 @@ class STAlgorithmSupport extends StructuredTextSupport {
 	}
 
 	override generate(Map<?, ?> options) throws ExportException {
-		prepare(options)
+		prepare()
 		parseResult?.generateStructuredTextAlgorithm
 	}
 
@@ -44,7 +44,7 @@ class STAlgorithmSupport extends StructuredTextSupport {
 	'''
 
 	override getDependencies(Map<?, ?> options) {
-		prepare(options)
+		prepare()
 		parseResult?.containedDependencies ?: emptySet
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/STAlgorithmSupport.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/STAlgorithmSupport.xtend
@@ -14,20 +14,30 @@ package org.eclipse.fordiac.ide.export.forte_ng.st
 
 import java.util.Map
 import org.eclipse.fordiac.ide.export.ExportException
+import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType
 import org.eclipse.fordiac.ide.structuredtextalgorithm.stalgorithm.STAlgorithm
-import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
 
 import static extension org.eclipse.fordiac.ide.structuredtextalgorithm.util.StructuredTextParseUtil.*
 
-@FinalFieldsConstructor
 class STAlgorithmSupport extends StructuredTextSupport {
 	final org.eclipse.fordiac.ide.model.libraryElement.STAlgorithm algorithm
+	final Map<Object, Object> cache;
 
 	STAlgorithm parseResult
+	
+	new(org.eclipse.fordiac.ide.model.libraryElement.STAlgorithm algorithm, Map<?, ?> options) {
+		this.algorithm = algorithm
+		this.cache = options.cacheOption
+	}
 
 	override prepare() {
 		if (parseResult === null && errors.empty) {
-			parseResult = algorithm.parse(errors, warnings, infos)
+			val container = algorithm.eContainer
+			if (container instanceof BaseFBType)
+				parseResult = cache.computeCached(container)[container.parse(errors, warnings, infos)]?.elements?.
+					filter(STAlgorithm)?.findFirst[name == algorithm.name]
+			else
+				parseResult = algorithm.parse(errors, warnings, infos)
 		}
 		return parseResult !== null
 	}

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/STFunctionBodySupport.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/STFunctionBodySupport.xtend
@@ -34,7 +34,7 @@ class STFunctionBodySupport implements ILanguageSupport {
 	STFunctionSource parseResult
 	STFunctionSupport support
 
-	override prepare(Map<?, ?> options) {
+	override prepare() {
 		if (parseResult === null && errors.empty) {
 			parseResult = body.parse(errors, warnings, infos)
 			if (parseResult !== null) {
@@ -45,12 +45,12 @@ class STFunctionBodySupport implements ILanguageSupport {
 	}
 
 	override generate(Map<?, ?> options) throws ExportException {
-		prepare(options)
+		prepare()
 		support?.generate(options)
 	}
 
 	override getDependencies(Map<?, ?> options) {
-		prepare(options)
+		prepare()
 		support?.getDependencies(options)
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/STFunctionSupport.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/STFunctionSupport.xtend
@@ -33,12 +33,12 @@ class STFunctionSupport extends StructuredTextSupport {
 	final STFunctionSource source
 	STFunction currentFunction
 
-	override prepare(Map<?, ?> options) {
+	override prepare() {
 		return true
 	}
 
 	override generate(Map<?, ?> options) throws ExportException {
-		prepare(options)
+		prepare()
 		if (options.get(ForteNgExportFilter.OPTION_HEADER) == Boolean.TRUE)
 			source.generateStructuredTextFunctionSourceHeader
 		else
@@ -110,7 +110,7 @@ class STFunctionSupport extends StructuredTextSupport {
 	}
 
 	override getDependencies(Map<?, ?> options) {
-		prepare(options)
+		prepare()
 		if (options.get(ForteNgExportFilter.OPTION_HEADER) == Boolean.TRUE)
 			(source.functions.map[returnType].filterNull + source.functions.flatMap [
 				varDeclarations.filter [

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/STMethodSupport.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/STMethodSupport.xtend
@@ -35,7 +35,7 @@ class STMethodSupport extends StructuredTextSupport {
 
 	STMethod parseResult
 
-	override prepare(Map<?, ?> options) {
+	override prepare() {
 		if (parseResult === null && errors.empty) {
 			parseResult = method.parse(errors, warnings, infos)
 		}
@@ -43,7 +43,7 @@ class STMethodSupport extends StructuredTextSupport {
 	}
 
 	override generate(Map<?, ?> options) throws ExportException {
-		prepare(options)
+		prepare()
 		if (options.get(ForteNgExportFilter.OPTION_HEADER) == Boolean.TRUE)
 			parseResult?.generateStructuredTextMethodHeader
 		else
@@ -96,7 +96,7 @@ class STMethodSupport extends StructuredTextSupport {
 	def private getFBType() { switch (root : method.rootContainer) { BaseFBType: root } }
 
 	override getDependencies(Map<?, ?> options) {
-		prepare(options)
+		prepare()
 		if (parseResult !== null) {
 			if (options.get(ForteNgExportFilter.OPTION_HEADER) == Boolean.TRUE)
 				(#[parseResult.returnType].filterNull + parseResult.body.varDeclarations.filter [

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/STMethodSupport.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/STMethodSupport.xtend
@@ -23,21 +23,30 @@ import org.eclipse.fordiac.ide.structuredtextcore.stcore.STVarInOutDeclarationBl
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STVarInputDeclarationBlock
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STVarOutputDeclarationBlock
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STVarTempDeclarationBlock
-import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
 
 import static extension org.eclipse.emf.ecore.util.EcoreUtil.*
 import static extension org.eclipse.fordiac.ide.export.forte_ng.util.ForteNgExportUtil.*
 import static extension org.eclipse.fordiac.ide.structuredtextalgorithm.util.StructuredTextParseUtil.*
 
-@FinalFieldsConstructor
 class STMethodSupport extends StructuredTextSupport {
 	final org.eclipse.fordiac.ide.model.libraryElement.STMethod method
+	final Map<Object, Object> cache;
 
 	STMethod parseResult
 
+	new(org.eclipse.fordiac.ide.model.libraryElement.STMethod method, Map<?, ?> options) {
+		this.method = method
+		this.cache = options.cacheOption
+	}
+
 	override prepare() {
 		if (parseResult === null && errors.empty) {
-			parseResult = method.parse(errors, warnings, infos)
+			val container = method.eContainer
+			if (container instanceof BaseFBType)
+				parseResult = cache.computeCached(container)[container.parse(errors, warnings, infos)]?.elements?.
+					filter(STMethod)?.findFirst[name == method.name]
+			else
+				parseResult = method.parse(errors, warnings, infos)
 		}
 		return parseResult !== null
 	}
@@ -69,7 +78,7 @@ class STMethodSupport extends StructuredTextSupport {
 
 	def private getStructuredTextMethodParameters(STMethod method) {
 		method.body.varDeclarations.filter(STVarInputDeclarationBlock).flatMap[varDeclarations].map[it -> false] +
-		method.body.varDeclarations.filter(STVarInOutDeclarationBlock).flatMap[varDeclarations].map[it -> true] +
+			method.body.varDeclarations.filter(STVarInOutDeclarationBlock).flatMap[varDeclarations].map[it -> true] +
 			method.body.varDeclarations.filter(STVarOutputDeclarationBlock).flatMap[varDeclarations].map[it -> true]
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/StructuredTextSupportFactory.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/StructuredTextSupportFactory.xtend
@@ -27,9 +27,9 @@ class StructuredTextSupportFactory implements ILanguageSupportFactory {
 
 	override createLanguageSupport(Object source, Map<?, ?> options) {
 		if (source instanceof STAlgorithm) {
-			new STAlgorithmSupport(source)
+			new STAlgorithmSupport(source, options)
 		} else if (source instanceof STMethod) {
-			new STMethodSupport(source)
+			new STMethodSupport(source, options)
 		} else if (source instanceof STFunctionSource) {
 			new STFunctionSupport(source)
 		} else if (source instanceof ECTransition) {

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/StructuredTextSupportFactory.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/StructuredTextSupportFactory.xtend
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.export.forte_ng.st
 
+import java.util.Map
 import org.eclipse.fordiac.ide.export.language.ILanguageSupportFactory
 import org.eclipse.fordiac.ide.globalconstantseditor.globalConstants.STGlobalConstsSource
 import org.eclipse.fordiac.ide.model.libraryElement.ECTransition
@@ -24,7 +25,7 @@ import org.eclipse.fordiac.ide.structuredtextfunctioneditor.stfunction.STFunctio
 
 class StructuredTextSupportFactory implements ILanguageSupportFactory {
 
-	override createLanguageSupport(Object source) {
+	override createLanguageSupport(Object source, Map<?, ?> options) {
 		if (source instanceof STAlgorithm) {
 			new STAlgorithmSupport(source)
 		} else if (source instanceof STMethod) {

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/VarDeclarationSupport.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/VarDeclarationSupport.xtend
@@ -33,7 +33,7 @@ class VarDeclarationSupport extends StructuredTextSupport {
 	INamedElement resultType
 	STInitializerExpressionSource parseResult
 
-	override prepare(Map<?, ?> options) {
+	override prepare() {
 		prepareResultType && prepareInitialValue
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/VarGlobalConstantsSupport.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/VarGlobalConstantsSupport.xtend
@@ -35,7 +35,7 @@ class VarGlobalConstantsSupport extends StructuredTextSupport {
 		this.source = source
 	}
 	
-	override prepare(Map<?, ?> options) {
+	override prepare() {
 		if (source === null && errors.empty) {
 			source = globalConstants.parse(errors, warnings, infos)
 		}
@@ -43,7 +43,7 @@ class VarGlobalConstantsSupport extends StructuredTextSupport {
 	}
 
 	override generate(Map<?, ?> options) throws ExportException {
-		prepare(options)
+		prepare()
 		if (options.get(ForteNgExportFilter.OPTION_HEADER) == Boolean.TRUE)
 			source.generateStructuredTextGlobalVariablesSourceHeader
 		else
@@ -91,7 +91,7 @@ class VarGlobalConstantsSupport extends StructuredTextSupport {
 	'''
 
 	override getDependencies(Map<?, ?> options) {
-		prepare(options)
+		prepare()
 		if (options.get(ForteNgExportFilter.OPTION_HEADER) == Boolean.TRUE)
 			source.elements.flatMap[varDeclarations].map[type].toSet
 		else

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/algorithm/OtherAlgorithmSupport.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/algorithm/OtherAlgorithmSupport.xtend
@@ -22,7 +22,7 @@ import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
 class OtherAlgorithmSupport implements ILanguageSupport {
 	final OtherAlgorithm algorithm
 	
-	override prepare(Map<?, ?> options) { true }
+	override prepare() { true }
 	
 	override generate(Map<?, ?> options) throws ExportException '''
 		#pragma GCC warning "Algorithm of type: '«algorithm.language»' may lead to unexpected results!"

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/algorithm/OtherAlgorithmSupportFactory.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/algorithm/OtherAlgorithmSupportFactory.xtend
@@ -12,11 +12,12 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.export.forte_ng.algorithm
 
+import java.util.Map
 import org.eclipse.fordiac.ide.export.language.ILanguageSupportFactory
 import org.eclipse.fordiac.ide.model.libraryElement.OtherAlgorithm
 
 class OtherAlgorithmSupportFactory implements ILanguageSupportFactory {
-	override createLanguageSupport(Object source) {
+	override createLanguageSupport(Object source, Map<?,?> options) {
 		if (source instanceof OtherAlgorithm) {
 			new OtherAlgorithmSupport(source)
 		}

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/base/BaseFBHeaderTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/base/BaseFBHeaderTemplate.xtend
@@ -29,11 +29,12 @@ import org.eclipse.fordiac.ide.model.libraryElement.Method
 
 abstract class BaseFBHeaderTemplate<T extends BaseFBType> extends ForteFBTemplate<T> {
 	final Map<Method, ILanguageSupport> methodLanguageSupport
+	final Map<Object, Object> cache = newHashMap
 
 	new(T type, String name, Path prefix, String baseClass) {
 		super(type, name, prefix, baseClass)
 		methodLanguageSupport = type.methods.toInvertedMap [
-			ILanguageSupportFactory.createLanguageSupport("forte_ng", it)
+			ILanguageSupportFactory.createLanguageSupport("forte_ng", it, #{ILanguageSupport.OPTION_CACHE -> cache})
 		]
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/base/BaseFBImplTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/base/BaseFBImplTemplate.xtend
@@ -30,14 +30,15 @@ import org.eclipse.fordiac.ide.model.libraryElement.Method
 abstract class BaseFBImplTemplate<T extends BaseFBType> extends ForteFBTemplate<T> {
 	final Map<Algorithm, ILanguageSupport> algorithmLanguageSupport
 	final Map<Method, ILanguageSupport> methodLanguageSupport
+	final Map<Object, Object> cache = newHashMap
 
 	new(T type, String name, Path prefix, String baseClass) {
 		super(type, name, prefix, baseClass)
 		algorithmLanguageSupport = type.algorithm.toInvertedMap [
-			ILanguageSupportFactory.createLanguageSupport("forte_ng", it)
+			ILanguageSupportFactory.createLanguageSupport("forte_ng", it, #{ILanguageSupport.OPTION_CACHE -> cache})
 		]
 		methodLanguageSupport = type.methods.toInvertedMap [
-			ILanguageSupportFactory.createLanguageSupport("forte_ng", it)
+			ILanguageSupportFactory.createLanguageSupport("forte_ng", it, #{ILanguageSupport.OPTION_CACHE -> cache})
 		]
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/language/ILanguageSupport.java
+++ b/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/language/ILanguageSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Martin Erich Jobst
+ * Copyright (c) 2022, 2024 Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -22,7 +22,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 public interface ILanguageSupport {
 
 	/** Prepare for export */
-	boolean prepare(Map<?, ?> options);
+	boolean prepare();
 
 	/** Generate the template contents. */
 	CharSequence generate(Map<?, ?> options) throws ExportException;

--- a/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/language/ILanguageSupport.java
+++ b/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/language/ILanguageSupport.java
@@ -15,11 +15,17 @@ package org.eclipse.fordiac.ide.export.language;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.eclipse.fordiac.ide.export.ExportException;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 
 public interface ILanguageSupport {
+
+	/**
+	 * A option providing a {@code Map<Object, Object>} cache map.
+	 */
+	String OPTION_CACHE = "CACHE"; //$NON-NLS-1$
 
 	/** Prepare for export */
 	boolean prepare();
@@ -38,4 +44,17 @@ public interface ILanguageSupport {
 
 	/** Return the infos. */
 	List<String> getInfos();
+
+	@SuppressWarnings("unchecked")
+	static Map<Object, Object> getCacheOption(final Map<?, ?> options) {
+		return (Map<Object, Object>) options.get(OPTION_CACHE);
+	}
+
+	@SuppressWarnings("unchecked")
+	static <K, V> V computeCached(final Map<Object, Object> cache, final K key, final Function<K, V> function) {
+		if (cache != null) {
+			return (V) cache.computeIfAbsent(key, k -> function.apply((K) k));
+		}
+		return function.apply(key);
+	}
 }

--- a/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/language/ILanguageSupportFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/language/ILanguageSupportFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Martin Erich Jobst
+ * Copyright (c) 2022, 2024 Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,19 +12,25 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.export.language;
 
+import java.util.Collections;
 import java.util.Map;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.fordiac.ide.export.language.impl.LanguageSupportRegistryImpl;
 
 public interface ILanguageSupportFactory {
-	ILanguageSupport createLanguageSupport(final Object source);
+	ILanguageSupport createLanguageSupport(final Object source, Map<?, ?> options);
 
 	static <T extends EObject> ILanguageSupport createLanguageSupport(final String filter, final T source) {
+		return createLanguageSupport(filter, source, Collections.emptyMap());
+	}
+
+	static <T extends EObject> ILanguageSupport createLanguageSupport(final String filter, final T source,
+			final Map<?, ?> options) {
 		final ILanguageSupportFactory factory = Registry.INSTANCE.getFactory(filter,
 				source.eClass().getInstanceClass());
 		if (factory != null) {
-			return factory.createLanguageSupport(source);
+			return factory.createLanguageSupport(source, options);
 		}
 		return null;
 	}

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/util/STCoreUtil.xtend
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/util/STCoreUtil.xtend
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.structuredtextcore.stcore.util
 
+import com.google.common.cache.CacheBuilder
+import com.google.common.cache.LoadingCache
 import java.lang.reflect.Method
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -112,6 +114,9 @@ import static extension org.eclipse.emf.ecore.util.EcoreUtil.copy
 import static extension org.eclipse.fordiac.ide.model.eval.function.Functions.*
 
 final class STCoreUtil {
+	static final LoadingCache<Pair<DataType, String>, DataType> TYPE_DECLARATION_CACHE = CacheBuilder.newBuilder.maximumSize(1000).
+		build[TypeDeclarationParser.parseTypeDeclaration(key, value)]
+
 	private new() {
 	}
 
@@ -496,7 +501,7 @@ final class STCoreUtil {
 		switch (feature) {
 			VarDeclaration:
 				if (feature.array)
-					TypeDeclarationParser.parseTypeDeclaration(feature.type, ArraySizeHelper.getArraySize(feature))
+					TYPE_DECLARATION_CACHE.get(feature.type -> ArraySizeHelper.getArraySize(feature))
 				else
 					feature.type
 			STVarDeclaration: {


### PR DESCRIPTION
Optimize export of blocks with arrays and methods by:
- caching parsed type declarations for array variables of the FB type,
- caching parsed ST code for algorithms and methods belonging to an enclosing FB type.