### PR TITLE
Disable Adapter Interface Elements for Adapters #373

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/plugin.xml
@@ -134,7 +134,7 @@
          </propertySection>
          <propertySection
                class="org.eclipse.fordiac.ide.fbtypeeditor.properties.EditInterfaceAdapterSection"
-               filter="org.eclipse.fordiac.ide.fbtypeeditor.properties.FBTypePropertiesFilter"
+               filter="org.eclipse.fordiac.ide.fbtypeeditor.properties.EditInterfaceAdapterSectionFilter"
                id="org.eclipse.fordiac.ide.fbtypeeditor.properties.section.EditAdapters"
                tab="org.eclipse.fordiac.ide.fbtypeeditor.property.tab.EditAdapters">
          </propertySection>

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/FBInterfacePaletteFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/FBInterfacePaletteFactory.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2011 - 2017 Profactor GmbH, TU Wien ACIN, fortiss GmbH
+ * Copyright (c) 2011, 2024 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
+ *                          Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -30,14 +31,18 @@ public final class FBInterfacePaletteFactory {
 			"FBInterfacePaletteFactory.Size", //$NON-NLS-1$
 			"FBInterfacePaletteFactory.State"); //$NON-NLS-1$
 
-	public static PaletteRoot createPalette(final TypeLibrary typeLib) {
+	public static PaletteRoot createPalette(final TypeLibrary typeLib, final boolean createAdapterEntries) {
 		final PaletteRoot palette = new PaletteRoot();
-		fillPalette(typeLib, palette);
+		palette.add(createEventDrawer());
+		palette.add(createDataTypeDrawer(typeLib));
+		if (createAdapterEntries) {
+			createAdapterEntry(palette, typeLib);
+		}
 		return palette;
 	}
 
-	private static void fillPalette(final TypeLibrary typeLib, final PaletteRoot palette) {
-		PaletteDrawer drawer = new PaletteDrawer(Messages.FBInterfacePaletteFactory_EventTypes);
+	private static PaletteDrawer createEventDrawer() {
+		final PaletteDrawer drawer = new PaletteDrawer(Messages.FBInterfacePaletteFactory_EventTypes);
 
 		for (final DataType type : EventTypeLibrary.getInstance().getEventTypes()) {
 			final ImageDescriptor desc = FordiacImage.ICON_DATA_TYPE.getImageDescriptor();
@@ -45,8 +50,11 @@ public final class FBInterfacePaletteFactory {
 					type.getComment(), new DataTypeCreationFactory(type), desc, desc);
 			drawer.add(combined);
 		}
-		palette.add(drawer);
+		return drawer;
+	}
 
+	private static PaletteDrawer createDataTypeDrawer(final TypeLibrary typeLib) {
+		PaletteDrawer drawer;
 		drawer = new PaletteDrawer(Messages.FBInterfacePaletteFactory_DataTypes);
 
 		for (final DataType dataType : typeLib.getDataTypeLibrary().getDataTypesSorted()) {
@@ -55,14 +63,11 @@ public final class FBInterfacePaletteFactory {
 					dataType.getComment(), new DataTypeCreationFactory(dataType), desc, desc);
 			drawer.add(combined);
 		}
-		palette.add(drawer);
-
-		createAdapterEntry(palette, typeLib);
-
+		return drawer;
 	}
 
 	private static void createAdapterEntry(final PaletteRoot palette, final TypeLibrary typeLib) {
-		final PaletteDrawer drawer = new PaletteDrawer("Adapters");
+		final PaletteDrawer drawer = new PaletteDrawer(Messages.FBInterfacePaletteFactory_AdapterTypes);
 
 		for (final AdapterTypeEntry entry : typeLib.getAdapterTypesSorted()) {
 			final ImageDescriptor desc = FordiacImage.ICON_DATA_TYPE.getImageDescriptor();

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/Messages.java
@@ -22,6 +22,8 @@ public final class Messages extends NLS {
 	public static String CreateFromNewAdapterAction_NewAdapter;
 	public static String CreateInputEventAction_CreateInputEvent;
 	public static String CreateOutputEventAction_CreateOutputEvent;
+
+	public static String FBInterfacePaletteFactory_AdapterTypes;
 	public static String FBInterfacePaletteFactory_DataTypes;
 	public static String FBInterfacePaletteFactory_EventTypes;
 	public static String FBInterfacePaletteFactory_RootGroup;

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editors/FBInterfaceEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editors/FBInterfaceEditor.java
@@ -29,6 +29,7 @@ import org.eclipse.fordiac.ide.gef.DiagramEditorWithFlyoutPalette;
 import org.eclipse.fordiac.ide.gef.editparts.ZoomScalableFreeformRootEditPart;
 import org.eclipse.fordiac.ide.gef.figures.AbstractFreeformFigure;
 import org.eclipse.fordiac.ide.gef.figures.MinSpaceFreeformFigure;
+import org.eclipse.fordiac.ide.model.libraryElement.AdapterType;
 import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
@@ -100,7 +101,7 @@ public class FBInterfaceEditor extends DiagramEditorWithFlyoutPalette implements
 	@Override
 	protected PaletteRoot getPaletteRoot() {
 		if (null == paletteRoot) {
-			paletteRoot = FBInterfacePaletteFactory.createPalette(typeLib);
+			paletteRoot = FBInterfacePaletteFactory.createPalette(typeLib, !(fbType instanceof AdapterType));
 		}
 		return paletteRoot;
 	}

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/messages.properties
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/messages.properties
@@ -17,8 +17,9 @@ CreateInputEventAction_CreateInputEvent=Create Input Event
 
 CreateOutputEventAction_CreateOutputEvent=Create Output Event
 
-FBInterfacePaletteFactory_EventTypes=EventTypes
-FBInterfacePaletteFactory_DataTypes=DataTypes
+FBInterfacePaletteFactory_AdapterTypes=Adapter types
+FBInterfacePaletteFactory_EventTypes=Event types
+FBInterfacePaletteFactory_DataTypes=Data types
 FBInterfacePaletteFactory_RootGroup=Root Group
 
 FBTypeEditor_CheckTypeSaveAble=The composite Function Block you are about to save contains the function block {0} which has no type. Saving is not possible as it may break any connections. Please correct this first!

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/properties/EditInterfaceAdapterSectionFilter.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/properties/EditInterfaceAdapterSectionFilter.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Johannes Kepler University Linz
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Alois Zoitl - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.fbtypeeditor.properties;
+
+import org.eclipse.fordiac.ide.model.libraryElement.AdapterType;
+
+public class EditInterfaceAdapterSectionFilter extends FBTypePropertiesFilter {
+
+	@Override
+	public boolean select(final Object toTest) {
+		final var retval = getFBTypeFromSelectedElement(toTest);
+		// the adapter interface section should not be shown for adapters as there
+		// cannot be adapters in adapters.
+		return (retval != null && !(retval instanceof AdapterType));
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/properties/FBTypePropertiesFilter.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/properties/FBTypePropertiesFilter.java
@@ -25,7 +25,7 @@ public class FBTypePropertiesFilter implements IFilter {
 	@Override
 	public boolean select(final Object toTest) {
 		final Object retval = getFBTypeFromSelectedElement(toTest);
-		return ((retval != null));
+		return (retval != null);
 	}
 
 	protected static FBType getFBTypeFromSelectedElement(final Object element) {
@@ -39,11 +39,11 @@ public class FBTypePropertiesFilter implements IFilter {
 			retval = ep.getModel();
 		}
 
-		if ((retval instanceof final FBNetwork fbnetwork) && ((fbnetwork.eContainer() instanceof FBType))) {
+		if ((retval instanceof final FBNetwork fbnetwork) && (fbnetwork.eContainer() instanceof FBType)) {
 			retval = fbnetwork.eContainer();
 		}
 
-		return (retval instanceof FBType) ? (FBType) retval : null;
+		return (retval instanceof final FBType fbType) ? fbType : null;
 	}
 
 	private static Object getTypeFromActiveEditor() {


### PR DESCRIPTION
The adapter interface property section and the palette in the interface editor allowed to added plugs and sockets to adapter types.

https://github.com/eclipse-4diac/4diac-ide/issues/373