### PR TITLE
Add additional information for model error markers

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/RepairCommandHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/RepairCommandHandler.java
@@ -21,9 +21,7 @@ import java.util.List;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
-import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.runtime.Assert;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
@@ -280,17 +278,7 @@ public class RepairCommandHandler extends AbstractHandler {
 	}
 
 	public static EObject getEObjectFromMarkerItem(final MarkerItem item) {
-		final IMarker marker = item.getMarker();
-		try {
-			final EObject target = FordiacErrorMarker.getTarget(marker);
-			if (target != null) {
-				return target;
-			}
-
-		} catch (IllegalArgumentException | CoreException e) {
-			return null;
-		}
-		return null;
+		return FordiacErrorMarker.getTarget(item.getMarker());
 	}
 
 	private void showRestrictedNewTypeWizard(final String name, final String fileEnding, final String projectName) {

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.network/src/org/eclipse/fordiac/ide/fbtypeeditor/network/CompositeNetworkEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.network/src/org/eclipse/fordiac/ide/fbtypeeditor/network/CompositeNetworkEditor.java
@@ -18,7 +18,6 @@ package org.eclipse.fordiac.ide.fbtypeeditor.network;
 import java.util.Map;
 
 import org.eclipse.core.resources.IMarker;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.emf.common.notify.Adapter;
 import org.eclipse.emf.common.notify.Notification;
@@ -41,7 +40,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
 import org.eclipse.fordiac.ide.typemanagement.FBTypeEditorInput;
-import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 import org.eclipse.fordiac.ide.ui.FordiacMessages;
 import org.eclipse.fordiac.ide.ui.editors.EditorUtils;
 import org.eclipse.fordiac.ide.ui.imageprovider.FordiacImage;
@@ -146,8 +144,7 @@ public class CompositeNetworkEditor extends FBNetworkEditor implements IFBTEdito
 
 	@Override
 	protected void setModel(final IEditorInput input) {
-		if (input instanceof FBTypeEditorInput) {
-			final FBTypeEditorInput untypedInput = (FBTypeEditorInput) input;
+		if (input instanceof final FBTypeEditorInput untypedInput) {
 			if (untypedInput.getContent() instanceof CompositeFBType) {
 				fbType = (CompositeFBType) untypedInput.getContent();
 				setModel(fbType.getFBNetwork());
@@ -204,26 +201,17 @@ public class CompositeNetworkEditor extends FBNetworkEditor implements IFBTEdito
 
 	@Override
 	public void gotoMarker(final IMarker marker) {
-		try {
-			final EObject target = FordiacErrorMarker.getTargetEditable(marker);
-			if (target != null) {
-				selectElement(target);
-			}
-		} catch (final CoreException e) {
-			FordiacLogHelper.logError("Could not get marker attributes", e); //$NON-NLS-1$
+		final EObject target = FordiacErrorMarker.getTargetEditable(marker);
+		if (target != null) {
+			selectElement(target);
 		}
 	}
 
 	@Override
 	public boolean isMarkerTarget(final IMarker marker) {
 		if (FordiacErrorMarker.markerTargetsValue(marker)) {
-			try {
-				final EObject target = FordiacErrorMarker.getTargetEditable(marker);
-				return EcoreUtil.isAncestor(getModel(), target);
-			} catch (final CoreException e) {
-				FordiacLogHelper.logWarning("Could not get marker attributes", e); //$NON-NLS-1$
-			}
-			return false;
+			final EObject target = FordiacErrorMarker.getTargetEditable(marker);
+			return EcoreUtil.isAncestor(getModel(), target);
 		}
 		return FordiacErrorMarker.markerTargetsFBNetworkElement(marker)
 				|| FordiacErrorMarker.markerTargetsErrorMarkerInterface(marker)

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/AbstractBreadCrumbEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/AbstractBreadCrumbEditor.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.core.resources.IMarker;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.draw2d.FigureCanvas;
 import org.eclipse.draw2d.geometry.Point;
@@ -276,12 +275,8 @@ public abstract class AbstractBreadCrumbEditor extends AbstractCloseAbleFormEdit
 
 	@Override
 	public void gotoMarker(final IMarker marker) {
-		try {
-			final EObject target = FordiacErrorMarker.getTargetEditable(marker);
-			gotoElement(target);
-		} catch (IllegalArgumentException | CoreException e) {
-			FordiacLogHelper.logWarning("Couldn't goto marker " + marker.toString(), e); //$NON-NLS-1$
-		}
+		final EObject target = FordiacErrorMarker.getTargetEditable(marker);
+		gotoElement(target);
 	}
 
 	private void gotoElement(final EObject element) {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/errormarker/ErrorMarkerBuilder.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/errormarker/ErrorMarkerBuilder.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2021 Primetals Technologies Austria GmbH
- *               2023 Martin Erich Jobst
+ * Copyright (c) 2021, 2024 Primetals Technologies Austria GmbH
+ *                          Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -11,6 +11,7 @@
  * Contributors:
  *   Michael Oberlehner - initial API and implementation and/or initial documentation
  *   Martin Jobst - refactor marker handling
+ *                - add code and source attributes
  *******************************************************************************/
 package org.eclipse.fordiac.ide.model.errormarker;
 
@@ -32,6 +33,8 @@ public final class ErrorMarkerBuilder {
 	private int lineNumber = -1;
 	private String message;
 	private String location;
+	private int code;
+	private String source;
 	private EObject target;
 	private EStructuralFeature feature;
 	private Map<String, Object> additionalAttributes;
@@ -69,6 +72,12 @@ public final class ErrorMarkerBuilder {
 			attributes.put(IMarker.LOCATION, location);
 		} else if (target != null) {
 			attributes.put(IMarker.LOCATION, FordiacMarkerHelper.getLocation(target, feature));
+		}
+		if (code != FordiacErrorMarker.DEFAULT_CODE) {
+			attributes.put(FordiacErrorMarker.CODE, Integer.valueOf(code));
+		}
+		if (source != null) {
+			attributes.put(FordiacErrorMarker.SOURCE, source);
 		}
 		if (target != null) {
 			attributes.put(FordiacErrorMarker.TARGET_URI,
@@ -144,6 +153,24 @@ public final class ErrorMarkerBuilder {
 
 	public EObject getTarget() {
 		return target;
+	}
+
+	public int getCode() {
+		return code;
+	}
+
+	public ErrorMarkerBuilder setCode(final int code) {
+		this.code = code;
+		return this;
+	}
+
+	public String getSource() {
+		return source;
+	}
+
+	public ErrorMarkerBuilder setSource(final String source) {
+		this.source = source;
+		return this;
 	}
 
 	public ErrorMarkerBuilder setTarget(final EObject target) {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/errormarker/FordiacErrorMarker.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/errormarker/FordiacErrorMarker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Martin Erich Jobst
+ * Copyright (c) 2023, 2024 Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,8 +17,8 @@ import java.util.Set;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.emf.common.util.Diagnostic;
 import org.eclipse.emf.common.util.SegmentSequence;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EClass;
@@ -29,10 +29,13 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.fordiac.ide.model.libraryElement.Connection;
+import org.eclipse.fordiac.ide.model.libraryElement.ErrorMarkerInterface;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
+import org.eclipse.fordiac.ide.model.libraryElement.Value;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
-import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 
 public final class FordiacErrorMarker {
 
@@ -49,24 +52,120 @@ public final class FordiacErrorMarker {
 	private static final Set<String> MODEL_MARKER_TYPES = Set.of(IEC61499_MARKER, VALIDATION_MARKER,
 			INITIAL_VALUE_MARKER, TYPE_DECLARATION_MARKER, IMPORT_MARKER, TYPE_LIBRARY_MARKER, LIBRARY_MARKER);
 
-	public static final String TARGET_URI = "org.eclipse.fordiac.ide.model.iec61499.targetUri"; //$NON-NLS-1$
-	public static final String TARGET_TYPE = "org.eclipse.fordiac.ide.model.iec61499.targetType"; //$NON-NLS-1$
-	public static final String TARGET_FEATURE = "org.eclipse.fordiac.ide.model.iec61499.targetFeature"; //$NON-NLS-1$
+	/**
+	 * The source-specific diagnostic code.
+	 *
+	 * @see Diagnostic#getCode()
+	 */
+	public static final String CODE = "org.eclipse.fordiac.ide.model.iec61499.code"; //$NON-NLS-1$
 
+	/**
+	 * The diagnostic source.
+	 *
+	 * @see Diagnostic#getSource()
+	 */
+	public static final String SOURCE = "org.eclipse.fordiac.ide.model.iec61499.source"; //$NON-NLS-1$
+
+	/**
+	 * The target URI to the originating model element.
+	 *
+	 * @see Diagnostic#getData()
+	 */
+	public static final String TARGET_URI = "org.eclipse.fordiac.ide.model.iec61499.targetUri"; //$NON-NLS-1$
+	/**
+	 * The target type of the originating model element.
+	 *
+	 * @see Diagnostic#getData()
+	 */
+	public static final String TARGET_TYPE = "org.eclipse.fordiac.ide.model.iec61499.targetType"; //$NON-NLS-1$
+	/**
+	 * The target feature of the originating model element.
+	 *
+	 * @see Diagnostic#getData()
+	 */
+	public static final String TARGET_FEATURE = "org.eclipse.fordiac.ide.model.iec61499.targetFeature"; //$NON-NLS-1$
+	/**
+	 * The additional data of the diagnostic.
+	 *
+	 * @see Diagnostic#getData()
+	 */
+	public static final String DATA = "org.eclipse.fordiac.ide.model.iec61499.data"; //$NON-NLS-1$
+
+	/**
+	 * The default source-specific code.
+	 *
+	 * @see #CODE
+	 */
+	public static final int DEFAULT_CODE = 0;
+
+	/**
+	 * Checks whether the marker type is a model marker type.
+	 *
+	 * @param markerType The marker type
+	 * @return true if yes, false otherwise
+	 */
 	public static boolean isModelMarkerType(final String markerType) {
 		return MODEL_MARKER_TYPES.contains(markerType);
 	}
 
-	public static URI getTargetUri(final IMarker marker) throws CoreException, IllegalArgumentException {
-		final String targetUriAttribute = (String) marker.getAttribute(TARGET_URI);
+	/**
+	 * Get the attribute for the source-specific diagnostic code.
+	 *
+	 * @param marker The marker
+	 * @return The diagnostic code or {@link #DEFAULT_CODE} if no such attribute is
+	 *         present.
+	 * @see Diagnostic#getCode()
+	 */
+	public static int getCode(final IMarker marker) {
+		return marker.getAttribute(CODE, DEFAULT_CODE);
+	}
+
+	/**
+	 * Get the attribute identifying the source of the diagnostic.
+	 *
+	 * @param marker The marker
+	 * @return The source or null if no such attribute is present.
+	 * @see Diagnostic#getSource()
+	 */
+	public static String getSource(final IMarker marker) {
+		return marker.getAttribute(SOURCE, null);
+	}
+
+	/**
+	 * Get the attribute for the remaining diagnostic data.
+	 *
+	 * @param marker The marker
+	 * @return The data or an empty array if no such attribute is present.
+	 * @see Diagnostic#getData()
+	 */
+	public static String[] getData(final IMarker marker) {
+		return marker.getAttribute(DATA, "").split("\u0000"); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	/**
+	 * Get the attribute for the target URI to the originating model element.
+	 *
+	 * @param marker The marker
+	 * @return The target URI or null if no such attribute is present.
+	 * @see Diagnostic#getData()
+	 */
+	public static URI getTargetUri(final IMarker marker) {
+		final String targetUriAttribute = marker.getAttribute(TARGET_URI, null);
 		if (targetUriAttribute != null) {
 			return URI.createURI(targetUriAttribute);
 		}
 		return null;
 	}
 
-	public static EClass getTargetType(final IMarker marker) throws CoreException, IllegalArgumentException {
-		final String targetTypeAttribute = (String) marker.getAttribute(TARGET_TYPE);
+	/**
+	 * Get the attribute for the target type of the originating model element.
+	 *
+	 * @param marker The marker
+	 * @return The target type or null if no valid attribute is present.
+	 * @see Diagnostic#getData()
+	 */
+	public static EClass getTargetType(final IMarker marker) {
+		final String targetTypeAttribute = marker.getAttribute(TARGET_TYPE, null);
 		if (targetTypeAttribute != null) {
 			final URI targetTypeUri = URI.createURI(targetTypeAttribute);
 			final EPackage ePackage = EPackage.Registry.INSTANCE.getEPackage(targetTypeUri.trimFragment().toString());
@@ -80,9 +179,15 @@ public final class FordiacErrorMarker {
 		return null;
 	}
 
-	public static EStructuralFeature getTargetFeature(final IMarker marker)
-			throws CoreException, IllegalArgumentException {
-		final String targetFeatureAttribute = (String) marker.getAttribute(TARGET_FEATURE);
+	/**
+	 * Get the attribute for the target feature of the originating model element.
+	 *
+	 * @param marker The marker
+	 * @return The target feature or null if no valid attribute is present.
+	 * @see Diagnostic#getData()
+	 */
+	public static EStructuralFeature getTargetFeature(final IMarker marker) {
+		final String targetFeatureAttribute = marker.getAttribute(TARGET_FEATURE, null);
 		if (targetFeatureAttribute != null) {
 			final URI targetFeatureUri = URI.createURI(targetFeatureAttribute);
 			final EPackage ePackage = EPackage.Registry.INSTANCE
@@ -97,7 +202,16 @@ public final class FordiacErrorMarker {
 		return null;
 	}
 
-	public static EObject getTarget(final IMarker marker) throws IllegalArgumentException, CoreException {
+	/**
+	 * Get the originating model element from the {@link TypeEntry#getType()}.
+	 *
+	 * @param marker The marker
+	 * @return The target or null if no valid attribute is present.
+	 * @see Diagnostic#getData()
+	 * @implNote This can be a resource-intensive operation since it may force to
+	 *           load the target file.
+	 */
+	public static EObject getTarget(final IMarker marker) {
 		final URI targetUri = FordiacErrorMarker.getTargetUri(marker);
 		if (targetUri != null && targetUri.isPlatformResource()) {
 			final ResourceSet resourceSet = new ResourceSetImpl();
@@ -106,7 +220,17 @@ public final class FordiacErrorMarker {
 		return null;
 	}
 
-	public static EObject getTargetEditable(final IMarker marker) throws IllegalArgumentException, CoreException {
+	/**
+	 * Get the originating model element from the
+	 * {@link TypeEntry#getTypeEditable()}.
+	 *
+	 * @param marker The marker
+	 * @return The target or null if no valid attribute is present.
+	 * @see Diagnostic#getData()
+	 * @implNote This can be a resource-intensive operation since it may force to
+	 *           load the target file.
+	 */
+	public static EObject getTargetEditable(final IMarker marker) {
 		final URI targetUri = FordiacErrorMarker.getTargetUri(marker);
 		if (targetUri != null) {
 			if (targetUri.isPlatformResource()) {
@@ -128,8 +252,14 @@ public final class FordiacErrorMarker {
 		return null;
 	}
 
-	public static EObject getTargetRelative(final IMarker marker, final EObject root)
-			throws IllegalArgumentException, CoreException {
+	/**
+	 * Get the originating model element relative to an existing root object.
+	 *
+	 * @param marker The marker
+	 * @return The target or null if no valid attribute is present.
+	 * @see Diagnostic#getData()
+	 */
+	public static EObject getTargetRelative(final IMarker marker, final EObject root) {
 		final URI targetUri = FordiacErrorMarker.getTargetUri(marker);
 		if (targetUri != null) {
 			final SegmentSequence segments = SegmentSequence.create("/", targetUri.fragment()); //$NON-NLS-1$
@@ -141,30 +271,58 @@ public final class FordiacErrorMarker {
 		return null;
 	}
 
+	/**
+	 * Test whether the marker originates from a {@link FBNetworkElement}.
+	 *
+	 * @param marker The marker
+	 * @return true if yes, false otherwise
+	 */
 	public static boolean markerTargetsFBNetworkElement(final IMarker marker) {
 		return isTargetOfType(marker, LibraryElementPackage.eINSTANCE.getFBNetworkElement());
 	}
 
+	/**
+	 * Test whether the marker originates from a {@link ErrorMarkerInterface}.
+	 *
+	 * @param marker The marker
+	 * @return true if yes, false otherwise
+	 */
 	public static boolean markerTargetsErrorMarkerInterface(final IMarker marker) {
 		return isTargetOfType(marker, LibraryElementPackage.eINSTANCE.getErrorMarkerInterface());
 	}
 
+	/**
+	 * Test whether the marker originates from a {@link Connection}.
+	 *
+	 * @param marker The marker
+	 * @return true if yes, false otherwise
+	 */
 	public static boolean markerTargetsConnection(final IMarker marker) {
 		return isTargetOfType(marker, LibraryElementPackage.eINSTANCE.getConnection());
 	}
 
+	/**
+	 * Test whether the marker originates from a {@link Value}.
+	 *
+	 * @param marker The marker
+	 * @return true if yes, false otherwise
+	 */
 	public static boolean markerTargetsValue(final IMarker marker) {
 		return isTargetOfType(marker, LibraryElementPackage.eINSTANCE.getValue());
 	}
 
+	/**
+	 * Test whether the marker originates from specific type or one of its
+	 * subclasses.
+	 *
+	 * @param marker The marker
+	 * @param type   The type
+	 * @return true if yes, false otherwise
+	 */
 	public static boolean isTargetOfType(final IMarker marker, final EClass type) {
-		try {
-			final EClass targetType = FordiacErrorMarker.getTargetType(marker);
-			if (targetType != null) {
-				return type.isSuperTypeOf(targetType);
-			}
-		} catch (IllegalArgumentException | CoreException e) {
-			FordiacLogHelper.logWarning("Cannot determine marker target type " + marker.toString(), e); //$NON-NLS-1$
+		final EClass targetType = FordiacErrorMarker.getTargetType(marker);
+		if (targetType != null) {
+			return type.isSuperTypeOf(targetType);
 		}
 		return false;
 	}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/errormarker/FordiacMarkerHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/errormarker/FordiacMarkerHelper.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
- * Copyright (c) 2020 Johannes Kepler University Linz, Primetals Technologies Austria GmbH
- *               2022 Primetals Technologies Austria GmbH
- *               2023 Martin Erich Jobst
+ * Copyright (c) 2020, 2024 Johannes Kepler University Linz, Primetals Technologies Austria GmbH
+ *                          Primetals Technologies Austria GmbH
+ *                          Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,10 +19,11 @@
 package org.eclipse.fordiac.ide.model.errormarker;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IResource;
@@ -54,6 +55,17 @@ import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 public final class FordiacMarkerHelper {
 	public static final JobGroup JOB_GROUP = new JobGroup("FordiacMarkerHelper JobGroup", 0, 0); //$NON-NLS-1$
 
+	/**
+	 * Get the human-readable location string for an object.
+	 *
+	 * @param object The object
+	 * @return The location string or an empty string if not applicable
+	 * @see INamedElement#getQualifiedName()
+	 * @implSpec The location string is based on the
+	 *           {@link INamedElement#getQualifiedName()} of the object if it is a
+	 *           {@link INamedElement} or the location of its parent together with
+	 *           the containing feature.
+	 */
 	public static String getLocation(final EObject object) {
 		if (object instanceof final INamedElement namedElement) {
 			return namedElement.getQualifiedName();
@@ -64,6 +76,14 @@ public final class FordiacMarkerHelper {
 		return ""; //$NON-NLS-1$
 	}
 
+	/**
+	 * Get the human-readable location string for an object and feature.
+	 *
+	 * @param object  The object
+	 * @param feature The feature (may be null)
+	 * @return The location string or an empty string if not applicable
+	 * @see #getLocation()
+	 */
 	public static String getLocation(final EObject object, final EStructuralFeature feature) {
 		if (feature != null) {
 			return getLocation(object) + "/" + feature.getName(); //$NON-NLS-1$
@@ -71,6 +91,12 @@ public final class FordiacMarkerHelper {
 		return getLocation(object);
 	}
 
+	/**
+	 * Get the workspace resource for an object
+	 *
+	 * @param object The object
+	 * @return The workspace resource or null if not applicable
+	 */
 	public static IResource getResource(final EObject object) {
 		if (object != null && object.eResource() != null) {
 			final URI uri = EcoreUtil.getURI(object);
@@ -81,6 +107,13 @@ public final class FordiacMarkerHelper {
 		return null;
 	}
 
+	/**
+	 * Get the target URI of an object
+	 *
+	 * @param resource The workspace resource
+	 * @param object   The object
+	 * @return The target URI or null if not applicable
+	 */
 	public static URI getTargetUri(final IResource resource, final EObject object) {
 		if (object != null) {
 			final URI uri = EcoreUtil.getURI(object);
@@ -93,6 +126,13 @@ public final class FordiacMarkerHelper {
 		return null;
 	}
 
+	/**
+	 * Get the target URI of an object as a string
+	 *
+	 * @param resource The workspace resource
+	 * @param object   The object
+	 * @return The target URI string or null if not applicable
+	 */
 	public static String getTargetUriString(final IResource resource, final EObject object) {
 		final URI uri = getTargetUri(resource, object);
 		if (uri != null) {
@@ -101,22 +141,61 @@ public final class FordiacMarkerHelper {
 		return null;
 	}
 
-	public static Object[] getDiagnosticData(final EObject object) {
-		return getDiagnosticData(object, null);
+	/**
+	 * Get the diagnostic data to be used for an object
+	 *
+	 * @param object The object
+	 * @param data   The additional data
+	 * @return The diagnostic data
+	 * @see Diagnostic#getData()
+	 * @see #getDiagnosticData(EObject, EStructuralFeature, String...)
+	 */
+	public static Object[] getDiagnosticData(final EObject object, final String... data) {
+		return getDiagnosticData(object, null, data);
 	}
 
-	public static Object[] getDiagnosticData(final EObject object, final EStructuralFeature feature) {
+	/**
+	 * Get the diagnostic data to be used for an object
+	 *
+	 * @param object  The object
+	 * @param feature The originating feature
+	 * @param data    The additional data
+	 * @return The diagnostic data
+	 * @see Diagnostic#getData()
+	 * @see #getDiagnosticAttributes(Diagnostic)
+	 * @implSpec The diagnostic data follows a specific structure so that it may
+	 *           later be converted to a marker or issue. It consists of:
+	 *           <ul>
+	 *           <li>{@code [0]} the object itself (per EMF convention),
+	 *           <li>{@code [1]} the location for the object using
+	 *           {@link #getLocation(EObject)},
+	 *           <li>{@code [2]} the target URI for the object using
+	 *           {@link #getTargetUriString(IResource, EObject)},
+	 *           <li>{@code [3]} the URI of the {@link EClass} of the object as a
+	 *           string,
+	 *           <li>{@code [4]} the URI of the {@link EStructuralFeature} feature
+	 *           as a string (or null).
+	 *           </ul>
+	 */
+	public static Object[] getDiagnosticData(final EObject object, final EStructuralFeature feature,
+			final String... data) {
 		if (object == null) {
-			return new Object[0];
+			return data;
 		}
-		return new Object[] { object, // [0] object itself (per EMF convention)
+		return Stream.concat(Stream.of(object, // [0] object itself (per EMF convention)
 				getLocation(object), // [1] LOCATION
 				getTargetUriString(null, object), // [2] TARGET_URI
 				EcoreUtil.getURI(object.eClass()).toString(), // [3] TARGET_TYPE
-				feature != null ? EcoreUtil.getURI(feature).toString() : null, // [4] TARGET_FEATURE
-		};
+				feature != null ? EcoreUtil.getURI(feature).toString() : null // [4] TARGET_FEATURE
+		), Stream.of(data)).toArray();
 	}
 
+	/**
+	 * Get the target from the data of a diagnostic
+	 *
+	 * @param diagnostic The diagnostic
+	 * @return The target object or null if not applicable
+	 */
 	public static EObject getDiagnosticTarget(final Diagnostic diagnostic) {
 		final List<?> data = diagnostic.getData();
 		if (data != null && !data.isEmpty() && data.get(0) instanceof final EObject target) {
@@ -125,20 +204,43 @@ public final class FordiacMarkerHelper {
 		return null;
 	}
 
+	/**
+	 * Get the marker attributes for a diagnostic
+	 *
+	 * @param diagnostic The diagnostic
+	 * @return The marker attributes
+	 */
 	public static Map<String, Object> getDiagnosticAttributes(final Diagnostic diagnostic) {
 		if (LibraryElementValidator.DIAGNOSTIC_SOURCE.equals(diagnostic.getSource())) {
 			final List<?> data = diagnostic.getData();
 			if (data != null && data.size() >= 5) {
 				if (data.get(4) != null) {
-					return Map.of(IMarker.LOCATION, data.get(1), FordiacErrorMarker.TARGET_URI, data.get(2),
-							FordiacErrorMarker.TARGET_TYPE, data.get(3), FordiacErrorMarker.TARGET_FEATURE,
-							data.get(4));
+					return Map.of(//
+							FordiacErrorMarker.CODE, Integer.valueOf(diagnostic.getCode()), //
+							FordiacErrorMarker.SOURCE, diagnostic.getSource(), //
+							IMarker.LOCATION, data.get(1), //
+							FordiacErrorMarker.TARGET_URI, data.get(2), //
+							FordiacErrorMarker.TARGET_TYPE, data.get(3), //
+							FordiacErrorMarker.TARGET_FEATURE, data.get(4), //
+							FordiacErrorMarker.DATA, data.subList(5, data.size()).stream().map(Object::toString)
+									.collect(Collectors.joining("\u0000")) //$NON-NLS-1$
+					);
 				}
-				return Map.of(IMarker.LOCATION, data.get(1), FordiacErrorMarker.TARGET_URI, data.get(2),
-						FordiacErrorMarker.TARGET_TYPE, data.get(3));
+				return Map.of(//
+						FordiacErrorMarker.CODE, Integer.valueOf(diagnostic.getCode()), //
+						FordiacErrorMarker.SOURCE, diagnostic.getSource(), //
+						IMarker.LOCATION, data.get(1), //
+						FordiacErrorMarker.TARGET_URI, data.get(2), //
+						FordiacErrorMarker.TARGET_TYPE, data.get(3), //
+						FordiacErrorMarker.DATA, data.subList(5, data.size()).stream().map(Object::toString)
+								.collect(Collectors.joining("\u0000")) //$NON-NLS-1$
+				);
 			}
 		}
-		return Collections.emptyMap();
+		return Map.of(//
+				FordiacErrorMarker.CODE, Integer.valueOf(diagnostic.getCode()), //
+				FordiacErrorMarker.SOURCE, diagnostic.getSource()//
+		);
 	}
 
 	public static List<IMarker> findMarkers(final EObject target) {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/CompilerInfoAnnotations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/CompilerInfoAnnotations.java
@@ -33,7 +33,8 @@ public final class CompilerInfoAnnotations {
 				diagnostics.add(new BasicDiagnostic(Diagnostic.ERROR, LibraryElementValidator.DIAGNOSTIC_SOURCE,
 						LibraryElementValidator.COMPILER_INFO__VALIDATE_PACKAGE_NAME, errorMessage.get(),
 						FordiacMarkerHelper.getDiagnosticData(compilerInfo,
-								LibraryElementPackage.Literals.COMPILER_INFO__PACKAGE_NAME)));
+								LibraryElementPackage.Literals.COMPILER_INFO__PACKAGE_NAME,
+								compilerInfo.getPackageName())));
 			}
 			return false;
 		}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/ConnectionAnnotations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/ConnectionAnnotations.java
@@ -50,7 +50,7 @@ public class ConnectionAnnotations {
 						LibraryElementValidator.CONNECTION__VALIDATE_MISSING_SOURCE,
 						MessageFormat.format(Messages.ConnectionAnnotations_SourceElementMissing, element.getName()),
 						FordiacMarkerHelper.getDiagnosticData(connection,
-								LibraryElementPackage.Literals.CONNECTION__SOURCE)));
+								LibraryElementPackage.Literals.CONNECTION__SOURCE, element.getQualifiedName())));
 			}
 			return false;
 		}
@@ -65,7 +65,7 @@ public class ConnectionAnnotations {
 						LibraryElementValidator.CONNECTION__VALIDATE_MISSING_SOURCE_ENDPOINT,
 						MessageFormat.format(Messages.ConnectionAnnotations_SourceEndpointMissing, endpoint.getName()),
 						FordiacMarkerHelper.getDiagnosticData(connection,
-								LibraryElementPackage.Literals.CONNECTION__SOURCE)));
+								LibraryElementPackage.Literals.CONNECTION__SOURCE, endpoint.getQualifiedName())));
 			}
 			return false;
 		}
@@ -81,7 +81,7 @@ public class ConnectionAnnotations {
 						MessageFormat.format(Messages.ConnectionAnnotations_DestinationElementMissing,
 								element.getName()),
 						FordiacMarkerHelper.getDiagnosticData(connection,
-								LibraryElementPackage.Literals.CONNECTION__DESTINATION)));
+								LibraryElementPackage.Literals.CONNECTION__DESTINATION, element.getQualifiedName())));
 			}
 			return false;
 		}
@@ -97,7 +97,7 @@ public class ConnectionAnnotations {
 						MessageFormat.format(Messages.ConnectionAnnotations_DestinationEndpointMissing,
 								endpoint.getName()),
 						FordiacMarkerHelper.getDiagnosticData(connection,
-								LibraryElementPackage.Literals.CONNECTION__DESTINATION)));
+								LibraryElementPackage.Literals.CONNECTION__DESTINATION, endpoint.getQualifiedName())));
 			}
 			return false;
 		}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/InterfaceElementAnnotations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/InterfaceElementAnnotations.java
@@ -84,7 +84,7 @@ public final class InterfaceElementAnnotations {
 						MessageFormat.format(Messages.InterfaceElementAnnotations_MemberNameCollidesWithDataType,
 								element.getQualifiedName()),
 						FordiacMarkerHelper.getDiagnosticData(element,
-								LibraryElementPackage.Literals.INAMED_ELEMENT__NAME)));
+								LibraryElementPackage.Literals.INAMED_ELEMENT__NAME, element.getQualifiedName())));
 			}
 			return false;
 		}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/NamedElementAnnotations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/NamedElementAnnotations.java
@@ -72,7 +72,7 @@ public final class NamedElementAnnotations {
 							MessageFormat.format(Messages.IdentifierVerifier_NameConsecutiveUnderscore,
 									element.getName()),
 							FordiacMarkerHelper.getDiagnosticData(element,
-									LibraryElementPackage.Literals.INAMED_ELEMENT__NAME)));
+									LibraryElementPackage.Literals.INAMED_ELEMENT__NAME, element.getName())));
 				}
 			} else if (element.getName().endsWith("_")) { //$NON-NLS-1$
 				if (diagnostics != null) {
@@ -129,7 +129,8 @@ public final class NamedElementAnnotations {
 		return new BasicDiagnostic(Diagnostic.ERROR, LibraryElementValidator.DIAGNOSTIC_SOURCE,
 				LibraryElementValidator.INAMED_ELEMENT__VALIDATE_NAME,
 				MessageFormat.format(Messages.InterfaceElementAnnotations_DuplicateName, element.getName()),
-				FordiacMarkerHelper.getDiagnosticData(element, LibraryElementPackage.Literals.INAMED_ELEMENT__NAME));
+				FordiacMarkerHelper.getDiagnosticData(element, LibraryElementPackage.Literals.INAMED_ELEMENT__NAME,
+						element.getQualifiedName()));
 	}
 
 	private static <K, V> V putConditional(final Map<K, V> map, final K key, final V valueIfAbsent,

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/TypedConfigureableObjectAnnotations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/TypedConfigureableObjectAnnotations.java
@@ -36,7 +36,8 @@ public final class TypedConfigureableObjectAnnotations {
 						MessageFormat.format(Messages.TypedElementAnnotations_TypeNotFound,
 								element.getTypeEntry().getFullTypeName()),
 						FordiacMarkerHelper.getDiagnosticData(element,
-								LibraryElementPackage.Literals.TYPED_CONFIGUREABLE_OBJECT__TYPE_ENTRY)));
+								LibraryElementPackage.Literals.TYPED_CONFIGUREABLE_OBJECT__TYPE_ENTRY,
+								element.getTypeEntry().getFullTypeName())));
 			}
 			return false;
 		}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/TypedElementAnnotations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/TypedElementAnnotations.java
@@ -22,6 +22,7 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.fordiac.ide.model.Messages;
 import org.eclipse.fordiac.ide.model.errormarker.FordiacMarkerHelper;
+import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
@@ -53,7 +54,14 @@ public final class TypedElementAnnotations {
 	private static Diagnostic createTypeValidationDiagnostic(final String message, final ITypedElement element) {
 		return new BasicDiagnostic(Diagnostic.ERROR, LibraryElementValidator.DIAGNOSTIC_SOURCE,
 				LibraryElementValidator.ITYPED_ELEMENT__VALIDATE_TYPE, message,
-				FordiacMarkerHelper.getDiagnosticData(element, getTypeFeature(element)));
+				FordiacMarkerHelper.getDiagnosticData(element, getTypeFeature(element), getFullTypeName(element)));
+	}
+
+	private static String getFullTypeName(final ITypedElement element) {
+		if (element.getType() instanceof final LibraryElement libraryElement) {
+			return PackageNameHelper.getFullTypeName(libraryElement);
+		}
+		return element.getTypeName();
 	}
 
 	private static EStructuralFeature getTypeFeature(final ITypedElement element) {

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/validation/STCoreMarkerCreator.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/validation/STCoreMarkerCreator.java
@@ -27,6 +27,8 @@ public class STCoreMarkerCreator extends MarkerCreator {
 		if (FordiacErrorMarker.isModelMarkerType(markerType)) {
 			ErrorMarkerBuilder.createErrorMarkerBuilder(issue.getMessage()).setType(markerType)
 					.setSeverity(ValidationUtil.getMarkerSeverity(issue))
+					.setCode(ValidationUtil.getModelMarkerCode(issue))
+					.setSource(ValidationUtil.getModelMarkerSource(issue))
 					.addAdditionalAttributes(ValidationUtil.getModelMarkerAttributes(issue)).createMarker(resource);
 		} else {
 			super.createMarker(issue, resource, markerType);


### PR DESCRIPTION
Add code, source, and validation-specific data for model error markers. Also avoid checked exceptions when querying marker attributes.