### PR TITLE
Added arraysize to InterfaceElements for Subapps

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/CreateSubAppCrossingConnectionsCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/CreateSubAppCrossingConnectionsCommand.java
@@ -345,8 +345,14 @@ public class CreateSubAppCrossingConnectionsCommand extends Command implements S
 		}
 
 		final boolean isInOut = source instanceof final VarDeclaration sourceVar && sourceVar.isInOutVar();
+
+		String arraySize = null;
+		if (source instanceof final VarDeclaration sourceVar && sourceVar.getArraySize() != null) {
+			arraySize = sourceVar.getArraySize().getValue();
+		}
+
 		final CreateSubAppInterfaceElementCommand pinCmd = new CreateSubAppInterfaceElementCommand(ie.getType(),
-				source.getName(), subapp.getInterface(), isRightPath, isInOut, -1);
+				source.getName(), subapp.getInterface(), isRightPath, isInOut, arraySize, -1);
 		pinCmd.execute();
 		commands.add(pinCmd);
 		return pinCmd.getCreatedElement();

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/CreateSubAppInterfaceElementCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/CreateSubAppInterfaceElementCommand.java
@@ -42,6 +42,12 @@ public class CreateSubAppInterfaceElementCommand extends CreateInterfaceElementC
 		super(dataType, name, interfaceList, isInput, isInOut, index);
 	}
 
+	public CreateSubAppInterfaceElementCommand(final DataType dataType, final String name,
+			final InterfaceList interfaceList, final boolean isInput, final boolean isInOut, final String arraySize,
+			final int index) {
+		super(dataType, name, interfaceList, isInput, isInOut, arraySize, index);
+	}
+
 	public CreateSubAppInterfaceElementCommand(final DataType dataType, final InterfaceList interfaceList,
 			final boolean isInput, final int index) {
 		super(dataType, interfaceList, isInput, index);

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/CreateInterfaceElementCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/CreateInterfaceElementCommand.java
@@ -63,7 +63,7 @@ public class CreateInterfaceElementCommand extends CreationCommand implements Sc
 	 * information
 	 */
 	public CreateInterfaceElementCommand(final DataType dataType, final String name, final InterfaceList interfaceList,
-			final boolean isInput, final boolean isInOut, final int index) {
+			final boolean isInput, final boolean isInOut, final String arraySize, final int index) {
 		this.isInput = isInput;
 		this.isInOut = isInOut;
 		this.switchOpposite = false;
@@ -71,7 +71,13 @@ public class CreateInterfaceElementCommand extends CreationCommand implements Sc
 		this.index = index;
 		this.targetInterfaceList = interfaceList;
 		this.name = ((null != name) && isValidName(name)) ? name : getNameProposal(dataType, isInput);
+		this.arraySize = arraySize;
 		this.value = ""; //$NON-NLS-1$
+	}
+
+	public CreateInterfaceElementCommand(final DataType dataType, final String name, final InterfaceList interfaceList,
+			final boolean isInput, final boolean isInOut, final int index) {
+		this(dataType, name, interfaceList, isInput, isInOut, null, index);
 	}
 
 	public CreateInterfaceElementCommand(final DataType dataType, final String name, final InterfaceList interfaceList,


### PR DESCRIPTION
When creating a SubAppBoarder crossing connection that is an array a wrong InterfaceElement was created which resulted in wrong connections