### PR TITLE
Escape space in URL when loading file from jar during LibraryImportTest

### DIFF
--- a/tests/org.eclipse.fordiac.ide.test.library/src/org/eclipse/fordiac/ide/test/library/LibraryImportTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.library/src/org/eclipse/fordiac/ide/test/library/LibraryImportTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Paths;
 import java.util.Collections;
@@ -75,7 +76,8 @@ class LibraryImportTest {
 		final Bundle bundle = Platform.getBundle("org.eclipse.fordiac.ide.test.library"); //$NON-NLS-1$
 		for (final var archive : archives) {
 			final URL url = FileLocator.toFileURL(FileLocator.find(bundle, new Path(archive)));
-			LibraryManager.INSTANCE.extractLibrary(Paths.get(url.toURI()), null, false, false);
+			final var uri = new URI(url.toString().replace(" ", "%20")); //$NON-NLS-1$//$NON-NLS-2$
+			LibraryManager.INSTANCE.extractLibrary(Paths.get(uri), null, false, false);
 		}
 
 		// deactivate other downloaders


### PR DESCRIPTION
milestone and nightly build failed last night

 - https://ci.eclipse.org/4diac/job/4diac%20IDE%20Milestone/489/
 - https://ci.eclipse.org/4diac/job/4diac%20IDE%20Develop/1334/

caused by a space in the build directory on jenkins