### PR TITLE
fixed testblock generation 

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/handler/CreateRuntimeTestFunctionBlockHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/handler/CreateRuntimeTestFunctionBlockHandler.java
@@ -29,7 +29,9 @@ import org.eclipse.fordiac.ide.fb.interpreter.testappgen.MatchFBGenerator;
 import org.eclipse.fordiac.ide.fb.interpreter.testappgen.MuxFBGenerator;
 import org.eclipse.fordiac.ide.fb.interpreter.testappgen.RunAllFBGenerator;
 import org.eclipse.fordiac.ide.fb.interpreter.testappgen.TestsignalFBGenerator;
+import org.eclipse.fordiac.ide.fb.interpreter.testappgen.internal.AbstractBlockGenerator;
 import org.eclipse.fordiac.ide.fb.interpreter.testcasemodel.TestSuite;
+import org.eclipse.fordiac.ide.model.libraryElement.BasicFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.CompositeFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
@@ -40,6 +42,7 @@ import org.eclipse.ui.actions.WorkspaceModifyOperation;
 import org.eclipse.ui.handlers.HandlerUtil;
 
 public class CreateRuntimeTestFunctionBlockHandler extends AbstractHandler {
+	private static final boolean SCHNEIDER_COMPLICIT = false;
 
 	@Override
 	public Object execute(final ExecutionEvent event) throws ExecutionException {
@@ -82,7 +85,12 @@ public class CreateRuntimeTestFunctionBlockHandler extends AbstractHandler {
 			throws CoreException {
 		// testsignal generator block
 		final FBType testType = new TestsignalFBGenerator(type, testSuite).generateTestFb();
-		testType.getTypeEntry().save(testType, monitor);
+		if (SCHNEIDER_COMPLICIT) {
+			final FBType fb = makeBlockCompliant((BasicFBType) testType);
+			fb.getTypeEntry().save(fb, monitor);
+		} else {
+			testType.getTypeEntry().save(testType, monitor);
+		}
 
 		// matches the expected with the actual behaviour
 		final List<FBType> list = new ArrayList<>();
@@ -90,7 +98,12 @@ public class CreateRuntimeTestFunctionBlockHandler extends AbstractHandler {
 			final FBType matchType = new MatchFBGenerator(type, testSuite).generateMatchFB();
 
 			try {
-				matchType.getTypeEntry().save(matchType, monitor);
+				if (SCHNEIDER_COMPLICIT) {
+					final FBType fb = makeBlockCompliant((BasicFBType) matchType);
+					fb.getTypeEntry().save(fb, monitor);
+				} else {
+					matchType.getTypeEntry().save(matchType, monitor);
+				}
 			} catch (final CoreException e) {
 				FordiacLogHelper.logError(e.getMessage());
 			}
@@ -99,7 +112,13 @@ public class CreateRuntimeTestFunctionBlockHandler extends AbstractHandler {
 			// composite
 			final FBType muxType = new MuxFBGenerator(type, testSuite).generateMuxFB();
 			try {
-				muxType.getTypeEntry().save(muxType, monitor);
+				if (SCHNEIDER_COMPLICIT) {
+					final FBType fb = makeBlockCompliant((BasicFBType) muxType);
+					fb.getTypeEntry().save(fb, monitor);
+				} else {
+					muxType.getTypeEntry().save(muxType, monitor);
+				}
+
 			} catch (final CoreException e) {
 				FordiacLogHelper.logError(e.getMessage());
 			}
@@ -107,7 +126,12 @@ public class CreateRuntimeTestFunctionBlockHandler extends AbstractHandler {
 			// generates the signals for the testsignal and mux fb
 			final FBType runAllType = new RunAllFBGenerator(type, testSuite).generateRunAllFB();
 			try {
-				runAllType.getTypeEntry().save(runAllType, monitor);
+				if (SCHNEIDER_COMPLICIT) {
+					final FBType fb = makeBlockCompliant((BasicFBType) runAllType);
+					fb.getTypeEntry().save(fb, monitor);
+				} else {
+					runAllType.getTypeEntry().save(runAllType, monitor);
+				}
 			} catch (final CoreException e) {
 				FordiacLogHelper.logError(e.getMessage());
 			}
@@ -121,12 +145,16 @@ public class CreateRuntimeTestFunctionBlockHandler extends AbstractHandler {
 
 			final CompositeFBType compositeType = new CompositeTestFBGenerator(type, testSuite, list)
 					.generateCompositeFB();
-
 			try {
 				compositeType.getTypeEntry().save(compositeType, monitor);
 			} catch (final CoreException e) {
 				FordiacLogHelper.logError(e.getMessage());
 			}
+
 		});
+	}
+
+	private static BasicFBType makeBlockCompliant(final BasicFBType fb) {
+		return AbstractBlockGenerator.createComplianceEcc(fb);
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/CompositeTestFBGenerator.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/CompositeTestFBGenerator.java
@@ -117,8 +117,7 @@ public class CompositeTestFBGenerator extends AbstractCompositeFBGenerator {
 
 	private void addTimeOutFB(final FBNetwork net, final int x, final int y) {
 		final FBNetworkElement compEl = LibraryElementFactory.eINSTANCE.createCFBInstance();
-
-		final TypeEntry compType = sourceType.getTypeLibrary().getFBTypeEntry("E_TimeOut"); //$NON-NLS-1$
+		final TypeEntry compType = sourceType.getTypeLibrary().getFBTypeEntry(TestGenBlockNames.TIMEOUT_COMPOSITE_NAME);
 		compEl.setTypeEntry(compType);
 		addPosition(compEl, x + (double) 200, y + (double) 150);
 
@@ -259,7 +258,7 @@ public class CompositeTestFBGenerator extends AbstractCompositeFBGenerator {
 
 		// data connections from the testsignal generator block
 		for (int i = 0; i < toTestFBs.get(index).getInterface().getInputVars().size(); i++) {
-			getDataConns().add(createDataConn(testFBs.get(index).getInterface().getOutputVars().get(i),
+			getDataConns().add(createDataConn(testFBs.get(index).getInterface().getOutputVars().get(i + 1),
 					toTestFBs.get(index).getInterface().getInputVars().get(i)));
 		}
 	}

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/CompositeTestFBGenerator.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/CompositeTestFBGenerator.java
@@ -93,9 +93,9 @@ public class CompositeTestFBGenerator extends AbstractCompositeFBGenerator {
 				// easier access when creating connections
 				addBlockToAccordingList(addedBlock, i, j);
 
-				// add timeOut block to matchFb
-				if (j == 2) {
-					addTimeOutFB(net, x, y);
+				// add timeOut block to testsignalgenFb and matchFb
+				if (j == 0 || j == 2) {
+					addTimeOutFB(net, addedBlock, x, y);
 				}
 			}
 		}
@@ -115,7 +115,7 @@ public class CompositeTestFBGenerator extends AbstractCompositeFBGenerator {
 		}
 	}
 
-	private void addTimeOutFB(final FBNetwork net, final int x, final int y) {
+	private void addTimeOutFB(final FBNetwork net, final FB fb, final int x, final int y) {
 		final FBNetworkElement compEl = LibraryElementFactory.eINSTANCE.createCFBInstance();
 		final TypeEntry compType = sourceType.getTypeLibrary().getFBTypeEntry(TestGenBlockNames.TIMEOUT_COMPOSITE_NAME);
 		compEl.setTypeEntry(compType);
@@ -128,7 +128,7 @@ public class CompositeTestFBGenerator extends AbstractCompositeFBGenerator {
 		compEl.setName(name);
 
 		// connection between matchFB and timeOut
-		final AdapterConnection a = createAdapterConnection(matchFBs.getLast().getInterface().getPlugs().get(0),
+		final AdapterConnection a = createAdapterConnection(fb.getInterface().getPlugs().get(0),
 				compositeFB.getFBNetwork().getFBNamed(name).getInterface().getSockets().get(0));
 		compositeFB.getFBNetwork().getAdapterConnections().add(a);
 	}

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/GeneratedNameConstants.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/GeneratedNameConstants.java
@@ -27,6 +27,8 @@ public class GeneratedNameConstants {
 
 	public static final String VARDECL_TESTCASENAME = "TestCaseName"; //$NON-NLS-1$
 
+	public static final String TESTSIGNALGEN_CASECOUNT_PINNAME = "case_count"; //$NON-NLS-1$
+
 	private GeneratedNameConstants() {
 		// empty private constructor
 	}

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/GeneratedNameConstants.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/GeneratedNameConstants.java
@@ -29,6 +29,8 @@ public class GeneratedNameConstants {
 
 	public static final String TESTSIGNALGEN_CASECOUNT_PINNAME = "case_count"; //$NON-NLS-1$
 
+	public static final String START_STATE = "START"; //$NON-NLS-1$
+
 	private GeneratedNameConstants() {
 		// empty private constructor
 	}

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/MatchFBGenerator.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/MatchFBGenerator.java
@@ -54,7 +54,7 @@ public class MatchFBGenerator extends AbstractBasicFBGenerator {
 	protected void generateECC() {
 		eccGen = new TestEccGenerator(destinationFB.getECC(), 0);
 		createTimeOutPlug();
-		final Algorithm timeout = createTimeOutAlg(destinationFB, 500);
+		final Algorithm timeout = createTimeOutAlgMatchFB(destinationFB, 300);
 
 		// retrieve input events with "expected" in the name
 		final List<Event> evExpected = destinationFB.getInterfaceList().getEventInputs().subList(0,

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/TestEccGenerator.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/TestEccGenerator.java
@@ -111,7 +111,29 @@ public class TestEccGenerator {
 		return act;
 	}
 
+	public static ECAction createAction(final Algorithm alg) {
+		final ECAction act = createAction();
+		act.setAlgorithm(alg);
+		return act;
+	}
+
 	public static Algorithm createAlgorithm(final BasicFBType fb, final String name, final String algText) {
+		if (fb.getAlgorithmNamed(name) != null) {
+			return fb.getAlgorithmNamed(name);
+		}
+		final TextAlgorithm alg = LibraryElementFactory.eINSTANCE.createSTAlgorithm();
+		alg.setName(name);
+		final StringBuilder sb = new StringBuilder();
+		sb.append("\n"); //$NON-NLS-1$
+		sb.append(algText);
+		alg.setText(sb.toString());
+		fb.getCallables().add(alg);
+		return alg;
+
+	}
+
+	public static Algorithm createSchneiderComplicitAlgorithm(final BasicFBType fb, final String name,
+			final String algText) {
 		if (fb.getAlgorithmNamed(name) != null) {
 			return fb.getAlgorithmNamed(name);
 		}
@@ -119,14 +141,13 @@ public class TestEccGenerator {
 		final TextAlgorithm alg = LibraryElementFactory.eINSTANCE.createSTAlgorithm();
 		alg.setName(name);
 		final StringBuilder sb = new StringBuilder();
-		sb.append("ALGORITHM "); //$NON-NLS-1$
-		sb.append(name);
-		sb.append("\n"); //$NON-NLS-1$
+		sb.append("***ALGORITHM*** \n"); //$NON-NLS-1$
 		sb.append(algText);
-		sb.append("\n END_ALGORITHM \n\n\n"); //$NON-NLS-1$
+		sb.append("\n***END_ALGORITHM*** \n\n"); //$NON-NLS-1$
 		alg.setText(sb.toString());
 		fb.getCallables().add(alg);
 		return alg;
+
 	}
 
 	public ECState getLastState() {

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/TestGenBlockNames.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/TestGenBlockNames.java
@@ -1,0 +1,13 @@
+package org.eclipse.fordiac.ide.fb.interpreter.testappgen;
+
+public class TestGenBlockNames {
+
+	public static final String TIMEOUT_ADAPTER_NAME = "ATimeOutS"; //$NON-NLS-1$
+	public static final String TIMEOUT_PIN_NAME = "DT1"; //$NON-NLS-1$
+	public static final String TIMEOUT_COMPOSITE_NAME = "E_TimeOutS"; //$NON-NLS-1$
+	public static final String MATCH_TIMEOUT_PINNAME = "timeout"; //$NON-NLS-1$
+
+	private TestGenBlockNames() {
+		// empty private constructor
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/TestsignalFBGenerator.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/TestsignalFBGenerator.java
@@ -22,6 +22,7 @@ import org.eclipse.fordiac.ide.fb.interpreter.testappgen.internal.AbstractBasicF
 import org.eclipse.fordiac.ide.fb.interpreter.testcasemodel.TestCase;
 import org.eclipse.fordiac.ide.fb.interpreter.testcasemodel.TestState;
 import org.eclipse.fordiac.ide.fb.interpreter.testcasemodel.TestSuite;
+import org.eclipse.fordiac.ide.model.FordiacKeywords;
 import org.eclipse.fordiac.ide.model.libraryElement.Algorithm;
 import org.eclipse.fordiac.ide.model.libraryElement.BasicFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.ECAction;
@@ -116,7 +117,6 @@ public class TestsignalFBGenerator extends AbstractBasicFBGenerator {
 	}
 
 	public static Algorithm createValueSettingAlgorithm(final BasicFBType fb, final TestState testState) {
-		boolean containsParameters = false;
 		int nameCnt = 0;
 		if (!fb.getAlgorithm().isEmpty()) {
 			nameCnt = Integer.parseInt(fb.getAlgorithm().getLast().getName().substring(1));
@@ -124,25 +124,22 @@ public class TestsignalFBGenerator extends AbstractBasicFBGenerator {
 		}
 
 		final StringBuilder algText = new StringBuilder();
+		algText.append(GeneratedNameConstants.TESTSIGNALGEN_CASECOUNT_PINNAME + " := " //$NON-NLS-1$
+				+ testState.getTestCase().getServiceSequence().getServiceTransaction().size() + "; \n"); //$NON-NLS-1$
 
 		if (testState.getTestTrigger().getParameters() != null
 				&& !testState.getTestTrigger().getParameters().equals("")) { //$NON-NLS-1$
-			containsParameters = true;
 			algText.append(testState.getTestTrigger().getParameters().replace(";", ";\n")); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 
 		for (final OutputPrimitive outP : testState.getTestOutputs()) {
 			if (outP.getParameters() != null && !outP.getParameters().equals("")) { //$NON-NLS-1$
-				containsParameters = true;
 				String s = outP.getParameters().replace(";", ";\n");//$NON-NLS-1$ //$NON-NLS-2$
 				s = createDataPinName(s);
 				algText.append(s);
 			}
 		}
 
-		if (!containsParameters) {
-			return null;
-		}
 		return TestEccGenerator.createAlgorithm(fb, "A" + nameCnt, algText.toString()); //$NON-NLS-1$
 	}
 
@@ -180,6 +177,8 @@ public class TestsignalFBGenerator extends AbstractBasicFBGenerator {
 	@Override
 	protected List<VarDeclaration> createOutputDataList() {
 		final List<VarDeclaration> list = new ArrayList<>();
+		list.add(createOutputVarDecl(sourceType.getTypeLibrary().getDataTypeLibrary().getType(FordiacKeywords.INT),
+				GeneratedNameConstants.TESTSIGNALGEN_CASECOUNT_PINNAME));
 		list.addAll(sourceType.getInterfaceList().getInputVars().stream()
 				.map(n -> createOutputVarDecl(n.getType(), n.getName())).toList());
 		list.addAll(sourceType.getInterfaceList().getOutputVars().stream()

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/TestsignalFBGenerator.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/TestsignalFBGenerator.java
@@ -68,7 +68,7 @@ public class TestsignalFBGenerator extends AbstractBasicFBGenerator {
 	@Override
 	protected void generateECC() {
 		createTimeOutPlug();
-		final Algorithm timeoutAlg = createTimeOutAlg(destinationFB, 300);
+		final Algorithm timeoutAlg = createTimeOutAlg(destinationFB, 250);
 
 		final TestEccGenerator eccGen = new TestEccGenerator(destinationFB.getECC(), 0);
 		for (final TestCase testCase : testSuite.getTestCases()) {

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/internal/AbstractBasicFBGenerator.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/internal/AbstractBasicFBGenerator.java
@@ -16,9 +16,16 @@ package org.eclipse.fordiac.ide.fb.interpreter.testappgen.internal;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.fordiac.ide.fb.interpreter.testappgen.GeneratedNameConstants;
+import org.eclipse.fordiac.ide.fb.interpreter.testappgen.TestEccGenerator;
+import org.eclipse.fordiac.ide.fb.interpreter.testappgen.TestGenBlockNames;
 import org.eclipse.fordiac.ide.fb.interpreter.testcasemodel.TestCase;
 import org.eclipse.fordiac.ide.fb.interpreter.testcasemodel.TestState;
 import org.eclipse.fordiac.ide.fb.interpreter.testcasemodel.TestSuite;
+import org.eclipse.fordiac.ide.fbtypeeditor.ecc.contentprovider.ECCContentAndLabelProvider;
+import org.eclipse.fordiac.ide.model.commands.create.CreateInterfaceElementCommand;
+import org.eclipse.fordiac.ide.model.libraryElement.AdapterDeclaration;
+import org.eclipse.fordiac.ide.model.libraryElement.Algorithm;
 import org.eclipse.fordiac.ide.model.libraryElement.BasicFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.ECState;
 import org.eclipse.fordiac.ide.model.libraryElement.Event;
@@ -26,6 +33,9 @@ import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.OutputPrimitive;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.typelibrary.AdapterTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
+import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 
 public abstract class AbstractBasicFBGenerator extends AbstractBlockGenerator {
 
@@ -133,6 +143,38 @@ public abstract class AbstractBasicFBGenerator extends AbstractBlockGenerator {
 			}
 		}
 		return list;
+	}
+
+	protected AdapterDeclaration createTimeOutPlug() {
+		final TypeLibrary typelib = entry.getTypeLibrary();
+		final AdapterTypeEntry timeOutEntry = typelib.getAdapterTypeEntry(TestGenBlockNames.TIMEOUT_ADAPTER_NAME);
+		final CreateInterfaceElementCommand cmd = new CreateInterfaceElementCommand(timeOutEntry.getType(),
+				TestGenBlockNames.MATCH_TIMEOUT_PINNAME, destinationFB.getInterfaceList(), false, -1);
+		try {
+			cmd.execute();
+		} catch (final Exception e) {
+			FordiacLogHelper.logError(e.getMessage());
+		}
+
+		final AdapterDeclaration timeOutPlug = (AdapterDeclaration) cmd.getCreatedElement();
+		destinationFB.getInterfaceList().getPlugs().add(timeOutPlug);
+		return timeOutPlug;
+	}
+
+	protected static Algorithm createTimeOutAlg(final BasicFBType fb, final int timeMS) {
+		final String algText = TestGenBlockNames.MATCH_TIMEOUT_PINNAME + "." + TestGenBlockNames.TIMEOUT_PIN_NAME //$NON-NLS-1$
+				+ " := TIME#" + timeMS + "ms; \n";//$NON-NLS-1$ //$NON-NLS-2$
+		return TestEccGenerator.createAlgorithm(fb, "TimeOutAlg", algText); //$NON-NLS-1$
+	}
+
+	protected Event getStartTimeoutEvent() {
+		return ECCContentAndLabelProvider.getOutputEvents(destinationFB).stream()
+				.filter(s -> s.getName().equals(GeneratedNameConstants.START_STATE)).findFirst().orElse(null);
+	}
+
+	protected Event getTransitionTimeOutEvent() {
+		return ECCContentAndLabelProvider.getInputEvents(destinationFB).stream().filter(s -> ECCContentAndLabelProvider
+				.getEventName(s).equals(TestGenBlockNames.MATCH_TIMEOUT_PINNAME + ".TimeOut")).findFirst().orElse(null); //$NON-NLS-1$
 	}
 
 	protected abstract List<Event> createInputEventList();

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testcasemodel/TestState.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testcasemodel/TestState.java
@@ -41,4 +41,8 @@ public class TestState {
 	public List<OutputPrimitive> getTestOutputs() {
 		return dataSource.getOutputPrimitive();
 	}
+
+	public ServiceTransaction getTestCase() {
+		return dataSource;
+	}
 }

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/figures/ServiceFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/figures/ServiceFigure.java
@@ -39,7 +39,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.FontData;
 
 public final class ServiceFigure extends FreeformLayeredPane {
-	private static final int MIDDLE_LINE_WIDTH = 5;
+	private static final int MIDDLE_LINE_WIDTH = 2;
 	public static final String LABEL_FONT = "labelFont"; //$NON-NLS-1$
 
 	private Label leftLabel;
@@ -65,8 +65,7 @@ public final class ServiceFigure extends FreeformLayeredPane {
 
 	private static FontRegistry createFontRegistry() {
 		final FontRegistry newfontRegistry = new FontRegistry();
-		newfontRegistry.put(LABEL_FONT, new FontData[] {
-				new FontData("Arial", 10, SWT.NONE) //$NON-NLS-1$
+		newfontRegistry.put(LABEL_FONT, new FontData[] { new FontData("Arial", 10, SWT.NONE) //$NON-NLS-1$
 		});
 		return newfontRegistry;
 	}
@@ -81,11 +80,14 @@ public final class ServiceFigure extends FreeformLayeredPane {
 		layout.verticalSpacing = 0;
 		baseLayer.setLayoutManager(layout);
 
-
 		final Figure leftFigure = new Figure();
+		final AdvancedLineBorder leftMiddleLine = new AdvancedLineBorder(PositionConstants.EAST);
+		leftMiddleLine.setWidth(2 * MIDDLE_LINE_WIDTH);
+		leftFigure.setBorder(leftMiddleLine);
 		baseLayer.add(leftFigure);
 
-		final LineBorder middleLines = new AdvancedLineBorder(PositionConstants.EAST | PositionConstants.WEST);
+		// final LineBorder middleLines = new LineBorder();
+		final LineBorder middleLines = leftMiddleLine;
 		middleLines.setWidth(MIDDLE_LINE_WIDTH);
 		middleLines.setColor(ColorManager.getColor(ServiceConstants.TEXT_BLUE));
 
@@ -118,7 +120,6 @@ public final class ServiceFigure extends FreeformLayeredPane {
 
 		add(baseLayer);
 	}
-
 
 	private void createInterfaceLayer() {
 		final Layer interfaceLayer = new FreeformLayer();
@@ -159,6 +160,7 @@ public final class ServiceFigure extends FreeformLayeredPane {
 		}
 		return label;
 	}
+
 	private void createServiceSequenceLayer() {
 		serviceSequenceContainer = new FreeformLayer();
 		serviceSequenceContainer.setBorder(new MarginBorder(20, 10, 5, 10));


### PR DESCRIPTION
Testsignalfb now has a timeout adapter, so it can send the next output event after some time, because the matchfb doesn't send nextCases if there are no expected outputs.
