### PR TITLE
Refactor parsing of values in evaluator

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/EvaluatorException.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/EvaluatorException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, 2023 Martin Erich Jobst
+ * Copyright (c) 2022, 2024 Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,25 +12,62 @@
  */
 package org.eclipse.fordiac.ide.model.eval;
 
+/**
+ * An exception while evaluating a model element
+ */
 public class EvaluatorException extends RuntimeException {
 	@java.io.Serial
 	private static final long serialVersionUID = -293618872722930949L;
 
 	private final transient Evaluator evaluator;
 
-	public EvaluatorException(final Evaluator evaluator) {
-		this(null, null, evaluator);
+	/**
+	 * Create a new evaluator exception with the given message
+	 *
+	 * @param message The message
+	 */
+	public EvaluatorException(final String message) {
+		this(message, (Evaluator) null);
 	}
 
+	/**
+	 * Create a new evaluator exception with the given message and cause
+	 *
+	 * @param message The message
+	 * @param cause   The cause
+	 */
+	public EvaluatorException(final String message, final Throwable cause) {
+		this(message, cause, null);
+	}
+
+	/**
+	 * Create a new evaluator exception with the given message and evaluator
+	 *
+	 * @param message   The message
+	 * @param evaluator The evaluator
+	 */
 	public EvaluatorException(final String message, final Evaluator evaluator) {
-		this(message, null, evaluator);
+		super(message);
+		this.evaluator = evaluator;
 	}
 
+	/**
+	 * Create a new evaluator exception with the given message, cause, and evaluator
+	 *
+	 * @param message   The message
+	 * @param cause     The cause
+	 * @param evaluator The evaluator
+	 */
 	public EvaluatorException(final String message, final Throwable cause, final Evaluator evaluator) {
 		super(message, cause);
 		this.evaluator = evaluator;
 	}
 
+	/**
+	 * Get the originating evaluator
+	 *
+	 * @return The evaluator or null if unknown
+	 */
 	public Evaluator getEvaluator() {
 		return evaluator;
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/EvaluatorInitializerException.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/EvaluatorInitializerException.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Martin Erich Jobst
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Martin Jobst - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.model.eval;
+
+import java.text.MessageFormat;
+
+import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+
+/**
+ * An exception while evaluating an initializer for a particular element
+ */
+public class EvaluatorInitializerException extends EvaluatorException {
+
+	private static final long serialVersionUID = 324858778456696289L;
+
+	private final transient INamedElement element;
+
+	/**
+	 * Create a new evaluator initializer exception
+	 *
+	 * @param message The message
+	 * @param element The element where the exception originated
+	 */
+	public EvaluatorInitializerException(final String message, final INamedElement element) {
+		super(message);
+		this.element = element;
+	}
+
+	/**
+	 * Create a new evaluator initializer exception
+	 *
+	 * @param message The message
+	 * @param element The element where the exception originated
+	 * @param cause   The cause
+	 */
+	public EvaluatorInitializerException(final String message, final INamedElement element, final Throwable cause) {
+		super(message, cause);
+		this.element = element;
+	}
+
+	/**
+	 * Create a new evaluator initializer exception with a default message
+	 *
+	 * @param element The element where the exception originated
+	 * @param cause   The cause
+	 */
+	public EvaluatorInitializerException(final INamedElement element, final Throwable cause) {
+		super(MessageFormat.format(Messages.EvaluatorInitializerException_DefaultMessage, element.getName(),
+				cause.getMessage()), cause);
+		this.element = element;
+	}
+
+	/**
+	 * Get the element where the exception originated
+	 *
+	 * @return The element (or null if unknown)
+	 */
+	public INamedElement getElement() {
+		return element;
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/Messages.java
@@ -23,6 +23,7 @@ public class Messages extends NLS {
 	public static String ValueOperations_Compare;
 	public static String ValueOperations_Divide;
 	public static String ValueOperations_DivisionByZero;
+	public static String ValueOperations_MemberMapCastMessage;
 	public static String ValueOperations_Multiply;
 	public static String ValueOperations_Negate;
 	public static String ValueOperations_Not;

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/Messages.java
@@ -16,6 +16,7 @@ import org.eclipse.osgi.util.NLS;
 
 public class Messages extends NLS {
 	private static final String BUNDLE_NAME = "org.eclipse.fordiac.ide.model.eval.messages"; //$NON-NLS-1$
+	public static String EvaluatorInitializerException_DefaultMessage;
 	public static String ValueOperations_Absolute;
 	public static String ValueOperations_Add;
 	public static String ValueOperations_And;

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/messages.properties
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/messages.properties
@@ -1,3 +1,4 @@
+EvaluatorInitializerException_DefaultMessage=Error initializing member ''{0}'': {1}
 ValueOperations_Absolute=absolute
 ValueOperations_Add=add
 ValueOperations_And=and

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/messages.properties
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/messages.properties
@@ -5,6 +5,7 @@ ValueOperations_And=and
 ValueOperations_Compare=compare
 ValueOperations_Divide=divide
 ValueOperations_DivisionByZero=Division by zero
+ValueOperations_MemberMapCastMessage=The key ''{0}'' of class {1} cannot be cast to {2}
 ValueOperations_Multiply=multiply
 ValueOperations_Negate=negate
 ValueOperations_Not=not

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/value/ArrayValue.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/value/ArrayValue.java
@@ -54,6 +54,12 @@ public final class ArrayValue implements AnyDerivedValue, Iterable<Value> {
 				.toList();
 	}
 
+	public ArrayValue(final ArrayType type, final List<?> values) {
+		this(type);
+		IntStream.range(0, values.size()).forEach(
+				index -> elements.get(index).setValue(ValueOperations.wrapValue(values.get(index), elementType)));
+	}
+
 	public Variable<?> get(final int index) {
 		return elements.get(index - start);
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/value/ArrayValue.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/value/ArrayValue.java
@@ -19,27 +19,39 @@ import java.util.StringJoiner;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.model.data.ArrayType;
+import org.eclipse.fordiac.ide.model.data.DataType;
 import org.eclipse.fordiac.ide.model.eval.variable.ArrayVariable;
 import org.eclipse.fordiac.ide.model.eval.variable.Variable;
+import org.eclipse.fordiac.ide.model.eval.variable.VariableOperations;
 
 public final class ArrayValue implements AnyDerivedValue, Iterable<Value> {
 	private static final int COLLAPSE_ELEMENTS_SIZE = 100;
 
 	private final ArrayType type;
-	private final List<Variable<?>> elements;
+	private final DataType elementType;
 	private final int start;
 	private final int end;
+	private final List<Variable<?>> elements;
 
-	public ArrayValue(final ArrayType type, final List<Variable<?>> elements) {
+	public ArrayValue(final ArrayType type) {
 		if (type.getSubranges().isEmpty() || type.getSubranges().stream()
 				.anyMatch(subrange -> !subrange.isSetLowerLimit() || !subrange.isSetUpperLimit())) {
 			throw new IllegalArgumentException("Cannot instantiate array value with unknown bounds"); //$NON-NLS-1$
 		}
 		this.type = type;
-		this.elements = elements;
+		if (type.getSubranges().size() > 1) {
+			elementType = ArrayVariable.newArrayType(type.getBaseType(),
+					type.getSubranges().stream().skip(1).map(EcoreUtil::copy).toList());
+		} else {
+			elementType = type.getBaseType();
+		}
 		start = type.getSubranges().get(0).getLowerLimit();
 		end = type.getSubranges().get(0).getUpperLimit();
+		elements = IntStream.rangeClosed(start, end)
+				.<Variable<?>>mapToObj(index -> VariableOperations.newVariable(Integer.toString(index), elementType))
+				.toList();
 	}
 
 	public Variable<?> get(final int index) {
@@ -143,6 +155,10 @@ public final class ArrayValue implements AnyDerivedValue, Iterable<Value> {
 	@Override
 	public ArrayType getType() {
 		return type;
+	}
+
+	public DataType getElementType() {
+		return elementType;
 	}
 
 	public List<Variable<?>> getElements() {

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/value/FBValue.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/value/FBValue.java
@@ -12,23 +12,74 @@
  */
 package org.eclipse.fordiac.ide.model.eval.value;
 
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.eclipse.fordiac.ide.model.eval.EvaluatorInitializerException;
+import org.eclipse.fordiac.ide.model.eval.variable.ECStateVariable;
 import org.eclipse.fordiac.ide.model.eval.variable.Variable;
+import org.eclipse.fordiac.ide.model.eval.variable.VariableOperations;
+import org.eclipse.fordiac.ide.model.libraryElement.AdapterDeclaration;
+import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType;
+import org.eclipse.fordiac.ide.model.libraryElement.BasicFBType;
+import org.eclipse.fordiac.ide.model.libraryElement.FB;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 
 public final class FBValue implements Value, Iterable<Value> {
+
 	private final FBType type;
+	private final Map<String, Variable<?>> members = new HashMap<>();
 
-	private final Map<String, Variable<?>> members;
+	public FBValue(final FBType type) {
+		this(type, Collections.emptyList());
+	}
 
-	public FBValue(final FBType type, final Map<String, Variable<?>> members) {
+	public FBValue(final FBType type, final Iterable<Variable<?>> variables) {
 		this.type = type;
-		this.members = members;
+		if (variables != null) {
+			variables.forEach(variable -> members.put(variable.getName(), variable));
+		}
+		type.getInterfaceList().getInputVars().forEach(this::initializeMember);
+		type.getInterfaceList().getInOutVars().forEach(this::initializeMember);
+		type.getInterfaceList().getOutputVars().forEach(this::initializeMember);
+		type.getInterfaceList().getSockets().stream().map(AdapterDeclaration::getAdapterFB)
+				.forEach(this::initializeMember);
+		type.getInterfaceList().getPlugs().stream().map(AdapterDeclaration::getAdapterFB)
+				.forEach(this::initializeMember);
+		if (type instanceof final BaseFBType baseFBType) {
+			baseFBType.getInternalConstVars().forEach(this::initializeMember);
+			baseFBType.getInternalVars().forEach(this::initializeMember);
+			baseFBType.getInternalFbs().forEach(this::initializeMember);
+		}
+		if (type instanceof final BasicFBType basicFBType) {
+			members.computeIfAbsent(ECStateVariable.NAME, unused -> new ECStateVariable(basicFBType));
+		}
+	}
+
+	protected void initializeMember(final VarDeclaration variable) {
+		members.computeIfAbsent(variable.getName(), unused -> {
+			try {
+				return VariableOperations.newVariable(variable);
+			} catch (final Exception e) {
+				throw new EvaluatorInitializerException(variable, e);
+			}
+		});
+	}
+
+	protected void initializeMember(final FB fb) {
+		members.computeIfAbsent(fb.getName(), unused -> {
+			try {
+				return VariableOperations.newVariable(fb);
+			} catch (final Exception e) {
+				throw new EvaluatorInitializerException(fb, e);
+			}
+		});
 	}
 
 	public Variable<?> get(final String key) {

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/value/FBValue.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/value/FBValue.java
@@ -62,6 +62,16 @@ public final class FBValue implements Value, Iterable<Value> {
 		}
 	}
 
+	public FBValue(final FBType type, final Map<String, ?> values) {
+		this(type);
+		values.forEach((name, value) -> {
+			final Variable<?> member = members.get(name);
+			if (member != null) {
+				member.setValue(ValueOperations.wrapValue(value, member.getType()));
+			}
+		});
+	}
+
 	protected void initializeMember(final VarDeclaration variable) {
 		members.computeIfAbsent(variable.getName(), unused -> {
 			try {

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/value/StructValue.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/value/StructValue.java
@@ -14,20 +14,34 @@ package org.eclipse.fordiac.ide.model.eval.value;
 
 import java.util.Comparator;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.eclipse.fordiac.ide.model.data.StructuredType;
+import org.eclipse.fordiac.ide.model.eval.EvaluatorInitializerException;
 import org.eclipse.fordiac.ide.model.eval.variable.Variable;
+import org.eclipse.fordiac.ide.model.eval.variable.VariableOperations;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 
 public final class StructValue implements AnyDerivedValue, Iterable<Value> {
 	private final StructuredType type;
 	private final Map<String, Variable<?>> members;
 
-	public StructValue(final StructuredType type, final Map<String, Variable<?>> members) {
+	public StructValue(final StructuredType type) {
 		this.type = type;
-		this.members = members;
+		members = type.getMemberVariables().stream().map(StructValue::initializeMember)
+				.collect(Collectors.toMap(Variable::getName, Function.identity(), (a, b) -> a, LinkedHashMap::new));
+	}
+
+	protected static Variable<?> initializeMember(final VarDeclaration variable) {
+		try {
+			return VariableOperations.newVariable(variable);
+		} catch (final Exception e) {
+			throw new EvaluatorInitializerException(variable, e);
+		}
 	}
 
 	public Variable<?> get(final String key) {

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/value/StructValue.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/value/StructValue.java
@@ -36,6 +36,16 @@ public final class StructValue implements AnyDerivedValue, Iterable<Value> {
 				.collect(Collectors.toMap(Variable::getName, Function.identity(), (a, b) -> a, LinkedHashMap::new));
 	}
 
+	public StructValue(final StructuredType type, final Map<String, ?> values) {
+		this(type);
+		values.forEach((name, value) -> {
+			final Variable<?> member = members.get(name);
+			if (member != null) {
+				member.setValue(ValueOperations.wrapValue(value, member.getType()));
+			}
+		});
+	}
+
 	protected static Variable<?> initializeMember(final VarDeclaration variable) {
 		try {
 			return VariableOperations.newVariable(variable);

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/AbstractVariable.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/AbstractVariable.java
@@ -17,6 +17,7 @@ import org.eclipse.fordiac.ide.model.data.AnyDurationType;
 import org.eclipse.fordiac.ide.model.data.DataType;
 import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes;
 import org.eclipse.fordiac.ide.model.eval.value.Value;
+import org.eclipse.fordiac.ide.model.eval.value.ValueOperations;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 
 public abstract class AbstractVariable<T extends Value> implements Variable<T> {
@@ -50,6 +51,21 @@ public abstract class AbstractVariable<T extends Value> implements Variable<T> {
 	@Override
 	public INamedElement getType() {
 		return type;
+	}
+
+	@Override
+	public void setValue(final String value) {
+		setValue(ValueOperations.parseValue(value, getType()));
+	}
+
+	@Override
+	public boolean validateValue(final String value) {
+		try {
+			ValueOperations.parseValue(value, getType());
+		} catch (final Exception e) {
+			return false;
+		}
+		return true;
 	}
 
 	protected RuntimeException createCastException(final Value value) {

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/ArrayVariable.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/ArrayVariable.java
@@ -56,16 +56,6 @@ public class ArrayVariable extends AbstractVariable<ArrayValue> implements Itera
 	}
 
 	@Override
-	public void setValue(final String value) {
-		setValue(VariableOperations.evaluateValue(getType(), value));
-	}
-
-	@Override
-	public boolean validateValue(final String value) {
-		return VariableOperations.validateValue(getType(), value).isEmpty();
-	}
-
-	@Override
 	public ArrayType getType() {
 		return (ArrayType) super.getType();
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/ArrayVariable.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/ArrayVariable.java
@@ -24,31 +24,13 @@ import org.eclipse.fordiac.ide.model.data.DataType;
 import org.eclipse.fordiac.ide.model.data.Subrange;
 import org.eclipse.fordiac.ide.model.eval.value.ArrayValue;
 import org.eclipse.fordiac.ide.model.eval.value.Value;
-import org.eclipse.fordiac.ide.model.eval.value.ValueOperations;
 
 public class ArrayVariable extends AbstractVariable<ArrayValue> implements Iterable<Variable<?>> {
-	private final DataType elementType;
-	private final List<Variable<?>> elements;
 	private final ArrayValue value;
 
 	public ArrayVariable(final String name, final ArrayType type) {
 		super(name, type);
-		if (type.getSubranges().isEmpty() || type.getSubranges().stream()
-				.anyMatch(subrange -> !subrange.isSetLowerLimit() || !subrange.isSetUpperLimit())) {
-			throw new IllegalArgumentException("Cannot instantiate array variable with unknown bounds"); //$NON-NLS-1$
-		}
-		if (type.getSubranges().size() > 1) {
-			elementType = ArrayVariable.newArrayType(type.getBaseType(),
-					type.getSubranges().stream().skip(1).map(EcoreUtil::copy).toList());
-		} else {
-			elementType = type.getBaseType();
-		}
-
-		elements = IntStream
-				.rangeClosed(type.getSubranges().get(0).getLowerLimit(), type.getSubranges().get(0).getUpperLimit())
-				.<Variable<?>>mapToObj(index -> VariableOperations.newVariable(Integer.toString(index), elementType))
-				.toList();
-		value = new ArrayValue(type, elements);
+		value = new ArrayValue(type);
 	}
 
 	public ArrayVariable(final String name, final ArrayType type, final String value) {
@@ -69,8 +51,8 @@ public class ArrayVariable extends AbstractVariable<ArrayValue> implements Itera
 
 		IntStream.rangeClosed(//
 				Math.max(this.value.getStart(), arrayValue.getStart()),
-				Math.min(this.value.getEnd(), arrayValue.getEnd())).forEach(index -> //
-		this.value.get(index).setValue(ValueOperations.castValue(arrayValue.get(index).getValue(), elementType)));
+				Math.min(this.value.getEnd(), arrayValue.getEnd()))
+				.forEach(index -> this.value.get(index).setValue(arrayValue.get(index).getValue()));
 	}
 
 	@Override
@@ -143,15 +125,15 @@ public class ArrayVariable extends AbstractVariable<ArrayValue> implements Itera
 
 	@Override
 	public Iterator<Variable<?>> iterator() {
-		return elements.iterator();
+		return value.getElements().iterator();
 	}
 
 	public DataType getElementType() {
-		return elementType;
+		return value.getElementType();
 	}
 
 	public List<Variable<?>> getElements() {
-		return elements;
+		return value.getElements();
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/DirectlyDerivedVariable.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/DirectlyDerivedVariable.java
@@ -13,6 +13,7 @@
 package org.eclipse.fordiac.ide.model.eval.variable;
 
 import org.eclipse.fordiac.ide.model.data.DirectlyDerivedType;
+import org.eclipse.fordiac.ide.model.eval.EvaluatorInitializerException;
 import org.eclipse.fordiac.ide.model.eval.value.Value;
 
 public class DirectlyDerivedVariable extends AbstractVariable<Value> {
@@ -21,7 +22,11 @@ public class DirectlyDerivedVariable extends AbstractVariable<Value> {
 
 	protected DirectlyDerivedVariable(final String name, final DirectlyDerivedType type) {
 		super(name, type);
-		delegate = VariableOperations.newVariable(type);
+		try {
+			delegate = VariableOperations.newVariable(type);
+		} catch (final Exception e) {
+			throw new EvaluatorInitializerException(type, e);
+		}
 	}
 
 	protected DirectlyDerivedVariable(final String name, final DirectlyDerivedType type, final String value) {

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/ElementaryVariable.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/ElementaryVariable.java
@@ -44,16 +44,6 @@ public final class ElementaryVariable<T extends AnyElementaryValue> extends Abst
 	}
 
 	@Override
-	public void setValue(final String value) {
-		setValue(VariableOperations.evaluateValue(getType(), value));
-	}
-
-	@Override
-	public boolean validateValue(final String value) {
-		return VariableOperations.validateValue(getType(), value).isEmpty();
-	}
-
-	@Override
 	public AnyType getType() {
 		return (AnyType) super.getType();
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/FBVariable.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/FBVariable.java
@@ -13,25 +13,18 @@
 package org.eclipse.fordiac.ide.model.eval.variable;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import org.eclipse.fordiac.ide.model.eval.value.FBValue;
 import org.eclipse.fordiac.ide.model.eval.value.Value;
-import org.eclipse.fordiac.ide.model.libraryElement.AdapterDeclaration;
-import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType;
-import org.eclipse.fordiac.ide.model.libraryElement.BasicFBType;
-import org.eclipse.fordiac.ide.model.libraryElement.FB;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
-import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 
 public class FBVariable extends AbstractVariable<FBValue> {
 	private static final Pattern MAP_PATTERN = Pattern.compile(",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)"); //$NON-NLS-1$
 	private static final Pattern MAP_KV_PATTERN = Pattern.compile(":=(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)"); //$NON-NLS-1$
 
-	private final Map<String, Variable<?>> members = new HashMap<>();
 	private final FBValue value;
 
 	public FBVariable(final String name, final FBType type) {
@@ -50,41 +43,7 @@ public class FBVariable extends AbstractVariable<FBValue> {
 
 	public FBVariable(final String name, final FBType type, final Iterable<Variable<?>> variables) {
 		super(name, type);
-		if (variables != null) {
-			variables.forEach(variable -> members.put(variable.getName(), variable));
-		}
-		type.getInterfaceList().getInputVars().forEach(this::initializeMember);
-		type.getInterfaceList().getInOutVars().forEach(this::initializeMember);
-		type.getInterfaceList().getOutputVars().forEach(this::initializeMember);
-		type.getInterfaceList().getSockets().stream().map(AdapterDeclaration::getAdapterFB)
-				.forEach(this::initializeMember);
-		type.getInterfaceList().getPlugs().stream().map(AdapterDeclaration::getAdapterFB)
-				.forEach(this::initializeMember);
-		if (type instanceof final BaseFBType baseFBType) {
-			baseFBType.getInternalConstVars().forEach(this::initializeMember);
-			baseFBType.getInternalVars().forEach(this::initializeMember);
-			baseFBType.getInternalFbs().forEach(this::initializeMember);
-		}
-		if (type instanceof final BasicFBType basicFBType) {
-			members.computeIfAbsent(ECStateVariable.NAME, unused -> new ECStateVariable(basicFBType));
-		}
-		value = new FBValue(type, members);
-	}
-
-	protected void initializeMember(final VarDeclaration variable) {
-		try {
-			members.computeIfAbsent(variable.getName(), unused -> VariableOperations.newVariable(variable));
-		} catch (final Exception e) {
-			throw new RuntimeException("Error initializing member " + variable.getName() + ": " + e.getMessage(), e); //$NON-NLS-1$ //$NON-NLS-2$
-		}
-	}
-
-	protected void initializeMember(final FB fb) {
-		try {
-			members.computeIfAbsent(fb.getName(), unused -> VariableOperations.newVariable(fb));
-		} catch (final Exception e) {
-			throw new RuntimeException("Error initializing member " + fb.getName() + ": " + e.getMessage(), e); //$NON-NLS-1$ //$NON-NLS-2$
-		}
+		value = new FBValue(type, variables);
 	}
 
 	@Override
@@ -92,7 +51,7 @@ public class FBVariable extends AbstractVariable<FBValue> {
 		if (!(value instanceof final FBValue fbValue) || fbValue.getType() != getType()) {
 			throw createCastException(value);
 		}
-		fbValue.getMembers().forEach((name, variable) -> members.get(name).setValue(variable.getValue()));
+		fbValue.getMembers().forEach((name, variable) -> this.value.get(name).setValue(variable.getValue()));
 	}
 
 	@Override
@@ -107,7 +66,7 @@ public class FBVariable extends AbstractVariable<FBValue> {
 			if (split.length != 2) {
 				throw createInvalidValueException();
 			}
-			final Variable<?> variable = members.get(split[0].trim());
+			final Variable<?> variable = this.value.get(split[0].trim());
 			if (variable == null) {
 				throw createInvalidValueException();
 			}
@@ -127,13 +86,13 @@ public class FBVariable extends AbstractVariable<FBValue> {
 			if (split.length != 2) {
 				return false;
 			}
-			final Variable<?> variable = this.members.get(split[0].trim());
+			final Variable<?> variable = this.value.get(split[0].trim());
 			return variable != null && variable.validateValue(split[1].trim());
 		});
 	}
 
 	public Map<String, Variable<?>> getMembers() {
-		return members;
+		return value.getMembers();
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/PartialVariable.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/PartialVariable.java
@@ -43,16 +43,6 @@ public class PartialVariable<T extends Value> extends AbstractVariable<T> {
 	}
 
 	@Override
-	public void setValue(final String value) {
-		setValue(VariableOperations.evaluateValue(getType(), value));
-	}
-
-	@Override
-	public boolean validateValue(final String value) {
-		return VariableOperations.validateValue(getType(), value).isEmpty();
-	}
-
-	@Override
 	public AnyBitType getType() {
 		return (AnyBitType) super.getType();
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/StringCharacterVariable.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/StringCharacterVariable.java
@@ -48,16 +48,6 @@ public class StringCharacterVariable extends AbstractVariable<CharValue> {
 	}
 
 	@Override
-	public void setValue(final String value) {
-		setValue(VariableOperations.evaluateValue(getType(), value));
-	}
-
-	@Override
-	public boolean validateValue(final String value) {
-		return VariableOperations.validateValue(getType(), value).isEmpty();
-	}
-
-	@Override
 	public CharType getType() {
 		return (CharType) super.getType();
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/StructVariable.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/StructVariable.java
@@ -13,24 +13,18 @@
 package org.eclipse.fordiac.ide.model.eval.variable;
 
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.eclipse.fordiac.ide.model.data.StructuredType;
 import org.eclipse.fordiac.ide.model.eval.value.StructValue;
 import org.eclipse.fordiac.ide.model.eval.value.Value;
 
 public class StructVariable extends AbstractVariable<StructValue> implements Iterable<Variable<?>> {
-	private final Map<String, Variable<?>> members;
 	private final StructValue value;
 
 	public StructVariable(final String name, final StructuredType type) {
 		super(name, type);
-		members = type.getMemberVariables().stream().map(VariableOperations::newVariable)
-				.collect(Collectors.toMap(Variable::getName, Function.identity(), (a, b) -> a, LinkedHashMap::new));
-		value = new StructValue(type, members);
+		value = new StructValue(type);
 	}
 
 	public StructVariable(final String name, final StructuredType type, final String value) {
@@ -48,7 +42,7 @@ public class StructVariable extends AbstractVariable<StructValue> implements Ite
 		if (!(value instanceof final StructValue structValue) || !getType().isAssignableFrom(structValue.getType())) {
 			throw createCastException(value);
 		}
-		structValue.getMembers().forEach((name, variable) -> members.get(name).setValue(variable.getValue()));
+		structValue.getMembers().forEach((name, variable) -> this.value.get(name).setValue(variable.getValue()));
 	}
 
 	@Override
@@ -68,11 +62,11 @@ public class StructVariable extends AbstractVariable<StructValue> implements Ite
 
 	@Override
 	public Iterator<Variable<?>> iterator() {
-		return members.values().iterator();
+		return value.getMembers().values().iterator();
 	}
 
 	public Map<String, Variable<?>> getMembers() {
-		return members;
+		return value.getMembers();
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/StructVariable.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/StructVariable.java
@@ -46,16 +46,6 @@ public class StructVariable extends AbstractVariable<StructValue> implements Ite
 	}
 
 	@Override
-	public void setValue(final String value) {
-		setValue(VariableOperations.evaluateValue(getType(), value));
-	}
-
-	@Override
-	public boolean validateValue(final String value) {
-		return VariableOperations.validateValue(getType(), value).isEmpty();
-	}
-
-	@Override
 	public StructuredType getType() {
 		return (StructuredType) super.getType();
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/WStringCharacterVariable.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/WStringCharacterVariable.java
@@ -48,16 +48,6 @@ public class WStringCharacterVariable extends AbstractVariable<WCharValue> {
 	}
 
 	@Override
-	public void setValue(final String value) {
-		setValue(VariableOperations.evaluateValue(getType(), value));
-	}
-
-	@Override
-	public boolean validateValue(final String value) {
-		return VariableOperations.validateValue(getType(), value).isEmpty();
-	}
-
-	@Override
 	public WcharType getType() {
 		return (WcharType) super.getType();
 	}

--- a/tests/org.eclipse.fordiac.ide.test.model.eval/src/org/eclipse/fordiac/ide/test/model/eval/value/ValueOperationsTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model.eval/src/org/eclipse/fordiac/ide/test/model/eval/value/ValueOperationsTest.java
@@ -39,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -60,6 +61,7 @@ import org.eclipse.fordiac.ide.model.data.LdateType;
 import org.eclipse.fordiac.ide.model.data.LdtType;
 import org.eclipse.fordiac.ide.model.data.LtimeType;
 import org.eclipse.fordiac.ide.model.data.LtodType;
+import org.eclipse.fordiac.ide.model.data.StructuredType;
 import org.eclipse.fordiac.ide.model.data.TimeOfDayType;
 import org.eclipse.fordiac.ide.model.data.TimeType;
 import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes.ElementaryTypes;
@@ -416,6 +418,8 @@ class ValueOperationsTest {
 			assertEquals(defaultValue, wrapValue("\u0000", type));
 		} else if (type instanceof AnyCharsType) {
 			assertEquals(defaultValue, wrapValue("", type));
+		} else if (type instanceof StructuredType) {
+			assertEquals(defaultValue, wrapValue(Map.of(), type));
 		} else {
 			assertEquals(defaultValue, wrapValue(Integer.valueOf(0), type));
 		}


### PR DESCRIPTION
Refactor parsing of values in evaluator to use the new structured value converters and thus improve performance by avoiding the full ST parser/evaluator. Also improve flexibility by moving member initialization to values.