### PR TITLE
Reworked DebugView Layout

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/FBDebugView.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/FBDebugView.java
@@ -22,6 +22,7 @@ import org.eclipse.debug.ui.contexts.IDebugContextListener;
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.FigureCanvas;
 import org.eclipse.draw2d.FreeformLayeredPane;
+import org.eclipse.draw2d.FreeformLayout;
 import org.eclipse.draw2d.FreeformViewport;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
@@ -191,6 +192,9 @@ public class FBDebugView extends ViewPart implements IDebugContextListener, ISel
 			@Override
 			protected IFigure createFigure() {
 				final FreeformViewport viewPort = (FreeformViewport) super.createFigure();
+
+				getLayer(PRIMARY_LAYER).setLayoutManager(new FreeformLayout());
+
 				final GridLayer grid = (GridLayer) getLayer(GRID_LAYER);
 				if (grid != null) {
 					// it does not make sense to have a grid in the interface layer so hide it

--- a/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/FBDebugViewEditPartFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/FBDebugViewEditPartFactory.java
@@ -13,6 +13,7 @@
 package org.eclipse.fordiac.ide.debug.ui.view;
 
 import org.eclipse.fordiac.ide.debug.EvaluatorProcess;
+import org.eclipse.fordiac.ide.debug.ui.view.editparts.DebugViewWithEditPart;
 import org.eclipse.fordiac.ide.debug.ui.view.editparts.EmptyDebugViewRootEditPart;
 import org.eclipse.fordiac.ide.debug.ui.view.editparts.EventValueEditPart;
 import org.eclipse.fordiac.ide.debug.ui.view.editparts.EventValueEntity;
@@ -30,6 +31,7 @@ import org.eclipse.fordiac.ide.fbtypeeditor.editparts.SocketContainer;
 import org.eclipse.fordiac.ide.fbtypeeditor.editparts.VariableInputContainer;
 import org.eclipse.fordiac.ide.fbtypeeditor.editparts.VariableOutputContainer;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
+import org.eclipse.fordiac.ide.model.libraryElement.With;
 import org.eclipse.gef.EditPart;
 
 public class FBDebugViewEditPartFactory extends FBInterfaceEditPartFactory {
@@ -70,6 +72,11 @@ public class FBDebugViewEditPartFactory extends FBInterfaceEditPartFactory {
 				}
 			};
 		}
+
+		if (modelElement instanceof With) {
+			return new DebugViewWithEditPart();
+		}
+
 		return super.getPartForElement(context, modelElement);
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/editparts/AbstractDebugInterfaceValueEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/editparts/AbstractDebugInterfaceValueEditPart.java
@@ -23,7 +23,6 @@ import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.fordiac.ide.fbtypeeditor.editparts.InterfaceEditPart;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
-import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.editparts.AbstractGraphicalEditPart;
 import org.eclipse.swt.graphics.Font;
@@ -64,7 +63,7 @@ public abstract class AbstractDebugInterfaceValueEditPart extends AbstractGraphi
 
 	protected abstract IInterfaceElement getInterfaceElement();
 
-	private boolean isInput() {
+	public boolean isInput() {
 		return getInterfaceElement().isIsInput();
 	}
 
@@ -105,8 +104,7 @@ public abstract class AbstractDebugInterfaceValueEditPart extends AbstractGraphi
 			final Rectangle bounds = referencedInterface.getFigure().getBounds();
 
 			final int width = getFigureWidth();
-			final int x = calcXPos(bounds, width);
-			final Rectangle newBounds = new Rectangle(x, bounds.y, width, -1);
+			final Rectangle newBounds = new Rectangle(0, bounds.y - bounds.height / 2, width, -1);
 			((GraphicalEditPart) getParent()).setLayoutConstraint(this, getFigure(), newBounds);
 		}
 	}
@@ -119,24 +117,6 @@ public abstract class AbstractDebugInterfaceValueEditPart extends AbstractGraphi
 			width = Math.max(width, 50);
 		}
 		return width;
-	}
-
-	private int calcXPos(final Rectangle bounds, final int width) {
-		int x = 0;
-		if (isInput()) {
-			x = bounds.x - 10 - width - 15 * getNumEventInputs();
-		} else {
-			x = bounds.x + bounds.width + 10 + 15 * getNumEventOutputs();
-		}
-		return x;
-	}
-
-	private int getNumEventInputs() {
-		return ((InterfaceList) getInterfaceElement().eContainer()).getEventInputs().size();
-	}
-
-	private int getNumEventOutputs() {
-		return ((InterfaceList) getInterfaceElement().eContainer()).getEventOutputs().size();
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/editparts/DebugViewWithEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/editparts/DebugViewWithEditPart.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Alois Zoitl - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.debug.ui.view.editparts;
+
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.fordiac.ide.debug.ui.view.figure.FBDebugViewFigure;
+import org.eclipse.fordiac.ide.fbtypeeditor.editparts.WithEditPart;
+
+public class DebugViewWithEditPart extends WithEditPart {
+
+	@Override
+	protected void activateFigure() {
+		final IFigure targetFigure = getTargetFigure();
+		if (targetFigure != null) {
+			targetFigure.add(getFigure());
+		} else {
+			super.activateFigure();
+		}
+	}
+
+	@Override
+	protected void deactivateFigure() {
+		final IFigure targetFigure = getTargetFigure();
+		if (targetFigure != null) {
+			targetFigure.remove(getFigure());
+			getConnectionFigure().setSourceAnchor(null);
+			getConnectionFigure().setTargetAnchor(null);
+		} else {
+			super.deactivateFigure();
+		}
+
+	}
+
+	private IFigure getTargetFigure() {
+		final FBDebugViewFigure debugViewFigure = getDebugViewFigure();
+		if (debugViewFigure != null) {
+			return (isInput()) ? debugViewFigure.getInputWiths() : debugViewFigure.getOutputWiths();
+		}
+		return null;
+	}
+
+	private FBDebugViewFigure getDebugViewFigure() {
+		if (getRoot().getChildren().getFirst() instanceof final FBDebugViewRootEditPart debugViewEP) {
+			return debugViewEP.getFigure();
+		}
+		return null;
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/editparts/FBDebugViewRootEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/editparts/FBDebugViewRootEditPart.java
@@ -24,15 +24,16 @@ import org.eclipse.debug.core.DebugEvent;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.IDebugEventSetListener;
 import org.eclipse.debug.core.model.IDebugTarget;
-import org.eclipse.draw2d.ConnectionRouter;
 import org.eclipse.draw2d.IFigure;
-import org.eclipse.draw2d.ShortestPathConnectionRouter;
+import org.eclipse.draw2d.MarginBorder;
 import org.eclipse.draw2d.geometry.Insets;
+import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.fordiac.ide.debug.EvaluatorDebugTarget;
 import org.eclipse.fordiac.ide.debug.EvaluatorDebugThread;
 import org.eclipse.fordiac.ide.debug.EvaluatorDebugVariable;
 import org.eclipse.fordiac.ide.debug.EvaluatorProcess;
-import org.eclipse.fordiac.ide.gef.editparts.AbstractDiagramEditPart;
+import org.eclipse.fordiac.ide.debug.ui.view.figure.FBDebugViewFigure;
+import org.eclipse.fordiac.ide.fbtypeeditor.editparts.FBTypeEditPart;
 import org.eclipse.fordiac.ide.gef.policies.EmptyXYLayoutEditPolicy;
 import org.eclipse.fordiac.ide.gef.policies.ModifiedNonResizeableEditPolicy;
 import org.eclipse.fordiac.ide.gef.preferences.DiagramPreferences;
@@ -48,10 +49,12 @@ import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPolicy;
+import org.eclipse.gef.GraphicalEditPart;
+import org.eclipse.gef.editparts.AbstractGraphicalEditPart;
 import org.eclipse.gef.editpolicies.RootComponentEditPolicy;
 import org.eclipse.swt.widgets.Display;
 
-public class FBDebugViewRootEditPart extends AbstractDiagramEditPart {
+public class FBDebugViewRootEditPart extends AbstractGraphicalEditPart {
 
 	private static final long MIN_UPDATE_INTERVAL = 100; // the minimal update interval between two full refresh of
 	// the shown values
@@ -117,8 +120,16 @@ public class FBDebugViewRootEditPart extends AbstractDiagramEditPart {
 	};
 
 	@Override
-	protected ConnectionRouter createConnectionRouter(final IFigure figure) {
-		return new ShortestPathConnectionRouter(figure);
+	public FBDebugViewFigure getFigure() {
+		return (FBDebugViewFigure) super.getFigure();
+	}
+
+	@Override
+	protected IFigure createFigure() {
+		final IFigure newFigure = new FBDebugViewFigure(getNumWithedEventInputs(), getNumWithedEventOutputs());
+		newFigure.setBorder(new MarginBorder(10));
+		newFigure.setOpaque(false);
+		return newFigure;
 	}
 
 	@Override
@@ -144,6 +155,7 @@ public class FBDebugViewRootEditPart extends AbstractDiagramEditPart {
 	@Override
 	public void activate() {
 		super.activate();
+		((GraphicalEditPart) getParent()).setLayoutConstraint(this, getFigure(), new Rectangle(0, 0, -1, -1));
 		getModel().getExecutor().addMonitor(evalMonitor);
 		DebugPlugin.getDefault().addDebugEventListener(debugEventListener);
 		lastUpdate = System.currentTimeMillis();
@@ -238,5 +250,44 @@ public class FBDebugViewRootEditPart extends AbstractDiagramEditPart {
 
 	private boolean isCorrectSource(final Object source) {
 		return ((source instanceof final EvaluatorDebugThread eDT) && eDT.getDebugTarget().getProcess() == getModel());
+	}
+
+	@Override
+	protected void addChildVisual(final EditPart childEditPart, final int index) {
+		final IFigure targetFigure = getTargetFigure(childEditPart);
+		if (targetFigure != null) {
+			targetFigure.add(((GraphicalEditPart) childEditPart).getFigure());
+		} else {
+			super.addChildVisual(childEditPart, index);
+		}
+	}
+
+	@Override
+	protected void removeChildVisual(final EditPart childEditPart) {
+		final IFigure targetFigure = getTargetFigure(childEditPart);
+		if (targetFigure != null) {
+			targetFigure.remove(((GraphicalEditPart) childEditPart).getFigure());
+		} else {
+			super.removeChildVisual(childEditPart);
+		}
+	}
+
+	private IFigure getTargetFigure(final EditPart childEditPart) {
+		return switch (childEditPart) {
+		case final FBTypeEditPart fbtEP -> getFigure().getFBFigureContainer();
+		case final AbstractDebugInterfaceValueEditPart ivEP ->
+			(ivEP.isInput()) ? getFigure().getOuterInputValues() : getFigure().getOuterOutputValues();
+		default -> null;
+		};
+	}
+
+	private int getNumWithedEventInputs() {
+		return (int) getFBType().getInterfaceList().getEventInputs().stream().filter(ev -> !ev.getWith().isEmpty())
+				.count();
+	}
+
+	private int getNumWithedEventOutputs() {
+		return (int) getFBType().getInterfaceList().getEventOutputs().stream().filter(ev -> !ev.getWith().isEmpty())
+				.count();
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/editparts/InputEventValueEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/editparts/InputEventValueEditPart.java
@@ -28,8 +28,6 @@ public class InputEventValueEditPart extends EventValueEditPart {
 		bt.setSize(50, -1);
 		bt.setOpaque(true);
 		bt.setBackgroundColor(org.eclipse.draw2d.ColorConstants.yellow);
-		bt.setPreferredSize(50, 20);
-
 		bt.addActionListener(e -> triggerEvent());
 		return bt;
 	}

--- a/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/figure/FBDebugViewFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/figure/FBDebugViewFigure.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Alois Zoitl - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.debug.ui.view.figure;
+
+import org.eclipse.draw2d.Container;
+import org.eclipse.draw2d.Figure;
+import org.eclipse.draw2d.GridData;
+import org.eclipse.draw2d.GridLayout;
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.XYLayout;
+import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.fordiac.ide.fbtypeeditor.editparts.WithAnchor;
+import org.eclipse.swt.SWT;
+
+public class FBDebugViewFigure extends Container {
+
+	final Figure outerInputValues;
+	final Figure inputWiths;
+	final Figure fbFigurecontainer;
+	final Figure outputWiths;
+	final Figure outerOutputValues;
+
+	public FBDebugViewFigure(final int numEi, final int numEo) {
+		super(createRootLayout());
+		outerInputValues = createContainer();
+		add(outerInputValues, createContainerGridData());
+
+		inputWiths = createWithContainer(numEi);
+		add(inputWiths, createContainerGridData());
+
+		fbFigurecontainer = createContainer();
+		add(fbFigurecontainer, createContainerGridData());
+
+		outputWiths = createWithContainer(numEo);
+		add(outputWiths, createContainerGridData());
+
+		outerOutputValues = createContainer();
+		add(outerOutputValues, createContainerGridData());
+	}
+
+	public IFigure getOuterInputValues() {
+		return outerInputValues;
+	}
+
+	public Figure getInputWiths() {
+		return inputWiths;
+	}
+
+	public IFigure getFBFigureContainer() {
+		return fbFigurecontainer;
+	}
+
+	public Figure getOutputWiths() {
+		return outputWiths;
+	}
+
+	public IFigure getOuterOutputValues() {
+		return outerOutputValues;
+	}
+
+	private static GridLayout createRootLayout() {
+		final GridLayout topLayout = new GridLayout(5, false);
+		topLayout.marginHeight = 0;
+		topLayout.marginWidth = 0;
+		topLayout.verticalSpacing = 0;
+		topLayout.horizontalSpacing = 0;
+		return topLayout;
+	}
+
+	private static Figure createContainer() {
+		final Figure newContainer = new Figure();
+		newContainer.setLayoutManager(new XYLayout());
+		return newContainer;
+	}
+
+	private static Figure createWithContainer(final int numEvents) {
+		final Figure newContainer = new Figure() {
+			@Override
+			public Dimension getPreferredSize(final int wHint, final int hHint) {
+				final Dimension prefSize = super.getPreferredSize(wHint, hHint);
+				// as the connection figures do not correctly give us their size we have to
+				// ensure a minum width
+				prefSize.union(new Dimension(
+						(int) (numEvents * WithAnchor.WITH_DISTANCE + 0.5 * WithAnchor.WITH_DISTANCE), 0));
+				return prefSize;
+			}
+		};
+		newContainer.setLayoutManager(new XYLayout());
+		return newContainer;
+	}
+
+	private static GridData createContainerGridData() {
+		return new GridData(SWT.BEGINNING, SWT.FILL, true, true);
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editparts/WithEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editparts/WithEditPart.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2011 - 2017 Profactor GmbH, TU Wien ACIN, fortiss GmbH
- * 				 2020		 Johannes Kepler University
+ * Copyright (c) 2011, 2024 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
+ * 				 			Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -42,7 +42,7 @@ public class WithEditPart extends AbstractConnectionEditPart {
 		return (With) getModel();
 	}
 
-	private boolean isInput() {
+	protected boolean isInput() {
 		final With with = getCastedModel();
 		if (null != with) {
 			final Event event = (Event) with.eContainer();


### PR DESCRIPTION
The debug view utilized more from the fb interface editor then necessary. This commit reduces the number of elements and simplifies the layout, which in the end ensure that the figure is better placed. This commit is also the basis for showing inner and outer values.