### PR TITLE
fix UnsupportedOperationException when reloading typelib

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/TypeLibrary.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/TypeLibrary.java
@@ -196,15 +196,15 @@ public final class TypeLibrary {
 	}
 
 	public void reload() {
-		getAdapterTypes().clear();
-		getAttributeTypes().clear();
-		getDeviceTypes().clear();
-		getFbTypes().clear();
-		getResourceTypes().clear();
-		getSegmentTypes().clear();
-		getSubAppTypes().clear();
-		getSystems().clear();
-		getGlobalConstants().clear();
+		adapterTypes.clear();
+		attributeTypes.clear();
+		deviceTypes.clear();
+		fbTypes.clear();
+		resourceTypes.clear();
+		segmentTypes.clear();
+		subAppTypes.clear();
+		systems.clear();
+		globalConstants.clear();
 		dataTypeLib.clear();
 		programTypes.clear();
 		fileMap.clear();


### PR DESCRIPTION
the public reload method was getting the TypeMaps via the getters which were changed to unmodifiableCollection in #304 and tried to call clear() on those