### PR TITLE
Disable usage of XbaseGenerated annotation in Xtend compiler

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.ant/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.ant/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.application/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.application/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.attributetypeeditor/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.attributetypeeditor/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.comgeneration/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.comgeneration/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.contracts/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.contracts/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.datatypeeditor/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.datatypeeditor/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.debug.st/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.debug.st/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.debug.ui.st/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.debug.ui.st/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.debug.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.debug.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.debug/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.debug/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.deployment.bootfile/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.deployment.bootfile/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.deployment.eval/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.deployment.eval/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.deployment.iec61499/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.deployment.iec61499/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.deployment.opcua/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.deployment.opcua/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.deployment/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.deployment/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.elk/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.elk/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.emf.compare/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.emf.compare/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.export.compare/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.export.compare/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.export.forte_lua.st/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_lua.st/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.export.forte_lua/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_lua/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.export.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.export.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.export.xmi/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.export.xmi/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.export/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.export/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter.edit/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter.edit/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter.editor/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter.editor/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.fbrtlauncher/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.fbrtlauncher/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.doc/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.doc/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.network/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.network/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.st/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.st/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.fmu/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.fmu/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.fortelauncher/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.fortelauncher/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.gef/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.gef/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.gitlab/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.gitlab/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ide/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ide/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor.model/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor.model/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor.tests/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor.tests/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui.tests/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui.tests/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.hierarchymanager.model.edit/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.hierarchymanager.model.edit/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.hierarchymanager.model/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.hierarchymanager.model/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.hierarchymanager.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.hierarchymanager.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.library.model/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.library.model/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.library.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.library/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.library/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -19,5 +19,6 @@ outlet.DEFAULT_OUTPUT.sourceFolder.src.ignore=
 outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.directory=
 outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
-targetJavaVersion=JAVA17
+targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.model.commands/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.model.edit/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.model.eval.st/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.model.eval.st/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.model.eval/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.model.search.st/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.model.search.st/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.model.search/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.model.search/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.model.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.model/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.model/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.monitoring/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.resourceediting/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.resourceediting/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.runtime/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.runtime/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ide/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ide/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.model/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.model/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.tests/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.tests/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ide/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ide/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ide/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ide/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.model/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.model/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.tests/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.tests/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.tests/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.tests/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.subapptypeeditor/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.subapptypeeditor/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.systemconfiguration.segment/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.systemconfiguration.segment/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.systemconfiguration/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.systemconfiguration/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.ui.errormessages/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.ui.errormessages/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.util/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.util/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide.validation/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide.validation/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/plugins/org.eclipse.fordiac.ide/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/plugins/org.eclipse.fordiac.ide/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/tests/org.eclipse.fordiac.ide.test.contracts/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/tests/org.eclipse.fordiac.ide.test.contracts/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/tests/org.eclipse.fordiac.ide.test.export/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/tests/org.eclipse.fordiac.ide.test.export/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/tests/org.eclipse.fordiac.ide.test.fb.interpreter/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/tests/org.eclipse.fordiac.ide.test.fb.interpreter/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/tests/org.eclipse.fordiac.ide.test.library/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/tests/org.eclipse.fordiac.ide.test.library/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/tests/org.eclipse.fordiac.ide.test.model.commands/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/tests/org.eclipse.fordiac.ide.test.model.commands/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/tests/org.eclipse.fordiac.ide.test.model.eval/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/tests/org.eclipse.fordiac.ide.test.model.eval/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/tests/org.eclipse.fordiac.ide.test.model.search/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/tests/org.eclipse.fordiac.ide.test.model.search/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/tests/org.eclipse.fordiac.ide.test.model/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/tests/org.eclipse.fordiac.ide.test.model/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/tests/org.eclipse.fordiac.ide.test.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/tests/org.eclipse.fordiac.ide.test.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false

--- a/tests/org.eclipse.fordiac.ide.test.util/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/tests/org.eclipse.fordiac.ide.test.util/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -21,3 +21,4 @@ outlet.DEFAULT_OUTPUT.sourceFolder.xtend-gen.ignore=
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=
 targetJavaVersion=JAVA21
 useJavaCompilerCompliance=false
+useXbaseGenerated=false


### PR DESCRIPTION
Disable usage of XbaseGenerated annotation in Xtend compiler to work around a compiler error when compiling with target platform 2024-06.