### PR TITLE
Restrict log error dialog to 4diac IDE or platform UI plugins

### DIFF
--- a/plugins/org.eclipse.fordiac.ide/src/org/eclipse/fordiac/ide/FordiacLogListener.java
+++ b/plugins/org.eclipse.fordiac.ide/src/org/eclipse/fordiac/ide/FordiacLogListener.java
@@ -64,11 +64,12 @@ public class FordiacLogListener implements ILogListener {
 
 	@Override
 	public void logging(final IStatus status, final String plugin) {
-		if ((status.getSeverity() == IStatus.ERROR) && (null != status.getException())
-				&& !singleWindow.getAndSet(true)) {
+		if ((status.getSeverity() == IStatus.ERROR) && (null != status.getException()) && !singleWindow.getAndSet(true)
+				&& (status.getPlugin().startsWith(Activator.PLUGIN_ID)
+						|| status.getPlugin().equals(PlatformUI.PLUGIN_ID))) {
 			// inform the user that an error has happened
-			// we currently only treat errors with exception and from a 4diac IDE plug-in as
-			// noteworthy
+			// we currently only treat errors with exception and from a 4diac IDE or the
+			// Platform UI plug-in as noteworthy
 			// if a error dialog is already showing we will not show another one.
 			try {
 				showErrorDialog(createStatusWithStackTrace(status));


### PR DESCRIPTION
Restrict the log error dialog to 4diac IDE or Eclipse platform UI plugins. The latter is to include uncaught exceptions in the main event loop.

This restores the behavior mentioned in the comment and avoids opening the log error dialog for unrelated errors logged by other plugins.