### PR TITLE
Add option to use system includes in forte_ng export

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteFBTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteFBTemplate.xtend
@@ -75,8 +75,6 @@ abstract class ForteFBTemplate<T extends FBType> extends ForteLibraryElementTemp
 		#include "«type.generateTypeGenIncludePath»"
 		#endif
 		
-		#include "criticalregion.h"
-		#include "resource.h"
 		«getDependencies(emptyMap).generateDependencyIncludes»
 		«type.compilerInfo?.header»
 	'''

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteFBTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteFBTemplate.xtend
@@ -79,18 +79,6 @@ abstract class ForteFBTemplate<T extends FBType> extends ForteLibraryElementTemp
 		«type.compilerInfo?.header»
 	'''
 
-	def protected generateImplTypeIncludes(Iterable<DataType> vars) '''
-		«IF !vars.empty»
-			«vars.generateTypeIncludes»
-		«ENDIF»
-	'''
-
-	def protected generateAdapterIncludes(Iterable<AdapterDeclaration> vars) '''
-		«FOR include : vars.map[type.generateDefiningInclude].toSet»
-			#include "«include»"
-		«ENDFOR»
-	'''
-
 	def protected generateFBDeclaration() '''
 		DECLARE_FIRMWARE_FB(«FBClassName»)
 	'''

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteNgExportTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteNgExportTemplate.xtend
@@ -28,20 +28,22 @@ abstract class ForteNgExportTemplate extends ExportTemplate {
 	def protected generateDependencyIncludes(Iterable<? extends INamedElement> dependencies) '''
 		«dependencies.filter(DataType).generateTypeIncludes»
 		«FOR include : dependencies.reject(DataType).map[generateDefiningInclude].toSet.sort»
-			#include "«include»"
+			«include.generateDependencyInclude»
 		«ENDFOR»
 	'''
 
 	def protected generateTypeIncludes(Iterable<DataType> types) '''
 		«FOR include : types.map[generateDefiningInclude].toSet.sort»
-			#include "«include»"
+			«include.generateDependencyInclude»
 		«ENDFOR»
-		#include "iec61131_functions.h"
-		#include "forte_array_common.h"
-		#include "forte_array.h"
-		#include "forte_array_fixed.h"
-		#include "forte_array_variable.h"
+		«generateDependencyInclude("iec61131_functions.h")»
+		«generateDependencyInclude("forte_array_common.h")»
+		«generateDependencyInclude("forte_array.h")»
+		«generateDependencyInclude("forte_array_fixed.h")»
+		«generateDependencyInclude("forte_array_variable.h")»
 	'''
+
+	def protected generateDependencyInclude(String path) '''#include "«path»"'''
 
 	def getFileBasename() { name.replaceAll("\\.[^.]+$", "") }
 }

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteNgExportTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteNgExportTemplate.xtend
@@ -14,6 +14,7 @@ package org.eclipse.fordiac.ide.export.forte_ng
 
 import java.nio.file.Path
 import org.eclipse.fordiac.ide.export.ExportTemplate
+import org.eclipse.fordiac.ide.export.forte_ng.util.ForteNgExportOptions
 import org.eclipse.fordiac.ide.model.data.DataType
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement
 
@@ -43,7 +44,12 @@ abstract class ForteNgExportTemplate extends ExportTemplate {
 		«generateDependencyInclude("forte_array_variable.h")»
 	'''
 
-	def protected generateDependencyInclude(String path) '''#include "«path»"'''
+	def protected generateDependencyInclude(String path) {
+		if (ForteNgExportOptions.useSystemIncludes)
+			'''#include <«path»>'''
+		else
+			'''#include "«path»"'''
+	}
 
 	def getFileBasename() { name.replaceAll("\\.[^.]+$", "") }
 }

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/adapter/AdapterFBHeaderTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/adapter/AdapterFBHeaderTemplate.xtend
@@ -69,8 +69,8 @@ class AdapterFBHeaderTemplate extends ForteFBTemplate<AdapterType> {
 	'''
 
 	override protected generateHeaderIncludes() '''
-		#include "adapter.h"
-		#include "typelib.h"
+		«generateDependencyInclude("adapter.h")»
+		«generateDependencyInclude("typelib.h")»
 		«super.generateHeaderIncludes»
 	'''
 

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/basic/BasicFBHeaderTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/basic/BasicFBHeaderTemplate.xtend
@@ -36,7 +36,7 @@ class BasicFBHeaderTemplate extends BaseFBHeaderTemplate<BasicFBType> {
 		«generateStates»
 	'''
 	
-	override generateClassInclude() '''#include "basicfb.h"'''
+	override generateClassInclude() '''«generateDependencyInclude("basicfb.h")»'''
 
 	def protected generateStates() '''
 		«FOR state : type.ECC.ECState AFTER '\n'»

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/composite/CompositeFBHeaderTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/composite/CompositeFBHeaderTemplate.xtend
@@ -79,8 +79,8 @@ class CompositeFBHeaderTemplate extends ForteFBTemplate<CompositeFBType> {
 	'''
 
 	override protected CharSequence generateHeaderIncludes() '''
-		#include "cfb.h"
-		#include "typelib.h"
+		«generateDependencyInclude("cfb.h")»
+		«generateDependencyInclude("typelib.h")»
 		«super.generateHeaderIncludes»
 	'''
 

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/function/FunctionFBHeaderTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/function/FunctionFBHeaderTemplate.xtend
@@ -59,7 +59,7 @@ class FunctionFBHeaderTemplate extends FunctionFBTemplate {
 	'''
 
 	override protected generateHeaderIncludes() '''
-		#include "funcbloc.h"
+		«generateDependencyInclude("funcbloc.h")»
 		«super.generateHeaderIncludes»
 	'''
 

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/language/LanguageImplTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/language/LanguageImplTemplate.xtend
@@ -52,7 +52,7 @@ class LanguageImplTemplate extends ForteNgExportTemplate {
 		#include "«fileBasename»_gen.cpp"
 		#endif
 
-		#include "iec61131_functions.h"
+		«generateDependencyInclude("iec61131_functions.h")»
 		«IF languageSupport !== null»«languageSupport.getDependencies(emptyMap).generateDependencyIncludes»«ENDIF»
 	'''
 

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/service/ServiceInterfaceFBHeaderTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/service/ServiceInterfaceFBHeaderTemplate.xtend
@@ -57,7 +57,7 @@ class ServiceInterfaceFBHeaderTemplate extends ForteFBTemplate<ServiceInterfaceF
 	'''
 
 	override protected generateHeaderIncludes() '''
-		#include "funcbloc.h"
+		«generateDependencyInclude("funcbloc.h")»
 		«super.generateHeaderIncludes»
 	'''
 }

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/simple/SimpleFBHeaderTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/simple/SimpleFBHeaderTemplate.xtend
@@ -27,7 +27,7 @@ class SimpleFBHeaderTemplate extends BaseFBHeaderTemplate<SimpleFBType> {
 		super(type, name, prefix, "CSimpleFB")
 	}
 
-	override generateClassInclude() '''#include "simplefb.h"'''
+	override generateClassInclude() '''«generateDependencyInclude("simplefb.h")»'''
 
 	override generateAdditionalDeclarations() { "" }
 }

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/struct/StructuredTypeHeaderTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/struct/StructuredTypeHeaderTemplate.xtend
@@ -71,7 +71,7 @@ class StructuredTypeHeaderTemplate extends StructBaseTemplate {
 	'''
 
 	def protected generateHeaderIncludes() '''
-		#include "forte_struct.h"
+		«generateDependencyInclude("forte_struct.h")»
 		
 		«getDependencies(#{ForteNgExportFilter.OPTION_HEADER -> Boolean.TRUE}).generateDependencyIncludes»
 		

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/util/ForteNgExportOptions.java
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/util/ForteNgExportOptions.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Martin Erich Jobst
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Martin Jobst - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.export.forte_ng.util;
+
+import org.eclipse.core.runtime.Platform;
+
+public final class ForteNgExportOptions {
+
+	private static final String USE_SYSTEM_INCLUDES = "-exportSystemIncludes"; //$NON-NLS-1$
+
+	private static boolean systemIncludes;
+
+	static {
+		for (final String arg : Platform.getCommandLineArgs()) {
+			if (USE_SYSTEM_INCLUDES.equals(arg)) {
+				systemIncludes = true;
+				break;
+			}
+		}
+	}
+
+	public static boolean useSystemIncludes() {
+		return systemIncludes;
+	}
+
+	private ForteNgExportOptions() {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/forte_ng/ForteNgBasicFBTest.xtend
+++ b/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/forte_ng/ForteNgBasicFBTest.xtend
@@ -116,8 +116,6 @@ class ForteNgBasicFBTest extends ExporterTestBasicFBTypeBase {
 						#include "«ExporterTestBase.BASICFUNCTIONBLOCK_NAME»_fbt_gen.cpp"
 						#endif
 						
-						#include "criticalregion.h"
-						#include "resource.h"
 						#include "forte_dword.h"
 						#include "forte_sint.h"
 						#include "iec61131_functions.h"

--- a/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/forte_ng/ForteNgTest.xtend
+++ b/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/forte_ng/ForteNgTest.xtend
@@ -301,8 +301,6 @@ class ForteNgTest extends ExporterTestBasicFBTypeBase {
 						#include "«ExporterTestBase.BASICFUNCTIONBLOCK_NAME»_fbt_gen.cpp"
 						#endif
 						
-						#include "criticalregion.h"
-						#include "resource.h"
 						#include "iec61131_functions.h"
 						#include "forte_array_common.h"
 						#include "forte_array.h"


### PR DESCRIPTION
Add an experimental argument `-exportSystemIncludes` to use system includes (i.e., `#include <path>`) instead of user includes (i.e., `#include "path"`) for dependencies in forte_ng export. This allows to avoid header file name collisions between identically named types with and without package.

The FB types `Test` and `pkgtest::test1::Test`, for example, currently result in two header files:
```
Test_fbt.h
pkgtest/test1/Test_fbt.h
```
If the second FB type uses the first internally, this would result in an include directive in `pkgtest/test1/Test_fbt.h`:
```cpp
#include "Test_fbt.h"
```
which means it will include itself, since the current folder is searched first for user includes.

Using a system include:
```cpp
#include <Test_fbt.h>
```
instead refers to the correct file, since that only searches the system include paths without considering the current folder.

At the same time, using system includes may break certain build environments, particularly when cross-compiling. Therefore, this is added as an experimental option only for now.