### PR TITLE
Add support for generic internal FBs in forte_ng export

### DIFF
--- a/data/typelibrary/convert-1.0.0/MANIFEST.MF
+++ b/data/typelibrary/convert-1.0.0/MANIFEST.MF
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="platform:/resource/org.eclipse.fordiac.ide.library.model/model/library.xsd" Scope="Library">
+    <Dependencies>
+        <Required SymbolicName="core" Version="1.0.0"/>
+    </Dependencies>
     <Product Name="Convert" SymbolicName="convert" Comment="Standard Library - Convert">
         <VersionInfo Version="1.0.0" Author="Eclipse 4diac" Date="2024-02-21"/>
     </Product>

--- a/data/typelibrary/convert-1.0.0/typelib/STRUCT_DEMUX.fbt
+++ b/data/typelibrary/convert-1.0.0/typelib/STRUCT_DEMUX.fbt
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="STRUCT_DEMUX" Comment="Generic block for demuxing structs">
-	  <Identification Description="Copyright (c) 2020 Johannes Kepler University Linz&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61499-2"/>
+<FBType Name="STRUCT_DEMUX" Comment="Service Interface Function Block Type">
+	<Identification Standard="61499-2" Description="Copyright (c) 2020 Johannes Kepler University Linz&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
 	<InterfaceList>
 		<EventInputs>
 			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
@@ -17,4 +18,5 @@
 	</InterfaceList>
 	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Service Interface Function Block Type">
 	</Service>
+	<Attribute Name="GenericClassName" Value="'GEN_STRUCT_DEMUX'"/>
 </FBType>

--- a/data/typelibrary/convert-1.0.0/typelib/STRUCT_MUX.fbt
+++ b/data/typelibrary/convert-1.0.0/typelib/STRUCT_MUX.fbt
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="STRUCT_MUX" Comment="Generic block for muxing structs">
-	  <Identification Description="Copyright (c) 2020 Johannes Kepler University Linz&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61499-2"/>
+<FBType Name="STRUCT_MUX" Comment="Service Interface Function Block Type">
+	<Identification Standard="61499-2" Description="Copyright (c) 2020 Johannes Kepler University Linz&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
 	<InterfaceList>
 		<EventInputs>
 			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
@@ -17,4 +18,5 @@
 	</InterfaceList>
 	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Service Interface Function Block Type">
 	</Service>
+	<Attribute Name="GenericClassName" Value="'GEN_STRUCT_MUX'"/>
 </FBType>

--- a/data/typelibrary/core-1.0.0/MANIFEST.MF
+++ b/data/typelibrary/core-1.0.0/MANIFEST.MF
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="platform:/resource/org.eclipse.fordiac.ide.library.model/model/library.xsd" Scope="Library">
+    <Product Name="Core" SymbolicName="core" Comment="Standard Library - Core">
+        <VersionInfo Version="1.0.0" Author="Eclipse 4diac" Date="2024-08-21"/>
+    </Product>
+</Manifest>

--- a/data/typelibrary/core-1.0.0/typelib/GenericClassName.atp
+++ b/data/typelibrary/core-1.0.0/typelib/GenericClassName.atp
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AttributeDeclaration Name="GenericClassName" Comment="The class name for generic types">
+	<Identification Standard="61499-1" Description="Copyright (c) 2024 Martin Erich Jobst&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Version="1.0" Author="Martin Erich Jobst" Date="2024-08-21" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<DirectlyDerivedType BaseType="STRING" InitialValue="'GEN_'" Comment="The class name for generic types"/>
+	<Attribute Name="TARGET" Value="(IInterfaceElement:=FALSE,SubApp:=FALSE,FBType:=TRUE,Application:=FALSE,Connection:=FALSE,FB:=FALSE,DataType:=FALSE)"/>
+</AttributeDeclaration>

--- a/data/typelibrary/iec61131-3-1.0.0/MANIFEST.MF
+++ b/data/typelibrary/iec61131-3-1.0.0/MANIFEST.MF
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="platform:/resource/org.eclipse.fordiac.ide.library.model/model/library.xsd" Scope="Library">
+    <Dependencies>
+        <Required SymbolicName="core" Version="1.0.0"/>
+    </Dependencies>
     <Product Name="IEC61131-3" SymbolicName="iec61131-3" Comment="Standard Library - IEC61131-3">
         <VersionInfo Version="1.0.0" Author="Eclipse 4diac" Date="2024-02-21"/>
     </Product>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/arithmetic/ADD_2.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/arithmetic/ADD_2.fbt
@@ -1,27 +1,30 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="Calculate arithmetical sum of magnitude inputs (generic FB)" Name="ADD_2">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard arithmetic function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="ADD input 1" Name="IN1" Type="ANY_MAGNITUDE"/>
-      <VarDeclaration Comment="ADD input 2" Name="IN2" Type="ANY_MAGNITUDE"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="ADD result" Name="OUT" Type="ANY_MAGNITUDE"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ADD_2" Comment="Calculate arithmetical sum of magnitude inputs (generic FB)">
+	<Identification Standard="61131-3" Classification="standard arithmetic function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_MAGNITUDE" Comment="ADD input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_MAGNITUDE" Comment="ADD input 2"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_MAGNITUDE" Comment="ADD result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_ADD'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/arithmetic/ADD_3.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/arithmetic/ADD_3.fbt
@@ -1,29 +1,32 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="Calculate arithmetical sum of magnitude inputs (generic FB)" Name="ADD_3">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard arithmetic function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-        <With Var="IN3"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="ADD input 1" Name="IN1" Type="ANY_MAGNITUDE"/>
-      <VarDeclaration Comment="ADD input 2" Name="IN2" Type="ANY_MAGNITUDE"/>
-      <VarDeclaration Comment="ADD input 3" Name="IN3" Type="ANY_MAGNITUDE"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="ADD result" Name="OUT" Type="ANY_MAGNITUDE"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ADD_3" Comment="Calculate arithmetical sum of magnitude inputs (generic FB)">
+	<Identification Standard="61131-3" Classification="standard arithmetic function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_MAGNITUDE" Comment="ADD input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_MAGNITUDE" Comment="ADD input 2"/>
+			<VarDeclaration Name="IN3" Type="ANY_MAGNITUDE" Comment="ADD input 3"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_MAGNITUDE" Comment="ADD result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_ADD'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/arithmetic/ADD_4.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/arithmetic/ADD_4.fbt
@@ -1,31 +1,34 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="Calculate arithmetical sum of magnitude inputs (generic FB)" Name="ADD_4">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard arithmetic function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-        <With Var="IN3"/>
-        <With Var="IN4"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="ADD input 1" Name="IN1" Type="ANY_MAGNITUDE"/>
-      <VarDeclaration Comment="ADD input 2" Name="IN2" Type="ANY_MAGNITUDE"/>
-      <VarDeclaration Comment="ADD input 3" Name="IN3" Type="ANY_MAGNITUDE"/>
-      <VarDeclaration Comment="ADD input 4" Name="IN4" Type="ANY_MAGNITUDE"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="ADD result" Name="OUT" Type="ANY_MAGNITUDE"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ADD_4" Comment="Calculate arithmetical sum of magnitude inputs (generic FB)">
+	<Identification Standard="61131-3" Classification="standard arithmetic function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_MAGNITUDE" Comment="ADD input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_MAGNITUDE" Comment="ADD input 2"/>
+			<VarDeclaration Name="IN3" Type="ANY_MAGNITUDE" Comment="ADD input 3"/>
+			<VarDeclaration Name="IN4" Type="ANY_MAGNITUDE" Comment="ADD input 4"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_MAGNITUDE" Comment="ADD result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_ADD'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/arithmetic/F_MOVE.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/arithmetic/F_MOVE.fbt
@@ -1,24 +1,26 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="moves input to output" Name="F_MOVE">
-  <Identification Description="Copyright (c) 2013 TU Wien ACIN&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard arithmetic function"/>
-  <VersionInfo Author="Monika Wenger" Date="2013-08-17" Organization="TU Wien ACIN" Version="1.0"/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="input" Name="IN" Type="ANY"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="input = output" Name="OUT" Type="ANY"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="F_MOVE" Comment="moves input to output">
+	<Identification Standard="61131-3" Classification="standard arithmetic function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="TU Wien ACIN" Version="1.0" Author="Monika Wenger" Date="2013-08-17">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="ANY" Comment="input"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY" Comment="input = output"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_FORTE_F_MOVE'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/AND_10.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/AND_10.fbt
@@ -1,43 +1,46 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean AND (generic FB)" Name="AND_10">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-        <With Var="IN3"/>
-        <With Var="IN4"/>
-        <With Var="IN5"/>
-        <With Var="IN6"/>
-        <With Var="IN7"/>
-        <With Var="IN8"/>
-        <With Var="IN9"/>
-        <With Var="IN10"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="AND input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 2" Name="IN2" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 3" Name="IN3" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 4" Name="IN4" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 5" Name="IN5" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 6" Name="IN6" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 7" Name="IN7" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 8" Name="IN8" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 9" Name="IN9" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 10" Name="IN10" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="AND result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AND_10" Comment="FB to calculate bitwise boolean AND (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+				<With Var="IN5"/>
+				<With Var="IN6"/>
+				<With Var="IN7"/>
+				<With Var="IN8"/>
+				<With Var="IN9"/>
+				<With Var="IN10"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="AND input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="AND input 2"/>
+			<VarDeclaration Name="IN3" Type="ANY_BIT" Comment="AND input 3"/>
+			<VarDeclaration Name="IN4" Type="ANY_BIT" Comment="AND input 4"/>
+			<VarDeclaration Name="IN5" Type="ANY_BIT" Comment="AND input 5"/>
+			<VarDeclaration Name="IN6" Type="ANY_BIT" Comment="AND input 6"/>
+			<VarDeclaration Name="IN7" Type="ANY_BIT" Comment="AND input 7"/>
+			<VarDeclaration Name="IN8" Type="ANY_BIT" Comment="AND input 8"/>
+			<VarDeclaration Name="IN9" Type="ANY_BIT" Comment="AND input 9"/>
+			<VarDeclaration Name="IN10" Type="ANY_BIT" Comment="AND input 10"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="AND result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_AND'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/AND_2.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/AND_2.fbt
@@ -1,27 +1,30 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean AND (generic FB)" Name="AND_2">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="AND input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 2" Name="IN2" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="AND result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AND_2" Comment="FB to calculate bitwise boolean AND (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="AND input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="AND input 2"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="AND result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_AND'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/AND_3.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/AND_3.fbt
@@ -1,29 +1,32 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean AND (generic FB)" Name="AND_3">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-        <With Var="IN3"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="AND input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 2" Name="IN2" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 3" Name="IN3" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="AND result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AND_3" Comment="FB to calculate bitwise boolean AND (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="AND input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="AND input 2"/>
+			<VarDeclaration Name="IN3" Type="ANY_BIT" Comment="AND input 3"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="AND result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_AND'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/AND_4.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/AND_4.fbt
@@ -1,31 +1,34 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean AND (generic FB)" Name="AND_4">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-        <With Var="IN3"/>
-        <With Var="IN4"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="AND input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 2" Name="IN2" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 3" Name="IN3" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 4" Name="IN4" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="AND result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AND_4" Comment="FB to calculate bitwise boolean AND (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="AND input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="AND input 2"/>
+			<VarDeclaration Name="IN3" Type="ANY_BIT" Comment="AND input 3"/>
+			<VarDeclaration Name="IN4" Type="ANY_BIT" Comment="AND input 4"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="AND result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_AND'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/AND_5.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/AND_5.fbt
@@ -1,33 +1,36 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean AND (generic FB)" Name="AND_5">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-        <With Var="IN3"/>
-        <With Var="IN4"/>
-        <With Var="IN5"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="AND input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 2" Name="IN2" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 3" Name="IN3" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 4" Name="IN4" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 5" Name="IN5" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="AND result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AND_5" Comment="FB to calculate bitwise boolean AND (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+				<With Var="IN5"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="AND input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="AND input 2"/>
+			<VarDeclaration Name="IN3" Type="ANY_BIT" Comment="AND input 3"/>
+			<VarDeclaration Name="IN4" Type="ANY_BIT" Comment="AND input 4"/>
+			<VarDeclaration Name="IN5" Type="ANY_BIT" Comment="AND input 5"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="AND result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_AND'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/AND_6.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/AND_6.fbt
@@ -1,35 +1,38 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean AND (generic FB)" Name="AND_6">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-        <With Var="IN3"/>
-        <With Var="IN4"/>
-        <With Var="IN5"/>
-        <With Var="IN6"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="AND input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 2" Name="IN2" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 3" Name="IN3" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 4" Name="IN4" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 5" Name="IN5" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 6" Name="IN6" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="AND result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AND_6" Comment="FB to calculate bitwise boolean AND (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+				<With Var="IN5"/>
+				<With Var="IN6"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="AND input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="AND input 2"/>
+			<VarDeclaration Name="IN3" Type="ANY_BIT" Comment="AND input 3"/>
+			<VarDeclaration Name="IN4" Type="ANY_BIT" Comment="AND input 4"/>
+			<VarDeclaration Name="IN5" Type="ANY_BIT" Comment="AND input 5"/>
+			<VarDeclaration Name="IN6" Type="ANY_BIT" Comment="AND input 6"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="AND result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_AND'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/AND_7.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/AND_7.fbt
@@ -1,37 +1,40 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean AND (generic FB)" Name="AND_7">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-        <With Var="IN3"/>
-        <With Var="IN4"/>
-        <With Var="IN5"/>
-        <With Var="IN6"/>
-        <With Var="IN7"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="AND input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 2" Name="IN2" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 3" Name="IN3" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 4" Name="IN4" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 5" Name="IN5" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 6" Name="IN6" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 7" Name="IN7" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="AND result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AND_7" Comment="FB to calculate bitwise boolean AND (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+				<With Var="IN5"/>
+				<With Var="IN6"/>
+				<With Var="IN7"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="AND input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="AND input 2"/>
+			<VarDeclaration Name="IN3" Type="ANY_BIT" Comment="AND input 3"/>
+			<VarDeclaration Name="IN4" Type="ANY_BIT" Comment="AND input 4"/>
+			<VarDeclaration Name="IN5" Type="ANY_BIT" Comment="AND input 5"/>
+			<VarDeclaration Name="IN6" Type="ANY_BIT" Comment="AND input 6"/>
+			<VarDeclaration Name="IN7" Type="ANY_BIT" Comment="AND input 7"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="AND result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_AND'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/AND_8.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/AND_8.fbt
@@ -1,39 +1,42 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean AND (generic FB)" Name="AND_8">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-        <With Var="IN3"/>
-        <With Var="IN4"/>
-        <With Var="IN5"/>
-        <With Var="IN6"/>
-        <With Var="IN7"/>
-        <With Var="IN8"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="AND input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 2" Name="IN2" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 3" Name="IN3" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 4" Name="IN4" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 5" Name="IN5" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 6" Name="IN6" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 7" Name="IN7" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 8" Name="IN8" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="AND result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AND_8" Comment="FB to calculate bitwise boolean AND (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+				<With Var="IN5"/>
+				<With Var="IN6"/>
+				<With Var="IN7"/>
+				<With Var="IN8"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="AND input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="AND input 2"/>
+			<VarDeclaration Name="IN3" Type="ANY_BIT" Comment="AND input 3"/>
+			<VarDeclaration Name="IN4" Type="ANY_BIT" Comment="AND input 4"/>
+			<VarDeclaration Name="IN5" Type="ANY_BIT" Comment="AND input 5"/>
+			<VarDeclaration Name="IN6" Type="ANY_BIT" Comment="AND input 6"/>
+			<VarDeclaration Name="IN7" Type="ANY_BIT" Comment="AND input 7"/>
+			<VarDeclaration Name="IN8" Type="ANY_BIT" Comment="AND input 8"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="AND result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_AND'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/AND_9.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/AND_9.fbt
@@ -1,41 +1,44 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean AND (generic FB)" Name="AND_9">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-        <With Var="IN3"/>
-        <With Var="IN4"/>
-        <With Var="IN5"/>
-        <With Var="IN6"/>
-        <With Var="IN7"/>
-        <With Var="IN8"/>
-        <With Var="IN9"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="AND input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 2" Name="IN2" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 3" Name="IN3" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 4" Name="IN4" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 5" Name="IN5" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 6" Name="IN6" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 7" Name="IN7" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 8" Name="IN8" Type="ANY_BIT"/>
-      <VarDeclaration Comment="AND input 9" Name="IN9" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="AND result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AND_9" Comment="FB to calculate bitwise boolean AND (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+				<With Var="IN5"/>
+				<With Var="IN6"/>
+				<With Var="IN7"/>
+				<With Var="IN8"/>
+				<With Var="IN9"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="AND input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="AND input 2"/>
+			<VarDeclaration Name="IN3" Type="ANY_BIT" Comment="AND input 3"/>
+			<VarDeclaration Name="IN4" Type="ANY_BIT" Comment="AND input 4"/>
+			<VarDeclaration Name="IN5" Type="ANY_BIT" Comment="AND input 5"/>
+			<VarDeclaration Name="IN6" Type="ANY_BIT" Comment="AND input 6"/>
+			<VarDeclaration Name="IN7" Type="ANY_BIT" Comment="AND input 7"/>
+			<VarDeclaration Name="IN8" Type="ANY_BIT" Comment="AND input 8"/>
+			<VarDeclaration Name="IN9" Type="ANY_BIT" Comment="AND input 9"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="AND result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_AND'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/OR_10.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/OR_10.fbt
@@ -1,43 +1,46 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean OR (generic FB)" Name="OR_10">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-        <With Var="IN3"/>
-        <With Var="IN4"/>
-        <With Var="IN5"/>
-        <With Var="IN6"/>
-        <With Var="IN7"/>
-        <With Var="IN8"/>
-        <With Var="IN9"/>
-        <With Var="IN10"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="OR input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 2" Name="IN2" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 3" Name="IN3" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 4" Name="IN4" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 5" Name="IN5" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 6" Name="IN6" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 7" Name="IN7" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 8" Name="IN8" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 9" Name="IN9" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 10" Name="IN10" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="OR result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="OR_10" Comment="FB to calculate bitwise boolean OR (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+				<With Var="IN5"/>
+				<With Var="IN6"/>
+				<With Var="IN7"/>
+				<With Var="IN8"/>
+				<With Var="IN9"/>
+				<With Var="IN10"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="OR input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="OR input 2"/>
+			<VarDeclaration Name="IN3" Type="ANY_BIT" Comment="OR input 3"/>
+			<VarDeclaration Name="IN4" Type="ANY_BIT" Comment="OR input 4"/>
+			<VarDeclaration Name="IN5" Type="ANY_BIT" Comment="OR input 5"/>
+			<VarDeclaration Name="IN6" Type="ANY_BIT" Comment="OR input 6"/>
+			<VarDeclaration Name="IN7" Type="ANY_BIT" Comment="OR input 7"/>
+			<VarDeclaration Name="IN8" Type="ANY_BIT" Comment="OR input 8"/>
+			<VarDeclaration Name="IN9" Type="ANY_BIT" Comment="OR input 9"/>
+			<VarDeclaration Name="IN10" Type="ANY_BIT" Comment="OR input 10"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="OR result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_OR'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/OR_16.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/OR_16.fbt
@@ -54,4 +54,5 @@
 			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="OR result"/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_OR'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/OR_2.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/OR_2.fbt
@@ -1,27 +1,30 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean OR (generic FB)" Name="OR_2">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="OR input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 2" Name="IN2" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="OR result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="OR_2" Comment="FB to calculate bitwise boolean OR (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="OR input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="OR input 2"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="OR result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_OR'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/OR_3.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/OR_3.fbt
@@ -1,29 +1,32 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean OR (generic FB)" Name="OR_3">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-        <With Var="IN3"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="OR input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 2" Name="IN2" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 3" Name="IN3" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="OR result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="OR_3" Comment="FB to calculate bitwise boolean OR (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="OR input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="OR input 2"/>
+			<VarDeclaration Name="IN3" Type="ANY_BIT" Comment="OR input 3"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="OR result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_OR'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/OR_4.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/OR_4.fbt
@@ -1,31 +1,34 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean OR (generic FB)" Name="OR_4">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-        <With Var="IN3"/>
-        <With Var="IN4"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="OR input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 2" Name="IN2" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 3" Name="IN3" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 4" Name="IN4" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="OR result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="OR_4" Comment="FB to calculate bitwise boolean OR (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="OR input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="OR input 2"/>
+			<VarDeclaration Name="IN3" Type="ANY_BIT" Comment="OR input 3"/>
+			<VarDeclaration Name="IN4" Type="ANY_BIT" Comment="OR input 4"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="OR result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_OR'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/OR_5.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/OR_5.fbt
@@ -1,33 +1,36 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean OR (generic FB)" Name="OR_5">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-        <With Var="IN3"/>
-        <With Var="IN4"/>
-        <With Var="IN5"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="OR input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 2" Name="IN2" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 3" Name="IN3" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 4" Name="IN4" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 5" Name="IN5" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="OR result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="OR_5" Comment="FB to calculate bitwise boolean OR (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+				<With Var="IN5"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="OR input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="OR input 2"/>
+			<VarDeclaration Name="IN3" Type="ANY_BIT" Comment="OR input 3"/>
+			<VarDeclaration Name="IN4" Type="ANY_BIT" Comment="OR input 4"/>
+			<VarDeclaration Name="IN5" Type="ANY_BIT" Comment="OR input 5"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="OR result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_OR'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/OR_6.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/OR_6.fbt
@@ -1,35 +1,38 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean OR (generic FB)" Name="OR_6">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-        <With Var="IN3"/>
-        <With Var="IN4"/>
-        <With Var="IN5"/>
-        <With Var="IN6"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="OR input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 2" Name="IN2" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 3" Name="IN3" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 4" Name="IN4" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 5" Name="IN5" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 6" Name="IN6" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="OR result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="OR_6" Comment="FB to calculate bitwise boolean OR (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+				<With Var="IN5"/>
+				<With Var="IN6"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="OR input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="OR input 2"/>
+			<VarDeclaration Name="IN3" Type="ANY_BIT" Comment="OR input 3"/>
+			<VarDeclaration Name="IN4" Type="ANY_BIT" Comment="OR input 4"/>
+			<VarDeclaration Name="IN5" Type="ANY_BIT" Comment="OR input 5"/>
+			<VarDeclaration Name="IN6" Type="ANY_BIT" Comment="OR input 6"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="OR result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_OR'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/OR_7.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/OR_7.fbt
@@ -1,37 +1,40 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean OR (generic FB)" Name="OR_7">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-        <With Var="IN3"/>
-        <With Var="IN4"/>
-        <With Var="IN5"/>
-        <With Var="IN6"/>
-        <With Var="IN7"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="OR input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 2" Name="IN2" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 3" Name="IN3" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 4" Name="IN4" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 5" Name="IN5" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 6" Name="IN6" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 7" Name="IN7" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="OR result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="OR_7" Comment="FB to calculate bitwise boolean OR (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+				<With Var="IN5"/>
+				<With Var="IN6"/>
+				<With Var="IN7"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="OR input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="OR input 2"/>
+			<VarDeclaration Name="IN3" Type="ANY_BIT" Comment="OR input 3"/>
+			<VarDeclaration Name="IN4" Type="ANY_BIT" Comment="OR input 4"/>
+			<VarDeclaration Name="IN5" Type="ANY_BIT" Comment="OR input 5"/>
+			<VarDeclaration Name="IN6" Type="ANY_BIT" Comment="OR input 6"/>
+			<VarDeclaration Name="IN7" Type="ANY_BIT" Comment="OR input 7"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="OR result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_OR'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/OR_8.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/OR_8.fbt
@@ -1,39 +1,42 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean OR (generic FB)" Name="OR_8">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-        <With Var="IN3"/>
-        <With Var="IN4"/>
-        <With Var="IN5"/>
-        <With Var="IN6"/>
-        <With Var="IN7"/>
-        <With Var="IN8"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="OR input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 2" Name="IN2" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 3" Name="IN3" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 4" Name="IN4" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 5" Name="IN5" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 6" Name="IN6" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 7" Name="IN7" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 8" Name="IN8" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="OR result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="OR_8" Comment="FB to calculate bitwise boolean OR (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+				<With Var="IN5"/>
+				<With Var="IN6"/>
+				<With Var="IN7"/>
+				<With Var="IN8"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="OR input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="OR input 2"/>
+			<VarDeclaration Name="IN3" Type="ANY_BIT" Comment="OR input 3"/>
+			<VarDeclaration Name="IN4" Type="ANY_BIT" Comment="OR input 4"/>
+			<VarDeclaration Name="IN5" Type="ANY_BIT" Comment="OR input 5"/>
+			<VarDeclaration Name="IN6" Type="ANY_BIT" Comment="OR input 6"/>
+			<VarDeclaration Name="IN7" Type="ANY_BIT" Comment="OR input 7"/>
+			<VarDeclaration Name="IN8" Type="ANY_BIT" Comment="OR input 8"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="OR result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_OR'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/OR_9.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/OR_9.fbt
@@ -1,41 +1,44 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean OR (generic FB)" Name="OR_9">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-        <With Var="IN3"/>
-        <With Var="IN4"/>
-        <With Var="IN5"/>
-        <With Var="IN6"/>
-        <With Var="IN7"/>
-        <With Var="IN8"/>
-        <With Var="IN9"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="OR input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 2" Name="IN2" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 3" Name="IN3" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 4" Name="IN4" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 5" Name="IN5" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 6" Name="IN6" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 7" Name="IN7" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 8" Name="IN8" Type="ANY_BIT"/>
-      <VarDeclaration Comment="OR input 9" Name="IN9" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="OR result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="OR_9" Comment="FB to calculate bitwise boolean OR (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+				<With Var="IN5"/>
+				<With Var="IN6"/>
+				<With Var="IN7"/>
+				<With Var="IN8"/>
+				<With Var="IN9"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="OR input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="OR input 2"/>
+			<VarDeclaration Name="IN3" Type="ANY_BIT" Comment="OR input 3"/>
+			<VarDeclaration Name="IN4" Type="ANY_BIT" Comment="OR input 4"/>
+			<VarDeclaration Name="IN5" Type="ANY_BIT" Comment="OR input 5"/>
+			<VarDeclaration Name="IN6" Type="ANY_BIT" Comment="OR input 6"/>
+			<VarDeclaration Name="IN7" Type="ANY_BIT" Comment="OR input 7"/>
+			<VarDeclaration Name="IN8" Type="ANY_BIT" Comment="OR input 8"/>
+			<VarDeclaration Name="IN9" Type="ANY_BIT" Comment="OR input 9"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="OR result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_OR'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/XOR_10.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/XOR_10.fbt
@@ -1,43 +1,46 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean XOR (generic FB)" Name="XOR_10">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-        <With Var="IN3"/>
-        <With Var="IN4"/>
-        <With Var="IN5"/>
-        <With Var="IN6"/>
-        <With Var="IN7"/>
-        <With Var="IN8"/>
-        <With Var="IN9"/>
-        <With Var="IN10"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="XOR input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 2" Name="IN2" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 3" Name="IN3" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 4" Name="IN4" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 5" Name="IN5" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 6" Name="IN6" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 7" Name="IN7" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 8" Name="IN8" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 9" Name="IN9" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 10" Name="IN10" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="XOR result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="XOR_10" Comment="FB to calculate bitwise boolean XOR (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+				<With Var="IN5"/>
+				<With Var="IN6"/>
+				<With Var="IN7"/>
+				<With Var="IN8"/>
+				<With Var="IN9"/>
+				<With Var="IN10"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="XOR input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="XOR input 2"/>
+			<VarDeclaration Name="IN3" Type="ANY_BIT" Comment="XOR input 3"/>
+			<VarDeclaration Name="IN4" Type="ANY_BIT" Comment="XOR input 4"/>
+			<VarDeclaration Name="IN5" Type="ANY_BIT" Comment="XOR input 5"/>
+			<VarDeclaration Name="IN6" Type="ANY_BIT" Comment="XOR input 6"/>
+			<VarDeclaration Name="IN7" Type="ANY_BIT" Comment="XOR input 7"/>
+			<VarDeclaration Name="IN8" Type="ANY_BIT" Comment="XOR input 8"/>
+			<VarDeclaration Name="IN9" Type="ANY_BIT" Comment="XOR input 9"/>
+			<VarDeclaration Name="IN10" Type="ANY_BIT" Comment="XOR input 10"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="XOR result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_XOR'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/XOR_2.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/XOR_2.fbt
@@ -1,27 +1,30 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean XOR (generic FB)" Name="XOR_2">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="XOR input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 2" Name="IN2" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="XOR result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="XOR_2" Comment="FB to calculate bitwise boolean XOR (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="XOR input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="XOR input 2"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="XOR result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_XOR'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/XOR_3.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/XOR_3.fbt
@@ -1,29 +1,32 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean XOR (generic FB)" Name="XOR_3">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-        <With Var="IN3"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="XOR input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 2" Name="IN2" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 3" Name="IN3" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="XOR result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="XOR_3" Comment="FB to calculate bitwise boolean XOR (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="XOR input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="XOR input 2"/>
+			<VarDeclaration Name="IN3" Type="ANY_BIT" Comment="XOR input 3"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="XOR result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_XOR'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/XOR_4.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/XOR_4.fbt
@@ -1,31 +1,34 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean XOR (generic FB)" Name="XOR_4">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-        <With Var="IN3"/>
-        <With Var="IN4"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="XOR input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 2" Name="IN2" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 3" Name="IN3" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 4" Name="IN4" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="XOR result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="XOR_4" Comment="FB to calculate bitwise boolean XOR (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="XOR input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="XOR input 2"/>
+			<VarDeclaration Name="IN3" Type="ANY_BIT" Comment="XOR input 3"/>
+			<VarDeclaration Name="IN4" Type="ANY_BIT" Comment="XOR input 4"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="XOR result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_XOR'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/XOR_5.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/XOR_5.fbt
@@ -1,33 +1,36 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean XOR (generic FB)" Name="XOR_5">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-        <With Var="IN3"/>
-        <With Var="IN4"/>
-        <With Var="IN5"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="XOR input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 2" Name="IN2" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 3" Name="IN3" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 4" Name="IN4" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 5" Name="IN5" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="XOR result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="XOR_5" Comment="FB to calculate bitwise boolean XOR (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+				<With Var="IN5"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="XOR input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="XOR input 2"/>
+			<VarDeclaration Name="IN3" Type="ANY_BIT" Comment="XOR input 3"/>
+			<VarDeclaration Name="IN4" Type="ANY_BIT" Comment="XOR input 4"/>
+			<VarDeclaration Name="IN5" Type="ANY_BIT" Comment="XOR input 5"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="XOR result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_XOR'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/XOR_6.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/XOR_6.fbt
@@ -1,35 +1,38 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean XOR (generic FB)" Name="XOR_6">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-        <With Var="IN3"/>
-        <With Var="IN4"/>
-        <With Var="IN5"/>
-        <With Var="IN6"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="XOR input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 2" Name="IN2" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 3" Name="IN3" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 4" Name="IN4" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 5" Name="IN5" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 6" Name="IN6" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="XOR result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="XOR_6" Comment="FB to calculate bitwise boolean XOR (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+				<With Var="IN5"/>
+				<With Var="IN6"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="XOR input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="XOR input 2"/>
+			<VarDeclaration Name="IN3" Type="ANY_BIT" Comment="XOR input 3"/>
+			<VarDeclaration Name="IN4" Type="ANY_BIT" Comment="XOR input 4"/>
+			<VarDeclaration Name="IN5" Type="ANY_BIT" Comment="XOR input 5"/>
+			<VarDeclaration Name="IN6" Type="ANY_BIT" Comment="XOR input 6"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="XOR result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_XOR'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/XOR_7.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/XOR_7.fbt
@@ -1,37 +1,40 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean XOR (generic FB)" Name="XOR_7">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-        <With Var="IN3"/>
-        <With Var="IN4"/>
-        <With Var="IN5"/>
-        <With Var="IN6"/>
-        <With Var="IN7"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="XOR input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 2" Name="IN2" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 3" Name="IN3" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 4" Name="IN4" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 5" Name="IN5" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 6" Name="IN6" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 7" Name="IN7" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="XOR result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="XOR_7" Comment="FB to calculate bitwise boolean XOR (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+				<With Var="IN5"/>
+				<With Var="IN6"/>
+				<With Var="IN7"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="XOR input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="XOR input 2"/>
+			<VarDeclaration Name="IN3" Type="ANY_BIT" Comment="XOR input 3"/>
+			<VarDeclaration Name="IN4" Type="ANY_BIT" Comment="XOR input 4"/>
+			<VarDeclaration Name="IN5" Type="ANY_BIT" Comment="XOR input 5"/>
+			<VarDeclaration Name="IN6" Type="ANY_BIT" Comment="XOR input 6"/>
+			<VarDeclaration Name="IN7" Type="ANY_BIT" Comment="XOR input 7"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="XOR result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_XOR'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/XOR_8.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/XOR_8.fbt
@@ -1,39 +1,42 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean XOR (generic FB)" Name="XOR_8">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-        <With Var="IN3"/>
-        <With Var="IN4"/>
-        <With Var="IN5"/>
-        <With Var="IN6"/>
-        <With Var="IN7"/>
-        <With Var="IN8"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="XOR input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 2" Name="IN2" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 3" Name="IN3" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 4" Name="IN4" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 5" Name="IN5" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 6" Name="IN6" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 7" Name="IN7" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 8" Name="IN8" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="XOR result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="XOR_8" Comment="FB to calculate bitwise boolean XOR (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+				<With Var="IN5"/>
+				<With Var="IN6"/>
+				<With Var="IN7"/>
+				<With Var="IN8"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="XOR input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="XOR input 2"/>
+			<VarDeclaration Name="IN3" Type="ANY_BIT" Comment="XOR input 3"/>
+			<VarDeclaration Name="IN4" Type="ANY_BIT" Comment="XOR input 4"/>
+			<VarDeclaration Name="IN5" Type="ANY_BIT" Comment="XOR input 5"/>
+			<VarDeclaration Name="IN6" Type="ANY_BIT" Comment="XOR input 6"/>
+			<VarDeclaration Name="IN7" Type="ANY_BIT" Comment="XOR input 7"/>
+			<VarDeclaration Name="IN8" Type="ANY_BIT" Comment="XOR input 8"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="XOR result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_XOR'"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/XOR_9.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/bitwiseOperators/XOR_9.fbt
@@ -1,41 +1,44 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="FB to calculate bitwise boolean XOR (generic FB)" Name="XOR_9">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61131-3" Classification="standard bitwise boolean function"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-10-11" Organization="Profactor GmbH" Version="1.0"/>
-  <CompilerInfo/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Normal Execution Request" Name="REQ" Type="Event">
-        <With Var="IN1"/>
-        <With Var="IN2"/>
-        <With Var="IN3"/>
-        <With Var="IN4"/>
-        <With Var="IN5"/>
-        <With Var="IN6"/>
-        <With Var="IN7"/>
-        <With Var="IN8"/>
-        <With Var="IN9"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Execution Confirmation" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="XOR input 1" Name="IN1" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 2" Name="IN2" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 3" Name="IN3" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 4" Name="IN4" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 5" Name="IN5" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 6" Name="IN6" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 7" Name="IN7" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 8" Name="IN8" Type="ANY_BIT"/>
-      <VarDeclaration Comment="XOR input 9" Name="IN9" Type="ANY_BIT"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="XOR result" Name="OUT" Type="ANY_BIT"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="XOR_9" Comment="FB to calculate bitwise boolean XOR (generic FB)">
+	<Identification Standard="61131-3" Classification="standard bitwise boolean function" Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-10-11">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+				<With Var="IN5"/>
+				<With Var="IN6"/>
+				<With Var="IN7"/>
+				<With Var="IN8"/>
+				<With Var="IN9"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_BIT" Comment="XOR input 1"/>
+			<VarDeclaration Name="IN2" Type="ANY_BIT" Comment="XOR input 2"/>
+			<VarDeclaration Name="IN3" Type="ANY_BIT" Comment="XOR input 3"/>
+			<VarDeclaration Name="IN4" Type="ANY_BIT" Comment="XOR input 4"/>
+			<VarDeclaration Name="IN5" Type="ANY_BIT" Comment="XOR input 5"/>
+			<VarDeclaration Name="IN6" Type="ANY_BIT" Comment="XOR input 6"/>
+			<VarDeclaration Name="IN7" Type="ANY_BIT" Comment="XOR input 7"/>
+			<VarDeclaration Name="IN8" Type="ANY_BIT" Comment="XOR input 8"/>
+			<VarDeclaration Name="IN9" Type="ANY_BIT" Comment="XOR input 9"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_BIT" Comment="XOR result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_XOR'"/>
 </FBType>

--- a/data/typelibrary/net-1.0.0/MANIFEST.MF
+++ b/data/typelibrary/net-1.0.0/MANIFEST.MF
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="platform:/resource/org.eclipse.fordiac.ide.library.model/model/library.xsd" Scope="Library">
+    <Dependencies>
+        <Required SymbolicName="core" Version="1.0.0"/>
+    </Dependencies>
     <Product Name="Net" SymbolicName="net" Comment="Standard Library - Net">
         <VersionInfo Version="1.0.0" Author="Eclipse 4diac" Date="2024-02-21"/>
     </Product>

--- a/data/typelibrary/net-1.0.0/typelib/CLIENT_1.fbt
+++ b/data/typelibrary/net-1.0.0/typelib/CLIENT_1.fbt
@@ -37,4 +37,5 @@
 			<VarDeclaration Name="RD_1" Type="ANY" Comment=""/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_CLIENT'"/>
 </FBType>

--- a/data/typelibrary/net-1.0.0/typelib/CLIENT_2_1.fbt
+++ b/data/typelibrary/net-1.0.0/typelib/CLIENT_2_1.fbt
@@ -39,4 +39,5 @@
 			<VarDeclaration Name="RD_1" Type="ANY" Comment=""/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_CLIENT'"/>
 </FBType>

--- a/data/typelibrary/net-1.0.0/typelib/PUBLISH_0.fbt
+++ b/data/typelibrary/net-1.0.0/typelib/PUBLISH_0.fbt
@@ -33,4 +33,5 @@
 			<VarDeclaration Name="STATUS" Type="WSTRING" Comment=""/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_PUBLISH'"/>
 </FBType>

--- a/data/typelibrary/net-1.0.0/typelib/PUBLISH_1.fbt
+++ b/data/typelibrary/net-1.0.0/typelib/PUBLISH_1.fbt
@@ -35,4 +35,5 @@
 			<VarDeclaration Name="STATUS" Type="WSTRING" Comment=""/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_PUBLISH'"/>
 </FBType>

--- a/data/typelibrary/net-1.0.0/typelib/PUBLISH_10.fbt
+++ b/data/typelibrary/net-1.0.0/typelib/PUBLISH_10.fbt
@@ -53,4 +53,5 @@
 			<VarDeclaration Name="STATUS" Type="WSTRING" Comment=""/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_PUBLISH'"/>
 </FBType>

--- a/data/typelibrary/net-1.0.0/typelib/PUBLISH_2.fbt
+++ b/data/typelibrary/net-1.0.0/typelib/PUBLISH_2.fbt
@@ -37,4 +37,5 @@
 			<VarDeclaration Name="STATUS" Type="WSTRING" Comment=""/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_PUBLISH'"/>
 </FBType>

--- a/data/typelibrary/net-1.0.0/typelib/PUBLISH_3.fbt
+++ b/data/typelibrary/net-1.0.0/typelib/PUBLISH_3.fbt
@@ -39,4 +39,5 @@
 			<VarDeclaration Name="STATUS" Type="WSTRING" Comment=""/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_PUBLISH'"/>
 </FBType>

--- a/data/typelibrary/net-1.0.0/typelib/PUBLISH_4.fbt
+++ b/data/typelibrary/net-1.0.0/typelib/PUBLISH_4.fbt
@@ -41,4 +41,5 @@
 			<VarDeclaration Name="STATUS" Type="WSTRING" Comment=""/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_PUBLISH'"/>
 </FBType>

--- a/data/typelibrary/net-1.0.0/typelib/PUBLISH_5.fbt
+++ b/data/typelibrary/net-1.0.0/typelib/PUBLISH_5.fbt
@@ -43,4 +43,5 @@
 			<VarDeclaration Name="STATUS" Type="WSTRING" Comment=""/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_PUBLISH'"/>
 </FBType>

--- a/data/typelibrary/net-1.0.0/typelib/PUBLISH_6.fbt
+++ b/data/typelibrary/net-1.0.0/typelib/PUBLISH_6.fbt
@@ -45,4 +45,5 @@
 			<VarDeclaration Name="STATUS" Type="WSTRING" Comment=""/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_PUBLISH'"/>
 </FBType>

--- a/data/typelibrary/net-1.0.0/typelib/PUBLISH_7.fbt
+++ b/data/typelibrary/net-1.0.0/typelib/PUBLISH_7.fbt
@@ -47,4 +47,5 @@
 			<VarDeclaration Name="STATUS" Type="WSTRING" Comment=""/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_PUBLISH'"/>
 </FBType>

--- a/data/typelibrary/net-1.0.0/typelib/PUBLISH_8.fbt
+++ b/data/typelibrary/net-1.0.0/typelib/PUBLISH_8.fbt
@@ -49,4 +49,5 @@
 			<VarDeclaration Name="STATUS" Type="WSTRING" Comment=""/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_PUBLISH'"/>
 </FBType>

--- a/data/typelibrary/net-1.0.0/typelib/PUBLISH_9.fbt
+++ b/data/typelibrary/net-1.0.0/typelib/PUBLISH_9.fbt
@@ -51,4 +51,5 @@
 			<VarDeclaration Name="STATUS" Type="WSTRING" Comment=""/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_PUBLISH'"/>
 </FBType>

--- a/data/typelibrary/net-1.0.0/typelib/SERVER_1.fbt
+++ b/data/typelibrary/net-1.0.0/typelib/SERVER_1.fbt
@@ -37,4 +37,5 @@
 			<VarDeclaration Name="RD_1" Type="ANY" Comment=""/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_SERVER'"/>
 </FBType>

--- a/data/typelibrary/net-1.0.0/typelib/SERVER_1_2.fbt
+++ b/data/typelibrary/net-1.0.0/typelib/SERVER_1_2.fbt
@@ -39,4 +39,5 @@
 			<VarDeclaration Name="RD_2" Type="ANY" Comment=""/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_SERVER'"/>
 </FBType>

--- a/data/typelibrary/net-1.0.0/typelib/SUBSCRIBE_0.fbt
+++ b/data/typelibrary/net-1.0.0/typelib/SUBSCRIBE_0.fbt
@@ -33,4 +33,5 @@
 			<VarDeclaration Name="STATUS" Type="WSTRING" Comment=""/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_SUBSCRIBE'"/>
 </FBType>

--- a/data/typelibrary/net-1.0.0/typelib/SUBSCRIBE_1.fbt
+++ b/data/typelibrary/net-1.0.0/typelib/SUBSCRIBE_1.fbt
@@ -35,4 +35,5 @@
 			<VarDeclaration Name="RD_1" Type="ANY" Comment=""/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_SUBSCRIBE'"/>
 </FBType>

--- a/data/typelibrary/net-1.0.0/typelib/SUBSCRIBE_10.fbt
+++ b/data/typelibrary/net-1.0.0/typelib/SUBSCRIBE_10.fbt
@@ -55,4 +55,5 @@
 	</InterfaceList>
 	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Subscribe to a PUBLISH_10 Block">
 	</Service>
+	<Attribute Name="GenericClassName" Value="'GEN_SUBSCRIBE'"/>
 </FBType>

--- a/data/typelibrary/net-1.0.0/typelib/SUBSCRIBE_2.fbt
+++ b/data/typelibrary/net-1.0.0/typelib/SUBSCRIBE_2.fbt
@@ -39,4 +39,5 @@
 	</InterfaceList>
 	<Attribute Name="Documentation" Type="CDATA"><![CDATA[<p>Subscribe to a PUBLISH_0 BlockSubscribe to a PUBLISH_0 Block</p>
 ]]></Attribute>
+	<Attribute Name="GenericClassName" Value="'GEN_SUBSCRIBE'"/>
 </FBType>

--- a/data/typelibrary/net-1.0.0/typelib/SUBSCRIBE_3.fbt
+++ b/data/typelibrary/net-1.0.0/typelib/SUBSCRIBE_3.fbt
@@ -39,4 +39,5 @@
 			<VarDeclaration Name="RD_3" Type="ANY" Comment=""/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_SUBSCRIBE'"/>
 </FBType>

--- a/data/typelibrary/net-1.0.0/typelib/SUBSCRIBE_4.fbt
+++ b/data/typelibrary/net-1.0.0/typelib/SUBSCRIBE_4.fbt
@@ -41,4 +41,5 @@
 			<VarDeclaration Name="RD_4" Type="ANY" Comment=""/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_SUBSCRIBE'"/>
 </FBType>

--- a/data/typelibrary/net-1.0.0/typelib/SUBSCRIBE_5.fbt
+++ b/data/typelibrary/net-1.0.0/typelib/SUBSCRIBE_5.fbt
@@ -43,4 +43,5 @@
 			<VarDeclaration Name="RD_5" Type="ANY" Comment=""/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_SUBSCRIBE'"/>
 </FBType>

--- a/data/typelibrary/net-1.0.0/typelib/SUBSCRIBE_6.fbt
+++ b/data/typelibrary/net-1.0.0/typelib/SUBSCRIBE_6.fbt
@@ -45,4 +45,5 @@
 			<VarDeclaration Name="RD_6" Type="ANY" Comment=""/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_SUBSCRIBE'"/>
 </FBType>

--- a/data/typelibrary/net-1.0.0/typelib/SUBSCRIBE_7.fbt
+++ b/data/typelibrary/net-1.0.0/typelib/SUBSCRIBE_7.fbt
@@ -47,4 +47,5 @@
 			<VarDeclaration Name="RD_7" Type="ANY" Comment=""/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_SUBSCRIBE'"/>
 </FBType>

--- a/data/typelibrary/net-1.0.0/typelib/SUBSCRIBE_8.fbt
+++ b/data/typelibrary/net-1.0.0/typelib/SUBSCRIBE_8.fbt
@@ -49,4 +49,5 @@
 			<VarDeclaration Name="RD_8" Type="ANY" Comment=""/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_SUBSCRIBE'"/>
 </FBType>

--- a/data/typelibrary/net-1.0.0/typelib/SUBSCRIBE_9.fbt
+++ b/data/typelibrary/net-1.0.0/typelib/SUBSCRIBE_9.fbt
@@ -51,4 +51,5 @@
 			<VarDeclaration Name="RD_9" Type="ANY" Comment=""/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_SUBSCRIBE'"/>
 </FBType>

--- a/data/typelibrary/rtevents-1.0.0/MANIFEST.MF
+++ b/data/typelibrary/rtevents-1.0.0/MANIFEST.MF
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="platform:/resource/org.eclipse.fordiac.ide.library.model/model/library.xsd" Scope="Library">
+    <Dependencies>
+        <Required SymbolicName="core" Version="1.0.0"/>
+    </Dependencies>
     <Product Name="Rtevents" SymbolicName="rtevents" Comment="Standard Library - RT Events">
         <VersionInfo Version="1.0.0" Author="Eclipse 4diac" Date="2024-02-21"/>
     </Product>

--- a/data/typelibrary/rtevents-1.0.0/typelib/RT_Bridge_1.FBT
+++ b/data/typelibrary/rtevents-1.0.0/typelib/RT_Bridge_1.FBT
@@ -26,6 +26,7 @@
 			<VarDeclaration Name="RD_1" Type="ANY" Comment="Data from data bridge"/>
 		</OutputVars>
 	</InterfaceList>
-	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Data connection decoupling bridge for data connection between real-time event chains">		
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Data connection decoupling bridge for data connection between real-time event chains">
 	</Service>
+	<Attribute Name="GenericClassName" Value="'GEN_RT_Bridge'"/>
 </FBType>

--- a/data/typelibrary/rtevents-1.0.0/typelib/RT_Bridge_10.FBT
+++ b/data/typelibrary/rtevents-1.0.0/typelib/RT_Bridge_10.FBT
@@ -62,6 +62,7 @@
 			<VarDeclaration Name="RD_10" Type="ANY" Comment="Data from data bridge"/>
 		</OutputVars>
 	</InterfaceList>
-	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Data connection decoupling bridge for data connection between real-time event chains">		
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Data connection decoupling bridge for data connection between real-time event chains">
 	</Service>
+	<Attribute Name="GenericClassName" Value="'GEN_RT_Bridge'"/>
 </FBType>

--- a/data/typelibrary/rtevents-1.0.0/typelib/RT_Bridge_11.FBT
+++ b/data/typelibrary/rtevents-1.0.0/typelib/RT_Bridge_11.FBT
@@ -66,6 +66,7 @@
 			<VarDeclaration Name="RD_11" Type="ANY" Comment="Data from data bridge"/>
 		</OutputVars>
 	</InterfaceList>
-	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Data connection decoupling bridge for data connection between real-time event chains">		
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Data connection decoupling bridge for data connection between real-time event chains">
 	</Service>
+	<Attribute Name="GenericClassName" Value="'GEN_RT_Bridge'"/>
 </FBType>

--- a/data/typelibrary/rtevents-1.0.0/typelib/RT_Bridge_2.FBT
+++ b/data/typelibrary/rtevents-1.0.0/typelib/RT_Bridge_2.FBT
@@ -30,6 +30,7 @@
 			<VarDeclaration Name="RD_2" Type="ANY" Comment="Data from data bridge"/>
 		</OutputVars>
 	</InterfaceList>
-	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Data connection decoupling bridge for data connection between real-time event chains">		
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Data connection decoupling bridge for data connection between real-time event chains">
 	</Service>
+	<Attribute Name="GenericClassName" Value="'GEN_RT_Bridge'"/>
 </FBType>

--- a/data/typelibrary/rtevents-1.0.0/typelib/RT_Bridge_3.FBT
+++ b/data/typelibrary/rtevents-1.0.0/typelib/RT_Bridge_3.FBT
@@ -34,6 +34,7 @@
 			<VarDeclaration Name="RD_3" Type="ANY" Comment="Data from data bridge"/>
 		</OutputVars>
 	</InterfaceList>
-	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Data connection decoupling bridge for data connection between real-time event chains">		
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Data connection decoupling bridge for data connection between real-time event chains">
 	</Service>
+	<Attribute Name="GenericClassName" Value="'GEN_RT_Bridge'"/>
 </FBType>

--- a/data/typelibrary/rtevents-1.0.0/typelib/RT_Bridge_4.FBT
+++ b/data/typelibrary/rtevents-1.0.0/typelib/RT_Bridge_4.FBT
@@ -38,6 +38,7 @@
 			<VarDeclaration Name="RD_4" Type="ANY" Comment="Data from data bridge"/>
 		</OutputVars>
 	</InterfaceList>
-	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Data connection decoupling bridge for data connection between real-time event chains">		
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Data connection decoupling bridge for data connection between real-time event chains">
 	</Service>
+	<Attribute Name="GenericClassName" Value="'GEN_RT_Bridge'"/>
 </FBType>

--- a/data/typelibrary/rtevents-1.0.0/typelib/RT_Bridge_5.FBT
+++ b/data/typelibrary/rtevents-1.0.0/typelib/RT_Bridge_5.FBT
@@ -42,6 +42,7 @@
 			<VarDeclaration Name="RD_5" Type="ANY" Comment="Data from data bridge"/>
 		</OutputVars>
 	</InterfaceList>
-	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Data connection decoupling bridge for data connection between real-time event chains">		
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Data connection decoupling bridge for data connection between real-time event chains">
 	</Service>
+	<Attribute Name="GenericClassName" Value="'GEN_RT_Bridge'"/>
 </FBType>

--- a/data/typelibrary/rtevents-1.0.0/typelib/RT_Bridge_6.FBT
+++ b/data/typelibrary/rtevents-1.0.0/typelib/RT_Bridge_6.FBT
@@ -46,6 +46,7 @@
 			<VarDeclaration Name="RD_6" Type="ANY" Comment="Data from data bridge"/>
 		</OutputVars>
 	</InterfaceList>
-	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Data connection decoupling bridge for data connection between real-time event chains">		
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Data connection decoupling bridge for data connection between real-time event chains">
 	</Service>
+	<Attribute Name="GenericClassName" Value="'GEN_RT_Bridge'"/>
 </FBType>

--- a/data/typelibrary/rtevents-1.0.0/typelib/RT_Bridge_7.FBT
+++ b/data/typelibrary/rtevents-1.0.0/typelib/RT_Bridge_7.FBT
@@ -52,6 +52,7 @@
 			<VarDeclaration Name="RD_8" Type="ANY" Comment="Data from data bridge"/>
 		</OutputVars>
 	</InterfaceList>
-	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Data connection decoupling bridge for data connection between real-time event chains">		
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Data connection decoupling bridge for data connection between real-time event chains">
 	</Service>
+	<Attribute Name="GenericClassName" Value="'GEN_RT_Bridge'"/>
 </FBType>

--- a/data/typelibrary/rtevents-1.0.0/typelib/RT_Bridge_8.FBT
+++ b/data/typelibrary/rtevents-1.0.0/typelib/RT_Bridge_8.FBT
@@ -56,6 +56,7 @@
 			<VarDeclaration Name="RD_9" Type="ANY" Comment="Data from data bridge"/>
 		</OutputVars>
 	</InterfaceList>
-	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Data connection decoupling bridge for data connection between real-time event chains">		
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Data connection decoupling bridge for data connection between real-time event chains">
 	</Service>
+	<Attribute Name="GenericClassName" Value="'GEN_RT_Bridge'"/>
 </FBType>

--- a/data/typelibrary/rtevents-1.0.0/typelib/RT_Bridge_9.FBT
+++ b/data/typelibrary/rtevents-1.0.0/typelib/RT_Bridge_9.FBT
@@ -58,6 +58,7 @@
 			<VarDeclaration Name="RD_9" Type="ANY" Comment="Data from data bridge"/>
 		</OutputVars>
 	</InterfaceList>
-	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Data connection decoupling bridge for data connection between real-time event chains">		
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Data connection decoupling bridge for data connection between real-time event chains">
 	</Service>
+	<Attribute Name="GenericClassName" Value="'GEN_RT_Bridge'"/>
 </FBType>

--- a/data/typelibrary/utils-1.0.0/MANIFEST.MF
+++ b/data/typelibrary/utils-1.0.0/MANIFEST.MF
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="platform:/resource/org.eclipse.fordiac.ide.library.model/model/library.xsd" Scope="Library">
+    <Dependencies>
+        <Required SymbolicName="core" Version="1.0.0"/>
+    </Dependencies>
     <Product Name="Utils" SymbolicName="utils" Comment="Standard Library - Utils">
         <VersionInfo Version="1.0.0" Author="Eclipse 4diac" Date="2024-02-21"/>
     </Product>

--- a/data/typelibrary/utils-1.0.0/typelib/ARRAY2ARRAY_2_LREAL.fbt
+++ b/data/typelibrary/utils-1.0.0/typelib/ARRAY2ARRAY_2_LREAL.fbt
@@ -1,25 +1,28 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="Service Interface Function Block Type" Name="ARRAY2ARRAY_2_LREAL">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-08-05" Organization="Profactor GmbH" Version="1.0"/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Service Request" Name="REQ" Type="Event">
-        <With Var="IN"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Confirmation of Requested Service" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration ArraySize="2" Comment="array input" Name="IN" Type="LREAL"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration ArraySize="2" Comment="array output" Name="OUT" Type="LREAL"/>
-    </OutputVars>
-  </InterfaceList>
-  <Service Comment="Service Interface Function Block Type" LeftInterface="APPLICATION" RightInterface="RESOURCE"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ARRAY2ARRAY_2_LREAL" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-08-05">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="IN"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="LREAL" Comment="array input" ArraySize="2"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="LREAL" Comment="array output" ArraySize="2"/>
+		</OutputVars>
+	</InterfaceList>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Service Interface Function Block Type">
+	</Service>
+	<Attribute Name="GenericClassName" Value="'GEN_ARRAY2ARRAY'"/>
 </FBType>

--- a/data/typelibrary/utils-1.0.0/typelib/ARRAY2VALUES_2_LREAL.fbt
+++ b/data/typelibrary/utils-1.0.0/typelib/ARRAY2VALUES_2_LREAL.fbt
@@ -1,26 +1,28 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="Service Interface Function Block Type" Name="ARRAY2VALUES_2_LREAL">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-07-09" Organization="Profactor GmbH" Version="1.0"/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Service Request" Name="REQ" Type="Event">
-        <With Var="IN"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Confirmation of Requested Service" Name="CNF" Type="Event">
-        <With Var="OUT_1"/>
-        <With Var="OUT_2"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration ArraySize="2" Comment="Array input" Name="IN" Type="LREAL"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="output number 1" Name="OUT_1" Type="LREAL"/>
-      <VarDeclaration Comment="output number 2" Name="OUT_2" Type="LREAL"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ARRAY2VALUES_2_LREAL" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-07-09">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="IN"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="OUT_1"/>
+				<With Var="OUT_2"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="LREAL" Comment="Array input" ArraySize="2"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT_1" Type="LREAL" Comment="output number 1"/>
+			<VarDeclaration Name="OUT_2" Type="LREAL" Comment="output number 2"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_ARRAY2ARRAY'"/>
 </FBType>

--- a/data/typelibrary/utils-1.0.0/typelib/CSV_WRITER_1.fbt
+++ b/data/typelibrary/utils-1.0.0/typelib/CSV_WRITER_1.fbt
@@ -1,37 +1,39 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="Service Interface Function Block Type" Name="CSV_WRITER_1">
-  <Identification Description="Copyright (c) 2012 ACIN&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0"/>
-  <VersionInfo Author="Alois Zoitl" Date="2012-06-16" Organization="ACIN" Version="1.0"/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Service Initialization" Name="INIT" Type="Event">
-        <With Var="QI"/>
-        <With Var="FILE_NAME"/>
-      </Event>
-      <Event Comment="Service Request" Name="REQ" Type="Event">
-        <With Var="QI"/>
-        <With Var="SD_1"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Initialization Confirm" Name="INITO" Type="Event">
-        <With Var="QO"/>
-        <With Var="STATUS"/>
-      </Event>
-      <Event Comment="Confirmation of Requested Service" Name="CNF" Type="Event">
-        <With Var="QO"/>
-        <With Var="STATUS"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="Event Input Qualifier" Name="QI" Type="BOOL"/>
-      <VarDeclaration Comment="Service Parameters" Name="FILE_NAME" Type="STRING"/>
-      <VarDeclaration Comment="Output data to resource" Name="SD_1" Type="ANY"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="Event Output Qualifier" Name="QO" Type="BOOL"/>
-      <VarDeclaration Comment="File access status" Name="STATUS" Type="STRING"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="CSV_WRITER_1" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2012 ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="ACIN" Version="1.0" Author="Alois Zoitl" Date="2012-06-16">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="Event" Comment="Service Initialization">
+				<With Var="QI"/>
+				<With Var="FILE_NAME"/>
+			</Event>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="QI"/>
+				<With Var="SD_1"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="Event" Comment="Initialization Confirm">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="FILE_NAME" Type="STRING" Comment="Service Parameters"/>
+			<VarDeclaration Name="SD_1" Type="ANY" Comment="Output data to resource"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
+			<VarDeclaration Name="STATUS" Type="STRING" Comment="File access status"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_CSV_WRITER'"/>
 </FBType>

--- a/data/typelibrary/utils-1.0.0/typelib/CSV_WRITER_10.fbt
+++ b/data/typelibrary/utils-1.0.0/typelib/CSV_WRITER_10.fbt
@@ -1,93 +1,95 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="Service Interface Function Block Type" Name="CSV_WRITER_10">
-  <Identification Description="Copyright (c) 2012 ACIN&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0"/>
-  <VersionInfo Author="Alois Zoitl" Date="2012-06-16" Organization="ACIN" Version="1.0"/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Service Initialization" Name="INIT" Type="Event">
-        <With Var="QI"/>
-        <With Var="FILE_NAME"/>
-      </Event>
-      <Event Comment="Service Request" Name="REQ" Type="Event">
-        <With Var="QI"/>
-        <With Var="SD_1"/>
-        <With Var="SD_2"/>
-        <With Var="SD_3"/>
-        <With Var="SD_4"/>
-        <With Var="SD_5"/>
-        <With Var="SD_6"/>
-        <With Var="SD_7"/>
-        <With Var="SD_8"/>
-        <With Var="SD_9"/>
-        <With Var="SD_10"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Initialization Confirm" Name="INITO" Type="Event">
-        <With Var="QO"/>
-        <With Var="STATUS"/>
-      </Event>
-      <Event Comment="Confirmation of Requested Service" Name="CNF" Type="Event">
-        <With Var="QO"/>
-        <With Var="STATUS"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="Event Input Qualifier" Name="QI" Type="BOOL"/>
-      <VarDeclaration Comment="Service Parameters" Name="FILE_NAME" Type="STRING"/>
-      <VarDeclaration Comment="Output data to resource" Name="SD_1" Type="ANY"/>
-      <VarDeclaration Name="SD_2" Type="ANY"/>
-      <VarDeclaration Name="SD_3" Type="ANY"/>
-      <VarDeclaration Name="SD_4" Type="ANY"/>
-      <VarDeclaration Name="SD_5" Type="ANY"/>
-      <VarDeclaration Name="SD_6" Type="ANY"/>
-      <VarDeclaration Name="SD_7" Type="ANY"/>
-      <VarDeclaration Name="SD_8" Type="ANY"/>
-      <VarDeclaration Name="SD_9" Type="ANY"/>
-      <VarDeclaration Name="SD_10" Type="ANY"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="Event Output Qualifier" Name="QO" Type="BOOL"/>
-      <VarDeclaration Comment="File access status" Name="STATUS" Type="STRING"/>
-    </OutputVars>
-  </InterfaceList>
-  <Service Comment="Service Interface Function Block Type" LeftInterface="APPLICATION" RightInterface="RESOURCE">
-    <ServiceSequence Name="normal_establishment">
-      <ServiceTransaction>
-        <InputPrimitive Event="INIT+" Interface="APPLICATION" Parameters="FILE_NAME"/>
-        <OutputPrimitive Event="INITO+" Interface="APPLICATION" Parameters="STATUS"/>
-      </ServiceTransaction>
-    </ServiceSequence>
-    <ServiceSequence Name="unsuccessful_establishment">
-      <ServiceTransaction>
-        <InputPrimitive Event="INIT+" Interface="APPLICATION" Parameters="FILE_NAME"/>
-        <OutputPrimitive Event="INITO-" Interface="APPLICATION" Parameters="STATUS"/>
-      </ServiceTransaction>
-    </ServiceSequence>
-    <ServiceSequence Name="request_confirm">
-      <ServiceTransaction>
-        <InputPrimitive Event="REQ+" Interface="APPLICATION" Parameters="SD_1,SD_2,SD_3,SD_4,SD_5,SD_6,SD_7,SD_8,SD_9,SD_10"/>
-        <OutputPrimitive Event="CNF+" Interface="APPLICATION" Parameters="STATUS"/>
-      </ServiceTransaction>
-    </ServiceSequence>
-    <ServiceSequence Name="request_inhibited">
-      <ServiceTransaction>
-        <InputPrimitive Event="REQ-" Interface="APPLICATION" Parameters="SD_1,SD_2,SD_3,SD_4,SD_5,SD_6,SD_7,SD_8,SD_9,SD_10"/>
-        <OutputPrimitive Event="CNF-" Interface="APPLICATION" Parameters="STATUS"/>
-      </ServiceTransaction>
-    </ServiceSequence>
-    <ServiceSequence Name="request_error">
-      <ServiceTransaction>
-        <InputPrimitive Event="REQ+" Interface="APPLICATION" Parameters="SD_1,SD_2,SD_3,SD_4,SD_5,SD_6,SD_7,SD_8,SD_9,SD_10"/>
-        <OutputPrimitive Event="CNF-" Interface="APPLICATION" Parameters="STATUS"/>
-      </ServiceTransaction>
-    </ServiceSequence>
-    <ServiceSequence Name="application_initiated_termination">
-      <ServiceTransaction>
-        <InputPrimitive Event="INIT-" Interface="APPLICATION"/>
-        <OutputPrimitive Event="INITO-" Interface="APPLICATION" Parameters="STATUS"/>
-      </ServiceTransaction>
-    </ServiceSequence>
-  </Service>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="CSV_WRITER_10" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2012 ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="ACIN" Version="1.0" Author="Alois Zoitl" Date="2012-06-16">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="Event" Comment="Service Initialization">
+				<With Var="QI"/>
+				<With Var="FILE_NAME"/>
+			</Event>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="QI"/>
+				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+				<With Var="SD_6"/>
+				<With Var="SD_7"/>
+				<With Var="SD_8"/>
+				<With Var="SD_9"/>
+				<With Var="SD_10"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="Event" Comment="Initialization Confirm">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="FILE_NAME" Type="STRING" Comment="Service Parameters"/>
+			<VarDeclaration Name="SD_1" Type="ANY" Comment="Output data to resource"/>
+			<VarDeclaration Name="SD_2" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_3" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_4" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_5" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_6" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_7" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_8" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_9" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_10" Type="ANY" Comment=""/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
+			<VarDeclaration Name="STATUS" Type="STRING" Comment="File access status"/>
+		</OutputVars>
+	</InterfaceList>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Service Interface Function Block Type">
+		<ServiceSequence Name="normal_establishment" Comment="">
+			<ServiceTransaction>
+				<InputPrimitive Interface="APPLICATION" Event="INIT+" Parameters="FILE_NAME"/>
+				<OutputPrimitive Interface="APPLICATION" Event="INITO+" Parameters="STATUS"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="unsuccessful_establishment" Comment="">
+			<ServiceTransaction>
+				<InputPrimitive Interface="APPLICATION" Event="INIT+" Parameters="FILE_NAME"/>
+				<OutputPrimitive Interface="APPLICATION" Event="INITO-" Parameters="STATUS"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="request_confirm" Comment="">
+			<ServiceTransaction>
+				<InputPrimitive Interface="APPLICATION" Event="REQ+" Parameters="SD_1,SD_2,SD_3,SD_4,SD_5,SD_6,SD_7,SD_8,SD_9,SD_10"/>
+				<OutputPrimitive Interface="APPLICATION" Event="CNF+" Parameters="STATUS"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="request_inhibited" Comment="">
+			<ServiceTransaction>
+				<InputPrimitive Interface="APPLICATION" Event="REQ-" Parameters="SD_1,SD_2,SD_3,SD_4,SD_5,SD_6,SD_7,SD_8,SD_9,SD_10"/>
+				<OutputPrimitive Interface="APPLICATION" Event="CNF-" Parameters="STATUS"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="request_error" Comment="">
+			<ServiceTransaction>
+				<InputPrimitive Interface="APPLICATION" Event="REQ+" Parameters="SD_1,SD_2,SD_3,SD_4,SD_5,SD_6,SD_7,SD_8,SD_9,SD_10"/>
+				<OutputPrimitive Interface="APPLICATION" Event="CNF-" Parameters="STATUS"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="application_initiated_termination" Comment="">
+			<ServiceTransaction>
+				<InputPrimitive Interface="APPLICATION" Event="INIT-"/>
+				<OutputPrimitive Interface="APPLICATION" Event="INITO-" Parameters="STATUS"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+	</Service>
+	<Attribute Name="GenericClassName" Value="'GEN_CSV_WRITER'"/>
 </FBType>

--- a/data/typelibrary/utils-1.0.0/typelib/CSV_WRITER_2.fbt
+++ b/data/typelibrary/utils-1.0.0/typelib/CSV_WRITER_2.fbt
@@ -1,39 +1,41 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="Service Interface Function Block Type" Name="CSV_WRITER_2">
-  <Identification Description="Copyright (c) 2012 ACIN&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0"/>
-  <VersionInfo Author="Alois Zoitl" Date="2012-06-16" Organization="ACIN" Version="1.0"/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Service Initialization" Name="INIT" Type="Event">
-        <With Var="QI"/>
-        <With Var="FILE_NAME"/>
-      </Event>
-      <Event Comment="Service Request" Name="REQ" Type="Event">
-        <With Var="QI"/>
-        <With Var="SD_1"/>
-        <With Var="SD_2"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Initialization Confirm" Name="INITO" Type="Event">
-        <With Var="QO"/>
-        <With Var="STATUS"/>
-      </Event>
-      <Event Comment="Confirmation of Requested Service" Name="CNF" Type="Event">
-        <With Var="QO"/>
-        <With Var="STATUS"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="Event Input Qualifier" Name="QI" Type="BOOL"/>
-      <VarDeclaration Comment="Service Parameters" Name="FILE_NAME" Type="STRING"/>
-      <VarDeclaration Comment="Output data to resource" Name="SD_1" Type="ANY"/>
-      <VarDeclaration Name="SD_2" Type="ANY"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="Event Output Qualifier" Name="QO" Type="BOOL"/>
-      <VarDeclaration Comment="File access status" Name="STATUS" Type="STRING"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="CSV_WRITER_2" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2012 ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="ACIN" Version="1.0" Author="Alois Zoitl" Date="2012-06-16">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="Event" Comment="Service Initialization">
+				<With Var="QI"/>
+				<With Var="FILE_NAME"/>
+			</Event>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="QI"/>
+				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="Event" Comment="Initialization Confirm">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="FILE_NAME" Type="STRING" Comment="Service Parameters"/>
+			<VarDeclaration Name="SD_1" Type="ANY" Comment="Output data to resource"/>
+			<VarDeclaration Name="SD_2" Type="ANY" Comment=""/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
+			<VarDeclaration Name="STATUS" Type="STRING" Comment="File access status"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_CSV_WRITER'"/>
 </FBType>

--- a/data/typelibrary/utils-1.0.0/typelib/CSV_WRITER_3.fbt
+++ b/data/typelibrary/utils-1.0.0/typelib/CSV_WRITER_3.fbt
@@ -1,41 +1,43 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="Service Interface Function Block Type" Name="CSV_WRITER_3">
-  <Identification Description="Copyright (c) 2012 ACIN&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0"/>
-  <VersionInfo Author="Alois Zoitl" Date="2012-06-16" Organization="ACIN" Version="1.0"/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Service Initialization" Name="INIT" Type="Event">
-        <With Var="QI"/>
-        <With Var="FILE_NAME"/>
-      </Event>
-      <Event Comment="Service Request" Name="REQ" Type="Event">
-        <With Var="QI"/>
-        <With Var="SD_1"/>
-        <With Var="SD_2"/>
-        <With Var="SD_3"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Initialization Confirm" Name="INITO" Type="Event">
-        <With Var="QO"/>
-        <With Var="STATUS"/>
-      </Event>
-      <Event Comment="Confirmation of Requested Service" Name="CNF" Type="Event">
-        <With Var="QO"/>
-        <With Var="STATUS"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="Event Input Qualifier" Name="QI" Type="BOOL"/>
-      <VarDeclaration Comment="Service Parameters" Name="FILE_NAME" Type="STRING"/>
-      <VarDeclaration Comment="Output data to resource" Name="SD_1" Type="ANY"/>
-      <VarDeclaration Name="SD_2" Type="ANY"/>
-      <VarDeclaration Name="SD_3" Type="ANY"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="Event Output Qualifier" Name="QO" Type="BOOL"/>
-      <VarDeclaration Comment="File access status" Name="STATUS" Type="STRING"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="CSV_WRITER_3" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2012 ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="ACIN" Version="1.0" Author="Alois Zoitl" Date="2012-06-16">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="Event" Comment="Service Initialization">
+				<With Var="QI"/>
+				<With Var="FILE_NAME"/>
+			</Event>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="QI"/>
+				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="Event" Comment="Initialization Confirm">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="FILE_NAME" Type="STRING" Comment="Service Parameters"/>
+			<VarDeclaration Name="SD_1" Type="ANY" Comment="Output data to resource"/>
+			<VarDeclaration Name="SD_2" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_3" Type="ANY" Comment=""/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
+			<VarDeclaration Name="STATUS" Type="STRING" Comment="File access status"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_CSV_WRITER'"/>
 </FBType>

--- a/data/typelibrary/utils-1.0.0/typelib/CSV_WRITER_4.fbt
+++ b/data/typelibrary/utils-1.0.0/typelib/CSV_WRITER_4.fbt
@@ -1,43 +1,45 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="Service Interface Function Block Type" Name="CSV_WRITER_4">
-  <Identification Description="Copyright (c) 2012 ACIN&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0"/>
-  <VersionInfo Author="Alois Zoitl" Date="2012-06-16" Organization="ACIN" Version="1.0"/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Service Initialization" Name="INIT" Type="Event">
-        <With Var="QI"/>
-        <With Var="FILE_NAME"/>
-      </Event>
-      <Event Comment="Service Request" Name="REQ" Type="Event">
-        <With Var="QI"/>
-        <With Var="SD_1"/>
-        <With Var="SD_2"/>
-        <With Var="SD_3"/>
-        <With Var="SD_4"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Initialization Confirm" Name="INITO" Type="Event">
-        <With Var="QO"/>
-        <With Var="STATUS"/>
-      </Event>
-      <Event Comment="Confirmation of Requested Service" Name="CNF" Type="Event">
-        <With Var="QO"/>
-        <With Var="STATUS"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="Event Input Qualifier" Name="QI" Type="BOOL"/>
-      <VarDeclaration Comment="Service Parameters" Name="FILE_NAME" Type="STRING"/>
-      <VarDeclaration Comment="Output data to resource" Name="SD_1" Type="ANY"/>
-      <VarDeclaration Name="SD_2" Type="ANY"/>
-      <VarDeclaration Name="SD_3" Type="ANY"/>
-      <VarDeclaration Name="SD_4" Type="ANY"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="Event Output Qualifier" Name="QO" Type="BOOL"/>
-      <VarDeclaration Comment="File access status" Name="STATUS" Type="STRING"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="CSV_WRITER_4" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2012 ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="ACIN" Version="1.0" Author="Alois Zoitl" Date="2012-06-16">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="Event" Comment="Service Initialization">
+				<With Var="QI"/>
+				<With Var="FILE_NAME"/>
+			</Event>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="QI"/>
+				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="Event" Comment="Initialization Confirm">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="FILE_NAME" Type="STRING" Comment="Service Parameters"/>
+			<VarDeclaration Name="SD_1" Type="ANY" Comment="Output data to resource"/>
+			<VarDeclaration Name="SD_2" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_3" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_4" Type="ANY" Comment=""/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
+			<VarDeclaration Name="STATUS" Type="STRING" Comment="File access status"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_CSV_WRITER'"/>
 </FBType>

--- a/data/typelibrary/utils-1.0.0/typelib/CSV_WRITER_5.fbt
+++ b/data/typelibrary/utils-1.0.0/typelib/CSV_WRITER_5.fbt
@@ -1,45 +1,47 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="Service Interface Function Block Type" Name="CSV_WRITER_5">
-  <Identification Description="Copyright (c) 2012 ACIN&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0"/>
-  <VersionInfo Author="Alois Zoitl" Date="2012-06-16" Organization="ACIN" Version="1.0"/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Service Initialization" Name="INIT" Type="Event">
-        <With Var="QI"/>
-        <With Var="FILE_NAME"/>
-      </Event>
-      <Event Comment="Service Request" Name="REQ" Type="Event">
-        <With Var="QI"/>
-        <With Var="SD_1"/>
-        <With Var="SD_2"/>
-        <With Var="SD_3"/>
-        <With Var="SD_4"/>
-        <With Var="SD_5"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Initialization Confirm" Name="INITO" Type="Event">
-        <With Var="QO"/>
-        <With Var="STATUS"/>
-      </Event>
-      <Event Comment="Confirmation of Requested Service" Name="CNF" Type="Event">
-        <With Var="QO"/>
-        <With Var="STATUS"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="Event Input Qualifier" Name="QI" Type="BOOL"/>
-      <VarDeclaration Comment="Service Parameters" Name="FILE_NAME" Type="STRING"/>
-      <VarDeclaration Comment="Output data to resource" Name="SD_1" Type="ANY"/>
-      <VarDeclaration Name="SD_2" Type="ANY"/>
-      <VarDeclaration Name="SD_3" Type="ANY"/>
-      <VarDeclaration Name="SD_4" Type="ANY"/>
-      <VarDeclaration Name="SD_5" Type="ANY"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="Event Output Qualifier" Name="QO" Type="BOOL"/>
-      <VarDeclaration Comment="File access status" Name="STATUS" Type="STRING"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="CSV_WRITER_5" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2012 ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="ACIN" Version="1.0" Author="Alois Zoitl" Date="2012-06-16">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="Event" Comment="Service Initialization">
+				<With Var="QI"/>
+				<With Var="FILE_NAME"/>
+			</Event>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="QI"/>
+				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="Event" Comment="Initialization Confirm">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="FILE_NAME" Type="STRING" Comment="Service Parameters"/>
+			<VarDeclaration Name="SD_1" Type="ANY" Comment="Output data to resource"/>
+			<VarDeclaration Name="SD_2" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_3" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_4" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_5" Type="ANY" Comment=""/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
+			<VarDeclaration Name="STATUS" Type="STRING" Comment="File access status"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_CSV_WRITER'"/>
 </FBType>

--- a/data/typelibrary/utils-1.0.0/typelib/CSV_WRITER_6.fbt
+++ b/data/typelibrary/utils-1.0.0/typelib/CSV_WRITER_6.fbt
@@ -1,47 +1,49 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="Service Interface Function Block Type" Name="CSV_WRITER_6">
-  <Identification Description="Copyright (c) 2012 ACIN&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0"/>
-  <VersionInfo Author="Alois Zoitl" Date="2012-06-16" Organization="ACIN" Version="1.0"/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Service Initialization" Name="INIT" Type="Event">
-        <With Var="QI"/>
-        <With Var="FILE_NAME"/>
-      </Event>
-      <Event Comment="Service Request" Name="REQ" Type="Event">
-        <With Var="QI"/>
-        <With Var="SD_1"/>
-        <With Var="SD_2"/>
-        <With Var="SD_3"/>
-        <With Var="SD_4"/>
-        <With Var="SD_5"/>
-        <With Var="SD_6"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Initialization Confirm" Name="INITO" Type="Event">
-        <With Var="QO"/>
-        <With Var="STATUS"/>
-      </Event>
-      <Event Comment="Confirmation of Requested Service" Name="CNF" Type="Event">
-        <With Var="QO"/>
-        <With Var="STATUS"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="Event Input Qualifier" Name="QI" Type="BOOL"/>
-      <VarDeclaration Comment="Service Parameters" Name="FILE_NAME" Type="STRING"/>
-      <VarDeclaration Comment="Output data to resource" Name="SD_1" Type="ANY"/>
-      <VarDeclaration Name="SD_2" Type="ANY"/>
-      <VarDeclaration Name="SD_3" Type="ANY"/>
-      <VarDeclaration Name="SD_4" Type="ANY"/>
-      <VarDeclaration Name="SD_5" Type="ANY"/>
-      <VarDeclaration Name="SD_6" Type="ANY"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="Event Output Qualifier" Name="QO" Type="BOOL"/>
-      <VarDeclaration Comment="File access status" Name="STATUS" Type="STRING"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="CSV_WRITER_6" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2012 ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="ACIN" Version="1.0" Author="Alois Zoitl" Date="2012-06-16">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="Event" Comment="Service Initialization">
+				<With Var="QI"/>
+				<With Var="FILE_NAME"/>
+			</Event>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="QI"/>
+				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+				<With Var="SD_6"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="Event" Comment="Initialization Confirm">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="FILE_NAME" Type="STRING" Comment="Service Parameters"/>
+			<VarDeclaration Name="SD_1" Type="ANY" Comment="Output data to resource"/>
+			<VarDeclaration Name="SD_2" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_3" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_4" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_5" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_6" Type="ANY" Comment=""/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
+			<VarDeclaration Name="STATUS" Type="STRING" Comment="File access status"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_CSV_WRITER'"/>
 </FBType>

--- a/data/typelibrary/utils-1.0.0/typelib/CSV_WRITER_7.fbt
+++ b/data/typelibrary/utils-1.0.0/typelib/CSV_WRITER_7.fbt
@@ -1,49 +1,51 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="Service Interface Function Block Type" Name="CSV_WRITER_7">
-  <Identification Description="Copyright (c) 2012 ACIN&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0"/>
-  <VersionInfo Author="Alois Zoitl" Date="2012-06-16" Organization="ACIN" Version="1.0"/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Service Initialization" Name="INIT" Type="Event">
-        <With Var="QI"/>
-        <With Var="FILE_NAME"/>
-      </Event>
-      <Event Comment="Service Request" Name="REQ" Type="Event">
-        <With Var="QI"/>
-        <With Var="SD_1"/>
-        <With Var="SD_2"/>
-        <With Var="SD_3"/>
-        <With Var="SD_4"/>
-        <With Var="SD_5"/>
-        <With Var="SD_6"/>
-        <With Var="SD_7"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Initialization Confirm" Name="INITO" Type="Event">
-        <With Var="QO"/>
-        <With Var="STATUS"/>
-      </Event>
-      <Event Comment="Confirmation of Requested Service" Name="CNF" Type="Event">
-        <With Var="QO"/>
-        <With Var="STATUS"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="Event Input Qualifier" Name="QI" Type="BOOL"/>
-      <VarDeclaration Comment="Service Parameters" Name="FILE_NAME" Type="STRING"/>
-      <VarDeclaration Comment="Output data to resource" Name="SD_1" Type="ANY"/>
-      <VarDeclaration Name="SD_2" Type="ANY"/>
-      <VarDeclaration Name="SD_3" Type="ANY"/>
-      <VarDeclaration Name="SD_4" Type="ANY"/>
-      <VarDeclaration Name="SD_5" Type="ANY"/>
-      <VarDeclaration Name="SD_6" Type="ANY"/>
-      <VarDeclaration Name="SD_7" Type="ANY"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="Event Output Qualifier" Name="QO" Type="BOOL"/>
-      <VarDeclaration Comment="File access status" Name="STATUS" Type="STRING"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="CSV_WRITER_7" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2012 ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="ACIN" Version="1.0" Author="Alois Zoitl" Date="2012-06-16">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="Event" Comment="Service Initialization">
+				<With Var="QI"/>
+				<With Var="FILE_NAME"/>
+			</Event>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="QI"/>
+				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+				<With Var="SD_6"/>
+				<With Var="SD_7"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="Event" Comment="Initialization Confirm">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="FILE_NAME" Type="STRING" Comment="Service Parameters"/>
+			<VarDeclaration Name="SD_1" Type="ANY" Comment="Output data to resource"/>
+			<VarDeclaration Name="SD_2" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_3" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_4" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_5" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_6" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_7" Type="ANY" Comment=""/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
+			<VarDeclaration Name="STATUS" Type="STRING" Comment="File access status"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_CSV_WRITER'"/>
 </FBType>

--- a/data/typelibrary/utils-1.0.0/typelib/CSV_WRITER_8.fbt
+++ b/data/typelibrary/utils-1.0.0/typelib/CSV_WRITER_8.fbt
@@ -1,51 +1,53 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="Service Interface Function Block Type" Name="CSV_WRITER_8">
-  <Identification Description="Copyright (c) 2012 ACIN&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0"/>
-  <VersionInfo Author="Alois Zoitl" Date="2012-06-16" Organization="ACIN" Version="1.0"/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Service Initialization" Name="INIT" Type="Event">
-        <With Var="QI"/>
-        <With Var="FILE_NAME"/>
-      </Event>
-      <Event Comment="Service Request" Name="REQ" Type="Event">
-        <With Var="QI"/>
-        <With Var="SD_1"/>
-        <With Var="SD_2"/>
-        <With Var="SD_3"/>
-        <With Var="SD_4"/>
-        <With Var="SD_5"/>
-        <With Var="SD_6"/>
-        <With Var="SD_7"/>
-        <With Var="SD_8"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Initialization Confirm" Name="INITO" Type="Event">
-        <With Var="QO"/>
-        <With Var="STATUS"/>
-      </Event>
-      <Event Comment="Confirmation of Requested Service" Name="CNF" Type="Event">
-        <With Var="QO"/>
-        <With Var="STATUS"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="Event Input Qualifier" Name="QI" Type="BOOL"/>
-      <VarDeclaration Comment="Service Parameters" Name="FILE_NAME" Type="STRING"/>
-      <VarDeclaration Comment="Output data to resource" Name="SD_1" Type="ANY"/>
-      <VarDeclaration Name="SD_2" Type="ANY"/>
-      <VarDeclaration Name="SD_3" Type="ANY"/>
-      <VarDeclaration Name="SD_4" Type="ANY"/>
-      <VarDeclaration Name="SD_5" Type="ANY"/>
-      <VarDeclaration Name="SD_6" Type="ANY"/>
-      <VarDeclaration Name="SD_7" Type="ANY"/>
-      <VarDeclaration Name="SD_8" Type="ANY"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="Event Output Qualifier" Name="QO" Type="BOOL"/>
-      <VarDeclaration Comment="File access status" Name="STATUS" Type="STRING"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="CSV_WRITER_8" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2012 ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="ACIN" Version="1.0" Author="Alois Zoitl" Date="2012-06-16">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="Event" Comment="Service Initialization">
+				<With Var="QI"/>
+				<With Var="FILE_NAME"/>
+			</Event>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="QI"/>
+				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+				<With Var="SD_6"/>
+				<With Var="SD_7"/>
+				<With Var="SD_8"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="Event" Comment="Initialization Confirm">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="FILE_NAME" Type="STRING" Comment="Service Parameters"/>
+			<VarDeclaration Name="SD_1" Type="ANY" Comment="Output data to resource"/>
+			<VarDeclaration Name="SD_2" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_3" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_4" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_5" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_6" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_7" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_8" Type="ANY" Comment=""/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
+			<VarDeclaration Name="STATUS" Type="STRING" Comment="File access status"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_CSV_WRITER'"/>
 </FBType>

--- a/data/typelibrary/utils-1.0.0/typelib/CSV_WRITER_9.fbt
+++ b/data/typelibrary/utils-1.0.0/typelib/CSV_WRITER_9.fbt
@@ -1,91 +1,93 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="Service Interface Function Block Type" Name="CSV_WRITER_9">
-  <Identification Description="Copyright (c) 2012 ACIN&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0"/>
-  <VersionInfo Author="Alois Zoitl" Date="2012-06-16" Organization="ACIN" Version="1.0"/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Service Initialization" Name="INIT" Type="Event">
-        <With Var="QI"/>
-        <With Var="FILE_NAME"/>
-      </Event>
-      <Event Comment="Service Request" Name="REQ" Type="Event">
-        <With Var="QI"/>
-        <With Var="SD_1"/>
-        <With Var="SD_2"/>
-        <With Var="SD_3"/>
-        <With Var="SD_4"/>
-        <With Var="SD_5"/>
-        <With Var="SD_6"/>
-        <With Var="SD_7"/>
-        <With Var="SD_8"/>
-        <With Var="SD_9"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Initialization Confirm" Name="INITO" Type="Event">
-        <With Var="QO"/>
-        <With Var="STATUS"/>
-      </Event>
-      <Event Comment="Confirmation of Requested Service" Name="CNF" Type="Event">
-        <With Var="QO"/>
-        <With Var="STATUS"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="Event Input Qualifier" Name="QI" Type="BOOL"/>
-      <VarDeclaration Comment="Service Parameters" Name="FILE_NAME" Type="STRING"/>
-      <VarDeclaration Comment="Output data to resource" Name="SD_1" Type="ANY"/>
-      <VarDeclaration Name="SD_2" Type="ANY"/>
-      <VarDeclaration Name="SD_3" Type="ANY"/>
-      <VarDeclaration Name="SD_4" Type="ANY"/>
-      <VarDeclaration Name="SD_5" Type="ANY"/>
-      <VarDeclaration Name="SD_6" Type="ANY"/>
-      <VarDeclaration Name="SD_7" Type="ANY"/>
-      <VarDeclaration Name="SD_8" Type="ANY"/>
-      <VarDeclaration Name="SD_9" Type="ANY"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="Event Output Qualifier" Name="QO" Type="BOOL"/>
-      <VarDeclaration Comment="File access status" Name="STATUS" Type="STRING"/>
-    </OutputVars>
-  </InterfaceList>
-  <Service Comment="Service Interface Function Block Type" LeftInterface="APPLICATION" RightInterface="RESOURCE">
-    <ServiceSequence Name="normal_establishment">
-      <ServiceTransaction>
-        <InputPrimitive Event="INIT+" Interface="APPLICATION" Parameters="FILE_NAME"/>
-        <OutputPrimitive Event="INITO+" Interface="APPLICATION" Parameters="STATUS"/>
-      </ServiceTransaction>
-    </ServiceSequence>
-    <ServiceSequence Name="unsuccessful_establishment">
-      <ServiceTransaction>
-        <InputPrimitive Event="INIT+" Interface="APPLICATION" Parameters="FILE_NAME"/>
-        <OutputPrimitive Event="INITO-" Interface="APPLICATION" Parameters="STATUS"/>
-      </ServiceTransaction>
-    </ServiceSequence>
-    <ServiceSequence Name="request_confirm">
-      <ServiceTransaction>
-        <InputPrimitive Event="REQ+" Interface="APPLICATION" Parameters="SD_1,SD_2,SD_3,SD_4,SD_5,SD_6,SD_7,SD_8,SD_9"/>
-        <OutputPrimitive Event="CNF+" Interface="APPLICATION" Parameters="STATUS"/>
-      </ServiceTransaction>
-    </ServiceSequence>
-    <ServiceSequence Name="request_inhibited">
-      <ServiceTransaction>
-        <InputPrimitive Event="REQ-" Interface="APPLICATION" Parameters="SD_1,SD_2,SD_3,SD_4,SD_5,SD_6,SD_7,SD_8,SD_9"/>
-        <OutputPrimitive Event="CNF-" Interface="APPLICATION" Parameters="STATUS"/>
-      </ServiceTransaction>
-    </ServiceSequence>
-    <ServiceSequence Name="request_error">
-      <ServiceTransaction>
-        <InputPrimitive Event="REQ+" Interface="APPLICATION" Parameters="SD_1,SD_2,SD_3,SD_4,SD_5,SD_6,SD_7,SD_8,SD_9"/>
-        <OutputPrimitive Event="CNF-" Interface="APPLICATION" Parameters="STATUS"/>
-      </ServiceTransaction>
-    </ServiceSequence>
-    <ServiceSequence Name="application_initiated_termination">
-      <ServiceTransaction>
-        <InputPrimitive Event="INIT-" Interface="APPLICATION"/>
-        <OutputPrimitive Event="INITO-" Interface="APPLICATION" Parameters="STATUS"/>
-      </ServiceTransaction>
-    </ServiceSequence>
-  </Service>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="CSV_WRITER_9" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2012 ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="ACIN" Version="1.0" Author="Alois Zoitl" Date="2012-06-16">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="Event" Comment="Service Initialization">
+				<With Var="QI"/>
+				<With Var="FILE_NAME"/>
+			</Event>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="QI"/>
+				<With Var="SD_1"/>
+				<With Var="SD_2"/>
+				<With Var="SD_3"/>
+				<With Var="SD_4"/>
+				<With Var="SD_5"/>
+				<With Var="SD_6"/>
+				<With Var="SD_7"/>
+				<With Var="SD_8"/>
+				<With Var="SD_9"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="Event" Comment="Initialization Confirm">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="FILE_NAME" Type="STRING" Comment="Service Parameters"/>
+			<VarDeclaration Name="SD_1" Type="ANY" Comment="Output data to resource"/>
+			<VarDeclaration Name="SD_2" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_3" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_4" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_5" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_6" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_7" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_8" Type="ANY" Comment=""/>
+			<VarDeclaration Name="SD_9" Type="ANY" Comment=""/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
+			<VarDeclaration Name="STATUS" Type="STRING" Comment="File access status"/>
+		</OutputVars>
+	</InterfaceList>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Service Interface Function Block Type">
+		<ServiceSequence Name="normal_establishment" Comment="">
+			<ServiceTransaction>
+				<InputPrimitive Interface="APPLICATION" Event="INIT+" Parameters="FILE_NAME"/>
+				<OutputPrimitive Interface="APPLICATION" Event="INITO+" Parameters="STATUS"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="unsuccessful_establishment" Comment="">
+			<ServiceTransaction>
+				<InputPrimitive Interface="APPLICATION" Event="INIT+" Parameters="FILE_NAME"/>
+				<OutputPrimitive Interface="APPLICATION" Event="INITO-" Parameters="STATUS"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="request_confirm" Comment="">
+			<ServiceTransaction>
+				<InputPrimitive Interface="APPLICATION" Event="REQ+" Parameters="SD_1,SD_2,SD_3,SD_4,SD_5,SD_6,SD_7,SD_8,SD_9"/>
+				<OutputPrimitive Interface="APPLICATION" Event="CNF+" Parameters="STATUS"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="request_inhibited" Comment="">
+			<ServiceTransaction>
+				<InputPrimitive Interface="APPLICATION" Event="REQ-" Parameters="SD_1,SD_2,SD_3,SD_4,SD_5,SD_6,SD_7,SD_8,SD_9"/>
+				<OutputPrimitive Interface="APPLICATION" Event="CNF-" Parameters="STATUS"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="request_error" Comment="">
+			<ServiceTransaction>
+				<InputPrimitive Interface="APPLICATION" Event="REQ+" Parameters="SD_1,SD_2,SD_3,SD_4,SD_5,SD_6,SD_7,SD_8,SD_9"/>
+				<OutputPrimitive Interface="APPLICATION" Event="CNF-" Parameters="STATUS"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="application_initiated_termination" Comment="">
+			<ServiceTransaction>
+				<InputPrimitive Interface="APPLICATION" Event="INIT-"/>
+				<OutputPrimitive Interface="APPLICATION" Event="INITO-" Parameters="STATUS"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+	</Service>
+	<Attribute Name="GenericClassName" Value="'GEN_CSV_WRITER'"/>
 </FBType>

--- a/data/typelibrary/utils-1.0.0/typelib/F_MUX_2_1.fbt
+++ b/data/typelibrary/utils-1.0.0/typelib/F_MUX_2_1.fbt
@@ -1,33 +1,36 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="Service Interface Function Block Type" Name="F_MUX_2_1">
-  <Identification Description="Copyright (c) 2012 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0"/>
-  <VersionInfo Author="Matthias Plasch" Date="2012-05-09" Organization="Profactor GmbH" Version="1.0"/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="event input 1" Name="EI1" Type="Event">
-        <With Var="IN_1_1"/>
-      </Event>
-      <Event Comment="event input 2" Name="EI2" Type="Event">
-        <With Var="IN_2_1"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="merge event output" Name="EO" Type="Event">
-        <With Var="QO"/>
-        <With Var="STATUS"/>
-        <With Var="OUT_1"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Name="IN_1_1" Type="ANY"/>
-      <VarDeclaration Name="IN_2_1" Type="ANY"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="Event Output Qualifier" Name="QO" Type="BOOL"/>
-      <VarDeclaration Comment="Service Status" Name="STATUS" Type="WSTRING"/>
-      <VarDeclaration Comment="meged data output" Name="OUT_1" Type="ANY"/>
-    </OutputVars>
-  </InterfaceList>
-  <Service Comment="Service Interface Function Block Type" LeftInterface="APPLICATION" RightInterface="RESOURCE"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="F_MUX_2_1" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2012 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2012-05-09">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="EI1" Type="Event" Comment="event input 1">
+				<With Var="IN_1_1"/>
+			</Event>
+			<Event Name="EI2" Type="Event" Comment="event input 2">
+				<With Var="IN_2_1"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="EO" Type="Event" Comment="merge event output">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+				<With Var="OUT_1"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN_1_1" Type="ANY" Comment=""/>
+			<VarDeclaration Name="IN_2_1" Type="ANY" Comment=""/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
+			<VarDeclaration Name="STATUS" Type="WSTRING" Comment="Service Status"/>
+			<VarDeclaration Name="OUT_1" Type="ANY" Comment="meged data output"/>
+		</OutputVars>
+	</InterfaceList>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Service Interface Function Block Type">
+	</Service>
+	<Attribute Name="GenericClassName" Value="'GEN_F_MUX'"/>
 </FBType>

--- a/data/typelibrary/utils-1.0.0/typelib/F_MUX_2_2.fbt
+++ b/data/typelibrary/utils-1.0.0/typelib/F_MUX_2_2.fbt
@@ -1,38 +1,40 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="Service Interface Function Block Type" Name="F_MUX_2_2">
-  <Identification Description="Copyright (c) 2012 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0"/>
-  <VersionInfo Author="Matthias Plasch" Date="2012-05-09" Organization="Profactor GmbH" Version="1.0"/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="event input 1" Name="EI1" Type="Event">
-        <With Var="IN_1_1"/>
-        <With Var="IN_1_2"/>
-      </Event>
-      <Event Comment="event input 2" Name="EI2" Type="Event">
-        <With Var="IN_2_1"/>
-        <With Var="IN_2_2"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="merge event output" Name="EO" Type="Event">
-        <With Var="QO"/>
-        <With Var="STATUS"/>
-        <With Var="OUT_1"/>
-        <With Var="OUT_2"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Name="IN_1_1" Type="ANY"/>
-      <VarDeclaration Name="IN_1_2" Type="ANY"/>
-      <VarDeclaration Name="IN_2_1" Type="ANY"/>
-      <VarDeclaration Name="IN_2_2" Type="ANY"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="Event Output Qualifier" Name="QO" Type="BOOL"/>
-      <VarDeclaration Comment="Service Status" Name="STATUS" Type="WSTRING"/>
-      <VarDeclaration Comment="meged data output" Name="OUT_1" Type="ANY"/>
-      <VarDeclaration Name="OUT_2" Type="ANY"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="F_MUX_2_2" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2012 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2012-05-09">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="EI1" Type="Event" Comment="event input 1">
+				<With Var="IN_1_1"/>
+				<With Var="IN_1_2"/>
+			</Event>
+			<Event Name="EI2" Type="Event" Comment="event input 2">
+				<With Var="IN_2_1"/>
+				<With Var="IN_2_2"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="EO" Type="Event" Comment="merge event output">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+				<With Var="OUT_1"/>
+				<With Var="OUT_2"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN_1_1" Type="ANY" Comment=""/>
+			<VarDeclaration Name="IN_1_2" Type="ANY" Comment=""/>
+			<VarDeclaration Name="IN_2_1" Type="ANY" Comment=""/>
+			<VarDeclaration Name="IN_2_2" Type="ANY" Comment=""/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
+			<VarDeclaration Name="STATUS" Type="WSTRING" Comment="Service Status"/>
+			<VarDeclaration Name="OUT_1" Type="ANY" Comment="meged data output"/>
+			<VarDeclaration Name="OUT_2" Type="ANY" Comment=""/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_F_MUX'"/>
 </FBType>

--- a/data/typelibrary/utils-1.0.0/typelib/VALUES2ARRAY_2_LREAL.fbt
+++ b/data/typelibrary/utils-1.0.0/typelib/VALUES2ARRAY_2_LREAL.fbt
@@ -1,26 +1,28 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="Service Interface Function Block Type" Name="VALUES2ARRAY_2_LREAL">
-  <Identification Description="Copyright (c) 2014 Profactor GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0"/>
-  <VersionInfo Author="Matthias Plasch" Date="2014-07-09" Organization="Profactor GmbH" Version="1.0"/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Service Request" Name="REQ" Type="Event">
-        <With Var="IN_1"/>
-        <With Var="IN_2"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Confirmation of Requested Service" Name="CNF" Type="Event">
-        <With Var="OUT"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="input number 1" Name="IN_1" Type="LREAL"/>
-      <VarDeclaration Comment="input number 2" Name="IN_2" Type="LREAL"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration ArraySize="2" Comment="Array output" Name="OUT" Type="LREAL"/>
-    </OutputVars>
-  </InterfaceList>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="VALUES2ARRAY_2_LREAL" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2014 Profactor GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="Profactor GmbH" Version="1.0" Author="Matthias Plasch" Date="2014-07-09">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="IN_1"/>
+				<With Var="IN_2"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN_1" Type="LREAL" Comment="input number 1"/>
+			<VarDeclaration Name="IN_2" Type="LREAL" Comment="input number 2"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="LREAL" Comment="Array output" ArraySize="2"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_VALUES2ARRAY'"/>
 </FBType>

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteFBTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteFBTemplate.xtend
@@ -510,7 +510,6 @@ abstract class ForteFBTemplate<T extends FBType> extends ForteLibraryElementTemp
 
 	def protected CharSequence generateNameAsConnectionVariable(INamedElement element) '''var_conn_«element.name»'''
 
-
 	def protected generateEventAccessorDefinitions() '''
 		«FOR event : type.interfaceList.eventInputs BEFORE '\n'»
 			«event.generateEventAccessorDefinition»
@@ -553,7 +552,6 @@ abstract class ForteFBTemplate<T extends FBType> extends ForteLibraryElementTemp
 
 	def protected getFBClassName() { className }
 
-
 	def protected generateInitializeDeclaration() '''
 		«IF !type.interfaceList.sockets.empty || !type.interfaceList.plugs.empty»
 			bool initialize() override;
@@ -586,8 +584,15 @@ abstract class ForteFBTemplate<T extends FBType> extends ForteLibraryElementTemp
 		«ENDFOR»		
 	'''
 
-	def generateInternalFBInitializer(List<FB> internalFbs) ///
-	'''«FOR fb : internalFbs BEFORE ",\n" SEPARATOR ",\n"»«fb.generateName»(«fb.name.FORTEStringId», *this)«ENDFOR»'''
+	def generateInternalFBInitializer(List<FB> internalFbs) // /
+	'''«FOR fb : internalFbs BEFORE ",\n" SEPARATOR ",\n"»«fb.generateInternalFBInitializer»«ENDFOR»'''
+
+	def generateInternalFBInitializer(FB fb) {
+		if (fb.type.genericType)
+			'''«fb.generateName»(«fb.name.FORTEStringId», "«fb.type.generateTypeNamePlain»", *this)'''
+		else
+			'''«fb.generateName»(«fb.name.FORTEStringId», *this)'''
+	}
 
 	override Set<INamedElement> getDependencies(Map<?, ?> options) {
 		(super.getDependencies(options) + (type.interfaceList.sockets + type.interfaceList.plugs).map[getType]

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/composite/CompositeFBImplTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/composite/CompositeFBImplTemplate.xtend
@@ -280,7 +280,11 @@ class CompositeFBImplTemplate extends ForteFBTemplate<CompositeFBType> {
 			void «FBClassName»::setFBNetworkInitialValues() {
 			  «FOR fb : fbs»
 			  	«FOR variable : fb.interface.inputVars.filter[!value?.value.nullOrEmpty]»
-			  		«fb.generateName»->«variable.generateName» = «variable.generateFBNetworkInitialValue»;
+			  		«IF fb.type.genericType»
+			  			if (auto v = «fb.generateName»->getDataInput(«variable.name.FORTEStringId»)) { v->setValue(«variable.generateFBNetworkInitialValue»); }
+			  		«ELSE»
+			  			«fb.generateName»->«variable.generateName» = «variable.generateFBNetworkInitialValue»;
+			  		«ENDIF»
 			  	«ENDFOR»
 			  «ENDFOR»
 			}


### PR DESCRIPTION
Add support for generic internal FBs in forte_ng export using a new attribute for the generic class name.