### PR TITLE
Update usage of GEF Classic EditPartRegistry to new typed interface

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/CreateSubAppInterfaceElementCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/CreateSubAppInterfaceElementCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 fortiss GmbH
+ * Copyright (c) 2017, 2024 fortiss GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -8,8 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *   Alois Zoitl
- *     - initial API and implementation and/or initial documentation
+ *   Alois Zoitl - initial API and implementation and/or initial documentation
  *******************************************************************************/
 package org.eclipse.fordiac.ide.application.commands;
 
@@ -20,6 +19,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
 import org.eclipse.fordiac.ide.ui.editors.EditorUtils;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.GraphicalViewer;
 
 public class CreateSubAppInterfaceElementCommand extends CreateInterfaceElementCommand {
@@ -77,9 +77,8 @@ public class CreateSubAppInterfaceElementCommand extends CreateInterfaceElementC
 					.getAdapter(GraphicalViewer.class);
 
 			if (graphicalViewer != null && getInterfaceList().eContainer() instanceof SubApp) {
-				final Object subAppforFBNetowrkEditPart = graphicalViewer.getEditPartRegistry()
-						.get((getInterfaceList().eContainer()));
-				if (subAppforFBNetowrkEditPart instanceof final SubAppForFBNetworkEditPart subAppEP
+				final EditPart registeredEP = graphicalViewer.getEditPartForModel((getInterfaceList().eContainer()));
+				if (registeredEP instanceof final SubAppForFBNetworkEditPart subAppEP
 						&& subAppEP.getContentEP() != null) {
 					resizeCmd = new ResizeGroupOrSubappCommand(subAppEP.getContentEP());
 					resizeCmd.execute();

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/ResizingSubappInterfaceCreationCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/ResizingSubappInterfaceCreationCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Primetals Technologies Austria GmbH
+ * Copyright (c) 2022, 2024 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -22,7 +22,6 @@ import org.eclipse.fordiac.ide.model.commands.change.AbstractChangeContainerBoun
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
 import org.eclipse.fordiac.ide.model.ui.editors.HandlerHelper;
 import org.eclipse.fordiac.ide.ui.providers.CreationCommand;
-import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.GraphicalViewer;
@@ -45,15 +44,15 @@ public final class ResizingSubappInterfaceCreationCommand extends CreationComman
 				return new WrapedResizeGroupOrSubappCommand(groupEP, cmd);
 
 			}
-		} else if (parent.getOuterFBNetworkElement() instanceof SubApp
-				&& ((SubApp) parent.getOuterFBNetworkElement()).isUnfolded()) {
+		} else if (parent.getOuterFBNetworkElement() instanceof final SubApp subApp && subApp.isUnfolded()) {
 			final GraphicalEditPart ep = findEditPart(parent.getOuterFBNetworkElement());
 			if (ep != null) {
 				return new WrapedResizeGroupOrSubappCommand(ep, cmd);
 
 			}
 		}
-		// we couldn't or shouldn't create a resizing command return the given one as fallback
+		// we couldn't or shouldn't create a resizing command return the given one as
+		// fallback
 		return cmd;
 	}
 
@@ -110,11 +109,8 @@ public final class ResizingSubappInterfaceCreationCommand extends CreationComman
 				.getActiveEditor();
 		if (editor != null) {
 			final GraphicalViewer viewer = HandlerHelper.getViewer(editor);
-			if (viewer != null) {
-				final Object ep = viewer.getEditPartRegistry().get(obj);
-				if (ep instanceof EditPart) {
-					return (GraphicalEditPart) ep;
-				}
+			if ((viewer != null) && (viewer.getEditPartForModel(obj) instanceof final GraphicalEditPart gep)) {
+				return gep;
 			}
 		}
 		return null;
@@ -122,8 +118,8 @@ public final class ResizingSubappInterfaceCreationCommand extends CreationComman
 
 	private static SubAppForFBNetworkEditPart findSubappEP(final SubApp parent) {
 		final Object ep = findEditPart(parent);
-		if (ep instanceof SubAppForFBNetworkEditPart) {
-			return (SubAppForFBNetworkEditPart) ep;
+		if (ep instanceof final SubAppForFBNetworkEditPart subAppEP) {
+			return subAppEP;
 		}
 		return null;
 	}
@@ -134,8 +130,7 @@ public final class ResizingSubappInterfaceCreationCommand extends CreationComman
 		if (containerBounds.height < expandedIOHeight) {
 			final int heightDelta = expandedIOHeight - containerBounds.height;
 			changeSubappHeightCmd = FBNetworkXYLayoutEditPolicy.createChangeBoundsCommand(subAppEP.getModel(),
-					new Dimension(0, heightDelta),
-					new Point());
+					new Dimension(0, heightDelta), new Point());
 			changeSubappHeightCmd.execute();
 		}
 	}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editors/FBNetworkEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editors/FBNetworkEditor.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 Profactor GmbH, TU Wien ACIN, AIT, fortiss GmbH,
- *                          Johannes Kepler University,
+ * Copyright (c) 2008, 2024 Profactor GmbH, TU Wien ACIN, AIT, fortiss GmbH,
+ *                          Johannes Kepler University Linz,
  *                          Primetals Technologies Germany GmbH
  *
  * This program and the accompanying materials are made available under the
@@ -233,7 +233,7 @@ public class FBNetworkEditor extends DiagramEditorWithFlyoutPalette implements I
 	}
 
 	public void selectElement(final Object element) {
-		final EditPart editPart = (EditPart) getGraphicalViewer().getEditPartRegistry().get(element);
+		final EditPart editPart = getGraphicalViewer().getEditPartForModel(element);
 		if (null != editPart) {
 			getGraphicalViewer().flush();
 			getGraphicalViewer().selectAndRevealEditPart(editPart);

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/ConnectionEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/ConnectionEditPart.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
- * Copyright (c) 2008 - 2022,2023 Profactor GmbH, TU Wien ACIN, fortiss GmbH, AIT,
- * 							 	  Johannes Kepler University Linz,
- * 							 	  Primetals Technologies Germany GmbH,
- *                           	  Primetals Technologies Austria GmbH
+ * Copyright (c) 2008, 2024 Profactor GmbH, TU Wien ACIN, fortiss GmbH, AIT,
+ * 							Johannes Kepler University Linz,
+ * 							Primetals Technologies Germany GmbH,
+ *                          Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -360,13 +360,12 @@ public class ConnectionEditPart extends AbstractConnectionEditPart implements An
 	private void followMultipleTargetConnections(final IInterfaceElement originPin,
 			final List<IInterfaceElement> targetList) {
 		final GraphicalViewer viewer = (GraphicalViewer) getViewer();
-		final GraphicalEditPart firstTargetEP = (GraphicalEditPart) viewer.getEditPartRegistry()
-				.get(targetList.getFirst());
+		final GraphicalEditPart firstTargetEP = (GraphicalEditPart) viewer.getEditPartForModel(targetList.getFirst());
 		HandlerHelper.selectEditPart(viewer, firstTargetEP);
 		viewer.flush();
 
-		final var dialog = new OppositeSelectionDialog(targetList, originPin,
-				viewer.getControl(), firstTargetEP.getFigure(),
+		final var dialog = new OppositeSelectionDialog(targetList, originPin, viewer.getControl(),
+				firstTargetEP.getFigure(),
 				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActiveEditor());
 		dialog.open();
 	}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/FBNetworkRootEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/FBNetworkRootEditPart.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008 - 2018 Profactor GmbH, TU Wien ACIN, AIT, fortiss GmbH,
- * 				 2018 - 2020 Johannes Kepler University
+ * Copyright (c) 2008, 2024 Profactor GmbH, TU Wien ACIN, AIT, fortiss GmbH,
+ * 				            Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -31,7 +31,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
 import org.eclipse.gef.DragTracker;
-import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.Request;
@@ -110,8 +109,7 @@ public class FBNetworkRootEditPart extends ZoomScalableFreeformRootEditPart {
 			final AbstractCreateFBNetworkElementCommand cmd = getDirectEditCommand(directEditRequest);
 			if (null != cmd && cmd.canExecute()) {
 				getViewer().getEditDomain().getCommandStack().execute(cmd);
-				final EditPart part = (EditPart) getViewer().getEditPartRegistry().get(cmd.getElement());
-				getViewer().select(part);
+				getViewer().select(getViewer().getEditPartForModel(cmd.getElement()));
 			}
 			return null;
 		}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/InterfaceEditPartForFBNetwork.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/InterfaceEditPartForFBNetwork.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008 - 2018 Profactor GmbH, fortiss GmbH
- * 				 2020 Primetals Technologies Germany GmbH
+ * Copyright (c) 2008, 2024 Profactor GmbH, fortiss GmbH,
+ *  						Primetals Technologies Germany GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -40,6 +40,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.impl.ErrorMarkerDataTypeImpl;
 import org.eclipse.fordiac.ide.model.ui.actions.OpenListenerManager;
 import org.eclipse.fordiac.ide.model.ui.editors.HandlerHelper;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.GraphicalViewer;
 import org.eclipse.gef.Request;
@@ -91,8 +92,8 @@ public class InterfaceEditPartForFBNetwork extends InterfaceEditPart {
 
 		IFigure getValueFigure() {
 			if (valueFigure == null) {
-				final Object object = ieEP.getViewer().getEditPartRegistry().get(getValue());
-				if (object instanceof final GraphicalEditPart graphicalEditPart) {
+				final EditPart ep = ieEP.getViewer().getEditPartForModel(getValue());
+				if (ep instanceof final GraphicalEditPart graphicalEditPart) {
 					valueFigure = graphicalEditPart.getFigure();
 				}
 			}
@@ -174,10 +175,7 @@ public class InterfaceEditPartForFBNetwork extends InterfaceEditPart {
 	}
 
 	protected boolean isUnfoldedSubapp() {
-		if (getModel().getFBNetworkElement() instanceof final SubApp subApp && subApp.isUnfolded()) {
-			return true;
-		}
-		return false;
+		return (getModel().getFBNetworkElement() instanceof final SubApp subApp && subApp.isUnfolded());
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/TargetInterfaceElementEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/TargetInterfaceElementEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Primetals Technologies Austria GmbH
+ * Copyright (c) 2023, 2024 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -147,7 +147,7 @@ public class TargetInterfaceElementEditPart extends AbstractGraphicalEditPart {
 	public void performRequest(final Request request) {
 		if ((request.getType() == RequestConstants.REQ_OPEN)) {
 			final var viewer = getViewer();
-			final EditPart editPart = (EditPart) viewer.getEditPartRegistry().get(getRefElement());
+			final EditPart editPart = viewer.getEditPartForModel(getRefElement());
 			if (editPart == null) {
 				// we need to go to another breadcrumb item
 				openInBreadCrumb(getRefElement());

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/FBNetworkConnection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/FBNetworkConnection.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 Profactor GbmH, fortiss GmbH,
- *               2023       Johannes Kepler University Linz
+ * Copyright (c) 2014, 2024 Profactor GbmH, fortiss GmbH,
+ *                          Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -183,8 +183,8 @@ public class FBNetworkConnection extends HideableConnection {
 	}
 
 	private IFigure getGroupFigure(final FBNetworkElement sourceElement) {
-		final GraphicalEditPart groupEP = (GraphicalEditPart) connEP.getViewer().getEditPartRegistry()
-				.get(sourceElement.getGroup());
+		final GraphicalEditPart groupEP = (GraphicalEditPart) connEP.getViewer()
+				.getEditPartForModel(sourceElement.getGroup());
 		return (groupEP != null) ? groupEP.getFigure() : null;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/FBNetworkConnectionLayerClippingStrategy.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/FBNetworkConnectionLayerClippingStrategy.java
@@ -15,6 +15,7 @@ package org.eclipse.fordiac.ide.application.figures;
 import org.eclipse.draw2d.IClippingStrategy;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.GraphicalViewer;
 
@@ -36,7 +37,7 @@ public class FBNetworkConnectionLayerClippingStrategy implements IClippingStrate
 	}
 
 	private Rectangle getgetFBNConnectionClippingRect(final FBNetworkConnection fbnConn) {
-		final Object ep = viewer.getEditPartRegistry().get(fbnConn.getModel().getFBNetwork());
+		final EditPart ep = viewer.getEditPartForModel(fbnConn.getModel().getFBNetwork());
 		if (ep instanceof final GraphicalEditPart fbnEP) {
 			final IFigure fbnFigure = fbnEP.getFigure();
 			final Rectangle fbnBounds = fbnFigure.getBounds().getCopy();

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/ClearFocusOn.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/ClearFocusOn.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Profactor GmbH, fortiss GmbH
+ * Copyright (c) 2011, 2024 Profactor GmbH, fortiss GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -24,6 +24,7 @@ import org.eclipse.fordiac.ide.gef.editparts.AbstractViewEditPart;
 import org.eclipse.fordiac.ide.model.libraryElement.Connection;
 import org.eclipse.fordiac.ide.model.libraryElement.FB;
 import org.eclipse.fordiac.ide.model.ui.editors.HandlerHelper;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.GraphicalViewer;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.handlers.HandlerUtil;
@@ -36,22 +37,18 @@ public class ClearFocusOn extends AbstractHandler {
 	 * application context.
 	 */
 	@Override
-	public Object execute(ExecutionEvent event) throws ExecutionException {
+	public Object execute(final ExecutionEvent event) throws ExecutionException {
 		final IEditorPart part = HandlerUtil.getActiveEditor(event);
 		final GraphicalViewer viewer = HandlerHelper.getViewer(part);
-		final Map<?, ?> map = viewer.getEditPartRegistry();
+		final Map<Object, EditPart> map = viewer.getEditPartRegistry();
 		for (final Entry<?, ?> entry : map.entrySet()) {
 			final Object obj = entry.getKey();
 			if (obj instanceof FB) {
-				final Object editPartAsObject = entry.getValue();
-				if (editPartAsObject instanceof AbstractViewEditPart) {
-					((AbstractViewEditPart) editPartAsObject).setTransparency(NOT_TRANSPARENT);
+				if (entry.getValue() instanceof final AbstractViewEditPart viewEP) {
+					viewEP.setTransparency(NOT_TRANSPARENT);
 				}
-			} else if (obj instanceof Connection) {
-				final Object editPartAsObject = entry.getValue();
-				if (editPartAsObject instanceof ConnectionEditPart) {
-					((ConnectionEditPart) editPartAsObject).setTransparency(NOT_TRANSPARENT);
-				}
+			} else if ((obj instanceof Connection) && (entry.getValue() instanceof final ConnectionEditPart connEP)) {
+				connEP.setTransparency(NOT_TRANSPARENT);
 			}
 		}
 		return null;

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/ConvertToSubappHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/ConvertToSubappHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Primetals Technologies Austria GmbH
+ * Copyright (c) 2022, 2024 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -51,7 +51,7 @@ public class ConvertToSubappHandler extends AbstractHandler {
 				refreshSelection(conversion.getCreatedElement());
 				final GraphicalViewer v = editor.getAdapter(GraphicalViewer.class);
 				v.flush();
-				final EditPart newSubappEP = (EditPart) v.getEditPartRegistry().get(conversion.getCreatedElement());
+				final EditPart newSubappEP = v.getEditPartForModel(conversion.getCreatedElement());
 				adjustMinBounds(commandStack, newSubappEP);
 			}
 		}
@@ -83,22 +83,21 @@ public class ConvertToSubappHandler extends AbstractHandler {
 	}
 
 	private static Group getSelectedGroup(final Object selection) {
-		if (selection instanceof final IStructuredSelection structSel) {
-			if (!structSel.isEmpty() && (structSel.size() == 1)) {
-				return getGroup(structSel.getFirstElement());
-			}
+		if ((selection instanceof final IStructuredSelection structSel)
+				&& (!structSel.isEmpty() && (structSel.size() == 1))) {
+			return getGroup(structSel.getFirstElement());
 		}
 		return null;
 	}
 
 	private static Group getGroup(final Object currentElement) {
 		Object elementToCheck = currentElement;
-		if (elementToCheck instanceof EditPart) {
-			elementToCheck = ((EditPart) elementToCheck).getModel();
+		if (elementToCheck instanceof final EditPart ep) {
+			elementToCheck = ep.getModel();
 		}
 
-		if (elementToCheck instanceof Group) {
-			return (Group) elementToCheck;
+		if (elementToCheck instanceof final Group group) {
+			return group;
 		}
 		return null;
 	}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/FollowConnectionHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/FollowConnectionHandler.java
@@ -100,7 +100,7 @@ public abstract class FollowConnectionHandler extends AbstractHandler {
 			final GraphicalViewer viewer) {
 		final List<IInterfaceElement> resolvedOpposites = new ArrayList<>();
 		for (final IInterfaceElement element : opposites) {
-			final EditPart ep = (EditPart) (viewer.getEditPartRegistry().get(element));
+			final EditPart ep = viewer.getEditPartForModel(element);
 			if ((ep instanceof final InterfaceEditPart iep) && isExpandedSubappPin(element)) {
 				if (useTargetPins(iep)) {
 					resolvedOpposites.addAll(getTargetPins(iep));

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/MoveThroughHierarchyHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/MoveThroughHierarchyHandler.java
@@ -114,7 +114,7 @@ public class MoveThroughHierarchyHandler extends AbstractHandler {
 			obj = obj.eContainer();
 		}
 
-		final GraphicalEditPart ep = (GraphicalEditPart) viewer.getEditPartRegistry().get(obj);
+		final GraphicalEditPart ep = (GraphicalEditPart) viewer.getEditPartForModel(obj);
 
 		final Rectangle bounds;
 		if (ep != null) {

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/MoveToParentHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/MoveToParentHandler.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021, 2023 Johannes Kepler University Linz,
- * 				                  Primetals Technologies Germany GmbH
+ * Copyright (c) 2019, 2024 Johannes Kepler University Linz,
+ * 				            Primetals Technologies Germany GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -82,8 +82,8 @@ public class MoveToParentHandler extends AbstractHandler {
 		final FBNetwork subappNetwork = getParentOfParent(fbelements.get(0));
 		final GraphicalViewer viewer = getViewer(subappNetwork, editor);
 		viewer.flush();
-		final GraphicalEditPart ep = (GraphicalEditPart) viewer.getEditPartRegistry()
-				.get(fbelements.get(0).getFbNetwork().eContainer());
+		final GraphicalEditPart ep = (GraphicalEditPart) viewer
+				.getEditPartForModel(fbelements.get(0).getFbNetwork().eContainer());
 		return ep.getFigure().getBounds();
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/ConfigurableMoveFBSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/ConfigurableMoveFBSection.java
@@ -100,8 +100,7 @@ public class ConfigurableMoveFBSection extends AbstractSection implements Comman
 		final GraphicalViewer viewer = activeEditor.getAdapter(GraphicalViewer.class);
 		if (null != viewer) {
 			viewer.flush();
-			EditorUtils.refreshPropertySheetWithSelection(activeEditor, viewer,
-					viewer.getEditPartRegistry().get(newFb));
+			EditorUtils.refreshPropertySheetWithSelection(activeEditor, viewer, viewer.getEditPartForModel(newFb));
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/GroupPropertySection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/GroupPropertySection.java
@@ -23,6 +23,7 @@ import org.eclipse.fordiac.ide.model.commands.change.ChangeNameCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.Group;
 import org.eclipse.fordiac.ide.ui.FordiacMessages;
 import org.eclipse.fordiac.ide.ui.editors.EditorUtils;
+import org.eclipse.gef.EditPart;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.swt.SWT;
@@ -176,8 +177,8 @@ public class GroupPropertySection extends AbstractDoubleColumnSection {
 			removeContentAdapter();
 
 			if (EditorUtils.getGraphicalViewerFromCurrentActiveEditor() != null && getType() != null) {
-				final Object groupforFBNetowrkEditPart = EditorUtils.getGraphicalViewerFromCurrentActiveEditor()
-						.getEditPartRegistry().get(getType());
+				final EditPart groupforFBNetowrkEditPart = EditorUtils.getGraphicalViewerFromCurrentActiveEditor()
+						.getEditPartForModel(getType());
 				if (groupforFBNetowrkEditPart instanceof final GroupEditPart gep && gep.getContentEP() != null) {
 					executeCommand(new ResizeGroupOrSubappCommand(gep.getContentEP(),
 							new ChangeCommentCommand(getType(), commentText.getText())));

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/InstancePropertySection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/InstancePropertySection.java
@@ -44,6 +44,7 @@ import org.eclipse.fordiac.ide.ui.widget.IChangeableRowDataProvider;
 import org.eclipse.fordiac.ide.ui.widget.NatTableColumnEditableRule;
 import org.eclipse.fordiac.ide.ui.widget.NatTableColumnProvider;
 import org.eclipse.fordiac.ide.ui.widget.NatTableWidgetFactory;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.layout.GridDataFactory;
@@ -212,8 +213,8 @@ public class InstancePropertySection extends AbstractSection {
 	protected Command createChangeCommentCommand() {
 		Command cmd = new ChangeCommentCommand(getType(), commentText.getText());
 		if (EditorUtils.getGraphicalViewerFromCurrentActiveEditor() != null && getType() instanceof SubApp) {
-			final Object editPart = EditorUtils.getGraphicalViewerFromCurrentActiveEditor().getEditPartRegistry()
-					.get(getType());
+			final EditPart editPart = EditorUtils.getGraphicalViewerFromCurrentActiveEditor()
+					.getEditPartForModel(getType());
 			if (editPart instanceof final SubAppForFBNetworkEditPart subAppforFBNetworkEditPart
 					&& subAppforFBNetworkEditPart.getContentEP() != null) {
 				cmd = new ResizeGroupOrSubappCommand(subAppforFBNetworkEditPart.getContentEP(), cmd);

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/StructManipulatorSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/StructManipulatorSection.java
@@ -161,8 +161,7 @@ public abstract class StructManipulatorSection extends AbstractSection implement
 			final GraphicalViewer viewer = activeEditor.getAdapter(GraphicalViewer.class);
 			if (null != viewer) {
 				viewer.flush();
-				EditorUtils.refreshPropertySheetWithSelection(activeEditor, viewer,
-						viewer.getEditPartRegistry().get(newMux));
+				EditorUtils.refreshPropertySheetWithSelection(activeEditor, viewer, viewer.getEditPartForModel(newMux));
 			}
 		});
 	}
@@ -198,15 +197,17 @@ public abstract class StructManipulatorSection extends AbstractSection implement
 		createContextMenu(memberVarViewer.getControl());
 	}
 
+	@SuppressWarnings("static-method") // allow subclasses to override
 	protected LabelProvider getLabelProvider() {
 		return new StructTreeLabelProvider();
 	}
 
+	@SuppressWarnings("static-method") // allow subclasses to override
 	protected ITreeContentProvider getContentProvider() {
 		return new StructTreeContentProvider();
 	}
 
-	private CheckboxTreeViewer createTreeViewer(final Composite parent) {
+	private static CheckboxTreeViewer createTreeViewer(final Composite parent) {
 		final CheckboxTreeViewer viewer = new CheckboxTreeViewer(parent);
 		viewer.setUseHashlookup(true);
 		return viewer;

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/tools/ColLocatedConnectionFinder.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/tools/ColLocatedConnectionFinder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Primetals Technologies Austria GmbH
+ * Copyright (c) 2021, 2024 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -29,16 +29,16 @@ final class ColLocatedConnectionFinder {
 			final EditPartViewer viewer, final Point loc) {
 		final Set<Connection> conns = getAllRelatedConnections(connEP);
 		final Point location = getRelativeLocation(connEP.getFigure(), loc);
-		return conns.stream().map(con -> (ConnectionEditPart) viewer.getEditPartRegistry().get(con))
-				.filter(Objects::nonNull).filter(ep -> ep.getFigure().findFigureAt(location) != null).toList();
+		return conns.stream().map(con -> (ConnectionEditPart) viewer.getEditPartForModel(con)).filter(Objects::nonNull)
+				.filter(ep -> ep.getFigure().findFigureAt(location) != null).toList();
 	}
 
 	public static List<ConnectionEditPart> getLeftCoLocatedConnections(final ConnectionEditPart connEP,
 			final EditPartViewer viewer, final Point loc) {
 		final Set<Connection> conns = getAllRelatedConnections(connEP);
 		final Point location = getRelativeLocation(connEP.getFigure(), loc);
-		return conns.stream().map(con -> (ConnectionEditPart) viewer.getEditPartRegistry().get(con))
-				.filter(Objects::nonNull).filter(ep -> ep.getFigure().findFigureAt(location) == null).toList();
+		return conns.stream().map(con -> (ConnectionEditPart) viewer.getEditPartForModel(con)).filter(Objects::nonNull)
+				.filter(ep -> ep.getFigure().findFigureAt(location) == null).toList();
 	}
 
 	private static Set<Connection> getAllRelatedConnections(final ConnectionEditPart connEP) {

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/utilities/GetEditPartFromGraficalViewerHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/utilities/GetEditPartFromGraficalViewerHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Primetals Technologies Austria GmbH
+ * Copyright (c) 2023, 2024 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -27,9 +27,9 @@ import org.eclipse.ui.IEditorPart;
 public final class GetEditPartFromGraficalViewerHelper {
 
 	public static AbstractContainerContentEditPart findAbstractContainerContentEditPartAtPosition(
-	        final IEditorPart editor, final Point pos, final FBNetwork fbNetwork) {
+			final IEditorPart editor, final Point pos, final FBNetwork fbNetwork) {
 		final GraphicalViewer graphicalViewer = editor.getAdapter(GraphicalViewer.class);
-		if (graphicalViewer.getEditPartRegistry().get(fbNetwork) instanceof final GraphicalEditPart graphicalEditPart) {
+		if (graphicalViewer.getEditPartForModel(fbNetwork) instanceof final GraphicalEditPart graphicalEditPart) {
 			final IFigure figure = graphicalEditPart.getFigure().findFigureAt(pos.x, pos.y);
 			if (figure != null) {
 				final Object targetObject = graphicalViewer.getVisualPartMap().get(figure);
@@ -42,21 +42,13 @@ public final class GetEditPartFromGraficalViewerHelper {
 	}
 
 	public static AbstractContainerContentEditPart findAbstractContainerContentEditFromInterfaceElement(
-	        final IInterfaceElement ie) {
-		final UntypedSubappIEAdapter adapter = ie.eAdapters()
-		        .stream()
-		        .filter(UntypedSubappIEAdapter.class::isInstance)
-		        .map(UntypedSubappIEAdapter.class::cast)
-		        .findFirst()
-		        .orElse(null);
+			final IInterfaceElement ie) {
+		final UntypedSubappIEAdapter adapter = ie.eAdapters().stream().filter(UntypedSubappIEAdapter.class::isInstance)
+				.map(UntypedSubappIEAdapter.class::cast).findFirst().orElse(null);
 		if (adapter != null && adapter.getUntypedSubAppInterfaceElementEditPart()
-		        .getParent() instanceof final SubAppForFBNetworkEditPart subappEP) {
-			return subappEP.getChildren()
-			        .stream()
-			        .filter(UnfoldedSubappContentEditPart.class::isInstance)
-			        .map(UnfoldedSubappContentEditPart.class::cast)
-			        .findFirst()
-			        .orElse(null);
+				.getParent() instanceof final SubAppForFBNetworkEditPart subappEP) {
+			return subappEP.getChildren().stream().filter(UnfoldedSubappContentEditPart.class::isInstance)
+					.map(UnfoldedSubappContentEditPart.class::cast).findFirst().orElse(null);
 		}
 		return null;
 	}

--- a/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/editparts/AbstractDebugInterfaceValueEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/editparts/AbstractDebugInterfaceValueEditPart.java
@@ -37,8 +37,7 @@ public abstract class AbstractDebugInterfaceValueEditPart extends AbstractGraphi
 	@Override
 	public void activate() {
 		super.activate();
-		final Object part = getViewer().getEditPartRegistry().get(getInterfaceElement());
-		if (part instanceof final InterfaceEditPart iep) {
+		if (getViewer().getEditPartForModel(getInterfaceElement()) instanceof final InterfaceEditPart iep) {
 			referencedInterface = iep;
 			referencedInterface.getFigure().addAncestorListener(new AncestorListener() {
 

--- a/plugins/org.eclipse.fordiac.ide.elk/src/org/eclipse/fordiac/ide/elk/helpers/FordiacGraphBuilder.java
+++ b/plugins/org.eclipse.fordiac.ide.elk/src/org/eclipse/fordiac/ide/elk/helpers/FordiacGraphBuilder.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
- * Copyright (c) 2020 Johannes Kepler University Linz
- * 				 2020 Primetals Technologies Germany GmbH
- * 				 2021, 2022 Primetals Technologies Austria GmbH
+ * Copyright (c) 2020, 2024 Johannes Kepler University Linz,
+ * 							Primetals Technologies Germany GmbH,
+ * 							Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -94,8 +94,7 @@ public final class FordiacGraphBuilder {
 	}
 
 	private static void processValue(final FordiacLayoutMapping mapping, final ValueEditPart valueEditPart) {
-		final Object iePart = valueEditPart.getViewer().getEditPartRegistry()
-				.get(valueEditPart.getModel().getParentIE());
+		final EditPart iePart = valueEditPart.getViewer().getEditPartForModel(valueEditPart.getModel().getParentIE());
 		final Point point = ((InterfaceEditPart) iePart).getFigure().getBounds().getTopLeft();
 		final ElkPort port = getPort(point, (InterfaceEditPart) iePart, mapping);
 		final ElkLabel label = ElkGraphUtil.createLabel(valueEditPart.getModel().getValue(), port);

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/commands/CreateTransitionCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/commands/CreateTransitionCommand.java
@@ -168,9 +168,9 @@ public class CreateTransitionCommand extends CreationCommand {
 			transition.setConditionExpression("1"); //$NON-NLS-1$
 		}
 		if (null != viewer) {
-			final Object obj = viewer.getEditPartRegistry().get(transition);
-			if (null != obj) {
-				viewer.select((EditPart) obj);
+			final EditPart ep = viewer.getEditPartForModel(transition);
+			if (ep != null) {
+				viewer.select(ep);
 			}
 		}
 	}

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editors/ECCEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editors/ECCEditor.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008 - 2018 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
- * 				 2018 - 2019 Johannes Kepler University Linz
+ * Copyright (c) 2008, 2024 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
+ * 				            Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -229,8 +229,7 @@ public class ECCEditor extends DiagramEditorWithFlyoutPalette implements IFBTEdi
 
 	@Override
 	public boolean outlineSelectionChanged(final Object selectedElement) {
-		final Object obj = getGraphicalViewer().getEditPartRegistry().get(selectedElement);
-		if (obj instanceof final EditPart ep) {
+		if (getGraphicalViewer().getEditPartForModel(selectedElement) instanceof final EditPart ep) {
 			getGraphicalViewer().select(ep);
 			return true;
 		}
@@ -246,11 +245,11 @@ public class ECCEditor extends DiagramEditorWithFlyoutPalette implements IFBTEdi
 	}
 
 	private void handleActionOutlineSelection(final ECAction action) {
-		Object obj = getGraphicalViewer().getEditPartRegistry().get(action.getECState());
+		Object obj = getGraphicalViewer().getEditPartForModel(action.getECState());
 		if (null != obj) {
 			for (final Object element : ((ECStateEditPart) obj).getCurrentChildren()) {
 				if ((element instanceof final ECActionAlgorithm ecAlg) && (action.equals(ecAlg.getAction()))) {
-					obj = getGraphicalViewer().getEditPartRegistry().get(element);
+					obj = getGraphicalViewer().getEditPartForModel(element);
 					if (null != obj) {
 						getGraphicalViewer().select((EditPart) obj);
 						break;
@@ -323,14 +322,14 @@ public class ECCEditor extends DiagramEditorWithFlyoutPalette implements IFBTEdi
 
 	@Override
 	public void gotoMarker(final IMarker marker) {
-		final Map<?, ?> map = getGraphicalViewer().getEditPartRegistry();
+		final Map<Object, EditPart> map = getGraphicalViewer().getEditPartRegistry();
 		final String lineNumber = marker.getAttribute(IMarker.LINE_NUMBER, UNKNOWN_LINE);
 		if (!UNKNOWN_LINE.equals(lineNumber)) {
 			final int hashCode = Integer.parseInt(lineNumber);
 			for (final Object key : map.keySet()) {
 				if (key.hashCode() == hashCode) {
-					final Object obj = getGraphicalViewer().getEditPartRegistry().get(key);
-					if (obj instanceof final EditPart ep) {
+					final EditPart ep = getGraphicalViewer().getEditPartForModel(key);
+					if (ep != null) {
 						getGraphicalViewer().select(ep);
 						break;
 					}
@@ -360,7 +359,7 @@ public class ECCEditor extends DiagramEditorWithFlyoutPalette implements IFBTEdi
 		if (getGraphicalViewer() == null) {
 			return null;
 		}
-		return getGraphicalViewer().getEditPartRegistry().get(getModel());
+		return getGraphicalViewer().getEditPartForModel(getModel());
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.network/src/org/eclipse/fordiac/ide/fbtypeeditor/network/CompositeNetworkEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.network/src/org/eclipse/fordiac/ide/fbtypeeditor/network/CompositeNetworkEditor.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2009, 2011 - 2017 Profactor GmbH, TU Wien ACIN, fortiss GmbH
- *               2023 Martin Erich Jobst
+ * Copyright (c) 2008, 2024 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
+ *                          Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,7 +15,7 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.fbtypeeditor.network;
 
-import java.util.Map;
+import java.util.Map.Entry;
 
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -114,20 +114,13 @@ public class CompositeNetworkEditor extends FBNetworkEditor implements IFBTEdito
 		return (selectedElement instanceof FBNetwork);
 	}
 
-	EditPart getEditPartForSelection(Object selectedElement) {
-		final Map<?, ?> map = getGraphicalViewer().getEditPartRegistry();
+	EditPart getEditPartForSelection(final Object selectedElement) {
 
-		for (final Object key : map.keySet()) {
-			if (((key instanceof FB) && (((FB) key) == selectedElement)) || //
-					((key instanceof Connection) && (((Connection) key) == selectedElement))) {
-				selectedElement = key;
-				break;
+		for (final Entry<Object, EditPart> entry : getGraphicalViewer().getEditPartRegistry().entrySet()) {
+			if (((entry.getKey() instanceof final FB fb) && (fb == selectedElement)) || //
+					((entry.getKey() instanceof final Connection con) && (con == selectedElement))) {
+				return entry.getValue();
 			}
-		}
-
-		final Object obj = getGraphicalViewer().getEditPartRegistry().get(selectedElement);
-		if (obj instanceof EditPart) {
-			return (EditPart) obj;
 		}
 		return null;
 	}
@@ -144,13 +137,12 @@ public class CompositeNetworkEditor extends FBNetworkEditor implements IFBTEdito
 
 	@Override
 	protected void setModel(final IEditorInput input) {
-		if (input instanceof final FBTypeEditorInput untypedInput) {
-			if (untypedInput.getContent() instanceof CompositeFBType) {
-				fbType = (CompositeFBType) untypedInput.getContent();
-				setModel(fbType.getFBNetwork());
-				getModel().eAdapters().add(adapter);
-				configurePalette(untypedInput);
-			}
+		if ((input instanceof final FBTypeEditorInput untypedInput)
+				&& (untypedInput.getContent() instanceof final CompositeFBType cfbTye)) {
+			fbType = cfbTye;
+			setModel(fbType.getFBNetwork());
+			getModel().eAdapters().add(adapter);
+			configurePalette(untypedInput);
 		}
 
 		setTitleImage(FordiacImage.ICON_FB_NETWORK.getImage());
@@ -220,9 +212,9 @@ public class CompositeNetworkEditor extends FBNetworkEditor implements IFBTEdito
 
 	@Override
 	public void reloadType(final FBType type) {
-		if (type instanceof CompositeFBType) {
+		if (type instanceof final CompositeFBType cfbTye) {
 			getModel().eAdapters().remove(adapter);
-			fbType = ((CompositeFBType) type);
+			fbType = cfbTye;
 			setModel(fbType.getFBNetwork());
 			if (getModel() != null) {
 				getModel().eAdapters().add(adapter);

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/ServiceSequenceEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/ServiceSequenceEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 - 2017 Profactor GmbH, TU Wien ACIN, AIT, fortiss GmbH.
+ * Copyright (c) 2008, 2024 Profactor GmbH, TU Wien ACIN, AIT, fortiss GmbH.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,10 +12,8 @@
  *     - initial API and implementation and/or initial documentation
  *   Bianca Wiesmayr, Melanie Winter
  *     - change canvas, fix problem with size calculation when dragging elements
- *   Felix Roithmayr
- *     - added support for new commands and context menu items
- *   Fabio Gandolfi
- *     - added Listener to load Service Sequences on tabswitch
+ *   Felix Roithmayr - added support for new commands and context menu items
+ *   Fabio Gandolfi  - added Listener to load Service Sequences on tabswitch
  *******************************************************************************/
 package org.eclipse.fordiac.ide.fbtypeeditor.servicesequence;
 
@@ -160,7 +158,7 @@ public class ServiceSequenceEditor extends DiagramEditorWithFlyoutPalette implem
 	@Override
 	public boolean outlineSelectionChanged(final Object selectedElement) {
 		if (null != selectedElement) {
-			final Object editpart = getGraphicalViewer().getEditPartRegistry().get(selectedElement);
+			final Object editpart = getGraphicalViewer().getEditPartForModel(selectedElement);
 			getGraphicalViewer().flush();
 			if (editpart instanceof final EditPart ep && ep.isSelectable()) {
 				getGraphicalViewer().select(ep);

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/editparts/OutputPrimitiveEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/editparts/OutputPrimitiveEditPart.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2009, 2011 - 2015 Profactor GmbH, fortiss GmbH
- *               2021 Johannes Kepler University Linz
+ * Copyright (c) 2008, 2024 Profactor GmbH, fortiss GmbH,
+ *                          Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -65,8 +65,8 @@ public class OutputPrimitiveEditPart extends AbstractPrimitiveEditPart {
 		}
 
 		final List<Object> conns = new ArrayList<>();
-		if (getModel().getServiceTransaction().getOutputPrimitive().indexOf(getModel()) < (getModel()
-				.getServiceTransaction().getOutputPrimitive().size() - 1)) {
+		if (getModel().getServiceTransaction().getOutputPrimitive()
+				.indexOf(getModel()) < (getModel().getServiceTransaction().getOutputPrimitive().size() - 1)) {
 			conns.add(getConnectingConnection());
 		}
 		conns.add(getPrimitiveConnection());
@@ -84,7 +84,7 @@ public class OutputPrimitiveEditPart extends AbstractPrimitiveEditPart {
 		final int currentIndex = getModel().getServiceTransaction().getOutputPrimitive().indexOf(getModel());
 		if (currentIndex == 0) { // First output primitive: connection from input primitive
 			final InputPrimitive iP = getModel().getServiceTransaction().getInputPrimitive();
-			final InputPrimitiveEditPart part = (InputPrimitiveEditPart) getViewer().getEditPartRegistry().get(iP);
+			final InputPrimitiveEditPart part = (InputPrimitiveEditPart) getViewer().getEditPartForModel(iP);
 			if (part != null && !part.getModelSourceConnections().isEmpty()) {
 				conns.add(part.getModelSourceConnections().get(0));
 			}
@@ -93,7 +93,7 @@ public class OutputPrimitiveEditPart extends AbstractPrimitiveEditPart {
 		// return previous output primitive
 
 		final OutputPrimitive oP = getModel().getServiceTransaction().getOutputPrimitive().get(currentIndex - 1);
-		final OutputPrimitiveEditPart part = (OutputPrimitiveEditPart) getViewer().getEditPartRegistry().get(oP);
+		final OutputPrimitiveEditPart part = (OutputPrimitiveEditPart) getViewer().getEditPartForModel(oP);
 		conns.add(part.getModelSourceConnections().get(0));
 
 		return conns;

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/handler/ExpandServiceSequenceHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/handler/ExpandServiceSequenceHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Johannes Kepler University Linz
+ * Copyright (c) 2021, 2024 Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -34,12 +34,11 @@ public class ExpandServiceSequenceHandler extends AbstractHandler {
 		final IStructuredSelection selection = (IStructuredSelection) HandlerUtil.getCurrentSelection(event);
 
 		for (final Object selected : selection.toList()) {
-			if (selected instanceof ServiceSequenceEditPart) {
-				final ServiceSequenceEditPart ep = (ServiceSequenceEditPart) selected;
+			if (selected instanceof final ServiceSequenceEditPart ep) {
 				ep.toggleExpanded();
 			} else if (selected instanceof ServiceSequence) {
 				final GraphicalViewer viewer = editor.getAdapter(GraphicalViewer.class);
-				final ServiceSequenceEditPart ep = (ServiceSequenceEditPart) viewer.getEditPartRegistry().get(selected);
+				final ServiceSequenceEditPart ep = (ServiceSequenceEditPart) viewer.getEditPartForModel(selected);
 				ep.toggleExpanded();
 			}
 		}

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editors/FBInterfaceEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editors/FBInterfaceEditor.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2011 - 2017 Profactor GmbH, TU Wien ACIN, fortiss GmbH
- * 				 2019 Johannes Kepler University
+ * Copyright (c) 2011 - 2024 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
+ * 				             Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -132,9 +132,9 @@ public class FBInterfaceEditor extends DiagramEditorWithFlyoutPalette implements
 
 	@Override
 	public boolean outlineSelectionChanged(final Object selectedElement) {
-		final Object editpart = getGraphicalViewer().getEditPartRegistry().get(selectedElement);
+		final EditPart ep = getGraphicalViewer().getEditPartForModel(selectedElement);
 		getGraphicalViewer().flush();
-		if (editpart instanceof final EditPart ep && ep.isSelectable()) {
+		if (ep != null && ep.isSelectable()) {
 			getGraphicalViewer().select(ep);
 			return true;
 		}
@@ -259,7 +259,7 @@ public class FBInterfaceEditor extends DiagramEditorWithFlyoutPalette implements
 		if (getGraphicalViewer() == null) {
 			return null;
 		}
-		return getGraphicalViewer().getEditPartRegistry().get(fbType);
+		return getGraphicalViewer().getEditPartForModel(fbType);
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editparts/CommentTypeEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editparts/CommentTypeEditPart.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2011 - 2017 Profactor GmbH, fortiss GmbH
- * 				 2019 - 2020 Johannes Kepler University
+ * Copyright (c) 2011, 2024 Profactor GmbH, fortiss GmbH,
+ *                          Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -10,9 +10,10 @@
  *
  * Contributors:
  *   Gerhard Ebenhofer, Alois Zoitl
- *     - initial API and implementation and/or initial documentation
+ *               - initial API and implementation and/or initial documentation
  *   Alois Zoitl - Moved position calculation to the comment type edit part
- *   Virendra Ashiwal - Regulate Space at both side of FB (between FB and its interfaces) based on number of WITH connections
+ *   Virendra Ashiwal - Regulate Space at both side of FB (between FB and its
+ *                      interfaces) based on number of WITH connections
  *******************************************************************************/
 package org.eclipse.fordiac.ide.fbtypeeditor.editparts;
 
@@ -78,8 +79,7 @@ class CommentTypeEditPart extends AbstractGraphicalEditPart implements Annotable
 	}
 
 	public void setupReferencedEP() {
-		final Object part = getViewer().getEditPartRegistry().get(getInterfaceElement());
-		if (part instanceof final InterfaceEditPart iep) {
+		if (getViewer().getEditPartForModel(getInterfaceElement()) instanceof final InterfaceEditPart iep) {
 			referencedInterface = iep;
 			referencedInterface.getFigure().addAncestorListener(new AncestorListener() {
 

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/annotation/GraphicalViewerAnnotationModelEventDispatcher.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/annotation/GraphicalViewerAnnotationModelEventDispatcher.java
@@ -46,11 +46,9 @@ public class GraphicalViewerAnnotationModelEventDispatcher implements GraphicalA
 	}
 
 	protected AnnotableGraphicalEditPart findEditPart(final Object target) {
-		if (target != null) {
-			final Object object = viewer.getEditPartRegistry().get(target);
-			if (object instanceof final AnnotableGraphicalEditPart editPart) {
-				return editPart;
-			}
+		if ((target != null)
+				&& (viewer.getEditPartForModel(target) instanceof final AnnotableGraphicalEditPart editPart)) {
+			return editPart;
 		}
 		return null;
 	}

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/InterfaceEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/InterfaceEditPart.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 Profactor GbmH, TU Wien ACIN, fortiss GmbH,
- *                          Johannes Kepler University,
+ * Copyright (c) 2008, 2024 Profactor GbmH, TU Wien ACIN, fortiss GmbH,
+ *                          Johannes Kepler University Linz,
  *                          Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
@@ -519,11 +519,8 @@ public abstract class InterfaceEditPart extends AbstractConnectableEditPart
 
 	public ValueEditPart getReferencedValueEditPart() {
 		final Value value = getValue();
-		if (value != null) {
-			final Object temp = getViewer().getEditPartRegistry().get(value);
-			if (temp instanceof final ValueEditPart vep) {
-				return vep;
-			}
+		if ((value != null) && (getViewer().getEditPartForModel(value) instanceof final ValueEditPart vep)) {
+			return vep;
 		}
 		return null;
 	}

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/ValueEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/ValueEditPart.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2009, 2012, 2014 - 2017 Profactor GbmH, fortiss GmbH
- * 				 2019 Johannes Kepler University Linz
+ * Copyright (c) 2008, 2024 Profactor GbmH, fortiss GmbH,
+ *                          Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -93,8 +93,7 @@ public class ValueEditPart extends AbstractGraphicalEditPart implements NodeEdit
 		getModel().eAdapters().add(contentAdapter);
 		// also add the adapter to parent to refresh the init value after type change
 		getModel().getParentIE().eAdapters().add(contentAdapter);
-		final Object part = getViewer().getEditPartRegistry().get(getModel().getParentIE());
-		if (part instanceof final InterfaceEditPart iep) {
+		if (getViewer().getEditPartForModel(getModel().getParentIE()) instanceof final InterfaceEditPart iep) {
 			parentPart = iep;
 			final IFigure parentFigure = parentPart.getFigure();
 			parentFigure.addAncestorListener(new AncestorListener() {

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/print/PrintPreview.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/print/PrintPreview.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Profactor GbmH, Johannes Kepler University
+ * Copyright (c) 2019, 2024 Profactor GbmH, Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -97,7 +97,7 @@ public class PrintPreview extends Dialog {
 	public PrintPreview(final Shell shell, final GraphicalViewer viewer, final String printName) {
 		super(shell);
 		this.printName = printName;
-		final LayerManager lm = (LayerManager) viewer.getEditPartRegistry().get(LayerManager.ID);
+		final LayerManager lm = (LayerManager) viewer.getEditPartForModel(LayerManager.ID);
 		figure = lm.getLayer(LayerConstants.PRINTABLE_LAYERS);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/HandlerHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/HandlerHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Primetals Technologies Austria GmbH
+ * Copyright (c) 2021, 2024 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -65,8 +65,8 @@ public final class HandlerHelper {
 
 	public static boolean selectElement(final Object element, final GraphicalViewer viewer) {
 		if (viewer != null) {
-			final EditPart editPart = viewer.getEditPartRegistry().get(element);
-			if (null != editPart) {
+			final EditPart editPart = viewer.getEditPartForModel(element);
+			if (editPart != null) {
 				selectEditPart(viewer, editPart);
 				return true;
 			}
@@ -123,15 +123,12 @@ public final class HandlerHelper {
 			// move canvas to show the top-left corner of an expanded subapp
 			final GraphicalViewer viewer = HandlerHelper.getViewer(editor);
 			if (null != viewer) {
-				final EditPart subappEP = viewer.getEditPartRegistry().get(subapp);
-				if (subappEP != null) {
-					final EditPart root = subappEP.getRoot();
-					if (root instanceof final ScalableFreeformRootEditPart gep
-							&& gep.getFigure() instanceof final FreeformViewport viewp) {
-						final Point pos = ((PositionableElement) subapp).getPosition().toScreenPoint();
-						viewp.setHorizontalLocation((int) (pos.x * gep.getZoomManager().getZoom()));
-						viewp.setVerticalLocation((int) (pos.y * gep.getZoomManager().getZoom()));
-					}
+				final EditPart subappEP = viewer.getEditPartForModel(subapp);
+				if ((subappEP != null) && (subappEP.getRoot() instanceof final ScalableFreeformRootEditPart gep
+						&& gep.getFigure() instanceof final FreeformViewport viewp)) {
+					final Point pos = ((PositionableElement) subapp).getPosition().toScreenPoint();
+					viewp.setHorizontalLocation((int) (pos.x * gep.getZoomManager().getZoom()));
+					viewp.setVerticalLocation((int) (pos.y * gep.getZoomManager().getZoom()));
 				}
 			}
 		});

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/FBNetworkHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/FBNetworkHelper.java
@@ -256,8 +256,8 @@ public final class FBNetworkHelper {
 				.getActivePart();
 		final GraphicalViewer viewer = part.getAdapter(GraphicalViewer.class);
 		if (viewer != null) {
-			final List<EditPart> eps = elements.stream().map(el -> viewer.getEditPartRegistry().get(el))
-					.filter(Objects::nonNull).toList();
+			final List<EditPart> eps = elements.stream().map(viewer::getEditPartForModel).filter(Objects::nonNull)
+					.toList();
 			if (eps != null) {
 				viewer.setSelection(new StructuredSelection(eps));
 			}

--- a/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/editparts/AbstractMonitoringBaseEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/editparts/AbstractMonitoringBaseEditPart.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
- * Copyright (c) 2012 - 2018 Profactor GmbH, fortiss GmbH, Johannes Kepler
- * 							 University
- * Copyright (c) 2021 Primetals Technologies Austria GmbH
+ * Copyright (c) 2012, 2024 Profactor GmbH, fortiss GmbH,
+ *                          Johannes Kepler University Linz,
+ *                          Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -69,15 +69,13 @@ public abstract class AbstractMonitoringBaseEditPart extends AbstractViewEditPar
 		final AbstractMonitoringBaseEditPart host;
 
 		public DeleteInterfaceAdapter(final AbstractMonitoringBaseEditPart host) {
-			super();
 			this.host = host;
 		}
 
 		@Override
 		public void notifyChanged(final Notification notification) {
 			switch (notification.getEventType()) {
-			case Notification.REMOVE:
-			case Notification.REMOVE_MANY:
+			case Notification.REMOVE, Notification.REMOVE_MANY:
 				if (isElementOrParentDeleted(notification.getOldValue())) {
 					deleteMonitoringElement();
 				}
@@ -103,7 +101,7 @@ public abstract class AbstractMonitoringBaseEditPart extends AbstractViewEditPar
 			}
 
 			if (deletedElement.equals(host.getInterfaceElement())) {
-				//our interface element was deleted
+				// our interface element was deleted
 				return true;
 			}
 
@@ -112,12 +110,12 @@ public abstract class AbstractMonitoringBaseEditPart extends AbstractViewEditPar
 					return true;
 				}
 
-				if (deletedElement instanceof SubApp) {
-					return host.getFBNetworks().contains(((SubApp) deletedElement).getSubAppNetwork());
+				if (deletedElement instanceof final SubApp subApp) {
+					return host.getFBNetworks().contains(subApp.getSubAppNetwork());
 				}
 
-				if (deletedElement instanceof Group) {
-					return isParentGroupDeleted((Group) deletedElement);
+				if (deletedElement instanceof final Group group) {
+					return isParentGroupDeleted(group);
 				}
 			}
 			return false;
@@ -129,13 +127,12 @@ public abstract class AbstractMonitoringBaseEditPart extends AbstractViewEditPar
 				if (element.equals(parent)) {
 					return true;
 				}
-				if (element instanceof SubApp) {
-					return host.getFBNetworks().contains(((SubApp) element).getSubAppNetwork());
+				if (element instanceof final SubApp subApp) {
+					return host.getFBNetworks().contains(subApp.getSubAppNetwork());
 				}
 			}
 			return false;
 		}
-
 
 	}
 
@@ -160,12 +157,11 @@ public abstract class AbstractMonitoringBaseEditPart extends AbstractViewEditPar
 	public void activate() {
 		super.activate();
 		for (final Object object : getViewer().getEditPartRegistry().keySet()) {
-			if (object instanceof IInterfaceElement) {
-				final IInterfaceElement interfaceElement = (IInterfaceElement) object;
+			if (object instanceof final IInterfaceElement interfaceElement) {
 				if (interfaceElement.equals(getInterfaceElement())) {
-					final EditPart part = (EditPart) getViewer().getEditPartRegistry().get(object);
-					if (part instanceof InterfaceEditPart) {
-						parentPart = (InterfaceEditPart) part;
+					final EditPart part = getViewer().getEditPartForModel(object);
+					if (part instanceof final InterfaceEditPart iep) {
+						parentPart = iep;
 						final IFigure f = parentPart.getFigure();
 						f.addAncestorListener(new AncestorListener() {
 
@@ -185,10 +181,9 @@ public abstract class AbstractMonitoringBaseEditPart extends AbstractViewEditPar
 							}
 						});
 					}
-				} else if (interfaceElement instanceof AdapterDeclaration) {
+				} else if (interfaceElement instanceof final AdapterDeclaration adp) {
 					IInterfaceElement subInterfaceElement = null;
-					final InterfaceList interfaceList = ((AdapterDeclaration) interfaceElement).getType()
-							.getInterfaceList();
+					final InterfaceList interfaceList = adp.getType().getInterfaceList();
 					final List<IInterfaceElement> list = new ArrayList<>();
 					list.addAll(interfaceList.getEventInputs());
 					list.addAll(interfaceList.getEventOutputs());
@@ -205,27 +200,24 @@ public abstract class AbstractMonitoringBaseEditPart extends AbstractViewEditPar
 					if (subInterfaceElement != null) {
 						Object subObject = null;
 						for (final Object obj : getViewer().getEditPartRegistry().values()) {
-							if (obj instanceof MonitoringAdapterEditPart) {
-								final MonitoringAdapterEditPart part = (MonitoringAdapterEditPart) obj;
-								if (part.getModel().getPort().getInterfaceElement() == interfaceElement) {
-									for (final Object subView : part.getModelChildren()) {
-										if (((IInterfaceElement) subView).getName()
-												.equals(subInterfaceElement.getName())) {
-											subObject = subView;
-											break;
-										}
-									}
-									if (subObject != null) {
+							if ((obj instanceof final MonitoringAdapterEditPart part)
+									&& (part.getModel().getPort().getInterfaceElement() == interfaceElement)) {
+								for (final Object subView : part.getModelChildren()) {
+									if (((IInterfaceElement) subView).getName().equals(subInterfaceElement.getName())) {
+										subObject = subView;
 										break;
 									}
+								}
+								if (subObject != null) {
+									break;
 								}
 							}
 						}
 
 						if (subObject != null) {
-							final EditPart part = (EditPart) getViewer().getEditPartRegistry().get(subObject);
-							if (part instanceof InterfaceEditPart) {
-								parentPart = (InterfaceEditPart) part;
+							final EditPart part = getViewer().getEditPartRegistry().get(subObject);
+							if (part instanceof final InterfaceEditPart iep) {
+								parentPart = iep;
 								final IFigure f = parentPart.getFigure();
 								f.addAncestorListener(new AncestorListener() {
 
@@ -326,7 +318,8 @@ public abstract class AbstractMonitoringBaseEditPart extends AbstractViewEditPar
 	@Override
 	public void removeNotify() {
 		if (isGrandParentDeletion()) {
-			// if a grandparent is removed or a subapp collapsed our figure is not removed as it is in a specific layer.
+			// if a grandparent is removed or a subapp collapsed our figure is not removed
+			// as it is in a specific layer.
 			// Therefore we have to do it here separatly.
 			final IFigure layerFig = getLayer(getSpecificLayer());
 			if (layerFig != null && layerFig.equals(getFigure().getParent())) {
@@ -338,7 +331,8 @@ public abstract class AbstractMonitoringBaseEditPart extends AbstractViewEditPar
 	}
 
 	private boolean isGrandParentDeletion() {
-		// if the interface element has a fbnetworkelement and this fbnetworkelement a network a grandparent was deleted
+		// if the interface element has a fbnetworkelement and this fbnetworkelement a
+		// network a grandparent was deleted
 		// or an expanded subapp folded
 		return (getInterfaceElement().getFBNetworkElement() != null
 				&& getInterfaceElement().getFBNetworkElement().getFbNetwork() != null);
@@ -382,7 +376,6 @@ public abstract class AbstractMonitoringBaseEditPart extends AbstractViewEditPar
 	private int getHeight() {
 		return FigureUtilities.getFontMetrics(JFaceResources.getFontRegistry().get(DIAGRAM_FONT)).getHeight();
 	}
-
 
 	protected void setBackgroundColor(final IFigure l) {
 		l.setBackgroundColor(PreferenceGetter.getColor(Activator.getDefault().getPreferenceStore(),

--- a/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/editparts/MonitoringEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/editparts/MonitoringEditPart.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2021 Profactor GmbH, fortiss GmbH,
- *                          Primetals Technologies Austria GmbH
- *               2022 		Primetals Technologies Austria GmbH
- *               2023 Martin Erich Jobst
+ * Copyright (c) 2012, 2024 Profactor GmbH, fortiss GmbH,
+ *                          Primetals Technologies Austria GmbH,
+ *                		    Primetals Technologies Austria GmbH,
+ *                          Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -133,13 +133,9 @@ public class MonitoringEditPart extends AbstractMonitoringBaseEditPart {
 	private void showPinValues(final boolean show) {
 		if (getModel().getCurrentValue() != null && !"".equals(getModel().getCurrentValue())) { //$NON-NLS-1$
 			final IInterfaceElement ie = getInterfaceElement();
-			if (ie instanceof final VarDeclaration varDec) {
-				if (null != getViewer()) {
-					final Object obj = getViewer().getEditPartRegistry().get(varDec.getValue());
-					if (obj instanceof final ValueEditPart valueEP) {
-						valueEP.setVisible(show);
-					}
-				}
+			if ((ie instanceof final VarDeclaration varDec) && (null != getViewer())
+					&& getViewer().getEditPartForModel(varDec.getValue()) instanceof final ValueEditPart valueEP) {
+				valueEP.setVisible(show);
 			}
 		}
 	}
@@ -242,11 +238,11 @@ public class MonitoringEditPart extends AbstractMonitoringBaseEditPart {
 	@Override
 	public DirectEditManager createDirectEditManager() {
 		final IInterfaceElement interfaceElement = getInterfaceElement();
-		if (interfaceElement instanceof VarDeclaration) {
+		if (interfaceElement instanceof final VarDeclaration varDecl) {
 			return new MonitoringValueDirectEditManager(this,
 					isStruct() ? new StructFigureCellEditorLocator(getFigure())
 							: new FigureCellEditorLocator(getFigure()),
-					(VarDeclaration) interfaceElement, getModel());
+					varDecl, getModel());
 		}
 		return super.createDirectEditManager();
 	}

--- a/plugins/org.eclipse.fordiac.ide.resourceediting/src/org/eclipse/fordiac/ide/resourceediting/editparts/InterfaceEditPartForResourceFBs.java
+++ b/plugins/org.eclipse.fordiac.ide.resourceediting/src/org/eclipse/fordiac/ide/resourceediting/editparts/InterfaceEditPartForResourceFBs.java
@@ -52,11 +52,9 @@ public class InterfaceEditPartForResourceFBs extends InterfaceEditPartForFBNetwo
 		if (parent != null) {
 			final FBNetworkContainerEditPart fbcep = (FBNetworkContainerEditPart) parent;
 			final VirtualIO referencedElement = fbcep.getVirtualIOElement(getModel());
-			if (referencedElement != null) {
-				final Object o = getViewer().getEditPartRegistry().get(referencedElement);
-				if (o instanceof VirtualInOutputEditPart) {
-					((VirtualInOutputEditPart) o).updatePos(this);
-				}
+			if ((referencedElement != null) && (getViewer()
+					.getEditPartForModel(referencedElement) instanceof final VirtualInOutputEditPart virtIOEP)) {
+				virtIOEP.updatePos(this);
 			}
 		}
 	}

--- a/plugins/org.eclipse.fordiac.ide.resourceediting/src/org/eclipse/fordiac/ide/resourceediting/editparts/UntypedSubAppInterfaceElementEditPartForResource.java
+++ b/plugins/org.eclipse.fordiac.ide.resourceediting/src/org/eclipse/fordiac/ide/resourceediting/editparts/UntypedSubAppInterfaceElementEditPartForResource.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008 - 2018 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
- * 							 Johannes Kepler University
+ * Copyright (c) 2008, 2024 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
+ * 							Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -53,11 +53,9 @@ public class UntypedSubAppInterfaceElementEditPartForResource extends UntypedSub
 		if (parent != null) {
 			final FBNetworkContainerEditPart fbcep = (FBNetworkContainerEditPart) parent;
 			final VirtualIO referencedElement = fbcep.getVirtualIOElement(getModel());
-			if (referencedElement != null) {
-				final Object o = getViewer().getEditPartRegistry().get(referencedElement);
-				if (o instanceof VirtualInOutputEditPart) {
-					((VirtualInOutputEditPart) o).updatePos(this);
-				}
+			if ((referencedElement != null) && (getViewer()
+					.getEditPartForModel(referencedElement) instanceof final VirtualInOutputEditPart virtIOEP)) {
+				virtIOEP.updatePos(this);
 			}
 		}
 	}

--- a/plugins/org.eclipse.fordiac.ide.resourceediting/src/org/eclipse/fordiac/ide/resourceediting/editparts/VirtualInOutputEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.resourceediting/src/org/eclipse/fordiac/ide/resourceediting/editparts/VirtualInOutputEditPart.java
@@ -1,8 +1,7 @@
 /*******************************************************************************
- * Copyright (c) 2008 - 2016 Profactor GmbH, fortiss GmbH
- * 						2017 fortiss GmbH
- * 						2019 Johannes Kepler University
- * 				 		2020 Primetals Technologies Germany GmbH
+ * Copyright (c) 2008, 2024 Profactor GmbH, fortiss GmbH,
+ *                          Johannes Kepler University Linz,
+ * 				 			Primetals Technologies Germany GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -97,14 +96,13 @@ public class VirtualInOutputEditPart extends AbstractViewEditPart implements Nod
 	private void updatePos() {
 		if (getParent() instanceof FBNetworkContainerEditPart) {
 			final IInterfaceElement element = getIInterfaceElement();
-			final Object o = getViewer().getEditPartRegistry().get(element);
-			if (o instanceof InterfaceEditPartForResourceFBs) {
-				updatePos((InterfaceEditPartForResourceFBs) o);
+			if (getViewer().getEditPartForModel(element) instanceof final InterfaceEditPartForResourceFBs ieEP) {
+				updatePos(ieEP);
 			}
 		}
 	}
 
-	void updatePos(InterfaceEditPartForFBNetwork referencedEditPart) {
+	void updatePos(final InterfaceEditPartForFBNetwork referencedEditPart) {
 		final String label = ((Label) getFigure()).getText();
 
 		final Rectangle bounds = referencedEditPart.getFigure().getBounds();
@@ -155,7 +153,7 @@ public class VirtualInOutputEditPart extends AbstractViewEditPart implements Nod
 	 * .gef.Request)
 	 */
 	@Override
-	public boolean understandsRequest(Request request) {
+	public boolean understandsRequest(final Request request) {
 		if (request.getType() == RequestConstants.REQ_MOVE) {
 			return false;
 		}
@@ -167,7 +165,7 @@ public class VirtualInOutputEditPart extends AbstractViewEditPart implements Nod
 	}
 
 	@Override
-	public void performRequest(Request request) {
+	public void performRequest(final Request request) {
 		if ((request.getType() == RequestConstants.REQ_DIRECT_EDIT)
 				|| (request.getType() == RequestConstants.REQ_OPEN)) {
 			return;
@@ -184,7 +182,6 @@ public class VirtualInOutputEditPart extends AbstractViewEditPart implements Nod
 		 * Instantiates a new virtual input output figure.
 		 */
 		public VirtualInputOutputFigure() {
-			super();
 			setOpaque(false);
 			if (!isInput()) {
 				setIcon(FordiacImage.ICON_LINK_OUTPUT.getImage());
@@ -217,20 +214,20 @@ public class VirtualInOutputEditPart extends AbstractViewEditPart implements Nod
 				return;
 			}
 
-			for (Connection conn : connections) {
+			for (final Connection conn : connections) {
 				FBNetworkElement oppositefbNetElement;
-				TextFlow connectionTo = new TextFlow();
-				FlowPage fp = new FlowPage();
-				Figure line = new VerticalLineCompartmentFigure();
-				IInterfaceElement oppositeIE = ConnectionsHelper.getOppositeInterfaceElement(getIInterfaceElement(),
-						conn);
+				final TextFlow connectionTo = new TextFlow();
+				final FlowPage fp = new FlowPage();
+				final Figure line = new VerticalLineCompartmentFigure();
+				final IInterfaceElement oppositeIE = ConnectionsHelper
+						.getOppositeInterfaceElement(getIInterfaceElement(), conn);
 
 				if ((oppositeIE != null) && (oppositeIE.getFBNetworkElement() != null)
 						&& (oppositeIE.getFBNetworkElement().getResource() != null)
 						&& (oppositeIE.getFBNetworkElement().getResource().getDevice() != null)) {
 					oppositefbNetElement = oppositeIE.getFBNetworkElement();
-					Resource res = oppositefbNetElement.getResource();
-					Device dev = res.getDevice();
+					final Resource res = oppositefbNetElement.getResource();
+					final Device dev = res.getDevice();
 
 					if (drawLine) {
 						add(line);
@@ -300,6 +297,6 @@ public class VirtualInOutputEditPart extends AbstractViewEditPart implements Nod
 
 	@Override
 	protected void refreshName() {
-		// we don't have a name to refresh and therfore nothing todo here
+		// we don't have a name to refresh and therefore nothing to be done here
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.resourceediting/src/org/eclipse/fordiac/ide/resourceediting/handlers/OpenConnectionOppositeResource.java
+++ b/plugins/org.eclipse.fordiac.ide.resourceediting/src/org/eclipse/fordiac/ide/resourceediting/handlers/OpenConnectionOppositeResource.java
@@ -1,6 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 fortiss GmbH
- * 				 2020 Primetals Technologies Germany GmbH
+ * Copyright (c) 2017, 2024 fortiss GmbH, Primetals Technologies Germany GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -11,14 +10,13 @@
  * Contributors:
  *   Alois Zoitl - initial implementation and/or documentation
  *   Alexander Lumplecker
- *     - extraced getOppositeInterfaceelement and getConnectionOpposite
+ *     - extracted getOppositeInterfaceelement and getConnectionOpposite
  *       to ConnectionsHelper
  *     - added getOppositeMappedIE
  *******************************************************************************/
 package org.eclipse.fordiac.ide.resourceediting.handlers;
 
 import java.util.List;
-import java.util.Map;
 
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
@@ -44,13 +42,11 @@ public class OpenConnectionOppositeResource extends AbstractHandler {
 	@Override
 	public Object execute(final ExecutionEvent event) throws ExecutionException {
 		final ISelection selection = HandlerUtil.getCurrentSelection(event);
-		if (selection instanceof IStructuredSelection) {
-			final Object first = ((IStructuredSelection) selection).getFirstElement();
-			if (first instanceof VirtualInOutputEditPart) {
-				final IInterfaceElement oppositeMappedIE = getOppositeMappedIE((VirtualInOutputEditPart) first);
-				if (null != oppositeMappedIE) {
-					openResource(oppositeMappedIE);
-				}
+		if ((selection instanceof final IStructuredSelection structSel)
+				&& (structSel.getFirstElement() instanceof final VirtualInOutputEditPart virtIOEP)) {
+			final IInterfaceElement oppositeMappedIE = getOppositeMappedIE(virtIOEP);
+			if (null != oppositeMappedIE) {
+				openResource(oppositeMappedIE);
 			}
 		}
 		return null;
@@ -67,8 +63,8 @@ public class OpenConnectionOppositeResource extends AbstractHandler {
 				obj = list.get(0);
 			}
 		}
-		if (obj instanceof VirtualInOutputEditPart) {
-			setBaseEnabled(null != getOppositeMappedIE((VirtualInOutputEditPart) obj));
+		if (obj instanceof final VirtualInOutputEditPart virtIOEP) {
+			setBaseEnabled(getOppositeMappedIE(virtIOEP) != null);
 		} else {
 			setBaseEnabled(false);
 		}
@@ -88,13 +84,12 @@ public class OpenConnectionOppositeResource extends AbstractHandler {
 
 		if (null != res) {
 			final IEditorPart editor = OpenListenerManager.openEditor(res);
-			if (editor instanceof ResourceDiagramEditor) {
-				final AdvancedScrollingGraphicalViewer viewer = ((ResourceDiagramEditor) editor).getViewer();
+			if (editor instanceof final ResourceDiagramEditor resEditor) {
+				final AdvancedScrollingGraphicalViewer viewer = resEditor.getViewer();
 				if (viewer != null) {
-					final Map<?, ?> map = viewer.getEditPartRegistry();
-					final Object ieToSelect = map.get(oppositeMappedIE);
-					if (ieToSelect instanceof EditPart) {
-						viewer.selectAndRevealEditPart((EditPart) ieToSelect);
+					final EditPart ieToSelect = viewer.getEditPartForModel(oppositeMappedIE);
+					if (ieToSelect != null) {
+						viewer.selectAndRevealEditPart(ieToSelect);
 					}
 				}
 			}

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/editors/AutomationSystemEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/editors/AutomationSystemEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Primetals Technologies Germany GmbH,
+ * Copyright (c) 2020, 2024 Primetals Technologies Germany GmbH,
  *                          Johannes Kepler University Linz,
  *                          Primetals Technologies Austria GmbH
  *
@@ -477,7 +477,7 @@ public class AutomationSystemEditor extends AbstractBreadCrumbEditor implements 
 		Object selection = null;
 		final IEditorPart activeEditor = getActiveEditor();
 		if (activeEditor instanceof final DiagramEditorWithFlyoutPalette diagramEditor) {
-			selection = viewer.getEditPartRegistry().get(diagramEditor.getModel());
+			selection = viewer.getEditPartForModel(diagramEditor.getModel());
 		}
 		if (selection == null) {
 			selection = viewer.getRootEditPart();


### PR DESCRIPTION
GEF Classic added types the EditPartRegsitry and added a new helper method for getting EditParts for models. This clean-up commit utilizes this new interfaces and cleans sonar warnings in the affected files.