### PR TITLE
add dependencies for events and rtevents standard libraries

### DIFF
--- a/data/typelibrary/events-1.0.0/MANIFEST.MF
+++ b/data/typelibrary/events-1.0.0/MANIFEST.MF
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="platform:/resource/org.eclipse.fordiac.ide.library.model/model/library.xsd" Scope="Library">
+    <Dependencies>
+        <Required SymbolicName="iec61131-3" Version="1.0.0"/>
+    </Dependencies>
     <Product Name="Events" SymbolicName="events" Comment="Standard Library - Events">
         <VersionInfo Version="1.0.0" Author="Eclipse 4diac" Date="2024-02-21"/>
     </Product>

--- a/data/typelibrary/rtevents-1.0.0/MANIFEST.MF
+++ b/data/typelibrary/rtevents-1.0.0/MANIFEST.MF
@@ -2,6 +2,7 @@
 <Manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="platform:/resource/org.eclipse.fordiac.ide.library.model/model/library.xsd" Scope="Library">
     <Dependencies>
         <Required SymbolicName="core" Version="1.0.0"/>
+        <Required SymbolicName="events" Version="1.0.0"/>
     </Dependencies>
     <Product Name="Rtevents" SymbolicName="rtevents" Comment="Standard Library - RT Events">
         <VersionInfo Version="1.0.0" Author="Eclipse 4diac" Date="2024-02-21"/>


### PR DESCRIPTION
Those libaries did not declare their dependencies, this led to error markers when the dependencies were not available.