### PR TITLE
make multiplexer configurable

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.application/META-INF/MANIFEST.MF
@@ -26,7 +26,8 @@ Require-Bundle: org.eclipse.emf.ecore.editor,
  org.eclipse.fordiac.ide.model.ui,
  org.eclipse.core.expressions,
  org.eclipse.fordiac.ide.ui.errormessages,
- org.eclipse.fordiac.ide.model.search
+ org.eclipse.fordiac.ide.model.search,
+ org.eclipse.jface
 Bundle-Vendor: Eclipse 4diac
 Bundle-ActivationPolicy: lazy
 Bundle-Version: 3.0.0.qualifier

--- a/plugins/org.eclipse.fordiac.ide.application/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.application/plugin.xml
@@ -186,9 +186,9 @@
               tab="org.eclipse.fordiac.ide.application.propertyDemultiplexerTab">
         </propertySection>
         <propertySection
-              class="org.eclipse.fordiac.ide.application.properties.StructManipulatorSection"
+              class="org.eclipse.fordiac.ide.application.properties.MultiplexerSection"
               filter="org.eclipse.fordiac.ide.application.properties.MultiplexerFilter"
-              id="org.eclipse.fordiac.ide.application.properties.StructManipulatorSection"
+              id="org.eclipse.fordiac.ide.application.properties.MultiplexerSection"
               tab="org.eclipse.fordiac.ide.application.propertyStructManipulatorTab">
         </propertySection>
         <propertySection

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractStructManipulatorEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractStructManipulatorEditPart.java
@@ -82,11 +82,11 @@ public abstract class AbstractStructManipulatorEditPart extends AbstractFBNEleme
 			@Override
 			public void notifyChanged(final Notification notification) {
 				super.notifyChanged(notification);
-				if (notification.getEventType() == Notification.ADD
-						|| notification.getEventType() == Notification.ADD_MANY
-						|| notification.getEventType() == Notification.MOVE
-						|| notification.getEventType() == Notification.REMOVE) {
+				if (!notification.isTouch()) {
 					refresh();
+					// this ensure that parameters are correctly updated when pins are added or
+					// removed (e.g., errormarkerpins are deleted)
+					getParent().refresh();
 				}
 			}
 		};

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/DemultiplexerSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/DemultiplexerSection.java
@@ -13,53 +13,28 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.application.properties;
 
+import org.eclipse.fordiac.ide.model.CheckableStructTree;
 import org.eclipse.fordiac.ide.model.CheckableStructTreeNode;
+import org.eclipse.fordiac.ide.model.StructTreeContentProvider;
 import org.eclipse.fordiac.ide.model.commands.create.AddDemuxPortCommand;
 import org.eclipse.fordiac.ide.model.commands.delete.DeleteDemuxPortCommand;
+import org.eclipse.fordiac.ide.model.data.StructuredType;
+import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.Demultiplexer;
+import org.eclipse.fordiac.ide.model.libraryElement.StructManipulator;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.gef.commands.CommandStackEvent;
 import org.eclipse.jface.viewers.CheckStateChangedEvent;
-import org.eclipse.jface.viewers.CheckboxTreeViewer;
 import org.eclipse.jface.viewers.ICheckStateListener;
 import org.eclipse.jface.viewers.ICheckStateProvider;
 import org.eclipse.jface.viewers.TreeViewer;
-import org.eclipse.swt.widgets.Composite;
-import org.eclipse.ui.views.properties.tabbed.TabbedPropertySheetPage;
 
 public class DemultiplexerSection extends StructManipulatorSection {
 
 	@Override
-	protected TreeViewer createTreeViewer(final Composite parent) {
-		final CheckboxTreeViewer viewer = new CheckboxTreeViewer(parent);
-		viewer.setUseHashlookup(true);
-		return viewer;
-	}
-
-	@Override
-	public void createControls(final Composite parent, final TabbedPropertySheetPage tabbedPropertySheetPage) {
-		super.createControls(parent, tabbedPropertySheetPage);
-
-		getViewer().setCheckStateProvider(new ICheckStateProvider() {
-			@Override
-			public boolean isChecked(final Object element) {
-				if (null != element) {
-					final CheckableStructTreeNode node = (CheckableStructTreeNode) element;
-					return node.isChecked() || node.isGrey();
-				}
-				return false;
-			}
-
-			@Override
-			public boolean isGrayed(final Object element) {
-				final CheckableStructTreeNode node = (CheckableStructTreeNode) element;
-				return node.isGrey();
-			}
-
-		});
-
-		getViewer().addCheckStateListener(new ICheckStateListener() {
+	protected ICheckStateListener getCheckStateListener() {
+		return new ICheckStateListener() {
 			@Override
 			public void checkStateChanged(final CheckStateChangedEvent event) {
 				final CheckableStructTreeNode node = (CheckableStructTreeNode) event.getElement();
@@ -80,9 +55,42 @@ public class DemultiplexerSection extends StructManipulatorSection {
 
 				return new DeleteDemuxPortCommand(getType(), node);
 			}
+		};
+	}
 
-		});
+	@Override
+	protected void initTree(final StructManipulator manipulator, final TreeViewer viewer) {
+		final StructuredType struct = manipulator.getTypeEntry().getTypeLibrary().getDataTypeLibrary()
+				.getStructuredType(PackageNameHelper.getFullTypeName(manipulator.getDataType()));
 
+		final CheckableStructTree tree;
+		if (viewer != null) {
+			tree = new CheckableStructTree(manipulator, struct, viewer);
+		} else {
+			tree = new CheckableStructTree(manipulator, struct);
+		}
+
+		((StructTreeContentProvider) getViewer().getContentProvider()).setRoot(tree.getRoot());
+	}
+
+	@Override
+	protected ICheckStateProvider getCheckStateProvider() {
+		return new ICheckStateProvider() {
+			@Override
+			public boolean isChecked(final Object element) {
+				if (null != element) {
+					final CheckableStructTreeNode node = (CheckableStructTreeNode) element;
+					return node.isChecked() || node.isGrey();
+				}
+				return false;
+			}
+
+			@Override
+			public boolean isGrayed(final Object element) {
+				final CheckableStructTreeNode node = (CheckableStructTreeNode) element;
+				return node.isGrey();
+			}
+		};
 	}
 
 	private void selectStructManipulator(final Command cmd) {
@@ -106,10 +114,6 @@ public class DemultiplexerSection extends StructManipulatorSection {
 		this.initTree = initTree;
 	}
 
-	private CheckboxTreeViewer getViewer() {
-		return (CheckboxTreeViewer) memberVarViewer;
-	}
-
 	@Override
 	protected Demultiplexer getType() {
 		return (Demultiplexer) super.getType();
@@ -125,4 +129,5 @@ public class DemultiplexerSection extends StructManipulatorSection {
 			super.stackChanged(event);
 		}
 	}
+
 }

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/MultiplexerSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/MultiplexerSection.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Bianca Wiesmayr - initial implementation and/or documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.application.properties;
+
+import org.eclipse.fordiac.ide.model.StructTreeLabelProvider;
+import org.eclipse.fordiac.ide.model.commands.change.HidePinCommand;
+import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
+import org.eclipse.fordiac.ide.model.libraryElement.MemberVarDeclaration;
+import org.eclipse.fordiac.ide.model.libraryElement.Multiplexer;
+import org.eclipse.fordiac.ide.model.libraryElement.StructManipulator;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.gef.commands.Command;
+import org.eclipse.jface.viewers.ICheckStateListener;
+import org.eclipse.jface.viewers.ICheckStateProvider;
+import org.eclipse.jface.viewers.ITreeContentProvider;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.TreeViewer;
+
+public class MultiplexerSection extends StructManipulatorSection {
+
+	@Override
+	protected ICheckStateListener getCheckStateListener() {
+		return event -> {
+			final Command cmd = createHideCommand(event.getElement(), event.getChecked());
+			if (cmd != null && cmd.canExecute()) {
+				executeCommand(cmd);
+			} else {
+				// reset checkmark as command was not executed
+				event.getCheckable().setChecked(event.getElement(), !event.getChecked());
+			}
+		};
+	}
+
+	private static Command createHideCommand(final Object selected, final boolean checked) {
+		if (selected instanceof final VarDeclaration variable) {
+			return new HidePinCommand(variable, checked);
+		}
+		return null;
+	}
+
+	@Override
+	public void initTree(final StructManipulator manipulator, final TreeViewer viewer) {
+		// nothing to do here
+	}
+
+	@Override
+	protected ICheckStateProvider getCheckStateProvider() {
+		return new ICheckStateProvider() {
+
+			@Override
+			public boolean isChecked(final Object element) {
+				if (element instanceof final IInterfaceElement iel) {
+					return iel.isVisible();
+				}
+				return false;
+			}
+
+			@Override
+			public boolean isGrayed(final Object element) {
+				return false;
+			}
+		};
+	}
+
+	@Override
+	protected ITreeContentProvider getContentProvider() {
+		return new ITreeContentProvider() {
+
+			@Override
+			public Object[] getElements(final Object inputElement) {
+				if (inputElement instanceof final Multiplexer mux) {
+					return mux.getInterface().getInputVars().toArray();
+				}
+				return new Object[0];
+			}
+
+			@Override
+			public Object[] getChildren(final Object parentElement) {
+				return new Object[0];
+			}
+
+			@Override
+			public Object getParent(final Object element) {
+				return null;
+			}
+
+			@Override
+			public boolean hasChildren(final Object element) {
+				return false;
+			}
+
+		};
+	}
+
+	@Override
+	protected LabelProvider getLabelProvider() {
+		return new StructTreeLabelProvider() {
+			@Override
+			public String getColumnText(final Object element, final int columnIndex) {
+				if (element instanceof final MemberVarDeclaration varDecl) {
+					switch (columnIndex) {
+					case 0:
+						return varDecl.getName();
+					case 1:
+						return varDecl.getTypeName();
+					case 2:
+						return varDecl.getComment();
+					default:
+						break;
+					}
+				}
+				return element.toString();
+			}
+		};
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/widgets/TypeSelectionWidget.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/widgets/TypeSelectionWidget.java
@@ -201,9 +201,17 @@ public class TypeSelectionWidget {
 		table.setLayout(new TableLayout());
 		table.setLayoutData(new GridData(SWT.FILL, 0, false, false));
 
-		new TableColumn(table, SWT.NONE)
-				.setWidth(table.getItemCount() > 0 ? table.getItem(0).getBounds().width + 30 : 150);
+		final TableColumn tableColumn = new TableColumn(table, SWT.NONE);
+		tableColumn.setWidth(getMinWidth(table));
 		table.requestLayout();
+	}
+
+	private static int getMinWidth(final Table table) {
+		final int width = table.getItemCount() > 0 ? table.getItem(0).getBounds().width + 30 : 150;
+		if (width < 150) {
+			return 150;
+		}
+		return width;
 	}
 
 	private void disableOpenEditorForAnyType() {

--- a/plugins/org.eclipse.fordiac.ide.subapptypeeditor/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.subapptypeeditor/plugin.xml
@@ -197,8 +197,8 @@
          	filter="org.eclipse.fordiac.ide.application.properties.DemultiplexerFilter">
          </propertySection>
          <propertySection
-         	class="org.eclipse.fordiac.ide.application.properties.StructManipulatorSection"
-         	id="org.eclipse.fordiac.ide.application.properties.StructManipulatorSection"
+         	class="org.eclipse.fordiac.ide.application.properties.MultiplexerSection"
+         	id="org.eclipse.fordiac.ide.application.properties.MultiplexerSection"
          	tab="org.eclipse.fordiac.ide.application.propertyStructManipulatorTab"
          	filter="org.eclipse.fordiac.ide.application.properties.MultiplexerFilter">
          </propertySection>


### PR DESCRIPTION
Multiplexers are now configurable. This means that pins can be hidden. Import from XML does not yet work, but edits within the IDE are possible.