### PR TITLE
Show Internal FB Interface Values for SamplingEvaluators

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/FBDebugViewEditPartFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/FBDebugViewEditPartFactory.java
@@ -18,18 +18,15 @@ import org.eclipse.fordiac.ide.debug.ui.view.editparts.EmptyDebugViewRootEditPar
 import org.eclipse.fordiac.ide.debug.ui.view.editparts.EventValueEditPart;
 import org.eclipse.fordiac.ide.debug.ui.view.editparts.EventValueEntity;
 import org.eclipse.fordiac.ide.debug.ui.view.editparts.FBDebugViewRootEditPart;
+import org.eclipse.fordiac.ide.debug.ui.view.editparts.InnerValueEditPart;
+import org.eclipse.fordiac.ide.debug.ui.view.editparts.InnerValueEntity;
 import org.eclipse.fordiac.ide.debug.ui.view.editparts.InputEventValueEditPart;
 import org.eclipse.fordiac.ide.debug.ui.view.editparts.InterfaceValueEditPart;
 import org.eclipse.fordiac.ide.debug.ui.view.editparts.InterfaceValueEntity;
-import org.eclipse.fordiac.ide.fbtypeeditor.editparts.EventInputContainer;
-import org.eclipse.fordiac.ide.fbtypeeditor.editparts.EventOutputContainer;
+import org.eclipse.fordiac.ide.fbtypeeditor.editparts.AbstractContainerElement;
 import org.eclipse.fordiac.ide.fbtypeeditor.editparts.FBInterfaceEditPartFactory;
 import org.eclipse.fordiac.ide.fbtypeeditor.editparts.FBTypeEditPart;
 import org.eclipse.fordiac.ide.fbtypeeditor.editparts.InterfaceContainerEditPart;
-import org.eclipse.fordiac.ide.fbtypeeditor.editparts.PlugContainer;
-import org.eclipse.fordiac.ide.fbtypeeditor.editparts.SocketContainer;
-import org.eclipse.fordiac.ide.fbtypeeditor.editparts.VariableInputContainer;
-import org.eclipse.fordiac.ide.fbtypeeditor.editparts.VariableOutputContainer;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.With;
 import org.eclipse.gef.EditPart;
@@ -46,37 +43,26 @@ public class FBDebugViewEditPartFactory extends FBInterfaceEditPartFactory {
 			// no debug is active show an empty view
 			return new EmptyDebugViewRootEditPart();
 		}
-		if (modelElement instanceof EvaluatorProcess) {
-			return new FBDebugViewRootEditPart();
-		}
-		if (modelElement instanceof FBType) {
+
+		return switch (modelElement) {
+		case final EvaluatorProcess ep -> new FBDebugViewRootEditPart();
+		case final FBType fbType ->
 			// we can not use the version of parent as this expects a FBTypeRootEditPart as
-			// context which we don't have
-			// here
-			return new FBTypeEditPart();
-		}
-		if (modelElement instanceof InterfaceValueEntity) {
-			return new InterfaceValueEditPart();
-		}
-		if (modelElement instanceof final EventValueEntity ev) {
-			return ev.getEvent().isIsInput() ? new InputEventValueEditPart() : new EventValueEditPart();
-		}
-
-		if (modelElement instanceof EventInputContainer || modelElement instanceof EventOutputContainer
-				|| modelElement instanceof VariableInputContainer || modelElement instanceof VariableOutputContainer
-				|| modelElement instanceof SocketContainer || modelElement instanceof PlugContainer) {
-			return new InterfaceContainerEditPart() {
-				@Override
-				protected void createEditPolicies() {
-					// we don't want dedicated editpolicies
-				}
-			};
-		}
-
-		if (modelElement instanceof With) {
-			return new DebugViewWithEditPart();
-		}
-
-		return super.getPartForElement(context, modelElement);
+			// context which we don't have here
+			new FBTypeEditPart();
+		case final InnerValueEntity innerValue -> new InnerValueEditPart();
+		case final InterfaceValueEntity interfaceValue -> new InterfaceValueEditPart();
+		case final EventValueEntity ev ->
+			ev.getEvent().isIsInput() ? new InputEventValueEditPart() : new EventValueEditPart();
+		case final With with -> new DebugViewWithEditPart();
+		case final AbstractContainerElement container -> new InterfaceContainerEditPart() {
+			@Override
+			protected void createEditPolicies() {
+				// we don't want dedicated editpolicies
+			}
+		};
+		case null -> super.getPartForElement(context, modelElement);
+		default -> super.getPartForElement(context, modelElement);
+		};
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/editparts/DebugViewWithEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/editparts/DebugViewWithEditPart.java
@@ -12,8 +12,12 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.debug.ui.view.editparts;
 
+import org.eclipse.draw2d.ConnectionAnchor;
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.fordiac.ide.debug.ui.view.figure.FBDebugViewFigure;
+import org.eclipse.fordiac.ide.fbtypeeditor.editparts.WithAnchor;
 import org.eclipse.fordiac.ide.fbtypeeditor.editparts.WithEditPart;
 
 public class DebugViewWithEditPart extends WithEditPart {
@@ -41,6 +45,11 @@ public class DebugViewWithEditPart extends WithEditPart {
 
 	}
 
+	@Override
+	protected void createEditPolicies() {
+		// we don't want any edit policies for the debug view withs
+	}
+
 	private IFigure getTargetFigure() {
 		final FBDebugViewFigure debugViewFigure = getDebugViewFigure();
 		if (debugViewFigure != null) {
@@ -54,6 +63,61 @@ public class DebugViewWithEditPart extends WithEditPart {
 			return debugViewEP.getFigure();
 		}
 		return null;
+	}
+
+	@Override
+	protected ConnectionAnchor getSourceConnectionAnchor() {
+		final ConnectionAnchor sourceConnectionAnchor = super.getSourceConnectionAnchor();
+		if (sourceConnectionAnchor instanceof final WithAnchor withAnchor) {
+			if (isInput()) {
+				return createInputAnchor(withAnchor);
+			}
+			return createOutputAnchor(withAnchor);
+		}
+		return sourceConnectionAnchor;
+	}
+
+	@Override
+	protected ConnectionAnchor getTargetConnectionAnchor() {
+		final ConnectionAnchor targetConnectionAnchor = super.getTargetConnectionAnchor();
+		if (targetConnectionAnchor instanceof final WithAnchor withAnchor) {
+			if (isInput()) {
+				return createInputAnchor(withAnchor);
+			}
+			return createOutputAnchor(withAnchor);
+		}
+		return targetConnectionAnchor;
+	}
+
+	private ConnectionAnchor createInputAnchor(final WithAnchor anchor) {
+		return new WithAnchor(anchor.getOwner(), anchor.getPos(), this) {
+			@Override
+			public Point getLocation(final Point reference) {
+				final Rectangle r = Rectangle.SINGLETON;
+				r.setBounds(getBox());
+				r.translate(0, -1);
+				r.resize(1, 1);
+				final int leftX = getFigure().getParent().getBounds().getRight().x - (int) (WITH_DISTANCE * getPos());
+				final int centerY = r.y + r.height / 2;
+				return new Point(leftX, centerY);
+			}
+		};
+	}
+
+	private ConnectionAnchor createOutputAnchor(final WithAnchor anchor) {
+		return new WithAnchor(anchor.getOwner(), anchor.getPos(), this) {
+			@Override
+			public Point getLocation(final Point reference) {
+				final Rectangle r = Rectangle.SINGLETON;
+				r.setBounds(getBox());
+				r.translate(-1, -1);
+				r.resize(1, 1);
+				getOwner().translateToAbsolute(r);
+				final int leftX = getFigure().getParent().getBounds().x + (int) (WITH_DISTANCE * getPos());
+				final int centerY = r.y + r.height / 2;
+				return new Point(leftX, centerY);
+			}
+		};
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/editparts/FBDebugViewRootEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/editparts/FBDebugViewRootEditPart.java
@@ -43,6 +43,7 @@ import org.eclipse.fordiac.ide.model.eval.EvaluatorMonitor.NullEvaluatorMonitor;
 import org.eclipse.fordiac.ide.model.eval.EvaluatorThreadPoolExecutor;
 import org.eclipse.fordiac.ide.model.eval.fb.FBEvaluator;
 import org.eclipse.fordiac.ide.model.eval.fb.FBEvaluatorCountingEventQueue;
+import org.eclipse.fordiac.ide.model.eval.fb.SamplingFBEvaluator;
 import org.eclipse.fordiac.ide.model.eval.variable.Variable;
 import org.eclipse.fordiac.ide.model.libraryElement.Event;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
@@ -221,6 +222,16 @@ public class FBDebugViewRootEditPart extends AbstractGraphicalEditPart {
 						new InterfaceValueEntity(interfaceElement, entry.getValue(), debugTarget));
 			}
 		});
+		if (getFBEvaluator() instanceof final SamplingFBEvaluator samplingEvaluator) {
+			samplingEvaluator.getDelegate().getContext().getMembers().entrySet().forEach(entry -> {
+				final IInterfaceElement interfaceElement = getFBType().getInterfaceList()
+						.getInterfaceElement(entry.getKey());
+				if (interfaceElement != null) {
+					interfaceValues.put(entry.getValue(),
+							new InnerValueEntity(interfaceElement, entry.getValue(), debugTarget));
+				}
+			});
+		}
 	}
 
 	private void updateVariable(final Map<Object, EditPart> editPartRegistry, final Variable<?> variable) {
@@ -275,6 +286,8 @@ public class FBDebugViewRootEditPart extends AbstractGraphicalEditPart {
 	private IFigure getTargetFigure(final EditPart childEditPart) {
 		return switch (childEditPart) {
 		case final FBTypeEditPart fbtEP -> getFigure().getFBFigureContainer();
+		case final InnerValueEditPart innerEP ->
+			(innerEP.isInput()) ? getFigure().getInnerInputValues() : getFigure().getInnerOutputValues();
 		case final AbstractDebugInterfaceValueEditPart ivEP ->
 			(ivEP.isInput()) ? getFigure().getOuterInputValues() : getFigure().getOuterOutputValues();
 		default -> null;

--- a/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/editparts/InnerValueEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/editparts/InnerValueEditPart.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Alois Zoitl - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.debug.ui.view.editparts;
+
+public class InnerValueEditPart extends InterfaceValueEditPart {
+
+	// marker class for correctly layouting the view
+
+}

--- a/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/editparts/InnerValueEntity.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/editparts/InnerValueEntity.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Alois Zoitl - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.debug.ui.view.editparts;
+
+import org.eclipse.fordiac.ide.debug.EvaluatorDebugTarget;
+import org.eclipse.fordiac.ide.model.eval.variable.Variable;
+import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
+
+/*
+ *  meta model class for marking inner values for the editpart factory
+ */
+public class InnerValueEntity extends InterfaceValueEntity {
+
+	public InnerValueEntity(final IInterfaceElement ie, final Variable<?> variable,
+			final EvaluatorDebugTarget debugTarget) {
+		super(ie, variable, debugTarget);
+		// nothing special to be done
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/figure/FBDebugViewFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/figure/FBDebugViewFigure.java
@@ -26,7 +26,9 @@ public class FBDebugViewFigure extends Container {
 
 	final Figure outerInputValues;
 	final Figure inputWiths;
+	final Figure innerInputValues;
 	final Figure fbFigurecontainer;
+	final Figure innerOutputValues;
 	final Figure outputWiths;
 	final Figure outerOutputValues;
 
@@ -38,8 +40,14 @@ public class FBDebugViewFigure extends Container {
 		inputWiths = createWithContainer(numEi);
 		add(inputWiths, createContainerGridData());
 
+		innerInputValues = createContainer();
+		add(innerInputValues, createContainerGridData());
+
 		fbFigurecontainer = createContainer();
 		add(fbFigurecontainer, createContainerGridData());
+
+		innerOutputValues = createContainer();
+		add(innerOutputValues, createContainerGridData());
 
 		outputWiths = createWithContainer(numEo);
 		add(outputWiths, createContainerGridData());
@@ -52,15 +60,23 @@ public class FBDebugViewFigure extends Container {
 		return outerInputValues;
 	}
 
-	public Figure getInputWiths() {
+	public IFigure getInputWiths() {
 		return inputWiths;
+	}
+
+	public IFigure getInnerInputValues() {
+		return innerInputValues;
 	}
 
 	public IFigure getFBFigureContainer() {
 		return fbFigurecontainer;
 	}
 
-	public Figure getOutputWiths() {
+	public IFigure getInnerOutputValues() {
+		return innerOutputValues;
+	}
+
+	public IFigure getOutputWiths() {
 		return outputWiths;
 	}
 
@@ -69,7 +85,7 @@ public class FBDebugViewFigure extends Container {
 	}
 
 	private static GridLayout createRootLayout() {
-		final GridLayout topLayout = new GridLayout(5, false);
+		final GridLayout topLayout = new GridLayout(7, false);
 		topLayout.marginHeight = 0;
 		topLayout.marginWidth = 0;
 		topLayout.verticalSpacing = 0;
@@ -91,7 +107,7 @@ public class FBDebugViewFigure extends Container {
 				// as the connection figures do not correctly give us their size we have to
 				// ensure a minum width
 				prefSize.union(new Dimension(
-						(int) (numEvents * WithAnchor.WITH_DISTANCE + 0.5 * WithAnchor.WITH_DISTANCE), 0));
+						(int) (numEvents * WithAnchor.WITH_DISTANCE + WithAnchor.WITH_DISTANCE), 0));
 				return prefSize;
 			}
 		};

--- a/plugins/org.eclipse.fordiac.ide.debug/src/org/eclipse/fordiac/ide/debug/fb/FBLaunchConfigurationDelegate.java
+++ b/plugins/org.eclipse.fordiac.ide.debug/src/org/eclipse/fordiac/ide/debug/fb/FBLaunchConfigurationDelegate.java
@@ -60,7 +60,7 @@ public class FBLaunchConfigurationDelegate extends CommonLaunchConfigurationDele
 	@SuppressWarnings("static-method") // allow subclasses to override
 	protected FBEvaluator<?> createEvaluator(final FBType type, final List<Variable<?>> variables) {
 		return (FBEvaluator<?>) EvaluatorFactory.createEvaluator(type,
-				type.eClass().getInstanceClass().asSubclass(FBType.class), null, variables, null);
+				type.eClass().getInstanceClass().asSubclass(FBType.class), "sampling", null, variables, null); //$NON-NLS-1$
 	}
 
 	public static List<Variable<?>> getDefaultArguments(final FBType type) throws CoreException {

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editparts/WithAnchor.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editparts/WithAnchor.java
@@ -33,13 +33,13 @@ public class WithAnchor extends ChopboxAnchor {
 
 	protected double getZoomFactor() {
 		double zoom = 1.0;
-		if (editPart.getRoot() instanceof ScalableFreeformRootEditPart) {
-			zoom = ((ScalableFreeformRootEditPart) editPart.getRoot()).getZoomManager().getZoom();
+		if (editPart.getRoot() instanceof final ScalableFreeformRootEditPart scaleableREP) {
+			zoom = scaleableREP.getZoomManager().getZoom();
 		}
 		return zoom;
 	}
 
-	protected int getPos() {
+	public int getPos() {
 		return pos;
 	}
 }


### PR DESCRIPTION
When an FB is debugged with a SamplingEvaluator the debug view shows now both the outside and the internal values.

@mx990 I made the sampling evaluator the default. Is this ok?