### PR TITLE
ZoomFit considers Selection

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/AdvancedZoomManager.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/AdvancedZoomManager.java
@@ -14,15 +14,35 @@ package org.eclipse.fordiac.ide.gef.editparts;
 
 import org.eclipse.draw2d.FreeformFigure;
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.RangeModel;
 import org.eclipse.draw2d.ScalableFigure;
 import org.eclipse.draw2d.Viewport;
 import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.gef.editparts.ZoomManager;
 
 public class AdvancedZoomManager extends ZoomManager {
 
 	AdvancedZoomManager(final ScalableFigure pane, final Viewport viewport) {
 		super(pane, viewport);
+	}
+
+	@Override
+	public void setZoomAsText(final String zoomString) {
+		super.setZoomAsText(zoomString);
+
+		if (FIT_HEIGHT.equalsIgnoreCase(zoomString) || FIT_ALL.equalsIgnoreCase(zoomString)
+				|| FIT_WIDTH.equalsIgnoreCase(zoomString)) {
+			// scroll to the center so that our drawing canvas is fully shown
+			final Point scrollPoint = new Point(calculateCenterScrollPos(getViewport().getHorizontalRangeModel()),
+					calculateCenterScrollPos(getViewport().getVerticalRangeModel()));
+			setViewLocation(scrollPoint);
+		}
+	}
+
+	private static int calculateCenterScrollPos(final RangeModel rangeModel) {
+		final int center = (rangeModel.getMaximum() + rangeModel.getMinimum()) / 2;
+		return center - rangeModel.getExtent() / 2;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/handlers/ZoomFitPageHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/handlers/ZoomFitPageHandler.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2021 Johannes Kepler University Linz
+ * Copyright (c) 2021, 2024 Johannes Kepler University Linz,
+ *                          Primetals Technology Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,7 +17,14 @@ import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.EditPart;
+import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.editparts.ZoomManager;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.handlers.HandlerUtil;
@@ -26,14 +34,72 @@ public class ZoomFitPageHandler extends AbstractHandler {
 	@Override
 	public Object execute(final ExecutionEvent event) throws ExecutionException {
 		final IWorkbenchPart part = HandlerUtil.getActiveEditor(event);
+		final ISelection currentSelection = HandlerUtil.getCurrentSelection(event);
 		if (part != null) {
 			final ZoomManager zoomManager = part.getAdapter(ZoomManager.class);
 			if (zoomManager != null) {
-				Display.getDefault().syncExec(() -> zoomManager.setZoomAsText(ZoomManager.FIT_ALL));
+				if (isZoomAll(currentSelection)) {
+					Display.getDefault().syncExec(() -> zoomManager.setZoomAsText(ZoomManager.FIT_ALL));
+				} else {
+					zoomSelection(currentSelection, zoomManager);
+				}
 			}
-
 		}
 		return Status.OK_STATUS;
+	}
+
+	private static boolean isZoomAll(final ISelection currentSelection) {
+		if (currentSelection == null || currentSelection.isEmpty()) {
+			return false;
+		}
+		if (currentSelection instanceof final IStructuredSelection structSel && structSel.size() == 1) {
+			final Object firstEl = structSel.getFirstElement();
+			return firstEl instanceof final EditPart ep && ep.getParent() == ep.getRoot();
+		}
+		return false;
+	}
+
+	private static void zoomSelection(final ISelection currentSelection, final ZoomManager zoomManager) {
+		final Rectangle zoomBounds = getZoomBoundsFromSelection(currentSelection);
+		if (zoomBounds != null) {
+			final double newZoom = getZoomFactor(zoomBounds, zoomManager);
+			Display.getDefault().syncExec(() -> {
+				zoomManager.setZoom(newZoom);
+				// for correctly setting the position we need to get bounds after zooming again
+				final Point newPos = zoomManager.getViewport().getViewLocation()
+						.getTranslated(getZoomBoundsFromSelection(currentSelection).getTopLeft());
+				zoomManager.setViewLocation(newPos);
+			});
+		}
+	}
+
+	private static Rectangle getZoomBoundsFromSelection(final ISelection currentSelection) {
+		if (currentSelection instanceof final IStructuredSelection structSel) {
+			Rectangle zoomBounds = null;
+			for (final Object ob : structSel.toList()) {
+				if (ob instanceof final GraphicalEditPart gep) {
+					final Rectangle bounds = new Rectangle(gep.getFigure().getBounds());
+					gep.getFigure().translateToAbsolute(bounds);
+					if (zoomBounds == null) {
+						zoomBounds = bounds;
+					} else {
+						zoomBounds.union(bounds);
+					}
+				}
+			}
+			return zoomBounds;
+		}
+		return null;
+	}
+
+	private static double getZoomFactor(final Rectangle zoomBounds, final ZoomManager zoomManager) {
+		final Dimension available = zoomManager.getViewport().getClientArea().getSize();
+		final double scaleX = Math.min(available.width * zoomManager.getZoom() / zoomBounds.width,
+				zoomManager.getMaxZoom());
+		final double scaleY = Math.min(available.height * zoomManager.getZoom() / zoomBounds.height,
+				zoomManager.getMaxZoom());
+		return Math.min(scaleX, scaleY);
+
 	}
 
 }


### PR DESCRIPTION
When now objects are selected the zoom all toolbar item will zoom to the bounds of the selection and position the viewport such that the top left is the top left of the selection bounds.

Furthermore a bug in positioning the viewport when zoom all is invoked without selection is also fixed.