### PR TITLE
Manifest file fixes for SWTBot Tests

### DIFF
--- a/tests/org.eclipse.fordiac.ide.test.ui/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.fordiac.ide.test.ui/META-INF/MANIFEST.MF
@@ -33,4 +33,4 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.swt,
  org.hamcrest.core,
  org.eclipse.draw2d,
- org.hamcrest.library;bundle-version="[1.3.0,2.0.0)"
+ org.hamcrest.library;bundle-version="[1.3.0,2.2.1)"

--- a/tests/org.eclipse.fordiac.ide.test.ui/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.fordiac.ide.test.ui/META-INF/MANIFEST.MF
@@ -33,4 +33,4 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.swt,
  org.hamcrest.core,
  org.eclipse.draw2d,
- org.hamcrest.library;bundle-version="[1.3.0,2.2.1)"
+ org.hamcrest.library


### PR DESCRIPTION
- Bundle version of org.hamcrest.library is fixed in MANIFEST.MF file in test.ui for SWTBot Tests.