### PR TITLE
New Menu Entry for monitoring internal vars

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.monitoring/model/monitoring.ecore
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/model/monitoring.ecore
@@ -58,4 +58,12 @@
     </eOperations>
     <eStructuralFeatures xsi:type="ecore:EReference" name="anchor" eType="ecore:EClass ../../org.eclipse.fordiac.ide.deployment/model/monitoringBase.ecore#//MonitoringBaseElement"/>
   </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="InternalVarInstance" eSuperTypes="../../org.eclipse.fordiac.ide.model/model/lib.ecore#//VarDeclaration">
+    <eOperations name="getFBNetworkElement" lowerBound="1" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//FBNetworkElement">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="body" value="return getFb();"/>
+      </eAnnotations>
+    </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="fb" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//FB"/>
+  </eClassifiers>
 </ecore:EPackage>

--- a/plugins/org.eclipse.fordiac.ide.monitoring/model/monitoring.genmodel
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/model/monitoring.genmodel
@@ -47,5 +47,10 @@
       <genOperations ecoreOperation="monitoring.ecore#//SubappMonitoringElement/getQualifiedString"
           body="&#x9;&#x9;return anchor.getQualifiedString();"/>
     </genClasses>
+    <genClasses ecoreClass="monitoring.ecore#//InternalVarInstance">
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference monitoring.ecore#//InternalVarInstance/fb"/>
+      <genOperations ecoreOperation="monitoring.ecore#//InternalVarInstance/getFBNetworkElement"
+          body="return getFb();"/>
+    </genClasses>
   </genPackages>
 </genmodel:GenModel>

--- a/plugins/org.eclipse.fordiac.ide.monitoring/plugin.properties
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/plugin.properties
@@ -14,6 +14,9 @@ contributions.menus.debug.triggerEventToolTip = Manually trigger event on the se
 contributions.menus.debug.watch = Watch
 contributions.menus.debug.watchToolTip = Watch all selected elements.
 
+contributions.menus.debug.watchInternals = Watch internal variables
+contributions.menus.debug.watchInternalsToolTip = Watch the internal variables of all selected elements.
+
 contributions.menus.debug.watchAll = Watch All
 contributions.menus.debug.watchAllToolTip = Watch all elements of the selected Function Blocks.
 

--- a/plugins/org.eclipse.fordiac.ide.monitoring/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/plugin.xml
@@ -155,6 +155,11 @@
             id="org.eclipse.fordiac.ide.monitoring.commands.addWatch"
             name="Watch">
       </command>
+       <command
+            categoryId="org.eclipse.fordiac.ide.monitoring"
+            id="org.eclipse.fordiac.ide.monitoring.commands.watchInternals"
+            name="Watch internal variables">
+      </command>
       <command
             categoryId="org.eclipse.fordiac.ide.monitoring"
             id="org.eclipse.fordiac.ide.monitoring.commands.triggerEvent"
@@ -211,6 +216,12 @@
                tooltip="%contributions.menus.debug.watchToolTip">
          </command>
          <command
+               commandId="org.eclipse.fordiac.ide.monitoring.commands.watchInternals"
+               icon="fordiacimage://ICON_WATCH_INTERFACE_ELEMENTS"
+               label="%contributions.menus.debug.watchInternals"
+               tooltip="%contributions.menus.debug.watchInernalsToolTip">
+         </command>
+         <command
                commandId="org.eclipse.fordiac.ide.monitoring.commands.removeAllWatches"
                icon="fordiacimage://ICON_REMOVE_WATCH"
                label="%contributions.menus.debug.removeAllWatches"
@@ -264,6 +275,15 @@
             </visibleWhen>
          </command>
          <command
+               commandId="org.eclipse.fordiac.ide.monitoring.commands.watchInternals"
+               icon="fordiacimage://ICON_WATCH_INTERFACE_ELEMENTS"
+               label="%contributions.menus.debug.watchInternals"
+               tooltip="%contributions.menus.debug.watchInernalsToolTip">
+            <visibleWhen checkEnabled="false">
+            	<reference definitionId="org.eclipse.fordiac.ide.monitoring.MonitoringCapableEditor" />
+            </visibleWhen>
+         </command>
+         <command
                commandId="org.eclipse.fordiac.ide.monitoring.commands.removeAllWatches"
                icon="fordiacimage://ICON_REMOVE_WATCH"
                label="%contributions.menus.debug.removeAllWatches"
@@ -275,6 +295,7 @@
 						<or>
 							<instanceof value="org.eclipse.fordiac.ide.model.libraryElement.Application" />
 							<instanceof value="org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem" />
+							<instanceof value="org.eclipse.fordiac.ide.monitoring.views.WatchValueTreeNode" />
 						</or>
 					</iterate>
 				</or>
@@ -324,6 +345,10 @@
       <handler
             class="org.eclipse.fordiac.ide.monitoring.handlers.AddWatchHandler"
             commandId="org.eclipse.fordiac.ide.monitoring.commands.addWatch">
+      </handler>
+      <handler
+            class="org.eclipse.fordiac.ide.monitoring.handlers.WatchInternalVarsHandler"
+            commandId="org.eclipse.fordiac.ide.monitoring.commands.watchInternals">
       </handler>
       <handler
             class="org.eclipse.fordiac.ide.monitoring.handlers.TriggerEventHandler"

--- a/plugins/org.eclipse.fordiac.ide.monitoring/src-gen/org/eclipse/fordiac/ide/model/monitoring/InternalVarInstance.java
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/src-gen/org/eclipse/fordiac/ide/model/monitoring/InternalVarInstance.java
@@ -1,0 +1,71 @@
+/**
+ * ******************************************************************************
+ * Copyright (c) 2012, 2013, 2015 - 2017 Profactor GmbH, fortiss GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Gerhard Ebenhofer, Alois Zoitl, Gerd Kainz
+ *      - initial API and implementation and/or initial documentation
+ * ******************************************************************************
+ *
+ */
+package org.eclipse.fordiac.ide.model.monitoring;
+
+import org.eclipse.fordiac.ide.model.libraryElement.FB;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the model object '<em><b>Internal Var Instance</b></em>'.
+ * <!-- end-user-doc -->
+ *
+ * <p>
+ * The following features are supported:
+ * </p>
+ * <ul>
+ *   <li>{@link org.eclipse.fordiac.ide.model.monitoring.InternalVarInstance#getFb <em>Fb</em>}</li>
+ * </ul>
+ *
+ * @see org.eclipse.fordiac.ide.model.monitoring.MonitoringPackage#getInternalVarInstance()
+ * @model
+ * @generated
+ */
+public interface InternalVarInstance extends VarDeclaration {
+	/**
+	 * Returns the value of the '<em><b>Fb</b></em>' reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Fb</em>' reference.
+	 * @see #setFb(FB)
+	 * @see org.eclipse.fordiac.ide.model.monitoring.MonitoringPackage#getInternalVarInstance_Fb()
+	 * @model
+	 * @generated
+	 */
+	FB getFb();
+
+	/**
+	 * Sets the value of the '{@link org.eclipse.fordiac.ide.model.monitoring.InternalVarInstance#getFb <em>Fb</em>}' reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Fb</em>' reference.
+	 * @see #getFb()
+	 * @generated
+	 */
+	void setFb(FB value);
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @model kind="operation" required="true"
+	 * @generated
+	 */
+	@Override
+	FBNetworkElement getFBNetworkElement();
+
+} // InternalVarInstance

--- a/plugins/org.eclipse.fordiac.ide.monitoring/src-gen/org/eclipse/fordiac/ide/model/monitoring/MonitoringFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/src-gen/org/eclipse/fordiac/ide/model/monitoring/MonitoringFactory.java
@@ -93,6 +93,15 @@ public interface MonitoringFactory extends EFactory {
 	SubappMonitoringElement createSubappMonitoringElement();
 
 	/**
+	 * Returns a new object of class '<em>Internal Var Instance</em>'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return a new object of class '<em>Internal Var Instance</em>'.
+	 * @generated
+	 */
+	InternalVarInstance createInternalVarInstance();
+
+	/**
 	 * Returns the package supported by this factory.
 	 * <!-- begin-user-doc --> <!--
 	 * end-user-doc -->

--- a/plugins/org.eclipse.fordiac.ide.monitoring/src-gen/org/eclipse/fordiac/ide/model/monitoring/MonitoringPackage.java
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/src-gen/org/eclipse/fordiac/ide/model/monitoring/MonitoringPackage.java
@@ -18,6 +18,7 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.fordiac.ide.deployment.monitoringbase.MonitoringBasePackage;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 
 /**
  * <!-- begin-user-doc --> The <b>Package</b> for the model. It contains
@@ -627,6 +628,124 @@ public interface MonitoringPackage extends EPackage {
 	int SUBAPP_MONITORING_ELEMENT_FEATURE_COUNT = MONITORING_ELEMENT_FEATURE_COUNT + 1;
 
 	/**
+	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.monitoring.impl.InternalVarInstanceImpl <em>Internal Var Instance</em>}' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see org.eclipse.fordiac.ide.model.monitoring.impl.InternalVarInstanceImpl
+	 * @see org.eclipse.fordiac.ide.model.monitoring.impl.MonitoringPackageImpl#getInternalVarInstance()
+	 * @generated
+	 */
+	int INTERNAL_VAR_INSTANCE = 8;
+
+	/**
+	 * The feature id for the '<em><b>Name</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int INTERNAL_VAR_INSTANCE__NAME = LibraryElementPackage.VAR_DECLARATION__NAME;
+
+	/**
+	 * The feature id for the '<em><b>Comment</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int INTERNAL_VAR_INSTANCE__COMMENT = LibraryElementPackage.VAR_DECLARATION__COMMENT;
+
+	/**
+	 * The feature id for the '<em><b>Attributes</b></em>' containment reference list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int INTERNAL_VAR_INSTANCE__ATTRIBUTES = LibraryElementPackage.VAR_DECLARATION__ATTRIBUTES;
+
+	/**
+	 * The feature id for the '<em><b>Is Input</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int INTERNAL_VAR_INSTANCE__IS_INPUT = LibraryElementPackage.VAR_DECLARATION__IS_INPUT;
+
+	/**
+	 * The feature id for the '<em><b>Input Connections</b></em>' reference list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int INTERNAL_VAR_INSTANCE__INPUT_CONNECTIONS = LibraryElementPackage.VAR_DECLARATION__INPUT_CONNECTIONS;
+
+	/**
+	 * The feature id for the '<em><b>Output Connections</b></em>' reference list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int INTERNAL_VAR_INSTANCE__OUTPUT_CONNECTIONS = LibraryElementPackage.VAR_DECLARATION__OUTPUT_CONNECTIONS;
+
+	/**
+	 * The feature id for the '<em><b>Type</b></em>' reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int INTERNAL_VAR_INSTANCE__TYPE = LibraryElementPackage.VAR_DECLARATION__TYPE;
+
+	/**
+	 * The feature id for the '<em><b>Array Size</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int INTERNAL_VAR_INSTANCE__ARRAY_SIZE = LibraryElementPackage.VAR_DECLARATION__ARRAY_SIZE;
+
+	/**
+	 * The feature id for the '<em><b>Withs</b></em>' reference list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int INTERNAL_VAR_INSTANCE__WITHS = LibraryElementPackage.VAR_DECLARATION__WITHS;
+
+	/**
+	 * The feature id for the '<em><b>Value</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int INTERNAL_VAR_INSTANCE__VALUE = LibraryElementPackage.VAR_DECLARATION__VALUE;
+
+	/**
+	 * The feature id for the '<em><b>Fb</b></em>' reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int INTERNAL_VAR_INSTANCE__FB = LibraryElementPackage.VAR_DECLARATION_FEATURE_COUNT + 0;
+
+	/**
+	 * The number of structural features of the '<em>Internal Var Instance</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int INTERNAL_VAR_INSTANCE_FEATURE_COUNT = LibraryElementPackage.VAR_DECLARATION_FEATURE_COUNT + 1;
+
+	/**
 	 * Returns the meta object for class '{@link org.eclipse.fordiac.ide.model.monitoring.MonitoringElement <em>Element</em>}'.
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @return the meta object for class '<em>Element</em>'.
@@ -768,6 +887,27 @@ public interface MonitoringPackage extends EPackage {
 	 * @generated
 	 */
 	EReference getSubappMonitoringElement_Anchor();
+
+	/**
+	 * Returns the meta object for class '{@link org.eclipse.fordiac.ide.model.monitoring.InternalVarInstance <em>Internal Var Instance</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for class '<em>Internal Var Instance</em>'.
+	 * @see org.eclipse.fordiac.ide.model.monitoring.InternalVarInstance
+	 * @generated
+	 */
+	EClass getInternalVarInstance();
+
+	/**
+	 * Returns the meta object for the reference '{@link org.eclipse.fordiac.ide.model.monitoring.InternalVarInstance#getFb <em>Fb</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the reference '<em>Fb</em>'.
+	 * @see org.eclipse.fordiac.ide.model.monitoring.InternalVarInstance#getFb()
+	 * @see #getInternalVarInstance()
+	 * @generated
+	 */
+	EReference getInternalVarInstance_Fb();
 
 	/**
 	 * Returns the meta object for class
@@ -947,6 +1087,24 @@ public interface MonitoringPackage extends EPackage {
 		 * @generated
 		 */
 		EReference SUBAPP_MONITORING_ELEMENT__ANCHOR = eINSTANCE.getSubappMonitoringElement_Anchor();
+
+		/**
+		 * The meta object literal for the '{@link org.eclipse.fordiac.ide.model.monitoring.impl.InternalVarInstanceImpl <em>Internal Var Instance</em>}' class.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @see org.eclipse.fordiac.ide.model.monitoring.impl.InternalVarInstanceImpl
+		 * @see org.eclipse.fordiac.ide.model.monitoring.impl.MonitoringPackageImpl#getInternalVarInstance()
+		 * @generated
+		 */
+		EClass INTERNAL_VAR_INSTANCE = eINSTANCE.getInternalVarInstance();
+
+		/**
+		 * The meta object literal for the '<em><b>Fb</b></em>' reference feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EReference INTERNAL_VAR_INSTANCE__FB = eINSTANCE.getInternalVarInstance_Fb();
 
 		/**
 		 * The meta object literal for the '{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterPortElementImpl <em>Adapter Port Element</em>}' class.

--- a/plugins/org.eclipse.fordiac.ide.monitoring/src-gen/org/eclipse/fordiac/ide/model/monitoring/impl/AdapterMonitoringEventImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/src-gen/org/eclipse/fordiac/ide/model/monitoring/impl/AdapterMonitoringEventImpl.java
@@ -53,22 +53,14 @@ import org.eclipse.gef.EditPart;
  * The following features are implemented:
  * </p>
  * <ul>
- * <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringEventImpl#getName
- * <em>Name</em>}</li>
- * <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringEventImpl#getComment
- * <em>Comment</em>}</li>
- * <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringEventImpl#getAttributes
- * <em>Attributes</em>}</li>
- * <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringEventImpl#isIsInput
- * <em>Is Input</em>}</li>
- * <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringEventImpl#getInputConnections
- * <em>Input Connections</em>}</li>
- * <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringEventImpl#getOutputConnections
- * <em>Output Connections</em>}</li>
- * <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringEventImpl#getType
- * <em>Type</em>}</li>
- * <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringEventImpl#getWith
- * <em>With</em>}</li>
+ *   <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringEventImpl#getName <em>Name</em>}</li>
+ *   <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringEventImpl#getComment <em>Comment</em>}</li>
+ *   <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringEventImpl#getAttributes <em>Attributes</em>}</li>
+ *   <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringEventImpl#isIsInput <em>Is Input</em>}</li>
+ *   <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringEventImpl#getInputConnections <em>Input Connections</em>}</li>
+ *   <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringEventImpl#getOutputConnections <em>Output Connections</em>}</li>
+ *   <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringEventImpl#getType <em>Type</em>}</li>
+ *   <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringEventImpl#getWith <em>With</em>}</li>
  * </ul>
  *
  * @generated
@@ -97,7 +89,6 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 	/**
 	 * The default value of the '{@link #getComment() <em>Comment</em>}' attribute.
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @see #getComment()
 	 * @generated
 	 * @ordered
@@ -107,7 +98,6 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 	/**
 	 * The cached value of the '{@link #getComment() <em>Comment</em>}' attribute.
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @see #getComment()
 	 * @generated
 	 * @ordered
@@ -115,9 +105,8 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 	protected String comment = COMMENT_EDEFAULT;
 
 	/**
-	 * The cached value of the '{@link #getAttributes() <em>Attributes</em>}'
-	 * containment reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
+	 * The cached value of the '{@link #getAttributes() <em>Attributes</em>}' containment reference list.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @see #getAttributes()
 	 * @generated
 	 * @ordered
@@ -127,7 +116,6 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 	/**
 	 * The default value of the '{@link #isIsInput() <em>Is Input</em>}' attribute.
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @see #isIsInput()
 	 * @generated
 	 * @ordered
@@ -137,7 +125,6 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 	/**
 	 * The cached value of the '{@link #isIsInput() <em>Is Input</em>}' attribute.
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @see #isIsInput()
 	 * @generated
 	 * @ordered
@@ -177,9 +164,8 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 	protected DataType type;
 
 	/**
-	 * The cached value of the '{@link #getWith() <em>With</em>}' containment
-	 * reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
+	 * The cached value of the '{@link #getWith() <em>With</em>}' containment reference list.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @see #getWith()
 	 * @generated
 	 * @ordered
@@ -188,15 +174,14 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	protected AdapterMonitoringEventImpl() {
+		super();
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -206,7 +191,6 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -216,22 +200,19 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
-	public void setName(final String newName) {
-		final String oldName = name;
+	public void setName(String newName) {
+		String oldName = name;
 		name = newName;
 		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(this, Notification.SET, MonitoringPackage.ADAPTER_MONITORING_EVENT__NAME,
-					oldName, name));
+			eNotify(new ENotificationImpl(this, Notification.SET, MonitoringPackage.ADAPTER_MONITORING_EVENT__NAME, oldName, name));
 		}
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -241,36 +222,31 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
-	public void setComment(final String newComment) {
-		final String oldComment = comment;
+	public void setComment(String newComment) {
+		String oldComment = comment;
 		comment = newComment;
 		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(this, Notification.SET, MonitoringPackage.ADAPTER_MONITORING_EVENT__COMMENT,
-					oldComment, comment));
+			eNotify(new ENotificationImpl(this, Notification.SET, MonitoringPackage.ADAPTER_MONITORING_EVENT__COMMENT, oldComment, comment));
 		}
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public EList<Attribute> getAttributes() {
 		if (attributes == null) {
-			attributes = new EObjectContainmentEList.Resolving<>(Attribute.class, this,
-					MonitoringPackage.ADAPTER_MONITORING_EVENT__ATTRIBUTES);
+			attributes = new EObjectContainmentEList.Resolving<>(Attribute.class, this, MonitoringPackage.ADAPTER_MONITORING_EVENT__ATTRIBUTES);
 		}
 		return attributes;
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -280,28 +256,25 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
-	public void setIsInput(final boolean newIsInput) {
-		final boolean oldIsInput = isInput;
+	public void setIsInput(boolean newIsInput) {
+		boolean oldIsInput = isInput;
 		isInput = newIsInput;
 		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(this, Notification.SET, MonitoringPackage.ADAPTER_MONITORING_EVENT__IS_INPUT,
-					oldIsInput, isInput));
+			eNotify(new ENotificationImpl(this, Notification.SET, MonitoringPackage.ADAPTER_MONITORING_EVENT__IS_INPUT, oldIsInput, isInput));
 		}
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public String getTypeName() {
-		final org.eclipse.fordiac.ide.model.libraryElement.INamedElement type = getType();
-		if (type != null) {
+		org.eclipse.fordiac.ide.model.libraryElement.INamedElement type = getType();
+		if(type != null){
 			return type.getName();
 		}
 		return null;
@@ -309,7 +282,6 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -319,69 +291,59 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public boolean validateType(final DiagnosticChain diagnostics, final Map<Object, Object> context) {
-		return org.eclipse.fordiac.ide.model.libraryElement.impl.TypedElementAnnotations.validateType(this, diagnostics,
-				context);
+		return org.eclipse.fordiac.ide.model.libraryElement.impl.TypedElementAnnotations.validateType(this, diagnostics, context);
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public boolean validateName(final DiagnosticChain diagnostics, final Map<Object, Object> context) {
-		return org.eclipse.fordiac.ide.model.libraryElement.impl.InterfaceElementAnnotations.validateName(this,
-				diagnostics, context);
+		return org.eclipse.fordiac.ide.model.libraryElement.impl.InterfaceElementAnnotations.validateName(this, diagnostics, context);
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public EList<Connection> getInputConnections() {
 		if (inputConnections == null) {
-			inputConnections = new EObjectWithInverseResolvingEList<>(Connection.class, this,
-					MonitoringPackage.ADAPTER_MONITORING_EVENT__INPUT_CONNECTIONS,
-					LibraryElementPackage.CONNECTION__DESTINATION);
+			inputConnections = new EObjectWithInverseResolvingEList<>(Connection.class, this, MonitoringPackage.ADAPTER_MONITORING_EVENT__INPUT_CONNECTIONS, LibraryElementPackage.CONNECTION__DESTINATION);
 		}
 		return inputConnections;
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public EList<Connection> getOutputConnections() {
 		if (outputConnections == null) {
-			outputConnections = new EObjectWithInverseResolvingEList<>(Connection.class, this,
-					MonitoringPackage.ADAPTER_MONITORING_EVENT__OUTPUT_CONNECTIONS,
-					LibraryElementPackage.CONNECTION__SOURCE);
+			outputConnections = new EObjectWithInverseResolvingEList<>(Connection.class, this, MonitoringPackage.ADAPTER_MONITORING_EVENT__OUTPUT_CONNECTIONS, LibraryElementPackage.CONNECTION__SOURCE);
 		}
 		return outputConnections;
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public DataType getType() {
 		if (type != null && type.eIsProxy()) {
-			final InternalEObject oldType = (InternalEObject) type;
-			type = (DataType) eResolveProxy(oldType);
-			if ((type != oldType) && eNotificationRequired()) {
-				eNotify(new ENotificationImpl(this, Notification.RESOLVE,
-						MonitoringPackage.ADAPTER_MONITORING_EVENT__TYPE, oldType, type));
+			InternalEObject oldType = (InternalEObject)type;
+			type = (DataType)eResolveProxy(oldType);
+			if (type != oldType) {
+				if (eNotificationRequired()) {
+					eNotify(new ENotificationImpl(this, Notification.RESOLVE, MonitoringPackage.ADAPTER_MONITORING_EVENT__TYPE, oldType, type));
+				}
 			}
 		}
 		return type;
@@ -389,7 +351,6 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	public DataType basicGetType() {
@@ -398,36 +359,31 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
-	public void setType(final DataType newType) {
-		final DataType oldType = type;
+	public void setType(DataType newType) {
+		DataType oldType = type;
 		type = newType;
 		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(this, Notification.SET, MonitoringPackage.ADAPTER_MONITORING_EVENT__TYPE,
-					oldType, type));
+			eNotify(new ENotificationImpl(this, Notification.SET, MonitoringPackage.ADAPTER_MONITORING_EVENT__TYPE, oldType, type));
 		}
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public EList<With> getWith() {
 		if (with == null) {
-			with = new EObjectContainmentEList<>(With.class, this,
-					MonitoringPackage.ADAPTER_MONITORING_EVENT__WITH);
+			with = new EObjectContainmentEList<>(With.class, this, MonitoringPackage.ADAPTER_MONITORING_EVENT__WITH);
 		}
 		return with;
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -437,7 +393,6 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -447,7 +402,6 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -457,7 +411,6 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -467,7 +420,6 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -477,17 +429,15 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public void setVisible(final boolean visible) {
-		org.eclipse.fordiac.ide.model.annotations.HiddenElementAnnotations.setVisible(this, visible);
+		org.eclipse.fordiac.ide.model.annotations.HiddenElementAnnotations.setVisible(this,visible);
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -497,7 +447,6 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -508,7 +457,6 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -519,7 +467,6 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -529,7 +476,6 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -539,7 +485,6 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -549,7 +494,6 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -559,278 +503,285 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public NotificationChain eInverseAdd(final InternalEObject otherEnd, final int featureID,
-			final NotificationChain msgs) {
-		return switch (featureID) {
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__INPUT_CONNECTIONS -> ((InternalEList<InternalEObject>) (InternalEList<?>) getInputConnections()).basicAdd(otherEnd, msgs);
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__OUTPUT_CONNECTIONS -> ((InternalEList<InternalEObject>) (InternalEList<?>) getOutputConnections()).basicAdd(otherEnd,
-							msgs);
-		default -> super.eInverseAdd(otherEnd, featureID, msgs);
-		};
-	}
-
-	/**
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
-	 * @generated
-	 */
-	@Override
-	public NotificationChain eInverseRemove(final InternalEObject otherEnd, final int featureID,
-			final NotificationChain msgs) {
-		return switch (featureID) {
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__ATTRIBUTES -> ((InternalEList<?>) getAttributes()).basicRemove(otherEnd, msgs);
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__INPUT_CONNECTIONS -> ((InternalEList<?>) getInputConnections()).basicRemove(otherEnd, msgs);
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__OUTPUT_CONNECTIONS -> ((InternalEList<?>) getOutputConnections()).basicRemove(otherEnd, msgs);
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__WITH -> ((InternalEList<?>) getWith()).basicRemove(otherEnd, msgs);
-		default -> super.eInverseRemove(otherEnd, featureID, msgs);
-		};
-	}
-
-	/**
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
-	 * @generated
-	 */
-	@Override
-	public Object eGet(final int featureID, final boolean resolve, final boolean coreType) {
+	public NotificationChain eInverseAdd(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
 		switch (featureID) {
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__NAME:
-			return getName();
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__COMMENT:
-			return getComment();
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__ATTRIBUTES:
-			return getAttributes();
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__IS_INPUT:
-			return isIsInput();
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__INPUT_CONNECTIONS:
-			return getInputConnections();
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__OUTPUT_CONNECTIONS:
-			return getOutputConnections();
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__TYPE:
-			if (resolve) {
-				return getType();
-			}
-			return basicGetType();
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__WITH:
-			return getWith();
-		default:
-			return super.eGet(featureID, resolve, coreType);
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__INPUT_CONNECTIONS:
+				return ((InternalEList<InternalEObject>)(InternalEList<?>)getInputConnections()).basicAdd(otherEnd, msgs);
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__OUTPUT_CONNECTIONS:
+				return ((InternalEList<InternalEObject>)(InternalEList<?>)getOutputConnections()).basicAdd(otherEnd, msgs);
+			default:
+				return super.eInverseAdd(otherEnd, featureID, msgs);
 		}
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
+	 * @generated
+	 */
+	@Override
+	public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
+		switch (featureID) {
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__ATTRIBUTES:
+				return ((InternalEList<?>)getAttributes()).basicRemove(otherEnd, msgs);
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__INPUT_CONNECTIONS:
+				return ((InternalEList<?>)getInputConnections()).basicRemove(otherEnd, msgs);
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__OUTPUT_CONNECTIONS:
+				return ((InternalEList<?>)getOutputConnections()).basicRemove(otherEnd, msgs);
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__WITH:
+				return ((InternalEList<?>)getWith()).basicRemove(otherEnd, msgs);
+			default:
+				return super.eInverseRemove(otherEnd, featureID, msgs);
+		}
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public Object eGet(int featureID, boolean resolve, boolean coreType) {
+		switch (featureID) {
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__NAME:
+				return getName();
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__COMMENT:
+				return getComment();
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__ATTRIBUTES:
+				return getAttributes();
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__IS_INPUT:
+				return isIsInput();
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__INPUT_CONNECTIONS:
+				return getInputConnections();
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__OUTPUT_CONNECTIONS:
+				return getOutputConnections();
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__TYPE:
+				if (resolve) {
+					return getType();
+				}
+				return basicGetType();
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__WITH:
+				return getWith();
+			default:
+				return super.eGet(featureID, resolve, coreType);
+		}
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public void eSet(final int featureID, final Object newValue) {
+	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__NAME:
-			setName((String) newValue);
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__COMMENT:
-			setComment((String) newValue);
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__ATTRIBUTES:
-			getAttributes().clear();
-			getAttributes().addAll((Collection<? extends Attribute>) newValue);
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__IS_INPUT:
-			setIsInput((Boolean) newValue);
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__INPUT_CONNECTIONS:
-			getInputConnections().clear();
-			getInputConnections().addAll((Collection<? extends Connection>) newValue);
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__OUTPUT_CONNECTIONS:
-			getOutputConnections().clear();
-			getOutputConnections().addAll((Collection<? extends Connection>) newValue);
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__TYPE:
-			setType((DataType) newValue);
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__WITH:
-			getWith().clear();
-			getWith().addAll((Collection<? extends With>) newValue);
-			return;
-		default:
-			super.eSet(featureID, newValue);
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__NAME:
+				setName((String)newValue);
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__COMMENT:
+				setComment((String)newValue);
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__ATTRIBUTES:
+				getAttributes().clear();
+				getAttributes().addAll((Collection<? extends Attribute>)newValue);
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__IS_INPUT:
+				setIsInput((Boolean)newValue);
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__INPUT_CONNECTIONS:
+				getInputConnections().clear();
+				getInputConnections().addAll((Collection<? extends Connection>)newValue);
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__OUTPUT_CONNECTIONS:
+				getOutputConnections().clear();
+				getOutputConnections().addAll((Collection<? extends Connection>)newValue);
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__TYPE:
+				setType((DataType)newValue);
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__WITH:
+				getWith().clear();
+				getWith().addAll((Collection<? extends With>)newValue);
+				return;
+			default:
+				super.eSet(featureID, newValue);
+				return;
 		}
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
-	public void eUnset(final int featureID) {
+	public void eUnset(int featureID) {
 		switch (featureID) {
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__NAME:
-			setName(NAME_EDEFAULT);
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__COMMENT:
-			setComment(COMMENT_EDEFAULT);
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__ATTRIBUTES:
-			getAttributes().clear();
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__IS_INPUT:
-			setIsInput(IS_INPUT_EDEFAULT);
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__INPUT_CONNECTIONS:
-			getInputConnections().clear();
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__OUTPUT_CONNECTIONS:
-			getOutputConnections().clear();
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__TYPE:
-			setType((DataType) null);
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__WITH:
-			getWith().clear();
-			return;
-		default:
-			super.eUnset(featureID);
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__NAME:
+				setName(NAME_EDEFAULT);
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__COMMENT:
+				setComment(COMMENT_EDEFAULT);
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__ATTRIBUTES:
+				getAttributes().clear();
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__IS_INPUT:
+				setIsInput(IS_INPUT_EDEFAULT);
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__INPUT_CONNECTIONS:
+				getInputConnections().clear();
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__OUTPUT_CONNECTIONS:
+				getOutputConnections().clear();
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__TYPE:
+				setType((DataType)null);
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__WITH:
+				getWith().clear();
+				return;
+			default:
+				super.eUnset(featureID);
+				return;
 		}
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
-	public boolean eIsSet(final int featureID) {
-		return switch (featureID) {
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__NAME -> NAME_EDEFAULT == null ? name != null : !NAME_EDEFAULT.equals(name);
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__COMMENT -> COMMENT_EDEFAULT == null ? comment != null : !COMMENT_EDEFAULT.equals(comment);
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__ATTRIBUTES -> attributes != null && !attributes.isEmpty();
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__IS_INPUT -> isInput != IS_INPUT_EDEFAULT;
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__INPUT_CONNECTIONS -> inputConnections != null && !inputConnections.isEmpty();
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__OUTPUT_CONNECTIONS -> outputConnections != null && !outputConnections.isEmpty();
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__TYPE -> type != null;
-		case MonitoringPackage.ADAPTER_MONITORING_EVENT__WITH -> with != null && !with.isEmpty();
-		default -> super.eIsSet(featureID);
-		};
+	public boolean eIsSet(int featureID) {
+		switch (featureID) {
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__NAME:
+				return NAME_EDEFAULT == null ? name != null : !NAME_EDEFAULT.equals(name);
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__COMMENT:
+				return COMMENT_EDEFAULT == null ? comment != null : !COMMENT_EDEFAULT.equals(comment);
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__ATTRIBUTES:
+				return attributes != null && !attributes.isEmpty();
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__IS_INPUT:
+				return isInput != IS_INPUT_EDEFAULT;
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__INPUT_CONNECTIONS:
+				return inputConnections != null && !inputConnections.isEmpty();
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__OUTPUT_CONNECTIONS:
+				return outputConnections != null && !outputConnections.isEmpty();
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__TYPE:
+				return type != null;
+			case MonitoringPackage.ADAPTER_MONITORING_EVENT__WITH:
+				return with != null && !with.isEmpty();
+			default:
+				return super.eIsSet(featureID);
+		}
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
-	public int eBaseStructuralFeatureID(final int derivedFeatureID, final Class<?> baseClass) {
+	public int eBaseStructuralFeatureID(int derivedFeatureID, Class<?> baseClass) {
 		if (baseClass == INamedElement.class) {
-			return switch (derivedFeatureID) {
-			case MonitoringPackage.ADAPTER_MONITORING_EVENT__NAME -> LibraryElementPackage.INAMED_ELEMENT__NAME;
-			case MonitoringPackage.ADAPTER_MONITORING_EVENT__COMMENT -> LibraryElementPackage.INAMED_ELEMENT__COMMENT;
-			default -> -1;
-			};
+			switch (derivedFeatureID) {
+				case MonitoringPackage.ADAPTER_MONITORING_EVENT__NAME: return LibraryElementPackage.INAMED_ELEMENT__NAME;
+				case MonitoringPackage.ADAPTER_MONITORING_EVENT__COMMENT: return LibraryElementPackage.INAMED_ELEMENT__COMMENT;
+				default: return -1;
+			}
 		}
 		if (baseClass == ITypedElement.class) {
-			return switch (derivedFeatureID) {
-			default -> -1;
-			};
+			switch (derivedFeatureID) {
+				default: return -1;
+			}
 		}
 		if (baseClass == ConfigurableObject.class) {
-			return switch (derivedFeatureID) {
-			case MonitoringPackage.ADAPTER_MONITORING_EVENT__ATTRIBUTES -> LibraryElementPackage.CONFIGURABLE_OBJECT__ATTRIBUTES;
-			default -> -1;
-			};
+			switch (derivedFeatureID) {
+				case MonitoringPackage.ADAPTER_MONITORING_EVENT__ATTRIBUTES: return LibraryElementPackage.CONFIGURABLE_OBJECT__ATTRIBUTES;
+				default: return -1;
+			}
 		}
 		if (baseClass == HiddenElement.class) {
-			return switch (derivedFeatureID) {
-			default -> -1;
-			};
+			switch (derivedFeatureID) {
+				default: return -1;
+			}
 		}
 		if (baseClass == IInterfaceElement.class) {
-			return switch (derivedFeatureID) {
-			case MonitoringPackage.ADAPTER_MONITORING_EVENT__IS_INPUT -> LibraryElementPackage.IINTERFACE_ELEMENT__IS_INPUT;
-			case MonitoringPackage.ADAPTER_MONITORING_EVENT__INPUT_CONNECTIONS -> LibraryElementPackage.IINTERFACE_ELEMENT__INPUT_CONNECTIONS;
-			case MonitoringPackage.ADAPTER_MONITORING_EVENT__OUTPUT_CONNECTIONS -> LibraryElementPackage.IINTERFACE_ELEMENT__OUTPUT_CONNECTIONS;
-			case MonitoringPackage.ADAPTER_MONITORING_EVENT__TYPE -> LibraryElementPackage.IINTERFACE_ELEMENT__TYPE;
-			default -> -1;
-			};
+			switch (derivedFeatureID) {
+				case MonitoringPackage.ADAPTER_MONITORING_EVENT__IS_INPUT: return LibraryElementPackage.IINTERFACE_ELEMENT__IS_INPUT;
+				case MonitoringPackage.ADAPTER_MONITORING_EVENT__INPUT_CONNECTIONS: return LibraryElementPackage.IINTERFACE_ELEMENT__INPUT_CONNECTIONS;
+				case MonitoringPackage.ADAPTER_MONITORING_EVENT__OUTPUT_CONNECTIONS: return LibraryElementPackage.IINTERFACE_ELEMENT__OUTPUT_CONNECTIONS;
+				case MonitoringPackage.ADAPTER_MONITORING_EVENT__TYPE: return LibraryElementPackage.IINTERFACE_ELEMENT__TYPE;
+				default: return -1;
+			}
 		}
 		if (baseClass == ICallable.class) {
-			return switch (derivedFeatureID) {
-			default -> -1;
-			};
+			switch (derivedFeatureID) {
+				default: return -1;
+			}
 		}
 		if (baseClass == Event.class) {
-			return switch (derivedFeatureID) {
-			case MonitoringPackage.ADAPTER_MONITORING_EVENT__WITH -> LibraryElementPackage.EVENT__WITH;
-			default -> -1;
-			};
+			switch (derivedFeatureID) {
+				case MonitoringPackage.ADAPTER_MONITORING_EVENT__WITH: return LibraryElementPackage.EVENT__WITH;
+				default: return -1;
+			}
 		}
 		return super.eBaseStructuralFeatureID(derivedFeatureID, baseClass);
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
-	public int eDerivedStructuralFeatureID(final int baseFeatureID, final Class<?> baseClass) {
+	public int eDerivedStructuralFeatureID(int baseFeatureID, Class<?> baseClass) {
 		if (baseClass == INamedElement.class) {
-			return switch (baseFeatureID) {
-			case LibraryElementPackage.INAMED_ELEMENT__NAME -> MonitoringPackage.ADAPTER_MONITORING_EVENT__NAME;
-			case LibraryElementPackage.INAMED_ELEMENT__COMMENT -> MonitoringPackage.ADAPTER_MONITORING_EVENT__COMMENT;
-			default -> -1;
-			};
+			switch (baseFeatureID) {
+				case LibraryElementPackage.INAMED_ELEMENT__NAME: return MonitoringPackage.ADAPTER_MONITORING_EVENT__NAME;
+				case LibraryElementPackage.INAMED_ELEMENT__COMMENT: return MonitoringPackage.ADAPTER_MONITORING_EVENT__COMMENT;
+				default: return -1;
+			}
 		}
 		if (baseClass == ITypedElement.class) {
-			return switch (baseFeatureID) {
-			default -> -1;
-			};
+			switch (baseFeatureID) {
+				default: return -1;
+			}
 		}
 		if (baseClass == ConfigurableObject.class) {
-			return switch (baseFeatureID) {
-			case LibraryElementPackage.CONFIGURABLE_OBJECT__ATTRIBUTES -> MonitoringPackage.ADAPTER_MONITORING_EVENT__ATTRIBUTES;
-			default -> -1;
-			};
+			switch (baseFeatureID) {
+				case LibraryElementPackage.CONFIGURABLE_OBJECT__ATTRIBUTES: return MonitoringPackage.ADAPTER_MONITORING_EVENT__ATTRIBUTES;
+				default: return -1;
+			}
 		}
 		if (baseClass == HiddenElement.class) {
-			return switch (baseFeatureID) {
-			default -> -1;
-			};
+			switch (baseFeatureID) {
+				default: return -1;
+			}
 		}
 		if (baseClass == IInterfaceElement.class) {
-			return switch (baseFeatureID) {
-			case LibraryElementPackage.IINTERFACE_ELEMENT__IS_INPUT -> MonitoringPackage.ADAPTER_MONITORING_EVENT__IS_INPUT;
-			case LibraryElementPackage.IINTERFACE_ELEMENT__INPUT_CONNECTIONS -> MonitoringPackage.ADAPTER_MONITORING_EVENT__INPUT_CONNECTIONS;
-			case LibraryElementPackage.IINTERFACE_ELEMENT__OUTPUT_CONNECTIONS -> MonitoringPackage.ADAPTER_MONITORING_EVENT__OUTPUT_CONNECTIONS;
-			case LibraryElementPackage.IINTERFACE_ELEMENT__TYPE -> MonitoringPackage.ADAPTER_MONITORING_EVENT__TYPE;
-			default -> -1;
-			};
+			switch (baseFeatureID) {
+				case LibraryElementPackage.IINTERFACE_ELEMENT__IS_INPUT: return MonitoringPackage.ADAPTER_MONITORING_EVENT__IS_INPUT;
+				case LibraryElementPackage.IINTERFACE_ELEMENT__INPUT_CONNECTIONS: return MonitoringPackage.ADAPTER_MONITORING_EVENT__INPUT_CONNECTIONS;
+				case LibraryElementPackage.IINTERFACE_ELEMENT__OUTPUT_CONNECTIONS: return MonitoringPackage.ADAPTER_MONITORING_EVENT__OUTPUT_CONNECTIONS;
+				case LibraryElementPackage.IINTERFACE_ELEMENT__TYPE: return MonitoringPackage.ADAPTER_MONITORING_EVENT__TYPE;
+				default: return -1;
+			}
 		}
 		if (baseClass == ICallable.class) {
-			return switch (baseFeatureID) {
-			default -> -1;
-			};
+			switch (baseFeatureID) {
+				default: return -1;
+			}
 		}
 		if (baseClass == Event.class) {
-			return switch (baseFeatureID) {
-			case LibraryElementPackage.EVENT__WITH -> MonitoringPackage.ADAPTER_MONITORING_EVENT__WITH;
-			default -> -1;
-			};
+			switch (baseFeatureID) {
+				case LibraryElementPackage.EVENT__WITH: return MonitoringPackage.ADAPTER_MONITORING_EVENT__WITH;
+				default: return -1;
+			}
 		}
 		return super.eDerivedStructuralFeatureID(baseFeatureID, baseClass);
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -839,7 +790,7 @@ public class AdapterMonitoringEventImpl extends EObjectImpl implements AdapterMo
 			return super.toString();
 		}
 
-		final StringBuilder result = new StringBuilder(super.toString());
+		StringBuilder result = new StringBuilder(super.toString());
 		result.append(" (name: "); //$NON-NLS-1$
 		result.append(name);
 		result.append(", comment: "); //$NON-NLS-1$

--- a/plugins/org.eclipse.fordiac.ide.monitoring/src-gen/org/eclipse/fordiac/ide/model/monitoring/impl/AdapterMonitoringVarDeclarationImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/src-gen/org/eclipse/fordiac/ide/model/monitoring/impl/AdapterMonitoringVarDeclarationImpl.java
@@ -55,26 +55,16 @@ import org.eclipse.gef.EditPart;
  * The following features are implemented:
  * </p>
  * <ul>
- * <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringVarDeclarationImpl#getName
- * <em>Name</em>}</li>
- * <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringVarDeclarationImpl#getComment
- * <em>Comment</em>}</li>
- * <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringVarDeclarationImpl#getAttributes
- * <em>Attributes</em>}</li>
- * <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringVarDeclarationImpl#isIsInput
- * <em>Is Input</em>}</li>
- * <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringVarDeclarationImpl#getInputConnections
- * <em>Input Connections</em>}</li>
- * <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringVarDeclarationImpl#getOutputConnections
- * <em>Output Connections</em>}</li>
- * <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringVarDeclarationImpl#getType
- * <em>Type</em>}</li>
- * <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringVarDeclarationImpl#getArraySize
- * <em>Array Size</em>}</li>
- * <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringVarDeclarationImpl#getWiths
- * <em>Withs</em>}</li>
- * <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringVarDeclarationImpl#getValue
- * <em>Value</em>}</li>
+ *   <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringVarDeclarationImpl#getName <em>Name</em>}</li>
+ *   <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringVarDeclarationImpl#getComment <em>Comment</em>}</li>
+ *   <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringVarDeclarationImpl#getAttributes <em>Attributes</em>}</li>
+ *   <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringVarDeclarationImpl#isIsInput <em>Is Input</em>}</li>
+ *   <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringVarDeclarationImpl#getInputConnections <em>Input Connections</em>}</li>
+ *   <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringVarDeclarationImpl#getOutputConnections <em>Output Connections</em>}</li>
+ *   <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringVarDeclarationImpl#getType <em>Type</em>}</li>
+ *   <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringVarDeclarationImpl#getArraySize <em>Array Size</em>}</li>
+ *   <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringVarDeclarationImpl#getWiths <em>Withs</em>}</li>
+ *   <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.AdapterMonitoringVarDeclarationImpl#getValue <em>Value</em>}</li>
  * </ul>
  *
  * @generated
@@ -103,7 +93,6 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 	/**
 	 * The default value of the '{@link #getComment() <em>Comment</em>}' attribute.
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @see #getComment()
 	 * @generated
 	 * @ordered
@@ -113,7 +102,6 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 	/**
 	 * The cached value of the '{@link #getComment() <em>Comment</em>}' attribute.
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @see #getComment()
 	 * @generated
 	 * @ordered
@@ -121,9 +109,8 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 	protected String comment = COMMENT_EDEFAULT;
 
 	/**
-	 * The cached value of the '{@link #getAttributes() <em>Attributes</em>}'
-	 * containment reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
+	 * The cached value of the '{@link #getAttributes() <em>Attributes</em>}' containment reference list.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @see #getAttributes()
 	 * @generated
 	 * @ordered
@@ -133,7 +120,6 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 	/**
 	 * The default value of the '{@link #isIsInput() <em>Is Input</em>}' attribute.
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @see #isIsInput()
 	 * @generated
 	 * @ordered
@@ -143,7 +129,6 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 	/**
 	 * The cached value of the '{@link #isIsInput() <em>Is Input</em>}' attribute.
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @see #isIsInput()
 	 * @generated
 	 * @ordered
@@ -183,9 +168,8 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 	protected DataType type;
 
 	/**
-	 * The cached value of the '{@link #getArraySize() <em>Array Size</em>}'
-	 * containment reference. <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
+	 * The cached value of the '{@link #getArraySize() <em>Array Size</em>}' containment reference.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @see #getArraySize()
 	 * @generated
 	 * @ordered
@@ -195,7 +179,6 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 	/**
 	 * The cached value of the '{@link #getWiths() <em>Withs</em>}' reference list.
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @see #getWiths()
 	 * @generated
 	 * @ordered
@@ -203,9 +186,8 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 	protected EList<With> withs;
 
 	/**
-	 * The cached value of the '{@link #getValue() <em>Value</em>}' containment
-	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
+	 * The cached value of the '{@link #getValue() <em>Value</em>}' containment reference.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @see #getValue()
 	 * @generated
 	 * @ordered
@@ -214,15 +196,14 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	protected AdapterMonitoringVarDeclarationImpl() {
+		super();
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -232,7 +213,6 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -242,22 +222,19 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
-	public void setName(final String newName) {
-		final String oldName = name;
+	public void setName(String newName) {
+		String oldName = name;
 		name = newName;
 		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(this, Notification.SET,
-					MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__NAME, oldName, name));
+			eNotify(new ENotificationImpl(this, Notification.SET, MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__NAME, oldName, name));
 		}
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -267,36 +244,31 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
-	public void setComment(final String newComment) {
-		final String oldComment = comment;
+	public void setComment(String newComment) {
+		String oldComment = comment;
 		comment = newComment;
 		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(this, Notification.SET,
-					MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__COMMENT, oldComment, comment));
+			eNotify(new ENotificationImpl(this, Notification.SET, MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__COMMENT, oldComment, comment));
 		}
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public EList<Attribute> getAttributes() {
 		if (attributes == null) {
-			attributes = new EObjectContainmentEList.Resolving<>(Attribute.class, this,
-					MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ATTRIBUTES);
+			attributes = new EObjectContainmentEList.Resolving<>(Attribute.class, this, MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ATTRIBUTES);
 		}
 		return attributes;
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -306,45 +278,37 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
-	public void setIsInput(final boolean newIsInput) {
-		final boolean oldIsInput = isInput;
+	public void setIsInput(boolean newIsInput) {
+		boolean oldIsInput = isInput;
 		isInput = newIsInput;
 		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(this, Notification.SET,
-					MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__IS_INPUT, oldIsInput, isInput));
+			eNotify(new ENotificationImpl(this, Notification.SET, MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__IS_INPUT, oldIsInput, isInput));
 		}
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public Value getValue() {
 		if (value != null && value.eIsProxy()) {
-			final InternalEObject oldValue = (InternalEObject) value;
-			value = (Value) eResolveProxy(oldValue);
+			InternalEObject oldValue = (InternalEObject)value;
+			value = (Value)eResolveProxy(oldValue);
 			if (value != oldValue) {
-				final InternalEObject newValue = (InternalEObject) value;
-				NotificationChain msgs = oldValue.eInverseRemove(this,
-						EOPPOSITE_FEATURE_BASE - MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE, null,
-						null);
+				InternalEObject newValue = (InternalEObject)value;
+				NotificationChain msgs = oldValue.eInverseRemove(this, EOPPOSITE_FEATURE_BASE - MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE, null, null);
 				if (newValue.eInternalContainer() == null) {
-					msgs = newValue.eInverseAdd(this,
-							EOPPOSITE_FEATURE_BASE - MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE, null,
-							msgs);
+					msgs = newValue.eInverseAdd(this, EOPPOSITE_FEATURE_BASE - MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE, null, msgs);
 				}
 				if (msgs != null) {
 					msgs.dispatch();
 				}
 				if (eNotificationRequired()) {
-					eNotify(new ENotificationImpl(this, Notification.RESOLVE,
-							MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE, oldValue, value));
+					eNotify(new ENotificationImpl(this, Notification.RESOLVE, MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE, oldValue, value));
 				}
 			}
 		}
@@ -353,7 +317,6 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	public Value basicGetValue() {
@@ -362,15 +325,13 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
-	public NotificationChain basicSetValue(final Value newValue, NotificationChain msgs) {
-		final Value oldValue = value;
+	public NotificationChain basicSetValue(Value newValue, NotificationChain msgs) {
+		Value oldValue = value;
 		value = newValue;
 		if (eNotificationRequired()) {
-			final ENotificationImpl notification = new ENotificationImpl(this, Notification.SET,
-					MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE, oldValue, newValue);
+			ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE, oldValue, newValue);
 			if (msgs == null) {
 				msgs = notification;
 			} else {
@@ -382,87 +343,72 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
-	public void setValue(final Value newValue) {
+	public void setValue(Value newValue) {
 		if (newValue != value) {
 			NotificationChain msgs = null;
 			if (value != null) {
-				msgs = ((InternalEObject) value).eInverseRemove(this,
-						EOPPOSITE_FEATURE_BASE - MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE, null,
-						msgs);
+				msgs = ((InternalEObject)value).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE, null, msgs);
 			}
 			if (newValue != null) {
-				msgs = ((InternalEObject) newValue).eInverseAdd(this,
-						EOPPOSITE_FEATURE_BASE - MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE, null,
-						msgs);
+				msgs = ((InternalEObject)newValue).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE, null, msgs);
 			}
 			msgs = basicSetValue(newValue, msgs);
 			if (msgs != null) {
 				msgs.dispatch();
 			}
-		} else if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(this, Notification.SET,
-					MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE, newValue, newValue));
+		}
+		else if (eNotificationRequired()) {
+			eNotify(new ENotificationImpl(this, Notification.SET, MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE, newValue, newValue));
 		}
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public EList<Connection> getInputConnections() {
 		if (inputConnections == null) {
-			inputConnections = new EObjectWithInverseResolvingEList<>(Connection.class, this,
-					MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__INPUT_CONNECTIONS,
-					LibraryElementPackage.CONNECTION__DESTINATION);
+			inputConnections = new EObjectWithInverseResolvingEList<>(Connection.class, this, MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__INPUT_CONNECTIONS, LibraryElementPackage.CONNECTION__DESTINATION);
 		}
 		return inputConnections;
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public EList<Connection> getOutputConnections() {
 		if (outputConnections == null) {
-			outputConnections = new EObjectWithInverseResolvingEList<>(Connection.class, this,
-					MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__OUTPUT_CONNECTIONS,
-					LibraryElementPackage.CONNECTION__SOURCE);
+			outputConnections = new EObjectWithInverseResolvingEList<>(Connection.class, this, MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__OUTPUT_CONNECTIONS, LibraryElementPackage.CONNECTION__SOURCE);
 		}
 		return outputConnections;
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public ArraySize getArraySize() {
 		if (arraySize != null && arraySize.eIsProxy()) {
-			final InternalEObject oldArraySize = (InternalEObject) arraySize;
-			arraySize = (ArraySize) eResolveProxy(oldArraySize);
+			InternalEObject oldArraySize = (InternalEObject)arraySize;
+			arraySize = (ArraySize)eResolveProxy(oldArraySize);
 			if (arraySize != oldArraySize) {
-				final InternalEObject newArraySize = (InternalEObject) arraySize;
-				NotificationChain msgs = oldArraySize.eInverseRemove(this,
-						LibraryElementPackage.ARRAY_SIZE__VAR_DECLARATION, ArraySize.class, null);
+				InternalEObject newArraySize = (InternalEObject)arraySize;
+				NotificationChain msgs =  oldArraySize.eInverseRemove(this, LibraryElementPackage.ARRAY_SIZE__VAR_DECLARATION, ArraySize.class, null);
 				if (newArraySize.eInternalContainer() == null) {
-					msgs = newArraySize.eInverseAdd(this, LibraryElementPackage.ARRAY_SIZE__VAR_DECLARATION,
-							ArraySize.class, msgs);
+					msgs =  newArraySize.eInverseAdd(this, LibraryElementPackage.ARRAY_SIZE__VAR_DECLARATION, ArraySize.class, msgs);
 				}
 				if (msgs != null) {
 					msgs.dispatch();
 				}
 				if (eNotificationRequired()) {
-					eNotify(new ENotificationImpl(this, Notification.RESOLVE,
-							MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ARRAY_SIZE, oldArraySize, arraySize));
+					eNotify(new ENotificationImpl(this, Notification.RESOLVE, MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ARRAY_SIZE, oldArraySize, arraySize));
 				}
 			}
 		}
@@ -471,7 +417,6 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	public ArraySize basicGetArraySize() {
@@ -480,15 +425,13 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
-	public NotificationChain basicSetArraySize(final ArraySize newArraySize, NotificationChain msgs) {
-		final ArraySize oldArraySize = arraySize;
+	public NotificationChain basicSetArraySize(ArraySize newArraySize, NotificationChain msgs) {
+		ArraySize oldArraySize = arraySize;
 		arraySize = newArraySize;
 		if (eNotificationRequired()) {
-			final ENotificationImpl notification = new ENotificationImpl(this, Notification.SET,
-					MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ARRAY_SIZE, oldArraySize, newArraySize);
+			ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ARRAY_SIZE, oldArraySize, newArraySize);
 			if (msgs == null) {
 				msgs = notification;
 			} else {
@@ -500,44 +443,41 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
-	public void setArraySize(final ArraySize newArraySize) {
+	public void setArraySize(ArraySize newArraySize) {
 		if (newArraySize != arraySize) {
 			NotificationChain msgs = null;
 			if (arraySize != null) {
-				msgs = ((InternalEObject) arraySize).eInverseRemove(this,
-						LibraryElementPackage.ARRAY_SIZE__VAR_DECLARATION, ArraySize.class, msgs);
+				msgs = ((InternalEObject)arraySize).eInverseRemove(this, LibraryElementPackage.ARRAY_SIZE__VAR_DECLARATION, ArraySize.class, msgs);
 			}
 			if (newArraySize != null) {
-				msgs = ((InternalEObject) newArraySize).eInverseAdd(this,
-						LibraryElementPackage.ARRAY_SIZE__VAR_DECLARATION, ArraySize.class, msgs);
+				msgs = ((InternalEObject)newArraySize).eInverseAdd(this, LibraryElementPackage.ARRAY_SIZE__VAR_DECLARATION, ArraySize.class, msgs);
 			}
 			msgs = basicSetArraySize(newArraySize, msgs);
 			if (msgs != null) {
 				msgs.dispatch();
 			}
-		} else if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(this, Notification.SET,
-					MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ARRAY_SIZE, newArraySize, newArraySize));
+		}
+		else if (eNotificationRequired()) {
+			eNotify(new ENotificationImpl(this, Notification.SET, MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ARRAY_SIZE, newArraySize, newArraySize));
 		}
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public DataType getType() {
 		if (type != null && type.eIsProxy()) {
-			final InternalEObject oldType = (InternalEObject) type;
-			type = (DataType) eResolveProxy(oldType);
-			if ((type != oldType) && eNotificationRequired()) {
-				eNotify(new ENotificationImpl(this, Notification.RESOLVE,
-						MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__TYPE, oldType, type));
+			InternalEObject oldType = (InternalEObject)type;
+			type = (DataType)eResolveProxy(oldType);
+			if (type != oldType) {
+				if (eNotificationRequired()) {
+					eNotify(new ENotificationImpl(this, Notification.RESOLVE, MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__TYPE, oldType, type));
+				}
 			}
 		}
 		return type;
@@ -545,7 +485,6 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	public DataType basicGetType() {
@@ -554,28 +493,25 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
-	public void setType(final DataType newType) {
-		final DataType oldType = type;
+	public void setType(DataType newType) {
+		DataType oldType = type;
 		type = newType;
 		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(this, Notification.SET,
-					MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__TYPE, oldType, type));
+			eNotify(new ENotificationImpl(this, Notification.SET, MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__TYPE, oldType, type));
 		}
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public String getTypeName() {
-		final org.eclipse.fordiac.ide.model.libraryElement.INamedElement type = getType();
-		if (type != null) {
+		org.eclipse.fordiac.ide.model.libraryElement.INamedElement type = getType();
+		if(type != null){
 			return type.getName();
 		}
 		return null;
@@ -583,43 +519,36 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public boolean validateType(final DiagnosticChain diagnostics, final Map<Object, Object> context) {
-		return org.eclipse.fordiac.ide.model.libraryElement.impl.TypedElementAnnotations.validateType(this, diagnostics,
-				context);
+		return org.eclipse.fordiac.ide.model.libraryElement.impl.TypedElementAnnotations.validateType(this, diagnostics, context);
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public boolean validateName(final DiagnosticChain diagnostics, final Map<Object, Object> context) {
-		return org.eclipse.fordiac.ide.model.libraryElement.impl.InterfaceElementAnnotations.validateName(this,
-				diagnostics, context);
+		return org.eclipse.fordiac.ide.model.libraryElement.impl.InterfaceElementAnnotations.validateName(this, diagnostics, context);
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public EList<With> getWiths() {
 		if (withs == null) {
-			withs = new EObjectWithInverseResolvingEList<>(With.class, this,
-					MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__WITHS, LibraryElementPackage.WITH__VARIABLES);
+			withs = new EObjectWithInverseResolvingEList<>(With.class, this, MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__WITHS, LibraryElementPackage.WITH__VARIABLES);
 		}
 		return withs;
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -629,7 +558,6 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -639,17 +567,15 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public void setVisible(final boolean visible) {
-		org.eclipse.fordiac.ide.model.annotations.HiddenElementAnnotations.setVisible(this, visible);
+		org.eclipse.fordiac.ide.model.annotations.HiddenElementAnnotations.setVisible(this,visible);
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -659,7 +585,6 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -670,7 +595,6 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -681,7 +605,6 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -691,7 +614,6 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -701,7 +623,6 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -711,7 +632,6 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -721,309 +641,316 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public NotificationChain eInverseAdd(final InternalEObject otherEnd, final int featureID, NotificationChain msgs) {
+	public NotificationChain eInverseAdd(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
 		switch (featureID) {
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__INPUT_CONNECTIONS:
-			return ((InternalEList<InternalEObject>) (InternalEList<?>) getInputConnections()).basicAdd(otherEnd, msgs);
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__OUTPUT_CONNECTIONS:
-			return ((InternalEList<InternalEObject>) (InternalEList<?>) getOutputConnections()).basicAdd(otherEnd,
-					msgs);
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ARRAY_SIZE:
-			if (arraySize != null) {
-				msgs = ((InternalEObject) arraySize).eInverseRemove(this,
-						EOPPOSITE_FEATURE_BASE - MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ARRAY_SIZE, null,
-						msgs);
-			}
-			return basicSetArraySize((ArraySize) otherEnd, msgs);
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__WITHS:
-			return ((InternalEList<InternalEObject>) (InternalEList<?>) getWiths()).basicAdd(otherEnd, msgs);
-		default:
-			return super.eInverseAdd(otherEnd, featureID, msgs);
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__INPUT_CONNECTIONS:
+				return ((InternalEList<InternalEObject>)(InternalEList<?>)getInputConnections()).basicAdd(otherEnd, msgs);
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__OUTPUT_CONNECTIONS:
+				return ((InternalEList<InternalEObject>)(InternalEList<?>)getOutputConnections()).basicAdd(otherEnd, msgs);
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ARRAY_SIZE:
+				if (arraySize != null) {
+					msgs = ((InternalEObject)arraySize).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ARRAY_SIZE, null, msgs);
+				}
+				return basicSetArraySize((ArraySize)otherEnd, msgs);
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__WITHS:
+				return ((InternalEList<InternalEObject>)(InternalEList<?>)getWiths()).basicAdd(otherEnd, msgs);
+			default:
+				return super.eInverseAdd(otherEnd, featureID, msgs);
 		}
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
-	public NotificationChain eInverseRemove(final InternalEObject otherEnd, final int featureID,
-			final NotificationChain msgs) {
-		return switch (featureID) {
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ATTRIBUTES -> ((InternalEList<?>) getAttributes()).basicRemove(otherEnd, msgs);
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__INPUT_CONNECTIONS -> ((InternalEList<?>) getInputConnections()).basicRemove(otherEnd, msgs);
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__OUTPUT_CONNECTIONS -> ((InternalEList<?>) getOutputConnections()).basicRemove(otherEnd, msgs);
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ARRAY_SIZE -> basicSetArraySize(null, msgs);
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__WITHS -> ((InternalEList<?>) getWiths()).basicRemove(otherEnd, msgs);
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE -> basicSetValue(null, msgs);
-		default -> super.eInverseRemove(otherEnd, featureID, msgs);
-		};
-	}
-
-	/**
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
-	 * @generated
-	 */
-	@Override
-	public Object eGet(final int featureID, final boolean resolve, final boolean coreType) {
+	public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
 		switch (featureID) {
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__NAME:
-			return getName();
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__COMMENT:
-			return getComment();
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ATTRIBUTES:
-			return getAttributes();
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__IS_INPUT:
-			return isIsInput();
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__INPUT_CONNECTIONS:
-			return getInputConnections();
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__OUTPUT_CONNECTIONS:
-			return getOutputConnections();
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__TYPE:
-			if (resolve) {
-				return getType();
-			}
-			return basicGetType();
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ARRAY_SIZE:
-			if (resolve) {
-				return getArraySize();
-			}
-			return basicGetArraySize();
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__WITHS:
-			return getWiths();
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE:
-			if (resolve) {
-				return getValue();
-			}
-			return basicGetValue();
-		default:
-			return super.eGet(featureID, resolve, coreType);
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ATTRIBUTES:
+				return ((InternalEList<?>)getAttributes()).basicRemove(otherEnd, msgs);
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__INPUT_CONNECTIONS:
+				return ((InternalEList<?>)getInputConnections()).basicRemove(otherEnd, msgs);
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__OUTPUT_CONNECTIONS:
+				return ((InternalEList<?>)getOutputConnections()).basicRemove(otherEnd, msgs);
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ARRAY_SIZE:
+				return basicSetArraySize(null, msgs);
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__WITHS:
+				return ((InternalEList<?>)getWiths()).basicRemove(otherEnd, msgs);
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE:
+				return basicSetValue(null, msgs);
+			default:
+				return super.eInverseRemove(otherEnd, featureID, msgs);
 		}
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
+	 * @generated
+	 */
+	@Override
+	public Object eGet(int featureID, boolean resolve, boolean coreType) {
+		switch (featureID) {
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__NAME:
+				return getName();
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__COMMENT:
+				return getComment();
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ATTRIBUTES:
+				return getAttributes();
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__IS_INPUT:
+				return isIsInput();
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__INPUT_CONNECTIONS:
+				return getInputConnections();
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__OUTPUT_CONNECTIONS:
+				return getOutputConnections();
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__TYPE:
+				if (resolve) {
+					return getType();
+				}
+				return basicGetType();
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ARRAY_SIZE:
+				if (resolve) {
+					return getArraySize();
+				}
+				return basicGetArraySize();
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__WITHS:
+				return getWiths();
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE:
+				if (resolve) {
+					return getValue();
+				}
+				return basicGetValue();
+			default:
+				return super.eGet(featureID, resolve, coreType);
+		}
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public void eSet(final int featureID, final Object newValue) {
+	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__NAME:
-			setName((String) newValue);
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__COMMENT:
-			setComment((String) newValue);
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ATTRIBUTES:
-			getAttributes().clear();
-			getAttributes().addAll((Collection<? extends Attribute>) newValue);
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__IS_INPUT:
-			setIsInput((Boolean) newValue);
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__INPUT_CONNECTIONS:
-			getInputConnections().clear();
-			getInputConnections().addAll((Collection<? extends Connection>) newValue);
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__OUTPUT_CONNECTIONS:
-			getOutputConnections().clear();
-			getOutputConnections().addAll((Collection<? extends Connection>) newValue);
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__TYPE:
-			setType((DataType) newValue);
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ARRAY_SIZE:
-			setArraySize((ArraySize) newValue);
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__WITHS:
-			getWiths().clear();
-			getWiths().addAll((Collection<? extends With>) newValue);
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE:
-			setValue((Value) newValue);
-			return;
-		default:
-			super.eSet(featureID, newValue);
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__NAME:
+				setName((String)newValue);
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__COMMENT:
+				setComment((String)newValue);
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ATTRIBUTES:
+				getAttributes().clear();
+				getAttributes().addAll((Collection<? extends Attribute>)newValue);
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__IS_INPUT:
+				setIsInput((Boolean)newValue);
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__INPUT_CONNECTIONS:
+				getInputConnections().clear();
+				getInputConnections().addAll((Collection<? extends Connection>)newValue);
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__OUTPUT_CONNECTIONS:
+				getOutputConnections().clear();
+				getOutputConnections().addAll((Collection<? extends Connection>)newValue);
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__TYPE:
+				setType((DataType)newValue);
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ARRAY_SIZE:
+				setArraySize((ArraySize)newValue);
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__WITHS:
+				getWiths().clear();
+				getWiths().addAll((Collection<? extends With>)newValue);
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE:
+				setValue((Value)newValue);
+				return;
+			default:
+				super.eSet(featureID, newValue);
+				return;
 		}
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
-	public void eUnset(final int featureID) {
+	public void eUnset(int featureID) {
 		switch (featureID) {
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__NAME:
-			setName(NAME_EDEFAULT);
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__COMMENT:
-			setComment(COMMENT_EDEFAULT);
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ATTRIBUTES:
-			getAttributes().clear();
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__IS_INPUT:
-			setIsInput(IS_INPUT_EDEFAULT);
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__INPUT_CONNECTIONS:
-			getInputConnections().clear();
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__OUTPUT_CONNECTIONS:
-			getOutputConnections().clear();
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__TYPE:
-			setType((DataType) null);
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ARRAY_SIZE:
-			setArraySize((ArraySize) null);
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__WITHS:
-			getWiths().clear();
-			return;
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE:
-			setValue((Value) null);
-			return;
-		default:
-			super.eUnset(featureID);
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__NAME:
+				setName(NAME_EDEFAULT);
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__COMMENT:
+				setComment(COMMENT_EDEFAULT);
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ATTRIBUTES:
+				getAttributes().clear();
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__IS_INPUT:
+				setIsInput(IS_INPUT_EDEFAULT);
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__INPUT_CONNECTIONS:
+				getInputConnections().clear();
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__OUTPUT_CONNECTIONS:
+				getOutputConnections().clear();
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__TYPE:
+				setType((DataType)null);
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ARRAY_SIZE:
+				setArraySize((ArraySize)null);
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__WITHS:
+				getWiths().clear();
+				return;
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE:
+				setValue((Value)null);
+				return;
+			default:
+				super.eUnset(featureID);
+				return;
 		}
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
-	public boolean eIsSet(final int featureID) {
-		return switch (featureID) {
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__NAME -> NAME_EDEFAULT == null ? name != null : !NAME_EDEFAULT.equals(name);
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__COMMENT -> COMMENT_EDEFAULT == null ? comment != null : !COMMENT_EDEFAULT.equals(comment);
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ATTRIBUTES -> attributes != null && !attributes.isEmpty();
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__IS_INPUT -> isInput != IS_INPUT_EDEFAULT;
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__INPUT_CONNECTIONS -> inputConnections != null && !inputConnections.isEmpty();
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__OUTPUT_CONNECTIONS -> outputConnections != null && !outputConnections.isEmpty();
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__TYPE -> type != null;
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ARRAY_SIZE -> arraySize != null;
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__WITHS -> withs != null && !withs.isEmpty();
-		case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE -> value != null;
-		default -> super.eIsSet(featureID);
-		};
+	public boolean eIsSet(int featureID) {
+		switch (featureID) {
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__NAME:
+				return NAME_EDEFAULT == null ? name != null : !NAME_EDEFAULT.equals(name);
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__COMMENT:
+				return COMMENT_EDEFAULT == null ? comment != null : !COMMENT_EDEFAULT.equals(comment);
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ATTRIBUTES:
+				return attributes != null && !attributes.isEmpty();
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__IS_INPUT:
+				return isInput != IS_INPUT_EDEFAULT;
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__INPUT_CONNECTIONS:
+				return inputConnections != null && !inputConnections.isEmpty();
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__OUTPUT_CONNECTIONS:
+				return outputConnections != null && !outputConnections.isEmpty();
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__TYPE:
+				return type != null;
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ARRAY_SIZE:
+				return arraySize != null;
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__WITHS:
+				return withs != null && !withs.isEmpty();
+			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE:
+				return value != null;
+			default:
+				return super.eIsSet(featureID);
+		}
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
-	public int eBaseStructuralFeatureID(final int derivedFeatureID, final Class<?> baseClass) {
+	public int eBaseStructuralFeatureID(int derivedFeatureID, Class<?> baseClass) {
 		if (baseClass == INamedElement.class) {
-			return switch (derivedFeatureID) {
-			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__NAME -> LibraryElementPackage.INAMED_ELEMENT__NAME;
-			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__COMMENT -> LibraryElementPackage.INAMED_ELEMENT__COMMENT;
-			default -> -1;
-			};
+			switch (derivedFeatureID) {
+				case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__NAME: return LibraryElementPackage.INAMED_ELEMENT__NAME;
+				case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__COMMENT: return LibraryElementPackage.INAMED_ELEMENT__COMMENT;
+				default: return -1;
+			}
 		}
 		if (baseClass == ITypedElement.class) {
-			return switch (derivedFeatureID) {
-			default -> -1;
-			};
+			switch (derivedFeatureID) {
+				default: return -1;
+			}
 		}
 		if (baseClass == ConfigurableObject.class) {
-			return switch (derivedFeatureID) {
-			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ATTRIBUTES -> LibraryElementPackage.CONFIGURABLE_OBJECT__ATTRIBUTES;
-			default -> -1;
-			};
+			switch (derivedFeatureID) {
+				case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ATTRIBUTES: return LibraryElementPackage.CONFIGURABLE_OBJECT__ATTRIBUTES;
+				default: return -1;
+			}
 		}
 		if (baseClass == HiddenElement.class) {
-			return switch (derivedFeatureID) {
-			default -> -1;
-			};
+			switch (derivedFeatureID) {
+				default: return -1;
+			}
 		}
 		if (baseClass == IInterfaceElement.class) {
-			return switch (derivedFeatureID) {
-			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__IS_INPUT -> LibraryElementPackage.IINTERFACE_ELEMENT__IS_INPUT;
-			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__INPUT_CONNECTIONS -> LibraryElementPackage.IINTERFACE_ELEMENT__INPUT_CONNECTIONS;
-			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__OUTPUT_CONNECTIONS -> LibraryElementPackage.IINTERFACE_ELEMENT__OUTPUT_CONNECTIONS;
-			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__TYPE -> LibraryElementPackage.IINTERFACE_ELEMENT__TYPE;
-			default -> -1;
-			};
+			switch (derivedFeatureID) {
+				case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__IS_INPUT: return LibraryElementPackage.IINTERFACE_ELEMENT__IS_INPUT;
+				case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__INPUT_CONNECTIONS: return LibraryElementPackage.IINTERFACE_ELEMENT__INPUT_CONNECTIONS;
+				case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__OUTPUT_CONNECTIONS: return LibraryElementPackage.IINTERFACE_ELEMENT__OUTPUT_CONNECTIONS;
+				case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__TYPE: return LibraryElementPackage.IINTERFACE_ELEMENT__TYPE;
+				default: return -1;
+			}
 		}
 		if (baseClass == VarDeclaration.class) {
-			return switch (derivedFeatureID) {
-			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ARRAY_SIZE -> LibraryElementPackage.VAR_DECLARATION__ARRAY_SIZE;
-			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__WITHS -> LibraryElementPackage.VAR_DECLARATION__WITHS;
-			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE -> LibraryElementPackage.VAR_DECLARATION__VALUE;
-			default -> -1;
-			};
+			switch (derivedFeatureID) {
+				case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ARRAY_SIZE: return LibraryElementPackage.VAR_DECLARATION__ARRAY_SIZE;
+				case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__WITHS: return LibraryElementPackage.VAR_DECLARATION__WITHS;
+				case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE: return LibraryElementPackage.VAR_DECLARATION__VALUE;
+				default: return -1;
+			}
 		}
 		return super.eBaseStructuralFeatureID(derivedFeatureID, baseClass);
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
-	public int eDerivedStructuralFeatureID(final int baseFeatureID, final Class<?> baseClass) {
+	public int eDerivedStructuralFeatureID(int baseFeatureID, Class<?> baseClass) {
 		if (baseClass == INamedElement.class) {
-			return switch (baseFeatureID) {
-			case LibraryElementPackage.INAMED_ELEMENT__NAME -> MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__NAME;
-			case LibraryElementPackage.INAMED_ELEMENT__COMMENT -> MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__COMMENT;
-			default -> -1;
-			};
+			switch (baseFeatureID) {
+				case LibraryElementPackage.INAMED_ELEMENT__NAME: return MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__NAME;
+				case LibraryElementPackage.INAMED_ELEMENT__COMMENT: return MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__COMMENT;
+				default: return -1;
+			}
 		}
 		if (baseClass == ITypedElement.class) {
-			return switch (baseFeatureID) {
-			default -> -1;
-			};
+			switch (baseFeatureID) {
+				default: return -1;
+			}
 		}
 		if (baseClass == ConfigurableObject.class) {
-			return switch (baseFeatureID) {
-			case LibraryElementPackage.CONFIGURABLE_OBJECT__ATTRIBUTES -> MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ATTRIBUTES;
-			default -> -1;
-			};
+			switch (baseFeatureID) {
+				case LibraryElementPackage.CONFIGURABLE_OBJECT__ATTRIBUTES: return MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ATTRIBUTES;
+				default: return -1;
+			}
 		}
 		if (baseClass == HiddenElement.class) {
-			return switch (baseFeatureID) {
-			default -> -1;
-			};
+			switch (baseFeatureID) {
+				default: return -1;
+			}
 		}
 		if (baseClass == IInterfaceElement.class) {
-			return switch (baseFeatureID) {
-			case LibraryElementPackage.IINTERFACE_ELEMENT__IS_INPUT -> MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__IS_INPUT;
-			case LibraryElementPackage.IINTERFACE_ELEMENT__INPUT_CONNECTIONS -> MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__INPUT_CONNECTIONS;
-			case LibraryElementPackage.IINTERFACE_ELEMENT__OUTPUT_CONNECTIONS -> MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__OUTPUT_CONNECTIONS;
-			case LibraryElementPackage.IINTERFACE_ELEMENT__TYPE -> MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__TYPE;
-			default -> -1;
-			};
+			switch (baseFeatureID) {
+				case LibraryElementPackage.IINTERFACE_ELEMENT__IS_INPUT: return MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__IS_INPUT;
+				case LibraryElementPackage.IINTERFACE_ELEMENT__INPUT_CONNECTIONS: return MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__INPUT_CONNECTIONS;
+				case LibraryElementPackage.IINTERFACE_ELEMENT__OUTPUT_CONNECTIONS: return MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__OUTPUT_CONNECTIONS;
+				case LibraryElementPackage.IINTERFACE_ELEMENT__TYPE: return MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__TYPE;
+				default: return -1;
+			}
 		}
 		if (baseClass == VarDeclaration.class) {
-			return switch (baseFeatureID) {
-			case LibraryElementPackage.VAR_DECLARATION__ARRAY_SIZE -> MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ARRAY_SIZE;
-			case LibraryElementPackage.VAR_DECLARATION__WITHS -> MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__WITHS;
-			case LibraryElementPackage.VAR_DECLARATION__VALUE -> MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE;
-			default -> -1;
-			};
+			switch (baseFeatureID) {
+				case LibraryElementPackage.VAR_DECLARATION__ARRAY_SIZE: return MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__ARRAY_SIZE;
+				case LibraryElementPackage.VAR_DECLARATION__WITHS: return MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__WITHS;
+				case LibraryElementPackage.VAR_DECLARATION__VALUE: return MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION__VALUE;
+				default: return -1;
+			}
 		}
 		return super.eDerivedStructuralFeatureID(baseFeatureID, baseClass);
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -1032,7 +959,7 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 			return super.toString();
 		}
 
-		final StringBuilder result = new StringBuilder(super.toString());
+		StringBuilder result = new StringBuilder(super.toString());
 		result.append(" (name: "); //$NON-NLS-1$
 		result.append(name);
 		result.append(", comment: "); //$NON-NLS-1$
@@ -1061,7 +988,6 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -1071,7 +997,6 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -1081,19 +1006,16 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public boolean validateVarInOutSourceTypeIsWellDefined(final DiagnosticChain diagnostics,
 			final Map<Object, Object> context) {
-		return org.eclipse.fordiac.ide.model.libraryElement.impl.VarDeclarationAnnotations
-				.validateVarInOutSourceTypeIsWellDefined(this, diagnostics, context);
+		return org.eclipse.fordiac.ide.model.libraryElement.impl.VarDeclarationAnnotations.validateVarInOutSourceTypeIsWellDefined(this, diagnostics, context);
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
@@ -1103,72 +1025,60 @@ public class AdapterMonitoringVarDeclarationImpl extends EObjectImpl implements 
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public boolean validateMultipleInputConnections(final DiagnosticChain diagnostics,
 			final Map<Object, Object> context) {
-		return org.eclipse.fordiac.ide.model.libraryElement.impl.VarDeclarationAnnotations
-				.validateMultipleInputConnections(this, diagnostics, context);
+		return org.eclipse.fordiac.ide.model.libraryElement.impl.VarDeclarationAnnotations.validateMultipleInputConnections(this, diagnostics, context);
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public boolean validateNoValueForGenericTypeVariable(final DiagnosticChain diagnostics,
 			final Map<Object, Object> context) {
-		return org.eclipse.fordiac.ide.model.libraryElement.impl.VarDeclarationAnnotations
-				.validateNoValueForGenericTypeVariable(this, diagnostics, context);
+		return org.eclipse.fordiac.ide.model.libraryElement.impl.VarDeclarationAnnotations.validateNoValueForGenericTypeVariable(this, diagnostics, context);
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public boolean validateValueForGenericInstanceVariable(final DiagnosticChain diagnostics,
 			final Map<Object, Object> context) {
-		return org.eclipse.fordiac.ide.model.libraryElement.impl.VarDeclarationAnnotations
-				.validateValueForGenericInstanceVariable(this, diagnostics, context);
+		return org.eclipse.fordiac.ide.model.libraryElement.impl.VarDeclarationAnnotations.validateValueForGenericInstanceVariable(this, diagnostics, context);
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public boolean validateVarInOutIsWithed(final DiagnosticChain diagnostics, final Map<Object, Object> context) {
-		return org.eclipse.fordiac.ide.model.libraryElement.impl.VarDeclarationAnnotations
-				.validateVarInOutIsWithed(this, diagnostics, context);
+		return org.eclipse.fordiac.ide.model.libraryElement.impl.VarDeclarationAnnotations.validateVarInOutIsWithed(this, diagnostics, context);
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public boolean validateVarInOutSubappInterface(final DiagnosticChain diagnostics,
 			final Map<Object, Object> context) {
-		return org.eclipse.fordiac.ide.model.libraryElement.impl.VarDeclarationAnnotations
-				.validateVarInOutSubappInterface(this, diagnostics, context);
+		return org.eclipse.fordiac.ide.model.libraryElement.impl.VarDeclarationAnnotations.validateVarInOutSubappInterface(this, diagnostics, context);
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
 	 * @generated
 	 */
 	@Override
 	public boolean validateVarInOutSubappNetwork(final DiagnosticChain diagnostics, final Map<Object, Object> context) {
-		return org.eclipse.fordiac.ide.model.libraryElement.impl.VarDeclarationAnnotations
-				.validateVarInOutSubappNetwork(this, diagnostics, context);
+		return org.eclipse.fordiac.ide.model.libraryElement.impl.VarDeclarationAnnotations.validateVarInOutSubappNetwork(this, diagnostics, context);
 	}
 
 } // AdapterMonitoringVarDeclarationImpl

--- a/plugins/org.eclipse.fordiac.ide.monitoring/src-gen/org/eclipse/fordiac/ide/model/monitoring/impl/InternalVarInstanceImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/src-gen/org/eclipse/fordiac/ide/model/monitoring/impl/InternalVarInstanceImpl.java
@@ -1,0 +1,191 @@
+/**
+ * ******************************************************************************
+ * Copyright (c) 2012, 2013, 2015 - 2017 Profactor GmbH, fortiss GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Gerhard Ebenhofer, Alois Zoitl, Gerd Kainz
+ *      - initial API and implementation and/or initial documentation
+ * ******************************************************************************
+ *
+ */
+package org.eclipse.fordiac.ide.model.monitoring.impl;
+
+import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.InternalEObject;
+import org.eclipse.emf.ecore.impl.ENotificationImpl;
+import org.eclipse.fordiac.ide.model.libraryElement.FB;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.impl.VarDeclarationImpl;
+import org.eclipse.fordiac.ide.model.monitoring.InternalVarInstance;
+import org.eclipse.fordiac.ide.model.monitoring.MonitoringPackage;
+
+/**
+ * <!-- begin-user-doc -->
+ * An implementation of the model object '<em><b>Internal Var Instance</b></em>'.
+ * <!-- end-user-doc -->
+ * <p>
+ * The following features are implemented:
+ * </p>
+ * <ul>
+ *   <li>{@link org.eclipse.fordiac.ide.model.monitoring.impl.InternalVarInstanceImpl#getFb <em>Fb</em>}</li>
+ * </ul>
+ *
+ * @generated
+ */
+public class InternalVarInstanceImpl extends VarDeclarationImpl implements InternalVarInstance {
+	/**
+	 * The cached value of the '{@link #getFb() <em>Fb</em>}' reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getFb()
+	 * @generated
+	 * @ordered
+	 */
+	protected FB fb;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected InternalVarInstanceImpl() {
+		super();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	protected EClass eStaticClass() {
+		return MonitoringPackage.Literals.INTERNAL_VAR_INSTANCE;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public FB getFb() {
+		if (fb != null && fb.eIsProxy()) {
+			InternalEObject oldFb = (InternalEObject)fb;
+			fb = (FB)eResolveProxy(oldFb);
+			if (fb != oldFb) {
+				if (eNotificationRequired()) {
+					eNotify(new ENotificationImpl(this, Notification.RESOLVE, MonitoringPackage.INTERNAL_VAR_INSTANCE__FB, oldFb, fb));
+				}
+			}
+		}
+		return fb;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public FB basicGetFb() {
+		return fb;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void setFb(FB newFb) {
+		FB oldFb = fb;
+		fb = newFb;
+		if (eNotificationRequired()) {
+			eNotify(new ENotificationImpl(this, Notification.SET, MonitoringPackage.INTERNAL_VAR_INSTANCE__FB, oldFb, fb));
+		}
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public FBNetworkElement getFBNetworkElement() {
+		return getFb();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public Object eGet(int featureID, boolean resolve, boolean coreType) {
+		switch (featureID) {
+			case MonitoringPackage.INTERNAL_VAR_INSTANCE__FB:
+				if (resolve) {
+					return getFb();
+				}
+				return basicGetFb();
+			default:
+				return super.eGet(featureID, resolve, coreType);
+		}
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void eSet(int featureID, Object newValue) {
+		switch (featureID) {
+			case MonitoringPackage.INTERNAL_VAR_INSTANCE__FB:
+				setFb((FB)newValue);
+				return;
+			default:
+				super.eSet(featureID, newValue);
+				return;
+		}
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void eUnset(int featureID) {
+		switch (featureID) {
+			case MonitoringPackage.INTERNAL_VAR_INSTANCE__FB:
+				setFb((FB)null);
+				return;
+			default:
+				super.eUnset(featureID);
+				return;
+		}
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public boolean eIsSet(int featureID) {
+		switch (featureID) {
+			case MonitoringPackage.INTERNAL_VAR_INSTANCE__FB:
+				return fb != null;
+			default:
+				return super.eIsSet(featureID);
+		}
+	}
+
+} //InternalVarInstanceImpl

--- a/plugins/org.eclipse.fordiac.ide.monitoring/src-gen/org/eclipse/fordiac/ide/model/monitoring/impl/MonitoringFactoryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/src-gen/org/eclipse/fordiac/ide/model/monitoring/impl/MonitoringFactoryImpl.java
@@ -22,6 +22,7 @@ import org.eclipse.emf.ecore.plugin.EcorePlugin;
 import org.eclipse.fordiac.ide.model.monitoring.AdapterMonitoringEvent;
 import org.eclipse.fordiac.ide.model.monitoring.AdapterMonitoringVarDeclaration;
 import org.eclipse.fordiac.ide.model.monitoring.AdapterPortElement;
+import org.eclipse.fordiac.ide.model.monitoring.InternalVarInstance;
 import org.eclipse.fordiac.ide.model.monitoring.MonitoringAdapterElement;
 import org.eclipse.fordiac.ide.model.monitoring.MonitoringElement;
 import org.eclipse.fordiac.ide.model.monitoring.MonitoringFactory;
@@ -78,6 +79,7 @@ public class MonitoringFactoryImpl extends EFactoryImpl implements MonitoringFac
 			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION: return createAdapterMonitoringVarDeclaration();
 			case MonitoringPackage.SUB_APP_PORT_ELEMENT: return createSubAppPortElement();
 			case MonitoringPackage.SUBAPP_MONITORING_ELEMENT: return createSubappMonitoringElement();
+			case MonitoringPackage.INTERNAL_VAR_INSTANCE: return createInternalVarInstance();
 			default:
 				throw new IllegalArgumentException("The class '" + eClass.getName() + "' is not a valid classifier"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
@@ -153,6 +155,17 @@ public class MonitoringFactoryImpl extends EFactoryImpl implements MonitoringFac
 	public SubappMonitoringElement createSubappMonitoringElement() {
 		SubappMonitoringElementImpl subappMonitoringElement = new SubappMonitoringElementImpl();
 		return subappMonitoringElement;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public InternalVarInstance createInternalVarInstance() {
+		InternalVarInstanceImpl internalVarInstance = new InternalVarInstanceImpl();
+		return internalVarInstance;
 	}
 
 	/**

--- a/plugins/org.eclipse.fordiac.ide.monitoring/src-gen/org/eclipse/fordiac/ide/model/monitoring/impl/MonitoringPackageImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/src-gen/org/eclipse/fordiac/ide/model/monitoring/impl/MonitoringPackageImpl.java
@@ -31,6 +31,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.monitoring.AdapterMonitoringEvent;
 import org.eclipse.fordiac.ide.model.monitoring.AdapterMonitoringVarDeclaration;
 import org.eclipse.fordiac.ide.model.monitoring.AdapterPortElement;
+import org.eclipse.fordiac.ide.model.monitoring.InternalVarInstance;
 import org.eclipse.fordiac.ide.model.monitoring.MonitoringAdapterElement;
 import org.eclipse.fordiac.ide.model.monitoring.MonitoringElement;
 import org.eclipse.fordiac.ide.model.monitoring.MonitoringFactory;
@@ -102,6 +103,13 @@ public class MonitoringPackageImpl extends EPackageImpl implements MonitoringPac
 	private EClass subappMonitoringElementEClass = null;
 
 	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private EClass internalVarInstanceEClass = null;
+
+	/**
 	 * Creates an instance of the model <b>Package</b>, registered with
 	 * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the package
 	 * package URI value.
@@ -140,7 +148,9 @@ public class MonitoringPackageImpl extends EPackageImpl implements MonitoringPac
 	 * @generated
 	 */
 	public static MonitoringPackage init() {
-		if (isInited) return (MonitoringPackage)EPackage.Registry.INSTANCE.getEPackage(MonitoringPackage.eNS_URI);
+		if (isInited) {
+			return (MonitoringPackage)EPackage.Registry.INSTANCE.getEPackage(MonitoringPackage.eNS_URI);
+		}
 
 		// Obtain or create and register package
 		Object registeredMonitoringPackage = EPackage.Registry.INSTANCE.get(eNS_URI);
@@ -355,6 +365,26 @@ public class MonitoringPackageImpl extends EPackageImpl implements MonitoringPac
 	 * @generated
 	 */
 	@Override
+	public EClass getInternalVarInstance() {
+		return internalVarInstanceEClass;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public EReference getInternalVarInstance_Fb() {
+		return (EReference)internalVarInstanceEClass.getEStructuralFeatures().get(0);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public MonitoringFactory getMonitoringFactory() {
 		return (MonitoringFactory)getEFactoryInstance();
 	}
@@ -374,7 +404,9 @@ public class MonitoringPackageImpl extends EPackageImpl implements MonitoringPac
 	 * @generated
 	 */
 	public void createPackageContents() {
-		if (isCreated) return;
+		if (isCreated) {
+			return;
+		}
 		isCreated = true;
 
 		// Create classes and their features
@@ -403,6 +435,9 @@ public class MonitoringPackageImpl extends EPackageImpl implements MonitoringPac
 
 		subappMonitoringElementEClass = createEClass(SUBAPP_MONITORING_ELEMENT);
 		createEReference(subappMonitoringElementEClass, SUBAPP_MONITORING_ELEMENT__ANCHOR);
+
+		internalVarInstanceEClass = createEClass(INTERNAL_VAR_INSTANCE);
+		createEReference(internalVarInstanceEClass, INTERNAL_VAR_INSTANCE__FB);
 	}
 
 	/**
@@ -420,7 +455,9 @@ public class MonitoringPackageImpl extends EPackageImpl implements MonitoringPac
 	 * @generated
 	 */
 	public void initializePackageContents() {
-		if (isInitialized) return;
+		if (isInitialized) {
+			return;
+		}
 		isInitialized = true;
 
 		// Initialize package
@@ -448,6 +485,7 @@ public class MonitoringPackageImpl extends EPackageImpl implements MonitoringPac
 		adapterMonitoringVarDeclarationEClass.getESuperTypes().add(theLibraryElementPackage.getVarDeclaration());
 		subAppPortElementEClass.getESuperTypes().add(theMonitoringBasePackage.getPortElement());
 		subappMonitoringElementEClass.getESuperTypes().add(this.getMonitoringElement());
+		internalVarInstanceEClass.getESuperTypes().add(theLibraryElementPackage.getVarDeclaration());
 
 		// Initialize classes and features; add operations and parameters
 		initEClass(monitoringElementEClass, MonitoringElement.class, "MonitoringElement", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
@@ -488,6 +526,11 @@ public class MonitoringPackageImpl extends EPackageImpl implements MonitoringPac
 		initEReference(getSubappMonitoringElement_Anchor(), theMonitoringBasePackage.getMonitoringBaseElement(), null, "anchor", null, 0, 1, SubappMonitoringElement.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
 		addEOperation(subappMonitoringElementEClass, theXMLTypePackage.getString(), "getQualifiedString", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+
+		initEClass(internalVarInstanceEClass, InternalVarInstance.class, "InternalVarInstance", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
+		initEReference(getInternalVarInstance_Fb(), theLibraryElementPackage.getFB(), null, "fb", null, 0, 1, InternalVarInstance.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
+
+		addEOperation(internalVarInstanceEClass, theLibraryElementPackage.getFBNetworkElement(), "getFBNetworkElement", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		// Create resource
 		createResource(eNS_URI);

--- a/plugins/org.eclipse.fordiac.ide.monitoring/src-gen/org/eclipse/fordiac/ide/model/monitoring/util/MonitoringAdapterFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/src-gen/org/eclipse/fordiac/ide/model/monitoring/util/MonitoringAdapterFactory.java
@@ -32,6 +32,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.monitoring.AdapterMonitoringEvent;
 import org.eclipse.fordiac.ide.model.monitoring.AdapterMonitoringVarDeclaration;
 import org.eclipse.fordiac.ide.model.monitoring.AdapterPortElement;
+import org.eclipse.fordiac.ide.model.monitoring.InternalVarInstance;
 import org.eclipse.fordiac.ide.model.monitoring.MonitoringAdapterElement;
 import org.eclipse.fordiac.ide.model.monitoring.MonitoringElement;
 import org.eclipse.fordiac.ide.model.monitoring.MonitoringPackage;
@@ -42,22 +43,21 @@ import org.eclipse.fordiac.ide.model.monitoring.SubappMonitoringElement;
  * <!-- begin-user-doc --> The <b>Adapter Factory</b> for the model. It provides
  * an adapter <code>createXXX</code> method for each class of the model. <!--
  * end-user-doc -->
- *
  * @see org.eclipse.fordiac.ide.model.monitoring.MonitoringPackage
  * @generated
  */
 public class MonitoringAdapterFactory extends AdapterFactoryImpl {
 	/**
-	 * The cached model package. <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
+	 * The cached model package.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	protected static MonitoringPackage modelPackage;
 
 	/**
-	 * Creates an instance of the adapter factory. <!-- begin-user-doc --> <!--
+	 * Creates an instance of the adapter factory.
+	 * <!-- begin-user-doc --> <!--
 	 * end-user-doc -->
-	 *
 	 * @generated
 	 */
 	public MonitoringAdapterFactory() {
@@ -76,12 +76,12 @@ public class MonitoringAdapterFactory extends AdapterFactoryImpl {
 	 * @generated
 	 */
 	@Override
-	public boolean isFactoryForType(final Object object) {
+	public boolean isFactoryForType(Object object) {
 		if (object == modelPackage) {
 			return true;
 		}
 		if (object instanceof EObject) {
-			return ((EObject) object).eClass().getEPackage() == modelPackage;
+			return ((EObject)object).eClass().getEPackage() == modelPackage;
 		}
 		return false;
 	}
@@ -93,127 +93,110 @@ public class MonitoringAdapterFactory extends AdapterFactoryImpl {
 	 * @generated
 	 */
 	protected MonitoringSwitch<Adapter> modelSwitch = new MonitoringSwitch<>() {
-		@Override
-		public Adapter caseMonitoringElement(final MonitoringElement object) {
-			return createMonitoringElementAdapter();
-		}
-
-		@Override
-		public Adapter caseMonitoringAdapterElement(final MonitoringAdapterElement object) {
-			return createMonitoringAdapterElementAdapter();
-		}
-
-		@Override
-		public Adapter caseAdapterPortElement(final AdapterPortElement object) {
-			return createAdapterPortElementAdapter();
-		}
-
-		@Override
-		public Adapter caseAdapterMonitoringEvent(final AdapterMonitoringEvent object) {
-			return createAdapterMonitoringEventAdapter();
-		}
-
-		@Override
-		public Adapter caseAdapterMonitoringVarDeclaration(final AdapterMonitoringVarDeclaration object) {
-			return createAdapterMonitoringVarDeclarationAdapter();
-		}
-
-		@Override
-		public Adapter caseIEditPartCreator(final IEditPartCreator object) {
-			return createIEditPartCreatorAdapter();
-		}
-
-		@Override
-		public Adapter caseSubAppPortElement(final SubAppPortElement object) {
-			return createSubAppPortElementAdapter();
-		}
-
-		@Override
-		public Adapter caseSubappMonitoringElement(final SubappMonitoringElement object) {
-			return createSubappMonitoringElementAdapter();
-		}
-
-		@Override
-		public Adapter caseMonitoringBase_IEditPartCreator(final IEditPartCreator object) {
-			return createMonitoringBase_IEditPartCreatorAdapter();
-		}
-
-		@Override
-		public Adapter caseMonitoringBaseElement(final MonitoringBaseElement object) {
-			return createMonitoringBaseElementAdapter();
-		}
-
-		@Override
-		public Adapter casePortElement(final PortElement object) {
-			return createPortElementAdapter();
-		}
-
-		@Override
-		public Adapter caseINamedElement(final INamedElement object) {
-			return createINamedElementAdapter();
-		}
-
-		@Override
-		public Adapter caseITypedElement(final ITypedElement object) {
-			return createITypedElementAdapter();
-		}
-
-		@Override
-		public Adapter caseConfigurableObject(final ConfigurableObject object) {
-			return createConfigurableObjectAdapter();
-		}
-
-		@Override
-		public Adapter caseHiddenElement(final HiddenElement object) {
-			return createHiddenElementAdapter();
-		}
-
-		@Override
-		public Adapter caseIInterfaceElement(final IInterfaceElement object) {
-			return createIInterfaceElementAdapter();
-		}
-
-		@Override
-		public Adapter caseICallable(final ICallable object) {
-			return createICallableAdapter();
-		}
-
-		@Override
-		public Adapter caseEvent(final Event object) {
-			return createEventAdapter();
-		}
-
-		@Override
-		public Adapter caseVarDeclaration(final VarDeclaration object) {
-			return createVarDeclarationAdapter();
-		}
-
-		@Override
-		public Adapter defaultCase(final EObject object) {
-			return createEObjectAdapter();
-		}
-	};
+			@Override
+			public Adapter caseMonitoringElement(MonitoringElement object) {
+				return createMonitoringElementAdapter();
+			}
+			@Override
+			public Adapter caseMonitoringAdapterElement(MonitoringAdapterElement object) {
+				return createMonitoringAdapterElementAdapter();
+			}
+			@Override
+			public Adapter caseAdapterPortElement(AdapterPortElement object) {
+				return createAdapterPortElementAdapter();
+			}
+			@Override
+			public Adapter caseAdapterMonitoringEvent(AdapterMonitoringEvent object) {
+				return createAdapterMonitoringEventAdapter();
+			}
+			@Override
+			public Adapter caseAdapterMonitoringVarDeclaration(AdapterMonitoringVarDeclaration object) {
+				return createAdapterMonitoringVarDeclarationAdapter();
+			}
+			@Override
+			public Adapter caseIEditPartCreator(IEditPartCreator object) {
+				return createIEditPartCreatorAdapter();
+			}
+			@Override
+			public Adapter caseSubAppPortElement(SubAppPortElement object) {
+				return createSubAppPortElementAdapter();
+			}
+			@Override
+			public Adapter caseSubappMonitoringElement(SubappMonitoringElement object) {
+				return createSubappMonitoringElementAdapter();
+			}
+			@Override
+			public Adapter caseInternalVarInstance(InternalVarInstance object) {
+				return createInternalVarInstanceAdapter();
+			}
+			@Override
+			public Adapter caseMonitoringBase_IEditPartCreator(IEditPartCreator object) {
+				return createMonitoringBase_IEditPartCreatorAdapter();
+			}
+			@Override
+			public Adapter caseMonitoringBaseElement(MonitoringBaseElement object) {
+				return createMonitoringBaseElementAdapter();
+			}
+			@Override
+			public Adapter casePortElement(PortElement object) {
+				return createPortElementAdapter();
+			}
+			@Override
+			public Adapter caseINamedElement(INamedElement object) {
+				return createINamedElementAdapter();
+			}
+			@Override
+			public Adapter caseITypedElement(ITypedElement object) {
+				return createITypedElementAdapter();
+			}
+			@Override
+			public Adapter caseConfigurableObject(ConfigurableObject object) {
+				return createConfigurableObjectAdapter();
+			}
+			@Override
+			public Adapter caseHiddenElement(HiddenElement object) {
+				return createHiddenElementAdapter();
+			}
+			@Override
+			public Adapter caseIInterfaceElement(IInterfaceElement object) {
+				return createIInterfaceElementAdapter();
+			}
+			@Override
+			public Adapter caseICallable(ICallable object) {
+				return createICallableAdapter();
+			}
+			@Override
+			public Adapter caseEvent(Event object) {
+				return createEventAdapter();
+			}
+			@Override
+			public Adapter caseVarDeclaration(VarDeclaration object) {
+				return createVarDeclarationAdapter();
+			}
+			@Override
+			public Adapter defaultCase(EObject object) {
+				return createEObjectAdapter();
+			}
+		};
 
 	/**
-	 * Creates an adapter for the <code>target</code>. <!-- begin-user-doc --> <!--
+	 * Creates an adapter for the <code>target</code>.
+	 * <!-- begin-user-doc --> <!--
 	 * end-user-doc -->
-	 *
 	 * @param target the object to adapt.
 	 * @return the adapter for the <code>target</code>.
 	 * @generated
 	 */
 	@Override
-	public Adapter createAdapter(final Notifier target) {
-		return modelSwitch.doSwitch((EObject) target);
+	public Adapter createAdapter(Notifier target) {
+		return modelSwitch.doSwitch((EObject)target);
 	}
 
 	/**
-	 * Creates a new adapter for an object of class
-	 * '{@link org.eclipse.fordiac.ide.deployment.monitoringbase.MonitoringBaseElement
-	 * <em>Element</em>}'. <!-- begin-user-doc --> This default implementation
+	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.deployment.monitoringbase.MonitoringBaseElement <em>Element</em>}'.
+	 * <!-- begin-user-doc --> This default implementation
 	 * returns null so that we can easily ignore cases; it's useful to ignore a case
 	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.deployment.monitoringbase.MonitoringBaseElement
 	 * @generated
@@ -223,12 +206,10 @@ public class MonitoringAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class
-	 * '{@link org.eclipse.fordiac.ide.model.monitoring.MonitoringElement
-	 * <em>Element</em>}'. <!-- begin-user-doc --> This default implementation
+	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.model.monitoring.MonitoringElement <em>Element</em>}'.
+	 * <!-- begin-user-doc --> This default implementation
 	 * returns null so that we can easily ignore cases; it's useful to ignore a case
 	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.model.monitoring.MonitoringElement
 	 * @generated
@@ -238,13 +219,11 @@ public class MonitoringAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class
-	 * '{@link org.eclipse.fordiac.ide.model.monitoring.MonitoringAdapterElement
-	 * <em>Adapter Element</em>}'. <!-- begin-user-doc --> This default
+	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.model.monitoring.MonitoringAdapterElement <em>Adapter Element</em>}'.
+	 * <!-- begin-user-doc --> This default
 	 * implementation returns null so that we can easily ignore cases; it's useful
 	 * to ignore a case when inheritance will catch all the cases anyway. <!--
 	 * end-user-doc -->
-	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.model.monitoring.MonitoringAdapterElement
 	 * @generated
@@ -254,12 +233,10 @@ public class MonitoringAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class
-	 * '{@link org.eclipse.fordiac.ide.gef.editparts.IEditPartCreator <em>IEdit Part
-	 * Creator</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.gef.editparts.IEditPartCreator <em>IEdit Part Creator</em>}'.
+	 * <!-- begin-user-doc --> This default implementation returns
 	 * null so that we can easily ignore cases; it's useful to ignore a case when
 	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
-	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.gef.editparts.IEditPartCreator
 	 * @generated
@@ -269,12 +246,10 @@ public class MonitoringAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class
-	 * '{@link org.eclipse.fordiac.ide.model.monitoring.SubAppPortElement <em>Sub
-	 * App Port Element</em>}'. <!-- begin-user-doc --> This default implementation
+	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.model.monitoring.SubAppPortElement <em>Sub App Port Element</em>}'.
+	 * <!-- begin-user-doc --> This default implementation
 	 * returns null so that we can easily ignore cases; it's useful to ignore a case
 	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.model.monitoring.SubAppPortElement
 	 * @generated
@@ -284,13 +259,11 @@ public class MonitoringAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class
-	 * '{@link org.eclipse.fordiac.ide.model.monitoring.SubappMonitoringElement
-	 * <em>Subapp Monitoring Element</em>}'. <!-- begin-user-doc --> This default
+	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.model.monitoring.SubappMonitoringElement <em>Subapp Monitoring Element</em>}'.
+	 * <!-- begin-user-doc --> This default
 	 * implementation returns null so that we can easily ignore cases; it's useful
 	 * to ignore a case when inheritance will catch all the cases anyway. <!--
 	 * end-user-doc -->
-	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.model.monitoring.SubappMonitoringElement
 	 * @generated
@@ -300,12 +273,24 @@ public class MonitoringAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class
-	 * '{@link org.eclipse.fordiac.ide.gef.editparts.IEditPartCreator <em>IEdit Part
-	 * Creator</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.model.monitoring.InternalVarInstance <em>Internal Var Instance</em>}'.
+	 * <!-- begin-user-doc -->
+	 * This default implementation returns null so that we can easily ignore cases;
+	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
+	 * <!-- end-user-doc -->
+	 * @return the new adapter.
+	 * @see org.eclipse.fordiac.ide.model.monitoring.InternalVarInstance
+	 * @generated
+	 */
+	public Adapter createInternalVarInstanceAdapter() {
+		return null;
+	}
+
+	/**
+	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.gef.editparts.IEditPartCreator <em>IEdit Part Creator</em>}'.
+	 * <!-- begin-user-doc --> This default implementation returns
 	 * null so that we can easily ignore cases; it's useful to ignore a case when
 	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
-	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.gef.editparts.IEditPartCreator
 	 * @generated
@@ -315,12 +300,10 @@ public class MonitoringAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class
-	 * '{@link org.eclipse.fordiac.ide.deployment.monitoringbase.PortElement
-	 * <em>Port Element</em>}'. <!-- begin-user-doc --> This default implementation
+	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.deployment.monitoringbase.PortElement <em>Port Element</em>}'.
+	 * <!-- begin-user-doc --> This default implementation
 	 * returns null so that we can easily ignore cases; it's useful to ignore a case
 	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.deployment.monitoringbase.PortElement
 	 * @generated
@@ -330,13 +313,11 @@ public class MonitoringAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class
-	 * '{@link org.eclipse.fordiac.ide.model.monitoring.AdapterPortElement
-	 * <em>Adapter Port Element</em>}'. <!-- begin-user-doc --> This default
+	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.model.monitoring.AdapterPortElement <em>Adapter Port Element</em>}'.
+	 * <!-- begin-user-doc --> This default
 	 * implementation returns null so that we can easily ignore cases; it's useful
 	 * to ignore a case when inheritance will catch all the cases anyway. <!--
 	 * end-user-doc -->
-	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.model.monitoring.AdapterPortElement
 	 * @generated
@@ -346,13 +327,11 @@ public class MonitoringAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class
-	 * '{@link org.eclipse.fordiac.ide.model.monitoring.AdapterMonitoringEvent
-	 * <em>Adapter Monitoring Event</em>}'. <!-- begin-user-doc --> This default
+	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.model.monitoring.AdapterMonitoringEvent <em>Adapter Monitoring Event</em>}'.
+	 * <!-- begin-user-doc --> This default
 	 * implementation returns null so that we can easily ignore cases; it's useful
 	 * to ignore a case when inheritance will catch all the cases anyway. <!--
 	 * end-user-doc -->
-	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.model.monitoring.AdapterMonitoringEvent
 	 * @generated
@@ -362,13 +341,11 @@ public class MonitoringAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class
-	 * '{@link org.eclipse.fordiac.ide.model.monitoring.AdapterMonitoringVarDeclaration
-	 * <em>Adapter Monitoring Var Declaration</em>}'. <!-- begin-user-doc --> This
+	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.model.monitoring.AdapterMonitoringVarDeclaration <em>Adapter Monitoring Var Declaration</em>}'.
+	 * <!-- begin-user-doc --> This
 	 * default implementation returns null so that we can easily ignore cases; it's
 	 * useful to ignore a case when inheritance will catch all the cases anyway.
 	 * <!-- end-user-doc -->
-	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.model.monitoring.AdapterMonitoringVarDeclaration
 	 * @generated
@@ -378,12 +355,10 @@ public class MonitoringAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class
-	 * '{@link org.eclipse.fordiac.ide.model.libraryElement.INamedElement <em>INamed
-	 * Element</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.model.libraryElement.INamedElement <em>INamed Element</em>}'.
+	 * <!-- begin-user-doc --> This default implementation returns
 	 * null so that we can easily ignore cases; it's useful to ignore a case when
 	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
-	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.INamedElement
 	 * @generated
@@ -393,12 +368,10 @@ public class MonitoringAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class
-	 * '{@link org.eclipse.fordiac.ide.model.libraryElement.ITypedElement <em>ITyped
-	 * Element</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.model.libraryElement.ITypedElement <em>ITyped Element</em>}'.
+	 * <!-- begin-user-doc --> This default implementation returns
 	 * null so that we can easily ignore cases; it's useful to ignore a case when
 	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
-	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.ITypedElement
 	 * @generated
@@ -408,13 +381,11 @@ public class MonitoringAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class
-	 * '{@link org.eclipse.fordiac.ide.model.libraryElement.ConfigurableObject
-	 * <em>Configurable Object</em>}'. <!-- begin-user-doc --> This default
+	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.model.libraryElement.ConfigurableObject <em>Configurable Object</em>}'.
+	 * <!-- begin-user-doc --> This default
 	 * implementation returns null so that we can easily ignore cases; it's useful
 	 * to ignore a case when inheritance will catch all the cases anyway. <!--
 	 * end-user-doc -->
-	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.ConfigurableObject
 	 * @generated
@@ -424,12 +395,10 @@ public class MonitoringAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class
-	 * '{@link org.eclipse.fordiac.ide.model.libraryElement.HiddenElement <em>Hidden
-	 * Element</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.model.libraryElement.HiddenElement <em>Hidden Element</em>}'.
+	 * <!-- begin-user-doc --> This default implementation returns
 	 * null so that we can easily ignore cases; it's useful to ignore a case when
 	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
-	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.HiddenElement
 	 * @generated
@@ -439,13 +408,11 @@ public class MonitoringAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class
-	 * '{@link org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement
-	 * <em>IInterface Element</em>}'. <!-- begin-user-doc --> This default
+	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement <em>IInterface Element</em>}'.
+	 * <!-- begin-user-doc --> This default
 	 * implementation returns null so that we can easily ignore cases; it's useful
 	 * to ignore a case when inheritance will catch all the cases anyway. <!--
 	 * end-user-doc -->
-	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement
 	 * @generated
@@ -455,12 +422,10 @@ public class MonitoringAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class
-	 * '{@link org.eclipse.fordiac.ide.model.libraryElement.ICallable
-	 * <em>ICallable</em>}'. <!-- begin-user-doc --> This default implementation
+	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.model.libraryElement.ICallable <em>ICallable</em>}'.
+	 * <!-- begin-user-doc --> This default implementation
 	 * returns null so that we can easily ignore cases; it's useful to ignore a case
 	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.ICallable
 	 * @generated
@@ -470,12 +435,10 @@ public class MonitoringAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class
-	 * '{@link org.eclipse.fordiac.ide.model.libraryElement.Event <em>Event</em>}'.
+	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.model.libraryElement.Event <em>Event</em>}'.
 	 * <!-- begin-user-doc --> This default implementation returns null so that we
 	 * can easily ignore cases; it's useful to ignore a case when inheritance will
 	 * catch all the cases anyway. <!-- end-user-doc -->
-	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.Event
 	 * @generated
@@ -485,12 +448,10 @@ public class MonitoringAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class
-	 * '{@link org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration <em>Var
-	 * Declaration</em>}'. <!-- begin-user-doc --> This default implementation
+	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration <em>Var Declaration</em>}'.
+	 * <!-- begin-user-doc --> This default implementation
 	 * returns null so that we can easily ignore cases; it's useful to ignore a case
 	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
-	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration
 	 * @generated
@@ -500,9 +461,9 @@ public class MonitoringAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for the default case. <!-- begin-user-doc --> This
+	 * Creates a new adapter for the default case.
+	 * <!-- begin-user-doc --> This
 	 * default implementation returns null. <!-- end-user-doc -->
-	 *
 	 * @return the new adapter.
 	 * @generated
 	 */

--- a/plugins/org.eclipse.fordiac.ide.monitoring/src-gen/org/eclipse/fordiac/ide/model/monitoring/util/MonitoringSwitch.java
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/src-gen/org/eclipse/fordiac/ide/model/monitoring/util/MonitoringSwitch.java
@@ -31,6 +31,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.monitoring.AdapterMonitoringEvent;
 import org.eclipse.fordiac.ide.model.monitoring.AdapterMonitoringVarDeclaration;
 import org.eclipse.fordiac.ide.model.monitoring.AdapterPortElement;
+import org.eclipse.fordiac.ide.model.monitoring.InternalVarInstance;
 import org.eclipse.fordiac.ide.model.monitoring.MonitoringAdapterElement;
 import org.eclipse.fordiac.ide.model.monitoring.MonitoringElement;
 import org.eclipse.fordiac.ide.model.monitoring.MonitoringPackage;
@@ -93,73 +94,163 @@ public class MonitoringSwitch<T> extends Switch<T> {
 			case MonitoringPackage.MONITORING_ELEMENT: {
 				MonitoringElement monitoringElement = (MonitoringElement)theEObject;
 				T result = caseMonitoringElement(monitoringElement);
-				if (result == null) result = caseMonitoringBaseElement(monitoringElement);
-				if (result == null) result = caseMonitoringBase_IEditPartCreator(monitoringElement);
-				if (result == null) result = defaultCase(theEObject);
+				if (result == null) {
+					result = caseMonitoringBaseElement(monitoringElement);
+				}
+				if (result == null) {
+					result = caseMonitoringBase_IEditPartCreator(monitoringElement);
+				}
+				if (result == null) {
+					result = defaultCase(theEObject);
+				}
 				return result;
 			}
 			case MonitoringPackage.MONITORING_ADAPTER_ELEMENT: {
 				MonitoringAdapterElement monitoringAdapterElement = (MonitoringAdapterElement)theEObject;
 				T result = caseMonitoringAdapterElement(monitoringAdapterElement);
-				if (result == null) result = caseMonitoringBaseElement(monitoringAdapterElement);
-				if (result == null) result = caseMonitoringBase_IEditPartCreator(monitoringAdapterElement);
-				if (result == null) result = defaultCase(theEObject);
+				if (result == null) {
+					result = caseMonitoringBaseElement(monitoringAdapterElement);
+				}
+				if (result == null) {
+					result = caseMonitoringBase_IEditPartCreator(monitoringAdapterElement);
+				}
+				if (result == null) {
+					result = defaultCase(theEObject);
+				}
 				return result;
 			}
 			case MonitoringPackage.ADAPTER_PORT_ELEMENT: {
 				AdapterPortElement adapterPortElement = (AdapterPortElement)theEObject;
 				T result = caseAdapterPortElement(adapterPortElement);
-				if (result == null) result = casePortElement(adapterPortElement);
-				if (result == null) result = defaultCase(theEObject);
+				if (result == null) {
+					result = casePortElement(adapterPortElement);
+				}
+				if (result == null) {
+					result = defaultCase(theEObject);
+				}
 				return result;
 			}
 			case MonitoringPackage.ADAPTER_MONITORING_EVENT: {
 				AdapterMonitoringEvent adapterMonitoringEvent = (AdapterMonitoringEvent)theEObject;
 				T result = caseAdapterMonitoringEvent(adapterMonitoringEvent);
-				if (result == null) result = caseIEditPartCreator(adapterMonitoringEvent);
-				if (result == null) result = caseEvent(adapterMonitoringEvent);
-				if (result == null) result = caseIInterfaceElement(adapterMonitoringEvent);
-				if (result == null) result = caseICallable(adapterMonitoringEvent);
-				if (result == null) result = caseITypedElement(adapterMonitoringEvent);
-				if (result == null) result = caseHiddenElement(adapterMonitoringEvent);
-				if (result == null) result = caseINamedElement(adapterMonitoringEvent);
-				if (result == null) result = caseConfigurableObject(adapterMonitoringEvent);
-				if (result == null) result = defaultCase(theEObject);
+				if (result == null) {
+					result = caseIEditPartCreator(adapterMonitoringEvent);
+				}
+				if (result == null) {
+					result = caseEvent(adapterMonitoringEvent);
+				}
+				if (result == null) {
+					result = caseIInterfaceElement(adapterMonitoringEvent);
+				}
+				if (result == null) {
+					result = caseICallable(adapterMonitoringEvent);
+				}
+				if (result == null) {
+					result = caseITypedElement(adapterMonitoringEvent);
+				}
+				if (result == null) {
+					result = caseHiddenElement(adapterMonitoringEvent);
+				}
+				if (result == null) {
+					result = caseINamedElement(adapterMonitoringEvent);
+				}
+				if (result == null) {
+					result = caseConfigurableObject(adapterMonitoringEvent);
+				}
+				if (result == null) {
+					result = defaultCase(theEObject);
+				}
 				return result;
 			}
 			case MonitoringPackage.ADAPTER_MONITORING_VAR_DECLARATION: {
 				AdapterMonitoringVarDeclaration adapterMonitoringVarDeclaration = (AdapterMonitoringVarDeclaration)theEObject;
 				T result = caseAdapterMonitoringVarDeclaration(adapterMonitoringVarDeclaration);
-				if (result == null) result = caseIEditPartCreator(adapterMonitoringVarDeclaration);
-				if (result == null) result = caseVarDeclaration(adapterMonitoringVarDeclaration);
-				if (result == null) result = caseIInterfaceElement(adapterMonitoringVarDeclaration);
-				if (result == null) result = caseITypedElement(adapterMonitoringVarDeclaration);
-				if (result == null) result = caseHiddenElement(adapterMonitoringVarDeclaration);
-				if (result == null) result = caseINamedElement(adapterMonitoringVarDeclaration);
-				if (result == null) result = caseConfigurableObject(adapterMonitoringVarDeclaration);
-				if (result == null) result = defaultCase(theEObject);
+				if (result == null) {
+					result = caseIEditPartCreator(adapterMonitoringVarDeclaration);
+				}
+				if (result == null) {
+					result = caseVarDeclaration(adapterMonitoringVarDeclaration);
+				}
+				if (result == null) {
+					result = caseIInterfaceElement(adapterMonitoringVarDeclaration);
+				}
+				if (result == null) {
+					result = caseITypedElement(adapterMonitoringVarDeclaration);
+				}
+				if (result == null) {
+					result = caseHiddenElement(adapterMonitoringVarDeclaration);
+				}
+				if (result == null) {
+					result = caseINamedElement(adapterMonitoringVarDeclaration);
+				}
+				if (result == null) {
+					result = caseConfigurableObject(adapterMonitoringVarDeclaration);
+				}
+				if (result == null) {
+					result = defaultCase(theEObject);
+				}
 				return result;
 			}
 			case MonitoringPackage.IEDIT_PART_CREATOR: {
 				IEditPartCreator iEditPartCreator = (IEditPartCreator)theEObject;
 				T result = caseIEditPartCreator(iEditPartCreator);
-				if (result == null) result = defaultCase(theEObject);
+				if (result == null) {
+					result = defaultCase(theEObject);
+				}
 				return result;
 			}
 			case MonitoringPackage.SUB_APP_PORT_ELEMENT: {
 				SubAppPortElement subAppPortElement = (SubAppPortElement)theEObject;
 				T result = caseSubAppPortElement(subAppPortElement);
-				if (result == null) result = casePortElement(subAppPortElement);
-				if (result == null) result = defaultCase(theEObject);
+				if (result == null) {
+					result = casePortElement(subAppPortElement);
+				}
+				if (result == null) {
+					result = defaultCase(theEObject);
+				}
 				return result;
 			}
 			case MonitoringPackage.SUBAPP_MONITORING_ELEMENT: {
 				SubappMonitoringElement subappMonitoringElement = (SubappMonitoringElement)theEObject;
 				T result = caseSubappMonitoringElement(subappMonitoringElement);
-				if (result == null) result = caseMonitoringElement(subappMonitoringElement);
-				if (result == null) result = caseMonitoringBaseElement(subappMonitoringElement);
-				if (result == null) result = caseMonitoringBase_IEditPartCreator(subappMonitoringElement);
-				if (result == null) result = defaultCase(theEObject);
+				if (result == null) {
+					result = caseMonitoringElement(subappMonitoringElement);
+				}
+				if (result == null) {
+					result = caseMonitoringBaseElement(subappMonitoringElement);
+				}
+				if (result == null) {
+					result = caseMonitoringBase_IEditPartCreator(subappMonitoringElement);
+				}
+				if (result == null) {
+					result = defaultCase(theEObject);
+				}
+				return result;
+			}
+			case MonitoringPackage.INTERNAL_VAR_INSTANCE: {
+				InternalVarInstance internalVarInstance = (InternalVarInstance)theEObject;
+				T result = caseInternalVarInstance(internalVarInstance);
+				if (result == null) {
+					result = caseVarDeclaration(internalVarInstance);
+				}
+				if (result == null) {
+					result = caseIInterfaceElement(internalVarInstance);
+				}
+				if (result == null) {
+					result = caseITypedElement(internalVarInstance);
+				}
+				if (result == null) {
+					result = caseHiddenElement(internalVarInstance);
+				}
+				if (result == null) {
+					result = caseINamedElement(internalVarInstance);
+				}
+				if (result == null) {
+					result = caseConfigurableObject(internalVarInstance);
+				}
+				if (result == null) {
+					result = defaultCase(theEObject);
+				}
 				return result;
 			}
 			default: return defaultCase(theEObject);
@@ -232,6 +323,21 @@ public class MonitoringSwitch<T> extends Switch<T> {
 	 * @generated
 	 */
 	public T caseSubappMonitoringElement(SubappMonitoringElement object) {
+		return null;
+	}
+
+	/**
+	 * Returns the result of interpreting the object as an instance of '<em>Internal Var Instance</em>'.
+	 * <!-- begin-user-doc -->
+	 * This implementation returns null;
+	 * returning a non-null result will terminate the switch.
+	 * <!-- end-user-doc -->
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Internal Var Instance</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
+	public T caseInternalVarInstance(InternalVarInstance object) {
 		return null;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/MonitoringChildren.java
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/MonitoringChildren.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2012 - 2021 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
- * 							 Johannes Kepler University,
+ * Copyright (c) 2012, 2024 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
+ * 							 Johannes Kepler University Linz,
  * 							 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
@@ -30,6 +30,7 @@ import org.eclipse.fordiac.ide.gef.editparts.IChildrenProvider;
 import org.eclipse.fordiac.ide.gef.editparts.IEditPartCreator;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.Group;
+import org.eclipse.fordiac.ide.model.monitoring.InternalVarInstance;
 
 public class MonitoringChildren implements IMonitoringListener, IChildrenProvider {
 
@@ -48,7 +49,11 @@ public class MonitoringChildren implements IMonitoringListener, IChildrenProvide
 	}
 
 	private static boolean shouldBeAdded(final MonitoringBaseElement element, final FBNetwork fbNetwork) {
-		if (element != null && element.getPort().getFb().getFbNetwork() != null) {
+		if (element == null || element.getPort().getInterfaceElement() instanceof InternalVarInstance) {
+			return false;
+		}
+
+		if (element.getPort().getFb().getFbNetwork() != null) {
 			if (element.getPort().getFb().getGroup() != null) {
 				return checkGroup(element, fbNetwork);
 			}

--- a/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/MonitoringManagerUtils.java
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/MonitoringManagerUtils.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2023 Profactor GmbH, AIT, fortiss GmbH,
- * 							Johannes Kepler University,
+ * Copyright (c) 2012, 2024 Profactor GmbH, AIT, fortiss GmbH,
+ * 							Johannes Kepler University Linz,
  * 							Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
@@ -45,12 +45,11 @@ public final class MonitoringManagerUtils {
 		if (fbNetworkElement instanceof final SubApp subApp) {
 			checkSubAppNetwork(subApp);
 			final IInterfaceElement anchor = SubAppPortHelper.findAnchorInterfaceElement(ie);
-			if (anchor == null) {
-				if (showError) {
-					ErrorMessenger.popUpErrorMessage(Messages.MonitoringManagerUtils_NoSubappAnchor);
-				}
-			} else {
-				canBeMonitored(anchor, false);
+			if (anchor != null) {
+				return canBeMonitored(anchor, false);
+			}
+			if (showError) {
+				ErrorMessenger.popUpErrorMessage(Messages.MonitoringManagerUtils_NoSubappAnchor);
 			}
 		}
 
@@ -62,6 +61,10 @@ public final class MonitoringManagerUtils {
 			// the contained network has not been loaded yet, load it now.
 			subApp.loadSubAppNetwork();
 		}
+	}
+
+	public static boolean canBeMonitored(final FB fb) {
+		return fb != null && fb.getResource() != null;
 	}
 
 	public static boolean canBeMonitored(final FBNetworkElement obj) {

--- a/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/handlers/AbstractAddWatchesHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/handlers/AbstractAddWatchesHandler.java
@@ -1,0 +1,218 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Alois Zoitl - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.monitoring.handlers;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.fordiac.ide.deployment.monitoringbase.MonitoringBaseElement;
+import org.eclipse.fordiac.ide.deployment.monitoringbase.MonitoringBaseFactory;
+import org.eclipse.fordiac.ide.deployment.monitoringbase.PortElement;
+import org.eclipse.fordiac.ide.model.libraryElement.AdapterDeclaration;
+import org.eclipse.fordiac.ide.model.libraryElement.AdapterFB;
+import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
+import org.eclipse.fordiac.ide.model.libraryElement.Event;
+import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
+import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.monitoring.AdapterPortElement;
+import org.eclipse.fordiac.ide.model.monitoring.MonitoringAdapterElement;
+import org.eclipse.fordiac.ide.model.monitoring.MonitoringElement;
+import org.eclipse.fordiac.ide.model.monitoring.MonitoringFactory;
+import org.eclipse.fordiac.ide.model.monitoring.SubAppPortElement;
+import org.eclipse.fordiac.ide.model.monitoring.SubappMonitoringElement;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
+import org.eclipse.fordiac.ide.monitoring.Activator;
+import org.eclipse.fordiac.ide.monitoring.Messages;
+import org.eclipse.fordiac.ide.monitoring.MonitoringManager;
+import org.eclipse.fordiac.ide.monitoring.MonitoringManagerUtils;
+import org.eclipse.fordiac.ide.monitoring.preferences.PreferenceConstants;
+import org.eclipse.fordiac.ide.ui.errormessages.ErrorMessenger;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Shell;
+
+public abstract class AbstractAddWatchesHandler extends AbstractMonitoringHandler {
+
+	private static boolean validatePort(final PortElement port, final IInterfaceElement ie) {
+		if (port instanceof final SubAppPortElement subAppPort && subAppPort.getAnchor() == null) {
+			ErrorMessenger.popUpErrorMessage(
+					MessageFormat.format(Messages.MonitoringManagerUtils_NoSubappAnchor, ie.getName()));
+			return false;
+		}
+		return true;
+	}
+
+	protected void createWatchForIE(final MonitoringManager manager, final IInterfaceElement ie) {
+		final PortElement port = MonitoringManagerUtils.createPortElement(ie);
+		if (validatePort(port, ie)) {
+			createMonitoringElement(manager, port);
+		}
+	}
+
+	public static MonitoringBaseElement createSubappElement(final PortElement port, final MonitoringManager manager) {
+		final MonitoringBaseElement element = MonitoringFactory.eINSTANCE.createSubappMonitoringElement();
+		final MonitoringBaseElement anchor = MonitoringFactory.eINSTANCE.createMonitoringElement();
+		final PortElement anchorPort = MonitoringManagerUtils.createPortElement(((SubAppPortElement) port).getAnchor());
+		anchor.setPort(anchorPort);
+		((SubappMonitoringElement) element).setAnchor(anchor);
+		final MonitoringBaseElement monitoringElement = manager.getMonitoringElement(anchorPort.getInterfaceElement());
+		if (monitoringElement == null) {
+			manager.addMonitoringElement(anchor);
+		} else {
+			((SubappMonitoringElement) element).setAnchor(monitoringElement);
+		}
+		return element;
+	}
+
+	private MonitoringBaseElement createMonitoringElement(final MonitoringManager manager, final PortElement port) {
+		MonitoringBaseElement element;
+		if (port instanceof AdapterPortElement) {
+			element = MonitoringFactory.eINSTANCE.createMonitoringAdapterElement();
+		} else if (port instanceof SubAppPortElement) {
+			element = createSubappElement(port, manager);
+		} else {
+			element = MonitoringFactory.eINSTANCE.createMonitoringElement();
+		}
+
+		element.setPort(port);
+
+		if (!manager.containsPort(port.getInterfaceElement())) {
+			manager.addMonitoringElement(element);
+		}
+		if (port instanceof AdapterPortElement) {
+			final MonitoringAdapterElement adpaterElement = (MonitoringAdapterElement) element;
+			createMonitoringElementsForAdapterInterface(manager, adpaterElement);
+		}
+		return element;
+	}
+
+	private static void createMonitoredAdpaterFBView(final MonitoringAdapterElement adpaterElement) {
+		final AdapterFB fb = LibraryElementFactory.eINSTANCE.createAdapterFB();
+		final AdapterDeclaration interfaceElement = (AdapterDeclaration) adpaterElement.getPort().getInterfaceElement();
+		final TypeEntry entry = interfaceElement.getType().getTypeEntry();
+		fb.setTypeEntry(entry);
+		fb.setAdapterDecl(interfaceElement);
+		fb.setInterface(LibraryElementFactory.eINSTANCE.createInterfaceList());
+		createMonitoredAdapterInterface(fb);
+		adpaterElement.setMonitoredAdapterFB(fb);
+	}
+
+	private void createMonitoringElementsForAdapterInterface(final MonitoringManager manager,
+			final MonitoringAdapterElement adpaterElement) {
+		createMonitoredAdpaterFBView(adpaterElement);
+		refreshEditor();
+		final PortElement port = adpaterElement.getPort();
+		final List<MonitoringElement> childElements = adpaterElement.getElements();
+		final InterfaceList interfaceList = adpaterElement.getMonitoredAdapterFB().getInterface();
+		final List<PortElement> ports = ((AdapterPortElement) port).getPorts();
+		final ArrayList<IInterfaceElement> ios = new ArrayList<>();
+		ios.addAll(interfaceList.getEventInputs());
+		ios.addAll(interfaceList.getEventOutputs());
+		ios.addAll(interfaceList.getInputVars());
+		ios.addAll(interfaceList.getOutputVars());
+		for (final IInterfaceElement io : ios) {
+			final PortElement newPort = MonitoringBaseFactory.eINSTANCE.createPortElement();
+			newPort.setFb(port.getFb());
+			newPort.setInterfaceElement(io);
+			newPort.setResource(port.getResource());
+			newPort.setHierarchy(port.getHierarchy());
+			ports.add(newPort);
+			childElements.add((MonitoringElement) createMonitoringElement(manager, newPort));
+		}
+	}
+
+	private static void createMonitoredAdapterInterface(final AdapterFB fb) {
+		final InterfaceList interfaceList = fb.getInterface();
+		for (final Event event : fb.getType().getInterfaceList().getEventInputs()) {
+			interfaceList.getEventInputs().add(EcoreUtil.copy(event));
+		}
+		for (final Event event : fb.getType().getInterfaceList().getEventOutputs()) {
+			interfaceList.getEventOutputs().add(EcoreUtil.copy(event));
+		}
+		for (final VarDeclaration inVar : fb.getType().getInterfaceList().getInputVars()) {
+			interfaceList.getInputVars().add(EcoreUtil.copy(inVar));
+		}
+		for (final VarDeclaration outVar : fb.getType().getInterfaceList().getOutputVars()) {
+			interfaceList.getOutputVars().add(EcoreUtil.copy(outVar));
+		}
+		// currently IEC 61499 does not allow adapters in adapters.
+		// If this changes here also plugs and sockets need to be added
+	}
+
+	protected static void handleMonitoringState(final Collection<? extends EObject> foundElements, final Shell shell) {
+		if (!foundElements.isEmpty()) {
+			final AutomationSystem system = getAutomationSystem(foundElements.iterator().next());
+			if ((system != null) && !MonitoringManager.getInstance().isSystemMonitored(system)
+					&& shouldEnableMonitoring(system, shell)) {
+				enableMonitoring(system);
+			}
+		}
+	}
+
+	private static AutomationSystem getAutomationSystem(final EObject eObj) {
+		return (EcoreUtil.getRootContainer(eObj) instanceof final AutomationSystem as) ? as : null;
+	}
+
+	private static boolean shouldEnableMonitoring(final AutomationSystem system, final Shell shell) {
+		if (!Activator.getDefault().getPreferenceStore()
+				.getBoolean(PreferenceConstants.P_MONITORING_STARTMONITORINGWITHOUTASKING)) {
+
+			final MessageDialog dialog = new MessageDialog(shell, Messages.MonitoringDialog_EnableMonitoring, null,
+					MessageFormat.format(Messages.MonitoringDialog_EnableMonitoringQuestion, system.getName()),
+					MessageDialog.QUESTION,
+					new String[] { Messages.MonitoringDialog_Enable, Messages.MonitoringDialog_No }, 0) {
+
+				@Override
+				protected Control createCustomArea(final Composite parent) {
+					final Button checkBox = new Button(parent, SWT.CHECK);
+					checkBox.setText(Messages.MonitoringPreferences_StartMonitoringWithoutAsking);
+					checkBox.addSelectionListener(new SelectionListener() {
+
+						@Override
+						public void widgetSelected(final SelectionEvent e) {
+							Activator.getDefault().getPreferenceStore().setValue(
+									PreferenceConstants.P_MONITORING_STARTMONITORINGWITHOUTASKING,
+									checkBox.getSelection());
+						}
+
+						@Override
+						public void widgetDefaultSelected(final SelectionEvent e) {
+							// Nothing to do here
+						}
+					});
+					return checkBox;
+				}
+
+			};
+
+			return dialog.open() == 0;
+		}
+		return true;
+	}
+
+	private static void enableMonitoring(final AutomationSystem system) {
+		MonitoringManager.getInstance().enableSystem(system);
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/handlers/AbstractMonitoringHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/handlers/AbstractMonitoringHandler.java
@@ -18,10 +18,13 @@ import java.util.List;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.fordiac.ide.model.ui.editors.HandlerHelper;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.GraphicalViewer;
 import org.eclipse.gef.RootEditPart;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.handlers.HandlerUtil;
 
@@ -30,10 +33,16 @@ public abstract class AbstractMonitoringHandler extends AbstractHandler {
 	private RootEditPart rootEditPart = null;
 
 	@Override
-	public Object execute(final ExecutionEvent event) throws ExecutionException {
+	public final Object execute(final ExecutionEvent event) throws ExecutionException {
 		setEditor(HandlerUtil.getActiveEditor(event));
-		return null;
+		final ISelection selection = HandlerUtil.getCurrentSelection(event);
+		if (selection instanceof final StructuredSelection structSel) {
+			doExecute(event, structSel);
+		}
+		return Status.OK_STATUS;
 	}
+
+	protected abstract void doExecute(ExecutionEvent event, StructuredSelection structSel) throws ExecutionException;
 
 	protected void setEditor(final IEditorPart activeEditor) {
 

--- a/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/handlers/AddWatchHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/handlers/AddWatchHandler.java
@@ -16,271 +16,62 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.monitoring.handlers;
 
-import java.text.MessageFormat;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
-import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.eclipse.fordiac.ide.deployment.monitoringbase.MonitoringBaseElement;
-import org.eclipse.fordiac.ide.deployment.monitoringbase.MonitoringBaseFactory;
-import org.eclipse.fordiac.ide.deployment.monitoringbase.PortElement;
-import org.eclipse.fordiac.ide.model.libraryElement.AdapterDeclaration;
-import org.eclipse.fordiac.ide.model.libraryElement.AdapterFB;
-import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
-import org.eclipse.fordiac.ide.model.libraryElement.Event;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
-import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
-import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
-import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
-import org.eclipse.fordiac.ide.model.monitoring.AdapterPortElement;
-import org.eclipse.fordiac.ide.model.monitoring.MonitoringAdapterElement;
-import org.eclipse.fordiac.ide.model.monitoring.MonitoringElement;
-import org.eclipse.fordiac.ide.model.monitoring.MonitoringFactory;
-import org.eclipse.fordiac.ide.model.monitoring.SubAppPortElement;
-import org.eclipse.fordiac.ide.model.monitoring.SubappMonitoringElement;
-import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
-import org.eclipse.fordiac.ide.monitoring.Activator;
-import org.eclipse.fordiac.ide.monitoring.Messages;
 import org.eclipse.fordiac.ide.monitoring.MonitoringManager;
 import org.eclipse.fordiac.ide.monitoring.MonitoringManagerUtils;
 import org.eclipse.fordiac.ide.monitoring.editparts.MonitoringAdapterInterfaceEditPart;
-import org.eclipse.fordiac.ide.monitoring.preferences.PreferenceConstants;
-import org.eclipse.fordiac.ide.ui.errormessages.ErrorMessenger;
 import org.eclipse.gef.EditPart;
-import org.eclipse.jface.dialogs.MessageDialog;
-import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.StructuredSelection;
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.events.SelectionListener;
-import org.eclipse.swt.widgets.Button;
-import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.ISources;
 import org.eclipse.ui.handlers.HandlerUtil;
 
-public class AddWatchHandler extends AbstractMonitoringHandler {
+public class AddWatchHandler extends AbstractAddWatchesHandler {
 
 	@Override
-	public Object execute(final ExecutionEvent event) throws ExecutionException {
-		super.execute(event);
-		final ISelection selection = HandlerUtil.getCurrentSelection(event);
-		if (selection instanceof StructuredSelection) {
-			final MonitoringManager manager = MonitoringManager.getInstance();
-			final Set<IInterfaceElement> foundElements = getSelectedWatchedElements(manager,
-					(StructuredSelection) selection);
-			handleMonitoringState(foundElements, HandlerUtil.getActiveSiteChecked(event).getShell());
-			for (final IInterfaceElement ie : foundElements) {
-				createElementFromPort(manager, ie);
-			}
-			refreshEditor();
-			MonitoringManager.getInstance().notifyWatchesChanged();
-
+	protected void doExecute(final ExecutionEvent event, final StructuredSelection structSel)
+			throws ExecutionException {
+		final MonitoringManager manager = MonitoringManager.getInstance();
+		final Set<IInterfaceElement> foundElements = getSelectedWatchedElements(manager, structSel);
+		handleMonitoringState(foundElements, HandlerUtil.getActiveSiteChecked(event).getShell());
+		for (final IInterfaceElement ie : foundElements) {
+			createWatchForIE(manager, ie);
 		}
-		return null;
-	}
-
-	public void createElementFromPort(final MonitoringManager manager, final IInterfaceElement ie) {
-		final PortElement port = MonitoringManagerUtils.createPortElement(ie);
-		if (validatePort(port, ie)) {
-			createMonitoringElement(manager, port);
-		}
-
-	}
-
-	private static boolean validatePort(final PortElement port, final IInterfaceElement ie) {
-		if (port instanceof SubAppPortElement && ((SubAppPortElement) port).getAnchor() == null) {
-			ErrorMessenger.popUpErrorMessage(
-					MessageFormat.format(Messages.MonitoringManagerUtils_NoSubappAnchor, ie.getName()));
-			return false;
-		}
-
-		return true;
+		refreshEditor();
+		MonitoringManager.getInstance().notifyWatchesChanged();
 	}
 
 	@Override
 	public void setEnabled(final Object evaluationContext) {
 		final Object selection = HandlerUtil.getVariable(evaluationContext, ISources.ACTIVE_CURRENT_SELECTION_NAME);
-		if (selection instanceof StructuredSelection) {
-			setBaseEnabled(!getSelectedWatchedElements(MonitoringManager.getInstance(), (StructuredSelection) selection)
-					.isEmpty());
-		} else {
-			setBaseEnabled(false);
-		}
+		setBaseEnabled(selection instanceof final StructuredSelection structSel
+				&& !getSelectedWatchedElements(MonitoringManager.getInstance(), structSel).isEmpty());
 	}
 
 	private static Set<IInterfaceElement> getSelectedWatchedElements(final MonitoringManager manager,
 			final StructuredSelection selection) {
 		final Set<IInterfaceElement> foundElements = new HashSet<>();
 		for (final Object selectedObject : selection) {
-			if ((selectedObject instanceof EditPart)
+			if ((selectedObject instanceof final EditPart ep)
 					&& (!(selectedObject instanceof MonitoringAdapterInterfaceEditPart))) {
-				final Object model = ((EditPart) selectedObject).getModel();
+				final Object model = ep.getModel();
 
-				if (model instanceof FBNetworkElement) {
-					if (MonitoringManagerUtils.canBeMonitored((FBNetworkElement) model)) {
-						foundElements.addAll(((FBNetworkElement) model).getInterface().getAllInterfaceElements());
+				if (model instanceof final FBNetworkElement fbnEl) {
+					if (MonitoringManagerUtils.canBeMonitored(fbnEl)) {
+						foundElements.addAll(fbnEl.getInterface().getAllInterfaceElements());
 					}
-				} else if (model instanceof final IInterfaceElement ie) {
-					if (MonitoringManagerUtils.canBeMonitored(ie, false) && !manager.containsPort(ie)) {
-						foundElements.add(ie);
-					}
+				} else if ((model instanceof final IInterfaceElement ie)
+						&& (MonitoringManagerUtils.canBeMonitored(ie, false) && !manager.containsPort(ie))) {
+					foundElements.add(ie);
 				}
 			}
 		}
 		return foundElements;
 	}
 
-	protected MonitoringBaseElement createMonitoringElement(final MonitoringManager manager, final PortElement port) {
-		MonitoringBaseElement element;
-		if (port instanceof AdapterPortElement) {
-			element = MonitoringFactory.eINSTANCE.createMonitoringAdapterElement();
-		} else if (port instanceof SubAppPortElement) {
-			element = createSubappElement(port, manager);
-		} else {
-			element = MonitoringFactory.eINSTANCE.createMonitoringElement();
-		}
-
-		element.setPort(port);
-
-		if (!manager.containsPort(port.getInterfaceElement())) {
-			manager.addMonitoringElement(element);
-		}
-		if (port instanceof AdapterPortElement) {
-			final MonitoringAdapterElement adpaterElement = (MonitoringAdapterElement) element;
-			createMonitoringElementsForAdapterInterface(manager, adpaterElement);
-		}
-		return element;
-	}
-
-	public static MonitoringBaseElement createSubappElement(final PortElement port, final MonitoringManager manager) {
-		final MonitoringBaseElement element = MonitoringFactory.eINSTANCE.createSubappMonitoringElement();
-		final MonitoringBaseElement anchor = MonitoringFactory.eINSTANCE.createMonitoringElement();
-		final PortElement anchorPort = MonitoringManagerUtils.createPortElement(((SubAppPortElement) port).getAnchor());
-		anchor.setPort(anchorPort);
-		((SubappMonitoringElement) element).setAnchor(anchor);
-		final MonitoringBaseElement monitoringElement = manager.getMonitoringElement(anchorPort.getInterfaceElement());
-		if (monitoringElement == null) {
-			manager.addMonitoringElement(anchor);
-		} else {
-			((SubappMonitoringElement) element).setAnchor(monitoringElement);
-		}
-		return element;
-	}
-
-	private void createMonitoringElementsForAdapterInterface(final MonitoringManager manager,
-			final MonitoringAdapterElement adpaterElement) {
-		createMonitoredAdpaterFBView(adpaterElement);
-		refreshEditor();
-		final PortElement port = adpaterElement.getPort();
-		final List<MonitoringElement> childElements = adpaterElement.getElements();
-		final InterfaceList interfaceList = adpaterElement.getMonitoredAdapterFB().getInterface();
-		final List<PortElement> ports = ((AdapterPortElement) port).getPorts();
-		final ArrayList<IInterfaceElement> ios = new ArrayList<>();
-		ios.addAll(interfaceList.getEventInputs());
-		ios.addAll(interfaceList.getEventOutputs());
-		ios.addAll(interfaceList.getInputVars());
-		ios.addAll(interfaceList.getOutputVars());
-		for (final IInterfaceElement io : ios) {
-			final PortElement newPort = MonitoringBaseFactory.eINSTANCE.createPortElement();
-			newPort.setFb(port.getFb());
-			newPort.setInterfaceElement(io);
-			newPort.setResource(port.getResource());
-			newPort.setHierarchy(port.getHierarchy());
-			ports.add(newPort);
-			childElements.add((MonitoringElement) createMonitoringElement(manager, newPort));
-		}
-	}
-
-	private static void createMonitoredAdpaterFBView(final MonitoringAdapterElement adpaterElement) {
-		final AdapterFB fb = LibraryElementFactory.eINSTANCE.createAdapterFB();
-		final AdapterDeclaration interfaceElement = (AdapterDeclaration) adpaterElement.getPort().getInterfaceElement();
-		final TypeEntry entry = interfaceElement.getType().getTypeEntry();
-		fb.setTypeEntry(entry);
-		fb.setAdapterDecl(interfaceElement);
-		fb.setInterface(LibraryElementFactory.eINSTANCE.createInterfaceList());
-		createMonitoredAdapterInterface(fb);
-		adpaterElement.setMonitoredAdapterFB(fb);
-	}
-
-	private static void createMonitoredAdapterInterface(final AdapterFB fb) {
-		final InterfaceList interfaceList = fb.getInterface();
-		for (final Event event : fb.getType().getInterfaceList().getEventInputs()) {
-			interfaceList.getEventInputs().add(EcoreUtil.copy(event));
-		}
-		for (final Event event : fb.getType().getInterfaceList().getEventOutputs()) {
-			interfaceList.getEventOutputs().add(EcoreUtil.copy(event));
-		}
-		for (final VarDeclaration inVar : fb.getType().getInterfaceList().getInputVars()) {
-			interfaceList.getInputVars().add(EcoreUtil.copy(inVar));
-		}
-		for (final VarDeclaration outVar : fb.getType().getInterfaceList().getOutputVars()) {
-			interfaceList.getOutputVars().add(EcoreUtil.copy(outVar));
-		}
-		// currently IEC 61499 does not allow adapters in adapters.
-		// If this changes here also plugs and sockets need to be added
-	}
-
-	private static void handleMonitoringState(final Set<IInterfaceElement> foundElements, final Shell shell) {
-		if (!foundElements.isEmpty()) {
-			final AutomationSystem system = getAutomationSystem(foundElements.iterator().next());
-			if ((system != null) && !MonitoringManager.getInstance().isSystemMonitored(system)
-					&& shouldEnableMonitoring(system, shell)) {
-				enableMonitoring(system);
-			}
-		}
-	}
-
-	private static AutomationSystem getAutomationSystem(final IInterfaceElement ie) {
-		final EObject root = EcoreUtil.getRootContainer(ie);
-		return (root instanceof AutomationSystem) ? (AutomationSystem) root : null;
-	}
-
-	private static boolean shouldEnableMonitoring(final AutomationSystem system, final Shell shell) {
-		if (!Activator.getDefault().getPreferenceStore()
-				.getBoolean(PreferenceConstants.P_MONITORING_STARTMONITORINGWITHOUTASKING)) {
-
-			final MessageDialog dialog = new MessageDialog(shell, Messages.MonitoringDialog_EnableMonitoring, null,
-					MessageFormat.format(Messages.MonitoringDialog_EnableMonitoringQuestion, system.getName()),
-					MessageDialog.QUESTION,
-					new String[] { Messages.MonitoringDialog_Enable, Messages.MonitoringDialog_No }, 0) {
-
-				@Override
-				protected Control createCustomArea(final Composite parent) {
-					final Button checkBox = new Button(parent, SWT.CHECK);
-					checkBox.setText(Messages.MonitoringPreferences_StartMonitoringWithoutAsking);
-					checkBox.addSelectionListener(new SelectionListener() {
-
-						@Override
-						public void widgetSelected(final SelectionEvent e) {
-							Activator.getDefault().getPreferenceStore().setValue(
-									PreferenceConstants.P_MONITORING_STARTMONITORINGWITHOUTASKING,
-									checkBox.getSelection());
-						}
-
-						@Override
-						public void widgetDefaultSelected(final SelectionEvent e) {
-							// Nothing to do here
-						}
-					});
-					return checkBox;
-				}
-
-			};
-
-			return dialog.open() == 0;
-		}
-		return true;
-	}
-
-	private static void enableMonitoring(final AutomationSystem system) {
-		MonitoringManager.getInstance().enableSystem(system);
-	}
 }

--- a/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/handlers/ClearForceHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/handlers/ClearForceHandler.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016, 2018 fortiss GmbH, Johannes Kepler University
+ * Copyright (c) 2015, 2024 fortiss GmbH, Johannes Kepler University Linz
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -13,7 +14,6 @@
 package org.eclipse.fordiac.ide.monitoring.handlers;
 
 import org.eclipse.core.commands.ExecutionEvent;
-import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.fordiac.ide.deployment.monitoringbase.MonitoringBaseElement;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.monitoring.MonitoringElement;
@@ -25,20 +25,16 @@ import org.eclipse.ui.handlers.HandlerUtil;
 public class ClearForceHandler extends AbstractMonitoringHandler {
 
 	@Override
-	public Object execute(final ExecutionEvent event) throws ExecutionException {
-		super.execute(event);
-		final StructuredSelection selection = (StructuredSelection) HandlerUtil.getCurrentSelection(event);
-		final VarDeclaration variable = ForceHandler.getVariable(selection.getFirstElement());
-		processHandler(variable);
-		return null;
+	protected void doExecute(final ExecutionEvent event, final StructuredSelection structSel) {
+		processHandler(ForceHandler.getVariable(structSel.getFirstElement()));
 	}
 
 	public static void processHandler(final VarDeclaration variable) {
 		if (null != variable) {
 			final MonitoringManager manager = MonitoringManager.getInstance();
 			final MonitoringBaseElement element = manager.getMonitoringElement(variable);
-			if (element instanceof MonitoringElement) {
-				manager.forceValue((MonitoringElement) element, ""); //$NON-NLS-1$
+			if (element instanceof final MonitoringElement me) {
+				manager.forceValue(me, ""); //$NON-NLS-1$
 			}
 		}
 	}
@@ -48,8 +44,7 @@ public class ClearForceHandler extends AbstractMonitoringHandler {
 		boolean needToAdd = false;
 		final Object selection = HandlerUtil.getVariable(evaluationContext, ISources.ACTIVE_CURRENT_SELECTION_NAME);
 
-		if (selection instanceof StructuredSelection) {
-			final StructuredSelection sel = (StructuredSelection) selection;
+		if (selection instanceof final StructuredSelection sel) {
 			final MonitoringManager manager = MonitoringManager.getInstance();
 
 			if (1 == sel.size()) {
@@ -57,7 +52,7 @@ public class ClearForceHandler extends AbstractMonitoringHandler {
 				final VarDeclaration variable = ForceHandler.getVariable(sel.getFirstElement());
 				if (null != variable) {
 					final MonitoringBaseElement element = manager.getMonitoringElement(variable);
-					needToAdd = (element instanceof MonitoringElement && ((MonitoringElement) element).isForce());
+					needToAdd = (element instanceof final MonitoringElement me && me.isForce());
 				}
 			}
 		}

--- a/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/handlers/ForceHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/handlers/ForceHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2021 fortiss GmbH, Johannes Kepler University,
+ * Copyright (c) 2015, 2024 fortiss GmbH, Johannes Kepler University Linz,
  *                          Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
@@ -17,7 +17,6 @@
 package org.eclipse.fordiac.ide.monitoring.handlers;
 
 import org.eclipse.core.commands.ExecutionEvent;
-import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.fordiac.ide.deployment.monitoringbase.MonitoringBaseElement;
 import org.eclipse.fordiac.ide.gef.editparts.InterfaceEditPart;
 import org.eclipse.fordiac.ide.model.data.StructuredType;
@@ -39,12 +38,8 @@ import org.eclipse.ui.handlers.HandlerUtil;
 public class ForceHandler extends AbstractMonitoringHandler {
 
 	@Override
-	public Object execute(final ExecutionEvent event) throws ExecutionException {
-		super.execute(event);
-		final StructuredSelection selection = (StructuredSelection) HandlerUtil.getCurrentSelection(event);
-		final VarDeclaration variable = getVariable(selection.getFirstElement());
-		showDialogAndProcess(variable);
-		return null;
+	protected void doExecute(final ExecutionEvent event, final StructuredSelection structSel) {
+		showDialogAndProcess(getVariable(structSel.getFirstElement()));
 	}
 
 	public static void showDialogAndProcess(final VarDeclaration variable, final IInterfaceElement interfaceElement) {
@@ -54,30 +49,28 @@ public class ForceHandler extends AbstractMonitoringHandler {
 		}
 		final MonitoringManager manager = MonitoringManager.getInstance();
 		final MonitoringBaseElement element = manager.getMonitoringElement(variable);
-		if (element instanceof MonitoringElement) {
-			final MonitoringElement monitoringElement = (MonitoringElement) element;
-			String oldValue = "";
+		if (element instanceof final MonitoringElement monitoringElement) {
+			String oldValue = ""; //$NON-NLS-1$
 			if (monitoringElement.isForce() && monitoringElement.getForceValue() != null) {
 				oldValue = monitoringElement.getForceValue().substring(
 						monitoringElement.getForceValue().toLowerCase().indexOf(
 								interfaceElement.getName().toLowerCase()) + interfaceElement.getName().length() + 2,
 						monitoringElement.getForceValue().toLowerCase().indexOf(',',
 								monitoringElement.getForceValue().toLowerCase()
-								.indexOf(interfaceElement.getName().toLowerCase())) == -1
-								? monitoringElement.getForceValue().toLowerCase().indexOf(')',
-										monitoringElement.getForceValue().toLowerCase()
-										.indexOf(interfaceElement.getName().toLowerCase()))
-										: monitoringElement.getForceValue().toLowerCase().indexOf(',',
-												monitoringElement.getForceValue().toLowerCase()
-												.indexOf(interfaceElement.getName().toLowerCase())));
+										.indexOf(interfaceElement.getName().toLowerCase())) == -1
+												? monitoringElement.getForceValue().toLowerCase().indexOf(')',
+														monitoringElement.getForceValue().toLowerCase()
+																.indexOf(interfaceElement.getName().toLowerCase()))
+												: monitoringElement.getForceValue().toLowerCase().indexOf(',',
+														monitoringElement.getForceValue().toLowerCase()
+																.indexOf(interfaceElement.getName().toLowerCase())));
 
 			}
 			final InputDialog input = new InputDialog(Display.getDefault().getActiveShell(),
-					Messages.MonitoringWatchesView_ForceValue, Messages.MonitoringWatchesView_Value,
-					oldValue,
+					Messages.MonitoringWatchesView_ForceValue, Messages.MonitoringWatchesView_Value, oldValue,
 					(newValue -> {
-						if (interfaceElement instanceof VarDeclaration) {
-							return ForceHandler.validateForceInput((VarDeclaration) interfaceElement, newValue);
+						if (interfaceElement instanceof final VarDeclaration varDecl) {
+							return ForceHandler.validateForceInput(varDecl, newValue);
 						}
 						return null;
 					}));
@@ -95,13 +88,12 @@ public class ForceHandler extends AbstractMonitoringHandler {
 		if (null != variable) {
 			final MonitoringManager manager = MonitoringManager.getInstance();
 			final MonitoringBaseElement element = manager.getMonitoringElement(variable);
-			if (element instanceof MonitoringElement) {
-				final MonitoringElement monitoringElement = (MonitoringElement) element;
+			if (element instanceof final MonitoringElement monitoringElement) {
 				final IInterfaceElement interfaceElement = monitoringElement.getPort().getInterfaceElement();
 
 				String input;
-				if (variable.getType() instanceof StructuredType) {
-					input = showStructForceDialog((StructuredType) variable.getType(), monitoringElement);
+				if (variable.getType() instanceof final StructuredType structType) {
+					input = showStructForceDialog(structType, monitoringElement);
 
 					if (variable.isArray() && input != null) {
 						input = StructParser.removeArrayIndexes(input);
@@ -124,17 +116,17 @@ public class ForceHandler extends AbstractMonitoringHandler {
 		return ret == org.eclipse.jface.window.Window.OK ? dialog.getValue() : null;
 	}
 
-	private static String showForceDialog(final MonitoringElement monitoringElement, final IInterfaceElement interfaceElement) {
+	private static String showForceDialog(final MonitoringElement monitoringElement,
+			final IInterfaceElement interfaceElement) {
 		final InputDialog input = new InputDialog(Display.getDefault().getActiveShell(),
-				Messages.MonitoringWatchesView_ForceValue,
-				Messages.MonitoringWatchesView_Value,
+				Messages.MonitoringWatchesView_ForceValue, Messages.MonitoringWatchesView_Value,
 				monitoringElement.isForce() ? monitoringElement.getForceValue() : "", //$NON-NLS-1$
-						(newValue -> {
-							if (interfaceElement instanceof VarDeclaration) {
-								return ForceHandler.validateForceInput((VarDeclaration) interfaceElement, newValue);
-							}
-							return null;
-						}));
+				(newValue -> {
+					if (interfaceElement instanceof final VarDeclaration varDecl) {
+						return ForceHandler.validateForceInput(varDecl, newValue);
+					}
+					return null;
+				}));
 		final int ret = input.open();
 		return ret == org.eclipse.jface.window.Window.OK ? input.getValue() : null;
 	}
@@ -154,8 +146,7 @@ public class ForceHandler extends AbstractMonitoringHandler {
 		boolean needToAdd = false;
 		final Object selection = HandlerUtil.getVariable(evaluationContext, ISources.ACTIVE_CURRENT_SELECTION_NAME);
 
-		if (selection instanceof StructuredSelection) {
-			final StructuredSelection sel = (StructuredSelection) selection;
+		if (selection instanceof final StructuredSelection sel) {
 			final MonitoringManager manager = MonitoringManager.getInstance();
 
 			if (1 == sel.size()) {
@@ -171,13 +162,13 @@ public class ForceHandler extends AbstractMonitoringHandler {
 
 	static VarDeclaration getVariable(final Object object) {
 		IInterfaceElement ie = null;
-		if (object instanceof InterfaceEditPart) {
-			ie = ((InterfaceEditPart) object).getModel();
-		} else if (object instanceof MonitoringEditPart) {
-			ie = ((MonitoringEditPart) object).getModel().getPort().getInterfaceElement();
+		if (object instanceof final InterfaceEditPart iep) {
+			ie = iep.getModel();
+		} else if (object instanceof final MonitoringEditPart me) {
+			ie = me.getModel().getPort().getInterfaceElement();
 		}
-		if (ie instanceof VarDeclaration) {
-			return (VarDeclaration) ie;
+		if (ie instanceof final VarDeclaration varDecl) {
+			return varDecl;
 		}
 		return null;
 	}

--- a/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/handlers/TriggerEventHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/handlers/TriggerEventHandler.java
@@ -12,7 +12,6 @@
 package org.eclipse.fordiac.ide.monitoring.handlers;
 
 import org.eclipse.core.commands.ExecutionEvent;
-import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.fordiac.ide.gef.editparts.InterfaceEditPart;
 import org.eclipse.fordiac.ide.model.libraryElement.Event;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
@@ -25,29 +24,24 @@ import org.eclipse.ui.handlers.HandlerUtil;
 public class TriggerEventHandler extends AbstractMonitoringHandler {
 
 	@Override
-	public Object execute(ExecutionEvent event) throws ExecutionException {
-		super.execute(event);
-		StructuredSelection selection = (StructuredSelection) HandlerUtil.getCurrentSelection(event);
-
-		Event ev = getEvent(selection.getFirstElement());
+	protected void doExecute(final ExecutionEvent event, final StructuredSelection structSel) {
+		final Event ev = getEvent(structSel.getFirstElement());
 		if (null != ev) {
 			MonitoringManager.getInstance().triggerEvent(ev);
 		}
-		return null;
 	}
 
 	@Override
-	public void setEnabled(Object evaluationContext) {
+	public void setEnabled(final Object evaluationContext) {
 		boolean needToAdd = false;
-		Object selection = HandlerUtil.getVariable(evaluationContext, ISources.ACTIVE_CURRENT_SELECTION_NAME);
+		final Object selection = HandlerUtil.getVariable(evaluationContext, ISources.ACTIVE_CURRENT_SELECTION_NAME);
 
-		if (selection instanceof StructuredSelection) {
-			StructuredSelection sel = (StructuredSelection) selection;
-			MonitoringManager manager = MonitoringManager.getInstance();
+		if (selection instanceof final StructuredSelection sel) {
+			final MonitoringManager manager = MonitoringManager.getInstance();
 
 			if (1 == sel.size()) {
 				// only allow trigger event if only one element is selected
-				Event ev = getEvent(sel.getFirstElement());
+				final Event ev = getEvent(sel.getFirstElement());
 				if ((null != ev) && manager.containsPort(ev)) {
 					needToAdd = true;
 				}
@@ -56,15 +50,15 @@ public class TriggerEventHandler extends AbstractMonitoringHandler {
 		setBaseEnabled(needToAdd);
 	}
 
-	private static Event getEvent(Object object) {
+	private static Event getEvent(final Object object) {
 		IInterfaceElement ie = null;
-		if (object instanceof InterfaceEditPart) {
-			ie = ((InterfaceEditPart) object).getModel();
-		} else if (object instanceof MonitoringEditPart) {
-			ie = ((MonitoringEditPart) object).getModel().getPort().getInterfaceElement();
+		if (object instanceof final InterfaceEditPart iep) {
+			ie = iep.getModel();
+		} else if (object instanceof final MonitoringEditPart mep) {
+			ie = mep.getModel().getPort().getInterfaceElement();
 		}
-		if (ie instanceof Event) {
-			return (Event) ie;
+		if (ie instanceof final Event ev) {
+			return ev;
 		}
 		return null;
 	}

--- a/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/handlers/WatchInternalVarsHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/handlers/WatchInternalVarsHandler.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Alois Zoitl - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.monitoring.handlers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType;
+import org.eclipse.fordiac.ide.model.libraryElement.FB;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.monitoring.InternalVarInstance;
+import org.eclipse.fordiac.ide.model.monitoring.MonitoringFactory;
+import org.eclipse.fordiac.ide.monitoring.MonitoringManager;
+import org.eclipse.fordiac.ide.monitoring.MonitoringManagerUtils;
+import org.eclipse.gef.EditPart;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.ui.ISources;
+import org.eclipse.ui.handlers.HandlerUtil;
+
+public class WatchInternalVarsHandler extends AbstractAddWatchesHandler {
+
+	@Override
+	protected void doExecute(final ExecutionEvent event, final StructuredSelection structSel)
+			throws ExecutionException {
+		final List<FB> foundFBs = getSelectedBaseFBInstances(structSel);
+		handleMonitoringState(foundFBs, HandlerUtil.getActiveSiteChecked(event).getShell());
+		addWatchesForFbs(foundFBs);
+		MonitoringManager.getInstance().notifyWatchesChanged();
+	}
+
+	@Override
+	public void setEnabled(final Object evaluationContext) {
+		final Object selection = HandlerUtil.getVariable(evaluationContext, ISources.ACTIVE_CURRENT_SELECTION_NAME);
+		if (selection instanceof final StructuredSelection structSel) {
+			setBaseEnabled(!getSelectedBaseFBInstances(structSel).isEmpty());
+		} else {
+			setBaseEnabled(false);
+		}
+	}
+
+	private static List<FB> getSelectedBaseFBInstances(final StructuredSelection structSel) {
+		final List<FB> fbInstances = new ArrayList<>();
+
+		for (final Object el : structSel.toList()) {
+			if ((el instanceof final EditPart ep) && (ep.getModel() instanceof final FB fb)
+					&& (fb.getType() instanceof BaseFBType) && MonitoringManagerUtils.canBeMonitored(fb)) {
+				fbInstances.add(fb);
+			}
+		}
+		return fbInstances;
+	}
+
+	private void addWatchesForFbs(final List<FB> foundFBs) {
+		final MonitoringManager manager = MonitoringManager.getInstance();
+
+		for (final FB fb : foundFBs) {
+			if (fb.getType() instanceof final BaseFBType baseFBType) {
+				for (final VarDeclaration internalVar : baseFBType.getInternalVars()) {
+					createWatchForIE(manager, createInternalVarInstance(fb, internalVar));
+				}
+			}
+		}
+	}
+
+	private static InternalVarInstance createInternalVarInstance(final FB fb, final VarDeclaration internalVar) {
+		final InternalVarInstance intVar = MonitoringFactory.eINSTANCE.createInternalVarInstance();
+		intVar.setArraySize(EcoreUtil.copy(internalVar.getArraySize()));
+		intVar.setFb(fb);
+		intVar.setName(internalVar.getName());
+		intVar.setType(internalVar.getType());
+		return intVar;
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/views/WatchesView.java
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/views/WatchesView.java
@@ -155,6 +155,8 @@ public class WatchesView extends ViewPart implements ISelectionListener {
 
 		createPartListener();
 
+		getSite().setSelectionProvider(filteredTree.getViewer());
+
 		addWatchesAdapters();
 	}
 


### PR DESCRIPTION
By selecting simple and basic fb instances their internal variables can be added for watching. They will be shown in the watches view only.

Removing an internal variable watch can only be done via the debug main menu.