### PR TITLE
Load expanded subapp for closed editors

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/AbstractBreadCrumbEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/AbstractBreadCrumbEditor.java
@@ -156,7 +156,7 @@ public abstract class AbstractBreadCrumbEditor extends AbstractCloseAbleFormEdit
 		final EObject container = getFBNetworkContainer(subapp);
 		breadcrumb.setInput(container);
 		openEditor(container);
-		Display.getCurrent().asyncExec(() -> HandlerHelper.showExpandedSubapp(subapp, getActiveEditor()));
+		HandlerHelper.showExpandedSubapp(subapp, this);
 	}
 
 	private void openEditor(final Object element) {

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/AbstractBreadCrumbEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/AbstractBreadCrumbEditor.java
@@ -154,7 +154,7 @@ public abstract class AbstractBreadCrumbEditor extends AbstractCloseAbleFormEdit
 
 	private void showAndSelectExpandedSubapp(final SubApp subapp) {
 		final EObject container = getFBNetworkContainer(subapp);
-		breadcrumb.setInput(container);
+		breadcrumb.setInput(container, (SelectionChangedEvent) null);
 		openEditor(container);
 		HandlerHelper.showExpandedSubapp(subapp, this);
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/HandlerHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/HandlerHelper.java
@@ -121,12 +121,15 @@ public final class HandlerHelper {
 		// move canvas to show the top-left corner of an expanded subapp
 		final GraphicalViewer viewer = HandlerHelper.getViewer(editor);
 		if (null != viewer) {
-			final EditPart root = viewer.getEditPartRegistry().get(subapp).getRoot();
-			if (root instanceof final ScalableFreeformRootEditPart gep
-					&& gep.getFigure() instanceof final FreeformViewport viewp) {
-				final Point pos = ((PositionableElement) subapp).getPosition().toScreenPoint();
-				viewp.setHorizontalLocation((int) (pos.x * gep.getZoomManager().getZoom()));
-				viewp.setVerticalLocation((int) (pos.y * gep.getZoomManager().getZoom()));
+			final EditPart subappEP = viewer.getEditPartRegistry().get(subapp);
+			if (subappEP != null) {
+				final EditPart root = subappEP.getRoot();
+				if (root instanceof final ScalableFreeformRootEditPart gep
+						&& gep.getFigure() instanceof final FreeformViewport viewp) {
+					final Point pos = ((PositionableElement) subapp).getPosition().toScreenPoint();
+					viewp.setHorizontalLocation((int) (pos.x * gep.getZoomManager().getZoom()));
+					viewp.setVerticalLocation((int) (pos.y * gep.getZoomManager().getZoom()));
+				}
 			}
 		}
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/HandlerHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/HandlerHelper.java
@@ -32,6 +32,7 @@ import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.gef.editparts.ScalableFreeformRootEditPart;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorPart;
 
 public final class HandlerHelper {
@@ -118,19 +119,21 @@ public final class HandlerHelper {
 	}
 
 	public static void showExpandedSubapp(final SubApp subapp, final IEditorPart editor) {
-		// move canvas to show the top-left corner of an expanded subapp
-		final GraphicalViewer viewer = HandlerHelper.getViewer(editor);
-		if (null != viewer) {
-			final EditPart subappEP = viewer.getEditPartRegistry().get(subapp);
-			if (subappEP != null) {
-				final EditPart root = subappEP.getRoot();
-				if (root instanceof final ScalableFreeformRootEditPart gep
-						&& gep.getFigure() instanceof final FreeformViewport viewp) {
-					final Point pos = ((PositionableElement) subapp).getPosition().toScreenPoint();
-					viewp.setHorizontalLocation((int) (pos.x * gep.getZoomManager().getZoom()));
-					viewp.setVerticalLocation((int) (pos.y * gep.getZoomManager().getZoom()));
+		Display.getCurrent().asyncExec(() -> {
+			// move canvas to show the top-left corner of an expanded subapp
+			final GraphicalViewer viewer = HandlerHelper.getViewer(editor);
+			if (null != viewer) {
+				final EditPart subappEP = viewer.getEditPartRegistry().get(subapp);
+				if (subappEP != null) {
+					final EditPart root = subappEP.getRoot();
+					if (root instanceof final ScalableFreeformRootEditPart gep
+							&& gep.getFigure() instanceof final FreeformViewport viewp) {
+						final Point pos = ((PositionableElement) subapp).getPosition().toScreenPoint();
+						viewp.setHorizontalLocation((int) (pos.x * gep.getZoomManager().getZoom()));
+						viewp.setVerticalLocation((int) (pos.y * gep.getZoomManager().getZoom()));
+					}
 				}
 			}
-		}
+		});
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/widgets/BreadcrumbWidget.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/widgets/BreadcrumbWidget.java
@@ -46,6 +46,7 @@ import org.eclipse.swt.widgets.ToolBar;
 
 public class BreadcrumbWidget implements ISelectionProvider {
 
+	private static final String SEPARATOR = "/"; //$NON-NLS-1$
 	private AdapterFactoryContentProvider contentProvider;
 	private AdapterFactoryLabelProvider labelProvider;
 
@@ -60,6 +61,10 @@ public class BreadcrumbWidget implements ISelectionProvider {
 	}
 
 	public void setInput(final Object input) {
+		setInput(input, new SelectionChangedEvent(this, new StructuredSelection(input)));
+	}
+
+	public void setInput(final Object input, final SelectionChangedEvent event) {
 		if (!items.isEmpty() && getActiveItem().getModel().equals(input)) {
 			return;
 		}
@@ -71,9 +76,7 @@ public class BreadcrumbWidget implements ISelectionProvider {
 			createBreadcrumbItems(input);
 			toolbar.pack();
 		}
-
-		final SelectionChangedEvent changeEvent = new SelectionChangedEvent(this, new StructuredSelection(input));
-		fireSelectionChanged(changeEvent);
+		fireSelectionChanged(event);
 	}
 
 	private void createBreadcrumbItems(final Object input) {
@@ -122,9 +125,7 @@ public class BreadcrumbWidget implements ISelectionProvider {
 	}
 
 	public String serializePath() {
-		return items.stream()
-				.map(item -> "/" + item.getText())
-				.collect(Collectors.joining());
+		return items.stream().map(item -> SEPARATOR + item.getText()).collect(Collectors.joining());
 	}
 
 	public boolean openPath(final String path, final AutomationSystem system) {
@@ -140,7 +141,7 @@ public class BreadcrumbWidget implements ISelectionProvider {
 			return false;
 		}
 
-		final String[] tokens = path.substring(1).split("/"); // remove first "/" and split
+		final String[] tokens = path.substring(1).split(SEPARATOR); // remove first "/" and split
 
 		if (tokens.length == 0) {
 			return false;
@@ -216,8 +217,8 @@ public class BreadcrumbWidget implements ISelectionProvider {
 
 	@Override
 	public void setSelection(final ISelection selection) {
-		if (!selection.isEmpty() && selection instanceof StructuredSelection) {
-			setInput(((StructuredSelection) selection).getFirstElement());
+		if (!selection.isEmpty() && selection instanceof final StructuredSelection structSel) {
+			setInput(structSel.getFirstElement());
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/widgets/BreadcrumbWidget.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/widgets/BreadcrumbWidget.java
@@ -76,7 +76,13 @@ public class BreadcrumbWidget implements ISelectionProvider {
 			createBreadcrumbItems(input);
 			toolbar.pack();
 		}
-		fireSelectionChanged(event);
+
+		// when calling setInput with null, no editor input will be provided
+		// sometimes needed when changing the content of the breadcrumb without needing
+		// an editor update
+		if (event != null) {
+			fireSelectionChanged(event);
+		}
 	}
 
 	private void createBreadcrumbItems(final Object input) {

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/widgets/GoIntoSubappSelectionEvent.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/widgets/GoIntoSubappSelectionEvent.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Bianca Wiesmayr - initial implementation and/or documentation
+ *******************************************************************************/
+
+package org.eclipse.fordiac.ide.model.ui.widgets;
+
+import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
+import org.eclipse.jface.viewers.ISelectionProvider;
+import org.eclipse.jface.viewers.SelectionChangedEvent;
+import org.eclipse.jface.viewers.StructuredSelection;
+
+public class GoIntoSubappSelectionEvent extends SelectionChangedEvent {
+
+	private final SubApp subapp;
+
+	public GoIntoSubappSelectionEvent(final ISelectionProvider source, final SubApp subapp) {
+		super(source, new StructuredSelection(subapp));
+		this.subapp = subapp;
+	}
+
+	public SubApp getSubApp() {
+		return subapp;
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/linkhelpers/SystemExplorerLinkHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/linkhelpers/SystemExplorerLinkHelper.java
@@ -126,7 +126,7 @@ public class SystemExplorerLinkHelper implements ILinkHelper {
 				breadCrumbEditor.getBreadcrumb().setInput(breadCrumbRef);
 				if (breadCrumbRef != elementToOpen || elementToOpen instanceof Device) {
 					if (elementToOpen instanceof final SubApp subapp && subapp.isUnfolded()) {
-						HandlerHelper.showExpandedSubapp(subapp, breadCrumbEditor);
+						HandlerHelper.showExpandedSubapp(subapp, editor);
 					} else {
 						HandlerHelper.selectElement(elementToOpen, editor);
 					}


### PR DESCRIPTION
Add async execution to make sure the editor is loaded before the position of the editpart of an expanded subapp is asked. 

This patch also ensures that subapp is correctly opened with go to child.