### PR TITLE
Fix ambiguous type resolution in attribute name column

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/AttributeColumnAccessor.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/AttributeColumnAccessor.java
@@ -21,7 +21,6 @@ import org.eclipse.fordiac.ide.model.commands.change.ChangeCommentCommand;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeNameCommand;
 import org.eclipse.fordiac.ide.model.edit.helper.CommentHelper;
 import org.eclipse.fordiac.ide.model.edit.helper.InitialValueHelper;
-import org.eclipse.fordiac.ide.model.helpers.ImportHelper;
 import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
 import org.eclipse.fordiac.ide.ui.widget.CommandExecutor;
@@ -58,12 +57,7 @@ public class AttributeColumnAccessor extends AbstractColumnAccessor<Attribute, A
 	@Override
 	public Command createCommand(final Attribute rowObject, final AttributeTableColumn column, final Object newValue) {
 		return switch (column) {
-		case NAME -> {
-			final String newName = ImportHelper.deresolveImport((String) newValue,
-					PackageNameHelper.getContainerPackageName(rowObject.eContainer()),
-					ImportHelper.getContainerImports(rowObject.eContainer()));
-			yield ChangeNameCommand.forName(rowObject, Objects.toString(newName, NULL_DEFAULT));
-		}
+		case NAME -> ChangeNameCommand.forName(rowObject, Objects.toString(newValue, NULL_DEFAULT));
 		case TYPE -> ChangeAttributeTypeCommand.forTypeName(rowObject, Objects.toString(newValue, NULL_DEFAULT));
 		case VALUE -> new ChangeAttributeValueCommand(rowObject, Objects.toString(newValue, NULL_DEFAULT));
 		case COMMENT -> new ChangeCommentCommand(rowObject, Objects.toString(newValue, NULL_DEFAULT));

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AttributeSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AttributeSection.java
@@ -34,19 +34,18 @@ import org.eclipse.fordiac.ide.model.commands.create.CreateAttributeCommand;
 import org.eclipse.fordiac.ide.model.commands.delete.DeleteAttributeCommand;
 import org.eclipse.fordiac.ide.model.data.InternalDataType;
 import org.eclipse.fordiac.ide.model.datatype.helper.InternalAttributeDeclarations;
-import org.eclipse.fordiac.ide.model.helpers.ImportHelper;
-import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
 import org.eclipse.fordiac.ide.model.libraryElement.AttributeDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableObject;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
-import org.eclipse.fordiac.ide.model.typelibrary.AttributeTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
 import org.eclipse.fordiac.ide.model.ui.nat.DataTypeSelectionTreeContentProvider;
 import org.eclipse.fordiac.ide.model.ui.widgets.AttributeSelectionContentProvider;
 import org.eclipse.fordiac.ide.model.ui.widgets.DataTypeSelectionContentProvider;
+import org.eclipse.fordiac.ide.model.ui.widgets.ImportContentProposal;
+import org.eclipse.fordiac.ide.model.ui.widgets.ImportTypeSelectionProposalProvider;
 import org.eclipse.fordiac.ide.model.ui.widgets.TypeSelectionButton;
-import org.eclipse.fordiac.ide.model.ui.widgets.TypeSelectionProposalProvider;
 import org.eclipse.fordiac.ide.ui.widget.AddDeleteReorderListWidget;
 import org.eclipse.fordiac.ide.ui.widget.ChangeableListDataProvider;
 import org.eclipse.fordiac.ide.ui.widget.I4diacNatTableUtil;
@@ -110,8 +109,8 @@ public class AttributeSection extends AbstractSection implements I4diacNatTableU
 			return true;
 		};
 		final AttributeNameCellEditor attributeNameCellEditor = new AttributeNameCellEditor();
-		attributeNameCellEditor.enableContentProposal(
-				new TextContentAdapter(), new TypeSelectionProposalProvider(this::getTypeLibrary,
+		attributeNameCellEditor.enableContentProposal(new TextContentAdapter(),
+				new ImportTypeSelectionProposalProvider(this::getType, TypeLibrary::getAttributeTypeEntry,
 						AttributeSelectionContentProvider.INSTANCE, targetFilter),
 				KeyStroke.getInstance(SWT.CTRL, SWT.SPACE), null);
 		table.addConfiguration(new AbstractRegistryConfiguration() {
@@ -236,13 +235,9 @@ public class AttributeSection extends AbstractSection implements I4diacNatTableU
 		}
 
 		protected void proposalAccepted(final IContentProposal proposal) {
-			final AttributeTypeEntry packageEntry = ImportHelper.resolveImport(
-					PackageNameHelper.extractPlainTypeName(proposal.getContent()), getType(),
-					getTypeLibrary()::getAttributeTypeEntry, name -> null);
-
-			if (packageEntry == null
+			if (proposal instanceof final ImportContentProposal importProposal
 					&& EcoreUtil.getRootContainer(getType()) instanceof final LibraryElement libraryElement) {
-				executeCommand(new AddNewImportCommand(libraryElement, proposal.getContent()));
+				executeCommand(new AddNewImportCommand(libraryElement, importProposal.getImportedNamespace()));
 			}
 		}
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/widgets/ImportContentProposal.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/widgets/ImportContentProposal.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Martin Erich Jobst
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Martin Jobst - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.model.ui.widgets;
+
+import java.util.Objects;
+
+import org.eclipse.jface.fieldassist.ContentProposal;
+
+public class ImportContentProposal extends ContentProposal {
+
+	private final String importedNamespace;
+
+	public ImportContentProposal(final String content, final String label, final String description,
+			final String importedNamespace) {
+		super(content, label, description);
+		this.importedNamespace = Objects.requireNonNull(importedNamespace);
+	}
+
+	public String getImportedNamespace() {
+		return importedNamespace;
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/widgets/ImportTypeSelectionProposalProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/widgets/ImportTypeSelectionProposalProvider.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Martin Erich Jobst
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Martin Jobst - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.model.ui.widgets;
+
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.fordiac.ide.model.helpers.ImportHelper;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
+import org.eclipse.jface.fieldassist.ContentProposal;
+
+public class ImportTypeSelectionProposalProvider extends TypeSelectionProposalProvider {
+
+	private final Supplier<? extends EObject> supplier;
+	private final BiFunction<TypeLibrary, String, ? extends TypeEntry> typeResolver;
+
+	public ImportTypeSelectionProposalProvider(final Supplier<? extends EObject> supplier,
+			final BiFunction<TypeLibrary, String, ? extends TypeEntry> typeResolver,
+			final ITypeSelectionContentProvider contentProvider) {
+		super(() -> TypeLibraryManager.INSTANCE.getTypeLibraryFromContext(supplier.get()), contentProvider);
+		this.supplier = supplier;
+		this.typeResolver = typeResolver;
+	}
+
+	public ImportTypeSelectionProposalProvider(final Supplier<? extends EObject> supplier,
+			final BiFunction<TypeLibrary, String, ? extends TypeEntry> typeResolver,
+			final ITypeSelectionContentProvider contentProvider, final Predicate<TypeEntry> additionalFilter) {
+		super(() -> TypeLibraryManager.INSTANCE.getTypeLibraryFromContext(supplier.get()), contentProvider,
+				additionalFilter);
+		this.supplier = supplier;
+		this.typeResolver = typeResolver;
+	}
+
+	@Override
+	protected ContentProposal createProposal(final TypeEntry typeEntry) {
+		final TypeEntry resolvedEntry = ImportHelper.resolveImport(typeEntry.getTypeName(), supplier.get(),
+				name -> typeResolver.apply(getTypeLibrary(), name), name -> null);
+		if (resolvedEntry == null) { // no import yet -> use unqualified name and add import
+			return new ImportContentProposal(typeEntry.getTypeName(), typeEntry.getTypeName(),
+					typeEntry.getFullTypeName(), typeEntry.getFullTypeName());
+		}
+		if (resolvedEntry == typeEntry) { // already imported -> use unqualified name
+			return new ContentProposal(typeEntry.getTypeName(), typeEntry.getTypeName(), typeEntry.getFullTypeName());
+		}
+		// different import -> use FQN
+		return new ContentProposal(typeEntry.getFullTypeName(), typeEntry.getTypeName(), typeEntry.getFullTypeName());
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/widgets/TypeSelectionProposalProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/widgets/TypeSelectionProposalProvider.java
@@ -67,4 +67,12 @@ public class TypeSelectionProposalProvider implements IContentProposalProvider {
 	protected ContentProposal createProposal(final TypeEntry typeEntry) {
 		return new ContentProposal(typeEntry.getFullTypeName(), typeEntry.getTypeName(), typeEntry.getFullTypeName());
 	}
+
+	protected TypeLibrary getTypeLibrary() {
+		return supplier.get();
+	}
+
+	protected ITypeSelectionContentProvider getContentProvider() {
+		return contentProvider;
+	}
 }


### PR DESCRIPTION
The AttributeColumnAccessor did attempt to deresolve the new attribute name with respect to the imports of the current type. This could lead to the wrong attribute declaration being used when there were two attribute declaration with the same name (but different package) in the current scope. An example would be an attribute declaration in the current package and one without any package, both with the same name.

This changes the name handling so that the entered name is used as-is. The determination whether to use a full or unqualified name and whether to add an import is now performed when creating the proposals.