### PR TITLE
Fix changing ECC event back to One

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/contentprovider/ECCContentAndLabelProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/contentprovider/ECCContentAndLabelProvider.java
@@ -27,6 +27,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.BasicFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.ECAction;
 import org.eclipse.fordiac.ide.model.libraryElement.ECState;
+import org.eclipse.fordiac.ide.model.libraryElement.ECTransition;
 import org.eclipse.fordiac.ide.model.libraryElement.Event;
 import org.eclipse.fordiac.ide.ui.FordiacMessages;
 
@@ -53,6 +54,10 @@ public final class ECCContentAndLabelProvider {
 		}
 
 		return events;
+	}
+
+	public static boolean isOneConditionExpression(final ECTransition transition) {
+		return transition.getConditionExpression() != null && transition.getConditionExpression().equals(ONE_CONDITION);
 	}
 
 	public static List<String> getOutputEventNames(final BasicFBType type) {

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/properties/TransitionSection.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/properties/TransitionSection.java
@@ -142,13 +142,11 @@ public class TransitionSection extends AbstractSection {
 			@Override
 			public void documentChanged(final DocumentEvent event) {
 				removeContentAdapter();
-				// someone deleted or modified this or the condition editor update led to this
-				// change
+				// updating the condition editor or modification lead to this change
 				if (conditionEditorModelAccess.getEditablePart().contentEquals("")) { //$NON-NLS-1$
-					if ((getType().getConditionEvent() == null && getType().getConditionExpression() != null
-							&& !getType().getConditionExpression().equals(ECCContentAndLabelProvider.ONE_CONDITION))
+					if (!ECCContentAndLabelProvider.isOneConditionExpression(getType())
 							|| getType().getConditionEvent() != null) {
-						executeCommand(new ChangeConditionExpressionCommand(getType(), "")); //$NON-NLS-1$
+						executeCommand(new ChangeConditionExpressionCommand(getType(), ""));//$NON-NLS-1$
 					}
 				} else {
 					executeCommand(new ChangeConditionExpressionCommand(getType(),
@@ -166,8 +164,7 @@ public class TransitionSection extends AbstractSection {
 	}
 
 	protected void updateConditionEditor() {
-		if ((getType().getConditionExpression() != null)
-				&& getType().getConditionExpression().equals(ECCContentAndLabelProvider.ONE_CONDITION)) {
+		if (ECCContentAndLabelProvider.isOneConditionExpression(getType())) {
 			conditionEditorModelAccess.updateModel(""); //$NON-NLS-1$
 			conditionEditor.getViewer().setEditable(false);
 		} else {
@@ -195,8 +192,7 @@ public class TransitionSection extends AbstractSection {
 		if (null != getBasicFBType()) {
 			fillEventConditionDropdown();
 			commentText.setText(getType().getComment() != null ? getType().getComment() : ""); //$NON-NLS-1$
-			if ((getType().getConditionExpression() != null)
-					&& getType().getConditionExpression().equals(ECCContentAndLabelProvider.ONE_CONDITION)) {
+			if (ECCContentAndLabelProvider.isOneConditionExpression(getType())) {
 				eventCombo.select(eventCombo.indexOf(ECCContentAndLabelProvider.ONE_CONDITION));
 			} else {
 				final Event conditionEvent = getType().getConditionEvent();

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/properties/TransitionSection.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/properties/TransitionSection.java
@@ -142,8 +142,18 @@ public class TransitionSection extends AbstractSection {
 			@Override
 			public void documentChanged(final DocumentEvent event) {
 				removeContentAdapter();
-				executeCommand(
-						new ChangeConditionExpressionCommand(getType(), conditionEditorModelAccess.getEditablePart()));
+				// someone deleted or modified this or the condition editor update led to this
+				// change
+				if (conditionEditorModelAccess.getEditablePart().contentEquals("")) { //$NON-NLS-1$
+					if ((getType().getConditionEvent() == null && getType().getConditionExpression() != null
+							&& !getType().getConditionExpression().equals(ECCContentAndLabelProvider.ONE_CONDITION))
+							|| getType().getConditionEvent() != null) {
+						executeCommand(new ChangeConditionExpressionCommand(getType(), "")); //$NON-NLS-1$
+					}
+				} else {
+					executeCommand(new ChangeConditionExpressionCommand(getType(),
+							conditionEditorModelAccess.getEditablePart()));
+				}
 				addContentAdapter();
 			}
 


### PR DESCRIPTION
If any event was selected and has been changed back a ONE condition expression in the ECC editor, internally [none] has been selected and displayed. This only happend when using the Transition Property sheet and not in the ECCTransitionCellEditor. 

fixes #403 