### PR TITLE
Zooming via Toolbar Combobox did a Different Scrolling

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/AdvancedZoomManager.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/AdvancedZoomManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Johannes Kepler University
+ * Copyright (c) 2019, 2024 Johannes Kepler University
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,11 +14,9 @@ package org.eclipse.fordiac.ide.gef.editparts;
 
 import org.eclipse.draw2d.FreeformFigure;
 import org.eclipse.draw2d.IFigure;
-import org.eclipse.draw2d.RangeModel;
 import org.eclipse.draw2d.ScalableFigure;
 import org.eclipse.draw2d.Viewport;
 import org.eclipse.draw2d.geometry.Dimension;
-import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.gef.editparts.ZoomManager;
 
 public class AdvancedZoomManager extends ZoomManager {
@@ -26,26 +24,6 @@ public class AdvancedZoomManager extends ZoomManager {
 	AdvancedZoomManager(final ScalableFigure pane, final Viewport viewport) {
 		super(pane, viewport);
 	}
-
-	@Override
-	public void setZoomAsText(final String zoomString) {
-		super.setZoomAsText(zoomString);
-
-		if (FIT_HEIGHT.equalsIgnoreCase(FIT_HEIGHT) || FIT_ALL.equalsIgnoreCase(zoomString)
-				|| FIT_WIDTH.equalsIgnoreCase(zoomString)) {
-			// scroll to the center so that our drawing canvas is fully shown
-			final Point scrollPoint = new Point(calculateCenterScrollPos(getViewport().getHorizontalRangeModel()),
-					calculateCenterScrollPos(getViewport().getVerticalRangeModel()));
-			setViewLocation(scrollPoint);
-		}
-
-	}
-
-	private static int calculateCenterScrollPos(final RangeModel rangeModel) {
-		final int center = (rangeModel.getMaximum() + rangeModel.getMinimum()) / 2;
-		return center - rangeModel.getExtent() / 2;
-	}
-
 
 	@Override
 	protected double getFitHeightZoomLevel() {
@@ -62,17 +40,20 @@ public class AdvancedZoomManager extends ZoomManager {
 		return getFitXZoomLevelBounds(0);
 	}
 
-	/** This method is copied from {@link ZoomManager} and adjusted such that it uses the bounds of the figure to
-	 * correctly take the modulo figure into account.
+	/**
+	 * This method is copied from {@link ZoomManager} and adjusted such that it uses
+	 * the bounds of the figure to correctly take the modulo figure into account.
 	 *
-	 * See {@link ZoomManager#getFitXZoomLevel(final int which)} for the original implementation. */
+	 * See {@link ZoomManager#getFitXZoomLevel(final int which)} for the original
+	 * implementation.
+	 */
 	private double getFitXZoomLevelBounds(final int which) {
 		IFigure fig = getScalableFigure();
 
 		final Dimension available = getViewport().getClientArea().getSize();
 		Dimension desired;
-		if (fig instanceof FreeformFigure) {
-			desired = ((FreeformFigure) fig).getBounds().getSize();
+		if (fig instanceof final FreeformFigure ff) {
+			desired = ff.getBounds().getSize();
 		} else {
 			desired = fig.getPreferredSize().getCopy();
 		}


### PR DESCRIPTION
When zooming in a graphical editor we either try to keep the position under the mouse, or if the mouse is outside of the editor the center of the current view, constant.

When zooming via the combobox this was different and always scrolled to the center of the whole canvas. This is now harmonized.