### PR TITLE
Escape URL when converting to URI (LibraryImportTest)

### DIFF
--- a/tests/org.eclipse.fordiac.ide.test.library/src/org/eclipse/fordiac/ide/test/library/LibraryImportTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.library/src/org/eclipse/fordiac/ide/test/library/LibraryImportTest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
-import java.net.URL;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
@@ -75,8 +74,9 @@ class LibraryImportTest {
 
 		final Bundle bundle = Platform.getBundle("org.eclipse.fordiac.ide.test.library"); //$NON-NLS-1$
 		for (final var archive : archives) {
-			final URL url = FileLocator.toFileURL(FileLocator.find(bundle, new Path(archive)));
-			final var uri = new URI(url.toString().replace(" ", "%20")); //$NON-NLS-1$//$NON-NLS-2$
+			final var url = FileLocator.toFileURL(FileLocator.find(bundle, new Path(archive)));
+			final var uri = new URI(url.getProtocol(), url.getUserInfo(), url.getHost(), url.getPort(), url.getFile(),
+					url.getQuery(), url.getRef());
 			LibraryManager.INSTANCE.extractLibrary(Paths.get(uri), null, false, false);
 		}
 


### PR DESCRIPTION
In #418 a workaround was introduced to escape space-characters during the URL to URI conversion.
As https://docs.oracle.com/javase%2Ftutorial%2F/networking/urls/creatingUrls.html points out: this should be done using the full 7-parameter constructor of URI by passing the parts of the URL/URI to be constructed; this will also handle other special characters and makes sure that encoding only happens in the correct parts of the URI (e.g. `:` is not encoded where it is used as a port-seperator, `@` is not encoded when it seperates the user-info part,...)