### PR TITLE
Add warning instead of Exception when exporting files that are not Types

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/Messages.java
@@ -30,6 +30,8 @@ public final class Messages extends NLS {
 
 	public static String TemplateExportFilter_FILE_EXISTS;
 
+	public static String TemplateExportFilter_FILE_IGNORED;
+
 	public static String TemplateExportFilter_LIST_FOUR_OR_MORE_ELEMENTS;
 
 	public static String TemplateExportFilter_LIST_ONE_ELEMENT;

--- a/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/TemplateExportFilter.java
+++ b/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/TemplateExportFilter.java
@@ -39,6 +39,7 @@ import org.eclipse.fordiac.ide.export.utils.CompareEditorOpenerUtil;
 import org.eclipse.fordiac.ide.export.utils.DelayedFiles;
 import org.eclipse.fordiac.ide.export.utils.DelayedFiles.StoredFiles;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
 import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 import org.eclipse.jface.dialogs.IDialogLabelKeys;
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -99,6 +100,11 @@ public abstract class TemplateExportFilter extends ExportFilter {
 	@Override
 	public void export(final IFile typeFile, final String destination, final boolean forceOverwrite, EObject source)
 			throws ExportException {
+		if (source == null && typeFile != null && TypeLibraryManager.INSTANCE.getTypeEntryForFile(typeFile) == null) {
+			getWarnings().add(MessageFormat.format(Messages.TemplateExportFilter_PREFIX_ERRORMESSAGE_WITH_TYPENAME,
+					typeFile.getFullPath(), Messages.TemplateExportFilter_FILE_IGNORED));
+			return; // Do not export files passed to the export that are not in the TypeLibrary
+		}
 		try {
 			if (source == null && typeFile != null) {
 				final ResourceSet resourceSet = new ResourceSetImpl();

--- a/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/messages.properties
+++ b/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/messages.properties
@@ -16,6 +16,7 @@ ExportTemplate_ExportTemplate=ExportTemplate [{0}]
 
 TemplateExportFilter_ErrorDuringTemplateGeneration=Error during template generation
 TemplateExportFilter_FILE_EXISTS=File Exists
+TemplateExportFilter_FILE_IGNORED=File was ignored during export.
 TemplateExportFilter_LIST_FOUR_OR_MORE_ELEMENTS={0}, {1}, {2}, ...
 TemplateExportFilter_LIST_ONE_ELEMENT={0}
 TemplateExportFilter_LIST_THREE_ELEMENTS={0}, {1} and {2}


### PR DESCRIPTION
When exporting a complete directory all files that are contained are exported. This led to a exception during export when e.g. a csv-file was stored with a FB.