### PR TITLE
Changed isValid from UntypedSubappPinChange

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/delete/UpdateUntypedSubappPinChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/delete/UpdateUntypedSubappPinChange.java
@@ -91,8 +91,8 @@ public class UpdateUntypedSubappPinChange extends AbstractCommandChange<VarDecla
 	public RefactoringStatus isValid(final VarDeclaration element, final IProgressMonitor pm)
 			throws CoreException, OperationCanceledException {
 		final RefactoringStatus status = new RefactoringStatus();
-		if (!(element.eContainer() instanceof UntypedSubApp)) {
-			status.addFatalError(Messages.UpdateUntypedSubappPinChange_0);
+		if (!(element.eContainer() != null && element.eContainer().eContainer() instanceof UntypedSubApp)) {
+			status.addFatalError(element.getQualifiedName() + Messages.UpdateUntypedSubappPinChange_0);
 		}
 		return status;
 	}


### PR DESCRIPTION
the eContainer of VarDeclaration is always an interface list. so this change can never be valid