### PR TITLE
Fix constant reload in ST breakpoint condition editor

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.debug.ui.st/src/org/eclipse/fordiac/ide/debug/ui/st/breakpoint/STBreakpointDetailPane.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.ui.st/src/org/eclipse/fordiac/ide/debug/ui/st/breakpoint/STBreakpointDetailPane.java
@@ -48,7 +48,9 @@ public class STBreakpointDetailPane implements IDetailPane3 {
 
 		editor = new STBreakpointConditionEditor();
 		editor.addPropertyListener((source, propId) -> {
-			editor.doSave();
+			if (propId == STBreakpointConditionEditor.PROP_CONDITION_ENABLED) {
+				editor.doSave(); // autosave only for condition enabled changes
+			}
 			firePropertyChange(IWorkbenchPartConstants.PROP_DIRTY);
 		});
 		editor.createControl(comp);
@@ -58,8 +60,9 @@ public class STBreakpointDetailPane implements IDetailPane3 {
 
 	@Override
 	public void display(final IStructuredSelection selection) {
-		if (selection != null && selection.size() == 1 && selection.getFirstElement() instanceof STLineBreakpoint) {
-			editor.setInput((STLineBreakpoint) selection.getFirstElement());
+		if (selection != null && selection.size() == 1
+				&& selection.getFirstElement() instanceof final STLineBreakpoint lineBreakpoint) {
+			editor.setInput(lineBreakpoint);
 		} else {
 			editor.setInput(null);
 		}


### PR DESCRIPTION
Fix constant reload in ST breakpoint condition editor by suppressing property changes during reload and restricting autosave to condition enabled changes.