### PR TITLE
Renamed helper classes to be consistent with other helper classes

### DIFF
--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/Abstract4diacUITests.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/Abstract4diacUITests.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
-import org.eclipse.fordiac.ide.test.ui.helpers.PropertySheetHelper;
+import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotPropertySheet;
 import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotSystemExplorer;
 import org.eclipse.fordiac.ide.test.ui.helpers.UITestNamesHelper;
 import org.eclipse.fordiac.ide.test.ui.swtbot.SWT4diacGefBot;
@@ -130,7 +130,7 @@ public class Abstract4diacUITests {
 		bot.viewByTitle(UITestNamesHelper.PROPERTIES_TITLE).setFocus();
 
 		// Tabs access inside property sheet
-		PropertySheetHelper.selectPropertyTabItem(tabName, propertiesBot);
+		SWTBotPropertySheet.selectPropertyTabItem(tabName, propertiesBot);
 		return propertiesBot;
 	}
 
@@ -150,7 +150,7 @@ public class Abstract4diacUITests {
 		bot.viewByTitle(UITestNamesHelper.PROPERTIES_TITLE).setFocus();
 
 		// Tabs access inside property sheet
-		PropertySheetHelper.selectPropertyTabItem(tabName, propertiesBot);
+		SWTBotPropertySheet.selectPropertyTabItem(tabName, propertiesBot);
 		return propertiesBot;
 	}
 

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/fbtype/AttributesTabTests.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/fbtype/AttributesTabTests.java
@@ -14,8 +14,8 @@ package org.eclipse.fordiac.ide.test.ui.fbtype;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.eclipse.fordiac.ide.test.ui.helpers.PropertySheetHelper;
 import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotFBType;
+import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotPropertySheet;
 import org.eclipse.fordiac.ide.test.ui.helpers.UITestNamesHelper;
 import org.eclipse.fordiac.ide.test.ui.swtbot.SWTBot4diacNatTable;
 import org.eclipse.nebula.widgets.nattable.NatTable;
@@ -47,7 +47,7 @@ public class AttributesTabTests extends NatTableWithoutEditorBehaviorTests {
 		assertNotNull(propertiesBot);
 		bot.viewByTitle(UITestNamesHelper.PROPERTIES_TITLE).setFocus();
 		bot.editorByTitle(UITestNamesHelper.FBT_TEST_PROJECT2).show();
-		PropertySheetHelper.selectPropertyTabItem(UITestNamesHelper.ATTRIBUTES, propertiesBot);
+		SWTBotPropertySheet.selectPropertyTabItem(UITestNamesHelper.ATTRIBUTES, propertiesBot);
 		natTable = propertiesBot.widget(WidgetMatcherFactory.widgetOfType(NatTable.class), 0);
 		natTableBot = new SWTBot4diacNatTable(natTable);
 		NatTableHelper.createNewVariableInDataTypeEditor(natTableBot);

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/fbtype/BasicFBTOperationTests.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/fbtype/BasicFBTOperationTests.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.fordiac.ide.test.ui.Abstract4diacUITests;
-import org.eclipse.fordiac.ide.test.ui.helpers.PinNamesHelper;
+import org.eclipse.fordiac.ide.test.ui.helpers.UITestPinHelper;
 import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotConnection;
 import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotFBType;
 import org.eclipse.fordiac.ide.test.ui.helpers.UITestNamesHelper;
@@ -80,7 +80,7 @@ public class BasicFBTOperationTests extends Abstract4diacUITests {
 	public void createNewEventInput() {
 		final SWTBot4diacGefEditor editor = (SWTBot4diacGefEditor) bot.gefEditor(UITestNamesHelper.FBT_TEST_PROJECT2);
 		editor.clickContextMenu(UITestNamesHelper.CREATE_INPUT_EVENT);
-		assertNotNull(editor.getEditPart(PinNamesHelper.EI1));
+		assertNotNull(editor.getEditPart(UITestPinHelper.EI1));
 	}
 
 	/**
@@ -95,7 +95,7 @@ public class BasicFBTOperationTests extends Abstract4diacUITests {
 	public void createNewEventOutput() {
 		final SWTBot4diacGefEditor editor = (SWTBot4diacGefEditor) bot.gefEditor(UITestNamesHelper.FBT_TEST_PROJECT2);
 		editor.clickContextMenu(UITestNamesHelper.CREATE_OUTPUT_EVENT);
-		assertNotNull(editor.getEditPart(PinNamesHelper.EO1));
+		assertNotNull(editor.getEditPart(UITestPinHelper.EO1));
 	}
 
 	/**
@@ -109,12 +109,12 @@ public class BasicFBTOperationTests extends Abstract4diacUITests {
 	 */
 	@SuppressWarnings("static-method")
 	@ParameterizedTest
-	@ValueSource(strings = { PinNamesHelper.INT })
+	@ValueSource(strings = { UITestPinHelper.INT })
 	public void createNewDataInput(final String dataType) {
 		final SWTBot4diacGefEditor editor = (SWTBot4diacGefEditor) bot.gefEditor(UITestNamesHelper.FBT_TEST_PROJECT2);
 		assertNotNull(editor);
 		editor.clickContextMenu(UITestNamesHelper.CREATE_DATA_INPUT).clickContextMenu(dataType);
-		assertNotNull(editor.getEditPart(PinNamesHelper.DI1));
+		assertNotNull(editor.getEditPart(UITestPinHelper.DI1));
 	}
 
 	/**
@@ -132,15 +132,15 @@ public class BasicFBTOperationTests extends Abstract4diacUITests {
 		assertNotNull(editor);
 		editor.clickContextMenu(UITestNamesHelper.CREATE_INPUT_EVENT);
 
-		assertNotNull(editor.getEditPart(PinNamesHelper.EI1));
+		assertNotNull(editor.getEditPart(UITestPinHelper.EI1));
 
-		final SWTBotGefEditPart pin = editor.getEditPart(PinNamesHelper.EI1);
+		final SWTBotGefEditPart pin = editor.getEditPart(UITestPinHelper.EI1);
 		pin.click();
 
 		final SWTBot propertiesBot = selectTabFromInterfaceProperties(UITestNamesHelper.EVENT);
 		propertiesBot.textWithLabel(UITestNamesHelper.NAME_LABEL).setText(UITestNamesHelper.EVENT);
 
-		assertNull(editor.getEditPart(PinNamesHelper.EI1));
+		assertNull(editor.getEditPart(UITestPinHelper.EI1));
 		assertNotNull(editor.getEditPart(UITestNamesHelper.EVENT));
 	}
 
@@ -158,7 +158,7 @@ public class BasicFBTOperationTests extends Abstract4diacUITests {
 		assertNotNull(editor);
 		editor.clickContextMenu(UITestNamesHelper.CREATE_INPUT_EVENT);
 
-		final SWTBotGefEditPart pin = editor.getEditPart(PinNamesHelper.EI1);
+		final SWTBotGefEditPart pin = editor.getEditPart(UITestPinHelper.EI1);
 		pin.click();
 
 		final SWTBot propertiesBot = selectTabFromInterfaceProperties(UITestNamesHelper.EVENT);
@@ -182,7 +182,7 @@ public class BasicFBTOperationTests extends Abstract4diacUITests {
 		assertNotNull(editor);
 		editor.clickContextMenu(UITestNamesHelper.CREATE_INPUT_EVENT);
 
-		final SWTBotGefEditPart pin = editor.getEditPart(PinNamesHelper.EI1);
+		final SWTBotGefEditPart pin = editor.getEditPart(UITestPinHelper.EI1);
 		pin.click();
 
 		final SWTBot propertiesBot = selectTabFromInterfaceProperties(UITestNamesHelper.DATA);
@@ -205,18 +205,18 @@ public class BasicFBTOperationTests extends Abstract4diacUITests {
 	public void addConnection() {
 		final SWTBot4diacGefEditor editor = (SWTBot4diacGefEditor) bot.gefEditor(UITestNamesHelper.FBT_TEST_PROJECT2);
 		editor.clickContextMenu(UITestNamesHelper.CREATE_INPUT_EVENT);
-		editor.clickContextMenu(UITestNamesHelper.CREATE_DATA_INPUT).clickContextMenu(PinNamesHelper.INT);
+		editor.clickContextMenu(UITestNamesHelper.CREATE_DATA_INPUT).clickContextMenu(UITestPinHelper.INT);
 
-		assertNotNull(editor.getEditPart(PinNamesHelper.DI1));
+		assertNotNull(editor.getEditPart(UITestPinHelper.DI1));
 
-		final SWTBotGefEditPart inputPin = editor.getEditPart(PinNamesHelper.EI1);
+		final SWTBotGefEditPart inputPin = editor.getEditPart(UITestPinHelper.EI1);
 		inputPin.click();
 
-		final SWTBotGefEditPart outputPin = editor.getEditPart(PinNamesHelper.DI1);
+		final SWTBotGefEditPart outputPin = editor.getEditPart(UITestPinHelper.DI1);
 		outputPin.click();
 
 		final SWTBotConnection connect = new SWTBotConnection(bot);
-		connect.createConnectionWithinFBTypeWithPropertySheet(PinNamesHelper.DI1, PinNamesHelper.EI1, editor);
+		connect.createConnectionWithinFBTypeWithPropertySheet(UITestPinHelper.DI1, UITestPinHelper.EI1, editor);
 	}
 
 	/**
@@ -232,19 +232,19 @@ public class BasicFBTOperationTests extends Abstract4diacUITests {
 	public void removeConnection() {
 		final SWTBot4diacGefEditor editor = (SWTBot4diacGefEditor) bot.gefEditor(UITestNamesHelper.FBT_TEST_PROJECT2);
 		editor.clickContextMenu(UITestNamesHelper.CREATE_INPUT_EVENT);
-		editor.clickContextMenu(UITestNamesHelper.CREATE_DATA_INPUT).clickContextMenu(PinNamesHelper.INT);
+		editor.clickContextMenu(UITestNamesHelper.CREATE_DATA_INPUT).clickContextMenu(UITestPinHelper.INT);
 
-		assertNotNull(editor.getEditPart(PinNamesHelper.DI1));
+		assertNotNull(editor.getEditPart(UITestPinHelper.DI1));
 
-		final SWTBotGefEditPart inputPin = editor.getEditPart(PinNamesHelper.EI1);
+		final SWTBotGefEditPart inputPin = editor.getEditPart(UITestPinHelper.EI1);
 		inputPin.click();
 
-		final SWTBotGefEditPart outputPin = editor.getEditPart(PinNamesHelper.DI1);
+		final SWTBotGefEditPart outputPin = editor.getEditPart(UITestPinHelper.DI1);
 		outputPin.click();
 
 		final SWTBotConnection connect = new SWTBotConnection(bot);
-		connect.createConnectionWithinFBTypeWithPropertySheet(PinNamesHelper.DI1, PinNamesHelper.EI1, editor);
-		connect.removeConnectionWithinFBTypeWithPropertySheet(PinNamesHelper.DI1, PinNamesHelper.EI1, editor);
+		connect.createConnectionWithinFBTypeWithPropertySheet(UITestPinHelper.DI1, UITestPinHelper.EI1, editor);
+		connect.removeConnectionWithinFBTypeWithPropertySheet(UITestPinHelper.DI1, UITestPinHelper.EI1, editor);
 	}
 
 	/**
@@ -261,13 +261,13 @@ public class BasicFBTOperationTests extends Abstract4diacUITests {
 	public void changePinDataType() {
 		final SWTBot4diacGefEditor editor = (SWTBot4diacGefEditor) bot.gefEditor(UITestNamesHelper.FBT_TEST_PROJECT2);
 		assertNotNull(editor);
-		editor.clickContextMenu(UITestNamesHelper.CREATE_DATA_INPUT).clickContextMenu(PinNamesHelper.INT);
+		editor.clickContextMenu(UITestNamesHelper.CREATE_DATA_INPUT).clickContextMenu(UITestPinHelper.INT);
 
-		final SWTBotGefEditPart port = editor.getEditPart(PinNamesHelper.DI1);
+		final SWTBotGefEditPart port = editor.getEditPart(UITestPinHelper.DI1);
 		port.click();
 
 		SWTBot propertiesBot = selectTabFromInterfaceProperties(UITestNamesHelper.DATA);
-		propertiesBot.table().select(PinNamesHelper.INT);
+		propertiesBot.table().select(UITestPinHelper.INT);
 		propertiesBot.button(UITestNamesHelper.DOT_BUTTON).click();
 
 		final SWTBotShell shell = bot.shell(UITestNamesHelper.TYPE_SELECTION);
@@ -275,13 +275,13 @@ public class BasicFBTOperationTests extends Abstract4diacUITests {
 
 		final SWTBotTree containerTree = bot.tree();
 		final SWTBotTreeItem containerItem = containerTree.getTreeItem(UITestNamesHelper.ELEMENTARY_TYPE);
-		containerItem.expand().select(PinNamesHelper.ANY);
+		containerItem.expand().select(UITestPinHelper.ANY);
 
 		bot.button(UITestNamesHelper.OK).click();
 
 		propertiesBot = selectTabFromInterfaceProperties(UITestNamesHelper.DATA);
 
-		assertTrue(propertiesBot.tableWithLabel(UITestNamesHelper.TYPE_LABEL).containsText(PinNamesHelper.ANY));
+		assertTrue(propertiesBot.tableWithLabel(UITestNamesHelper.TYPE_LABEL).containsText(UITestPinHelper.ANY));
 	}
 
 }

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/fbtype/ConstantsTabTests.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/fbtype/ConstantsTabTests.java
@@ -14,7 +14,7 @@ package org.eclipse.fordiac.ide.test.ui.fbtype;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.eclipse.fordiac.ide.test.ui.helpers.PropertySheetHelper;
+import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotPropertySheet;
 import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotFBType;
 import org.eclipse.fordiac.ide.test.ui.helpers.UITestNamesHelper;
 import org.eclipse.fordiac.ide.test.ui.swtbot.SWTBot4diacNatTable;
@@ -39,7 +39,7 @@ public class ConstantsTabTests extends NatTableWithoutEditorBehaviorTests {
 		assertNotNull(propertiesBot);
 		bot.viewByTitle(UITestNamesHelper.PROPERTIES_TITLE).setFocus();
 		bot.editorByTitle(UITestNamesHelper.FBT_TEST_PROJECT2).show();
-		PropertySheetHelper.selectPropertyTabItem(UITestNamesHelper.CONSTANTS, propertiesBot);
+		SWTBotPropertySheet.selectPropertyTabItem(UITestNamesHelper.CONSTANTS, propertiesBot);
 		natTable = propertiesBot.widget(WidgetMatcherFactory.widgetOfType(NatTable.class), 0);
 		natTableBot = new SWTBot4diacNatTable(natTable);
 		NatTableHelper.createNewVariableInDataTypeEditor(natTableBot);

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/fbtype/ECCEditorTests.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/fbtype/ECCEditorTests.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.fordiac.ide.test.ui.Abstract4diacUITests;
-import org.eclipse.fordiac.ide.test.ui.helpers.PinNamesHelper;
+import org.eclipse.fordiac.ide.test.ui.helpers.UITestPinHelper;
 import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotFBType;
 import org.eclipse.fordiac.ide.test.ui.helpers.UITestNamesHelper;
 import org.eclipse.fordiac.ide.test.ui.swtbot.SWTBot4diacGefEditor;
@@ -189,7 +189,7 @@ public class ECCEditorTests extends Abstract4diacUITests {
 	@Order(9)
 	public void changeECTransitionConditionExpression() {
 		final SWTBotGefEditPart part = editor
-				.getEditPart(UITestNamesHelper.INIT + "[" + UITestNamesHelper.TRUE + " = " + PinNamesHelper.QI + "]");
+				.getEditPart(UITestNamesHelper.INIT + "[" + UITestNamesHelper.TRUE + " = " + UITestPinHelper.QI + "]");
 		editor.select(part);
 		final SWTBot propertiesBot = selectTabFromECCProperties(UITestNamesHelper.TRANSITION);
 		assertNotNull(propertiesBot);
@@ -197,13 +197,13 @@ public class ECCEditorTests extends Abstract4diacUITests {
 		propertiesBot.ccomboBoxWithLabel(UITestNamesHelper.CONDITION_LABEL).setSelection(UITestNamesHelper.REQ);
 
 		propertiesBot.styledTextWithLabel(UITestNamesHelper.CONDITION_LABEL)
-				.setText(UITestNamesHelper.TRUE + " = " + PinNamesHelper.QO);
+				.setText(UITestNamesHelper.TRUE + " = " + UITestPinHelper.QO);
 		assertEquals(propertiesBot.styledTextWithLabel(UITestNamesHelper.CONDITION_LABEL).getText(),
-				UITestNamesHelper.TRUE + " = " + PinNamesHelper.QO);
+				UITestNamesHelper.TRUE + " = " + UITestPinHelper.QO);
 		assertNull(editor
-				.getEditPart(UITestNamesHelper.INIT + "[" + UITestNamesHelper.TRUE + " = " + PinNamesHelper.QI + "]"));
+				.getEditPart(UITestNamesHelper.INIT + "[" + UITestNamesHelper.TRUE + " = " + UITestPinHelper.QI + "]"));
 		assertNotNull(editor
-				.getEditPart(UITestNamesHelper.REQ + "[" + UITestNamesHelper.TRUE + " = " + PinNamesHelper.QO + "]"));
+				.getEditPart(UITestNamesHelper.REQ + "[" + UITestNamesHelper.TRUE + " = " + UITestPinHelper.QO + "]"));
 
 	}
 
@@ -216,7 +216,7 @@ public class ECCEditorTests extends Abstract4diacUITests {
 	@Order(10)
 	public void changeECTransitionComment() {
 		final SWTBotGefEditPart part = editor
-				.getEditPart(UITestNamesHelper.REQ + "[" + UITestNamesHelper.TRUE + " = " + PinNamesHelper.QO + "]");
+				.getEditPart(UITestNamesHelper.REQ + "[" + UITestNamesHelper.TRUE + " = " + UITestPinHelper.QO + "]");
 		editor.select(part);
 		final SWTBot propertiesBot = selectTabFromECCProperties(UITestNamesHelper.TRANSITION);
 		assertNotNull(propertiesBot);
@@ -280,7 +280,7 @@ public class ECCEditorTests extends Abstract4diacUITests {
 	public void tryToInvalidECTransitionConditionExpression() {
 		// Select the EC transition part
 		final SWTBotGefEditPart part = editor
-				.getEditPart(UITestNamesHelper.REQ + "[" + UITestNamesHelper.TRUE + " = " + PinNamesHelper.QO + "]");
+				.getEditPart(UITestNamesHelper.REQ + "[" + UITestNamesHelper.TRUE + " = " + UITestPinHelper.QO + "]");
 		editor.select(part);
 
 		// Access the Transition tab and set an invalid condition
@@ -288,17 +288,17 @@ public class ECCEditorTests extends Abstract4diacUITests {
 		assertNotNull(propertiesBot);
 		propertiesBot.ccomboBoxWithLabel(UITestNamesHelper.CONDITION_LABEL).setSelection(UITestNamesHelper.INIT);
 		propertiesBot.styledTextWithLabel(UITestNamesHelper.CONDITION_LABEL)
-				.setText(UITestNamesHelper.TRUE + " = " + PinNamesHelper.AB);
+				.setText(UITestNamesHelper.TRUE + " = " + UITestPinHelper.AB);
 
 		// Validate the new condition expression
 		assertEquals(propertiesBot.styledTextWithLabel(UITestNamesHelper.CONDITION_LABEL).getText(),
-				UITestNamesHelper.TRUE + " = " + PinNamesHelper.AB);
+				UITestNamesHelper.TRUE + " = " + UITestPinHelper.AB);
 
 		// Verify that the transition part is correctly updated
 		assertNull(editor
-				.getEditPart(UITestNamesHelper.REQ + "[" + UITestNamesHelper.TRUE + " = " + PinNamesHelper.QO + "]"));
+				.getEditPart(UITestNamesHelper.REQ + "[" + UITestNamesHelper.TRUE + " = " + UITestPinHelper.QO + "]"));
 		assertNotNull(editor
-				.getEditPart(UITestNamesHelper.INIT + "[" + UITestNamesHelper.TRUE + " = " + PinNamesHelper.AB + "]"));
+				.getEditPart(UITestNamesHelper.INIT + "[" + UITestNamesHelper.TRUE + " = " + UITestPinHelper.AB + "]"));
 	}
 
 	/**
@@ -378,7 +378,7 @@ public class ECCEditorTests extends Abstract4diacUITests {
 	public void deleteTransition() {
 		// Select the transition part and focus on it
 		final SWTBotGefEditPart part = editor
-				.getEditPart(UITestNamesHelper.INIT + "[" + UITestNamesHelper.TRUE + " = " + PinNamesHelper.AB + "]");
+				.getEditPart(UITestNamesHelper.INIT + "[" + UITestNamesHelper.TRUE + " = " + UITestPinHelper.AB + "]");
 		editor.select(part);
 		assertNotNull(part);
 
@@ -389,7 +389,7 @@ public class ECCEditorTests extends Abstract4diacUITests {
 
 		// Verify that the transition part is successfully deleted
 		assertNull(editor
-				.getEditPart(UITestNamesHelper.INIT + "[" + UITestNamesHelper.TRUE + " = " + PinNamesHelper.AB + "]"));
+				.getEditPart(UITestNamesHelper.INIT + "[" + UITestNamesHelper.TRUE + " = " + UITestPinHelper.AB + "]"));
 	}
 
 	/**

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/fbtype/EventInOutputsTabTests.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/fbtype/EventInOutputsTabTests.java
@@ -15,7 +15,7 @@ package org.eclipse.fordiac.ide.test.ui.fbtype;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.eclipse.fordiac.ide.test.ui.helpers.PinNamesHelper;
+import org.eclipse.fordiac.ide.test.ui.helpers.UITestPinHelper;
 import org.eclipse.fordiac.ide.test.ui.helpers.PropertySheetHelper;
 import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotFBType;
 import org.eclipse.fordiac.ide.test.ui.helpers.UITestNamesHelper;
@@ -32,9 +32,9 @@ public class EventInOutputsTabTests extends NatTableWithEditorBehaviorTests {
 	@Override
 	@BeforeEach
 	public void operationsInitialization() {
-		TESTVAR1 = PinNamesHelper.EI1;
-		TESTVAR2 = PinNamesHelper.EI2;
-		TESTVAR3 = PinNamesHelper.EI3;
+		TESTVAR1 = UITestPinHelper.EI1;
+		TESTVAR2 = UITestPinHelper.EI2;
+		TESTVAR3 = UITestPinHelper.EI3;
 		final SWTBotFBType fbTypeBot = new SWTBotFBType(bot);
 		fbTypeBot.createFBType(UITestNamesHelper.PROJECT_NAME, UITestNamesHelper.FBT_TEST_PROJECT2,
 				UITestNamesHelper.ADAPTER);

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/fbtype/EventInOutputsTabTests.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/fbtype/EventInOutputsTabTests.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.fordiac.ide.test.ui.helpers.UITestPinHelper;
-import org.eclipse.fordiac.ide.test.ui.helpers.PropertySheetHelper;
+import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotPropertySheet;
 import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotFBType;
 import org.eclipse.fordiac.ide.test.ui.helpers.UITestNamesHelper;
 import org.eclipse.fordiac.ide.test.ui.swtbot.SWTBot4diacGefEditor;
@@ -43,7 +43,7 @@ public class EventInOutputsTabTests extends NatTableWithEditorBehaviorTests {
 		assertNotNull(propertiesBot);
 		bot.viewByTitle(UITestNamesHelper.PROPERTIES_TITLE).setFocus();
 		bot.editorByTitle(UITestNamesHelper.FBT_TEST_PROJECT2).show();
-		PropertySheetHelper.selectPropertyTabItem(UITestNamesHelper.EVENT_IN_AND_OUTPUTS, propertiesBot);
+		SWTBotPropertySheet.selectPropertyTabItem(UITestNamesHelper.EVENT_IN_AND_OUTPUTS, propertiesBot);
 		natTable = propertiesBot.widget(WidgetMatcherFactory.widgetOfType(NatTable.class), 0);
 		natTableBot = new SWTBot4diacNatTable(natTable);
 		editor = (SWTBot4diacGefEditor) bot.gefEditor(UITestNamesHelper.FBT_TEST_PROJECT2);

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/fbtype/FunctionBlocksTabTests.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/fbtype/FunctionBlocksTabTests.java
@@ -15,7 +15,7 @@ package org.eclipse.fordiac.ide.test.ui.fbtype;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.eclipse.fordiac.ide.test.ui.helpers.PropertySheetHelper;
+import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotPropertySheet;
 import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotFBType;
 import org.eclipse.fordiac.ide.test.ui.helpers.UITestNamesHelper;
 import org.eclipse.fordiac.ide.test.ui.swtbot.SWTBot4diacNatTable;
@@ -43,7 +43,7 @@ public class FunctionBlocksTabTests extends NatTableWithoutEditorBehaviorTests {
 		assertNotNull(propertiesBot);
 		bot.viewByTitle(UITestNamesHelper.PROPERTIES_TITLE).setFocus();
 		bot.editorByTitle(UITestNamesHelper.FBT_TEST_PROJECT2).show();
-		PropertySheetHelper.selectPropertyTabItem(UITestNamesHelper.FUNCTIONAL__BLOCKS, propertiesBot);
+		SWTBotPropertySheet.selectPropertyTabItem(UITestNamesHelper.FUNCTIONAL__BLOCKS, propertiesBot);
 		natTable = propertiesBot.widget(WidgetMatcherFactory.widgetOfType(NatTable.class), 0);
 		natTableBot = new SWTBot4diacNatTable(natTable);
 		NatTableHelper.createNewVariableInDataTypeEditor(natTableBot);

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/fbtype/VarInAndOutputsTabTests.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/fbtype/VarInAndOutputsTabTests.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.fordiac.ide.model.datatype.helper.RetainHelper.RetainTag;
 import org.eclipse.fordiac.ide.test.ui.helpers.UITestPinHelper;
-import org.eclipse.fordiac.ide.test.ui.helpers.PropertySheetHelper;
+import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotPropertySheet;
 import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotFBType;
 import org.eclipse.fordiac.ide.test.ui.helpers.UITestNamesHelper;
 import org.eclipse.fordiac.ide.test.ui.swtbot.SWTBot4diacGefEditor;
@@ -44,7 +44,7 @@ public class VarInAndOutputsTabTests extends NatTableWithEditorBehaviorTests {
 		assertNotNull(propertiesBot);
 		bot.viewByTitle(UITestNamesHelper.PROPERTIES_TITLE).setFocus();
 		bot.editorByTitle(UITestNamesHelper.FBT_TEST_PROJECT2).show();
-		PropertySheetHelper.selectPropertyTabItem(UITestNamesHelper.VAR_IN_AND_OUTPUTS, propertiesBot);
+		SWTBotPropertySheet.selectPropertyTabItem(UITestNamesHelper.VAR_IN_AND_OUTPUTS, propertiesBot);
 		natTable = propertiesBot.widget(WidgetMatcherFactory.widgetOfType(NatTable.class), 0);
 		natTableBot = new SWTBot4diacNatTable(natTable);
 		editor = (SWTBot4diacGefEditor) bot.gefEditor(UITestNamesHelper.FBT_TEST_PROJECT2);

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/fbtype/VarInAndOutputsTabTests.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/fbtype/VarInAndOutputsTabTests.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.fordiac.ide.model.datatype.helper.RetainHelper.RetainTag;
-import org.eclipse.fordiac.ide.test.ui.helpers.PinNamesHelper;
+import org.eclipse.fordiac.ide.test.ui.helpers.UITestPinHelper;
 import org.eclipse.fordiac.ide.test.ui.helpers.PropertySheetHelper;
 import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotFBType;
 import org.eclipse.fordiac.ide.test.ui.helpers.UITestNamesHelper;
@@ -33,9 +33,9 @@ public class VarInAndOutputsTabTests extends NatTableWithEditorBehaviorTests {
 	@Override
 	@BeforeEach
 	public void operationsInitialization() {
-		TESTVAR1 = PinNamesHelper.DI1;
-		TESTVAR2 = PinNamesHelper.DI2;
-		TESTVAR3 = PinNamesHelper.DI3;
+		TESTVAR1 = UITestPinHelper.DI1;
+		TESTVAR2 = UITestPinHelper.DI2;
+		TESTVAR3 = UITestPinHelper.DI3;
 		final SWTBotFBType fbTypeBot = new SWTBotFBType(bot);
 		fbTypeBot.createFBType(UITestNamesHelper.PROJECT_NAME, UITestNamesHelper.FBT_TEST_PROJECT2,
 				UITestNamesHelper.ADAPTER);

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/fbtype/VarInternalsTabTests.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/fbtype/VarInternalsTabTests.java
@@ -15,7 +15,7 @@ package org.eclipse.fordiac.ide.test.ui.fbtype;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.fordiac.ide.model.datatype.helper.RetainHelper.RetainTag;
-import org.eclipse.fordiac.ide.test.ui.helpers.PropertySheetHelper;
+import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotPropertySheet;
 import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotFBType;
 import org.eclipse.fordiac.ide.test.ui.helpers.UITestNamesHelper;
 import org.eclipse.fordiac.ide.test.ui.swtbot.SWTBot4diacNatTable;
@@ -41,7 +41,7 @@ public class VarInternalsTabTests extends NatTableWithoutEditorBehaviorTests {
 		assertNotNull(propertiesBot);
 		bot.viewByTitle(UITestNamesHelper.PROPERTIES_TITLE).setFocus();
 		bot.editorByTitle(UITestNamesHelper.FBT_TEST_PROJECT2).show();
-		PropertySheetHelper.selectPropertyTabItem(UITestNamesHelper.VAR_INTERNALS, propertiesBot);
+		SWTBotPropertySheet.selectPropertyTabItem(UITestNamesHelper.VAR_INTERNALS, propertiesBot);
 		natTable = propertiesBot.widget(WidgetMatcherFactory.widgetOfType(NatTable.class), 0);
 		natTableBot = new SWTBot4diacNatTable(natTable);
 		NatTableHelper.createNewVariableInDataTypeEditor(natTableBot);

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/helpers/SWTBotConnection.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/helpers/SWTBotConnection.java
@@ -141,7 +141,7 @@ public class SWTBotConnection {
 		SWTBot propertiesBot = bot.viewByTitle(UITestNamesHelper.PROPERTIES_TITLE).bot();
 		bot.viewByTitle(UITestNamesHelper.PROPERTIES_TITLE).setFocus();
 
-		if (PropertySheetHelper.selectPropertyTabItem(UITestNamesHelper.EVENT, propertiesBot)) {
+		if (SWTBotPropertySheet.selectPropertyTabItem(UITestNamesHelper.EVENT, propertiesBot)) {
 			propertiesBot = Abstract4diacUITests.selectTabFromInterfaceProperties(UITestNamesHelper.EVENT);
 		} else {
 			propertiesBot = Abstract4diacUITests.selectTabFromInterfaceProperties(UITestNamesHelper.DATA);
@@ -175,7 +175,7 @@ public class SWTBotConnection {
 		SWTBot propertiesBot = bot.viewByTitle(UITestNamesHelper.PROPERTIES_TITLE).bot();
 		bot.viewByTitle(UITestNamesHelper.PROPERTIES_TITLE).setFocus();
 
-		if (PropertySheetHelper.selectPropertyTabItem(UITestNamesHelper.EVENT, propertiesBot)) {
+		if (SWTBotPropertySheet.selectPropertyTabItem(UITestNamesHelper.EVENT, propertiesBot)) {
 			propertiesBot = Abstract4diacUITests.selectTabFromInterfaceProperties(UITestNamesHelper.EVENT);
 		} else {
 			propertiesBot = Abstract4diacUITests.selectTabFromInterfaceProperties(UITestNamesHelper.DATA);

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/helpers/SWTBotPropertySheet.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/helpers/SWTBotPropertySheet.java
@@ -29,7 +29,7 @@ import org.eclipse.ui.internal.views.properties.tabbed.view.TabbedPropertyList;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 
-public class PropertySheetHelper {
+public class SWTBotPropertySheet {
 
 	/**
 	 * SWTWorkbenchBot

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/helpers/UITestPinHelper.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/helpers/UITestPinHelper.java
@@ -16,7 +16,7 @@
 
 package org.eclipse.fordiac.ide.test.ui.helpers;
 
-public final class PinNamesHelper {
+public final class UITestPinHelper {
 
 	// FB pins and values in alphabetical order and length
 

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/networkediting/basicfb/Basic1FBNetworkEditingTests.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/networkediting/basicfb/Basic1FBNetworkEditingTests.java
@@ -29,7 +29,7 @@ import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.fordiac.ide.application.editparts.InstanceNameEditPart;
 import org.eclipse.fordiac.ide.application.figures.InstanceNameFigure;
 import org.eclipse.fordiac.ide.test.ui.Abstract4diacUITests;
-import org.eclipse.fordiac.ide.test.ui.helpers.PinNamesHelper;
+import org.eclipse.fordiac.ide.test.ui.helpers.UITestPinHelper;
 import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotConnection;
 import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotFB;
 import org.eclipse.fordiac.ide.test.ui.helpers.UITestNamesHelper;
@@ -309,13 +309,13 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_CYCLE_TREE_ITEM, new Point(200, 200));
 		final SWTBotGefEditor editor = bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
 		assertNotNull(editor);
-		editor.getEditPart(PinNamesHelper.DEF_VAL);
-		editor.doubleClick(PinNamesHelper.DEF_VAL);
+		editor.getEditPart(UITestPinHelper.DEF_VAL);
+		editor.doubleClick(UITestPinHelper.DEF_VAL);
 		final SWTBotEclipseEditor e = editor.toTextEditor();
 		assertNotNull(e);
-		e.setText(PinNamesHelper.NEW_VAL);
+		e.setText(UITestPinHelper.NEW_VAL);
 		e.save();
-		assertNotNull(editor.getEditPart(PinNamesHelper.NEW_VAL));
+		assertNotNull(editor.getEditPart(UITestPinHelper.NEW_VAL));
 	}
 
 	/**
@@ -331,11 +331,11 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_CYCLE_TREE_ITEM, new Point(200, 100));
 		final SWTBotGefEditor editor = bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
 		assertNotNull(editor);
-		editor.getEditPart(PinNamesHelper.DEF_VAL);
-		editor.doubleClick(PinNamesHelper.DEF_VAL);
+		editor.getEditPart(UITestPinHelper.DEF_VAL);
+		editor.doubleClick(UITestPinHelper.DEF_VAL);
 		final SWTBotEclipseEditor e = editor.toTextEditor();
 		assertNotNull(e);
-		assertEquals(PinNamesHelper.DEF_VAL, e.getText());
+		assertEquals(UITestPinHelper.DEF_VAL, e.getText());
 		e.save();
 	}
 
@@ -352,15 +352,15 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_CYCLE_TREE_ITEM, new Point(200, 100));
 		final SWTBotGefEditor editor = bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
 		assertNotNull(editor);
-		editor.getEditPart(PinNamesHelper.DEF_VAL);
-		editor.doubleClick(PinNamesHelper.DEF_VAL);
+		editor.getEditPart(UITestPinHelper.DEF_VAL);
+		editor.doubleClick(UITestPinHelper.DEF_VAL);
 		final SWTBotEclipseEditor e = editor.toTextEditor();
 		assertNotNull(e);
-		e.setText(PinNamesHelper.NEW_VAL);
+		e.setText(UITestPinHelper.NEW_VAL);
 		e.save();
-		editor.getEditPart(PinNamesHelper.NEW_VAL);
-		editor.doubleClick(PinNamesHelper.NEW_VAL);
-		assertEquals(PinNamesHelper.NEW_VAL, editor.toTextEditor().getText());
+		editor.getEditPart(UITestPinHelper.NEW_VAL);
+		editor.doubleClick(UITestPinHelper.NEW_VAL);
+		assertEquals(UITestPinHelper.NEW_VAL, editor.toTextEditor().getText());
 	}
 
 	/**
@@ -420,7 +420,7 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_CYCLE_TREE_ITEM, new Point(200, 200));
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		final SWTBot4diacGefViewer viewer = connectBot.createConnection(PinNamesHelper.START, PinNamesHelper.EO);
+		final SWTBot4diacGefViewer viewer = connectBot.createConnection(UITestPinHelper.START, UITestPinHelper.EO);
 		assertDoesNotThrow(viewer::waitForConnection);
 	}
 
@@ -439,7 +439,7 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_N_TABLE_TREE_ITEM, new Point(100, 100));
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		final SWTBot4diacGefViewer viewer = connectBot.createConnection(PinNamesHelper.EO1, PinNamesHelper.START);
+		final SWTBot4diacGefViewer viewer = connectBot.createConnection(UITestPinHelper.EO1, UITestPinHelper.START);
 		assertDoesNotThrow(viewer::waitForConnection);
 	}
 
@@ -458,7 +458,7 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_CTUD_TREE_ITEM, new Point(150, 150));
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		final SWTBot4diacGefViewer viewer = connectBot.createConnection(PinNamesHelper.PV, PinNamesHelper.CV);
+		final SWTBot4diacGefViewer viewer = connectBot.createConnection(UITestPinHelper.PV, UITestPinHelper.CV);
 		assertDoesNotThrow(viewer::waitForConnection);
 	}
 
@@ -477,7 +477,7 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_D_FF_TREE_ITEM, new Point(150, 150));
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		final SWTBot4diacGefViewer viewer = connectBot.createConnection(PinNamesHelper.D, PinNamesHelper.Q);
+		final SWTBot4diacGefViewer viewer = connectBot.createConnection(UITestPinHelper.D, UITestPinHelper.Q);
 		assertDoesNotThrow(viewer::waitForConnection);
 	}
 
@@ -492,8 +492,8 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_TABLE_CTRL_TREE_ITEM, pos1);
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		connectBot.createConnection(PinNamesHelper.INIT, PinNamesHelper.CLKO);
-		connectBot.createConnection(PinNamesHelper.N, PinNamesHelper.CV);
+		connectBot.createConnection(UITestPinHelper.INIT, UITestPinHelper.CLKO);
+		connectBot.createConnection(UITestPinHelper.N, UITestPinHelper.CV);
 
 		final SWTBotGefEditor editor = bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
 		final SWTBot4diacGefViewer viewer = (SWTBot4diacGefViewer) editor.getSWTBotGefViewer();
@@ -502,8 +502,8 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		assertNotNull(canvas);
 		canvas.setFocus();
 
-		assertTrue(connectBot.checkIfConnectionCanBeFound(PinNamesHelper.CLKO, PinNamesHelper.INIT));
-		assertTrue(connectBot.checkIfConnectionCanBeFound(PinNamesHelper.CV, PinNamesHelper.N));
+		assertTrue(connectBot.checkIfConnectionCanBeFound(UITestPinHelper.CLKO, UITestPinHelper.INIT));
+		assertTrue(connectBot.checkIfConnectionCanBeFound(UITestPinHelper.CV, UITestPinHelper.N));
 
 		assertNotNull(editor);
 		assertNotNull(editor.getEditPart(UITestNamesHelper.E_TABLE_CTRL_FB));
@@ -535,8 +535,8 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		assertEquals(posToCheck2.x, fbBounds.x);
 		assertEquals(posToCheck2.y, fbBounds.y);
 
-		assertTrue(connectBot.checkIfConnectionCanBeFound(PinNamesHelper.CLKO, PinNamesHelper.INIT));
-		assertTrue(connectBot.checkIfConnectionCanBeFound(PinNamesHelper.CV, PinNamesHelper.N));
+		assertTrue(connectBot.checkIfConnectionCanBeFound(UITestPinHelper.CLKO, UITestPinHelper.INIT));
+		assertTrue(connectBot.checkIfConnectionCanBeFound(UITestPinHelper.CV, UITestPinHelper.N));
 	}
 
 	/**
@@ -555,7 +555,7 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_N_TABLE_TREE_ITEM, new Point(100, 100));
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		final SWTBot4diacGefViewer viewer = connectBot.createConnection(PinNamesHelper.START, PinNamesHelper.STOP);
+		final SWTBot4diacGefViewer viewer = connectBot.createConnection(UITestPinHelper.START, UITestPinHelper.STOP);
 		assertThrows(TimeoutException.class, viewer::waitForConnection);
 	}
 
@@ -575,7 +575,7 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_N_TABLE_TREE_ITEM, new Point(150, 100));
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		final SWTBot4diacGefViewer viewer = connectBot.createConnection(PinNamesHelper.START, PinNamesHelper.N);
+		final SWTBot4diacGefViewer viewer = connectBot.createConnection(UITestPinHelper.START, UITestPinHelper.N);
 		assertThrows(TimeoutException.class, viewer::waitForConnection);
 	}
 
@@ -595,7 +595,7 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_N_TABLE_TREE_ITEM, new Point(150, 100));
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		final SWTBot4diacGefViewer viewer = connectBot.createConnection(PinNamesHelper.START, PinNamesHelper.DT);
+		final SWTBot4diacGefViewer viewer = connectBot.createConnection(UITestPinHelper.START, UITestPinHelper.DT);
 		assertThrows(TimeoutException.class, viewer::waitForConnection);
 	}
 
@@ -615,7 +615,7 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_D_FF_TREE_ITEM, new Point(150, 100));
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		final SWTBot4diacGefViewer viewer = connectBot.createConnection(PinNamesHelper.CLK, PinNamesHelper.D);
+		final SWTBot4diacGefViewer viewer = connectBot.createConnection(UITestPinHelper.CLK, UITestPinHelper.D);
 		assertThrows(TimeoutException.class, viewer::waitForConnection);
 	}
 
@@ -635,7 +635,7 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_CTUD_TREE_ITEM, new Point(100, 150));
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		final SWTBot4diacGefViewer viewer = connectBot.createConnection(PinNamesHelper.CD, PinNamesHelper.CV);
+		final SWTBot4diacGefViewer viewer = connectBot.createConnection(UITestPinHelper.CD, UITestPinHelper.CV);
 		assertThrows(TimeoutException.class, viewer::waitForConnection);
 	}
 
@@ -655,7 +655,7 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_TABLE_CTRL_TREE_ITEM, new Point(100, 100));
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		final SWTBot4diacGefViewer viewer = connectBot.createConnection(PinNamesHelper.INIT, PinNamesHelper.DTO);
+		final SWTBot4diacGefViewer viewer = connectBot.createConnection(UITestPinHelper.INIT, UITestPinHelper.DTO);
 		assertThrows(TimeoutException.class, viewer::waitForConnection);
 	}
 
@@ -675,7 +675,7 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_CTUD_TREE_ITEM, new Point(100, 150));
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		final SWTBot4diacGefViewer viewer = connectBot.createConnection(PinNamesHelper.CD, PinNamesHelper.QU);
+		final SWTBot4diacGefViewer viewer = connectBot.createConnection(UITestPinHelper.CD, UITestPinHelper.QU);
 		assertThrows(TimeoutException.class, viewer::waitForConnection);
 	}
 
@@ -695,7 +695,7 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_TABLE_CTRL_TREE_ITEM, new Point(100, 100));
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		final SWTBot4diacGefViewer viewer = connectBot.createConnection(PinNamesHelper.DT, PinNamesHelper.DTO);
+		final SWTBot4diacGefViewer viewer = connectBot.createConnection(UITestPinHelper.DT, UITestPinHelper.DTO);
 		assertThrows(TimeoutException.class, viewer::waitForConnection);
 	}
 
@@ -715,7 +715,7 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_N_TABLE_TREE_ITEM, new Point(100, 100));
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		final SWTBot4diacGefViewer viewer = connectBot.createConnection(PinNamesHelper.DT, PinNamesHelper.N);
+		final SWTBot4diacGefViewer viewer = connectBot.createConnection(UITestPinHelper.DT, UITestPinHelper.N);
 		assertThrows(TimeoutException.class, viewer::waitForConnection);
 	}
 
@@ -735,7 +735,7 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_CTUD_TREE_ITEM, new Point(100, 100));
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		final SWTBot4diacGefViewer viewer = connectBot.createConnection(PinNamesHelper.PV, PinNamesHelper.QU);
+		final SWTBot4diacGefViewer viewer = connectBot.createConnection(UITestPinHelper.PV, UITestPinHelper.QU);
 		assertThrows(TimeoutException.class, viewer::waitForConnection);
 	}
 
@@ -755,7 +755,7 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_N_TABLE_TREE_ITEM, new Point(100, 100));
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		final SWTBot4diacGefViewer viewer = connectBot.createConnection(PinNamesHelper.EO0, PinNamesHelper.N);
+		final SWTBot4diacGefViewer viewer = connectBot.createConnection(UITestPinHelper.EO0, UITestPinHelper.N);
 		assertThrows(TimeoutException.class, viewer::waitForConnection);
 	}
 
@@ -775,7 +775,7 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_N_TABLE_TREE_ITEM, new Point(100, 100));
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		final SWTBot4diacGefViewer viewer = connectBot.createConnection(PinNamesHelper.EO1, PinNamesHelper.DT);
+		final SWTBot4diacGefViewer viewer = connectBot.createConnection(UITestPinHelper.EO1, UITestPinHelper.DT);
 		assertThrows(TimeoutException.class, viewer::waitForConnection);
 	}
 
@@ -795,7 +795,7 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_D_FF_TREE_ITEM, new Point(100, 100));
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		final SWTBot4diacGefViewer viewer = connectBot.createConnection(PinNamesHelper.EO, PinNamesHelper.D);
+		final SWTBot4diacGefViewer viewer = connectBot.createConnection(UITestPinHelper.EO, UITestPinHelper.D);
 		assertThrows(TimeoutException.class, viewer::waitForConnection);
 	}
 
@@ -815,7 +815,7 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_N_TABLE_TREE_ITEM, new Point(100, 100));
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		final SWTBot4diacGefViewer viewer = connectBot.createConnection(PinNamesHelper.EO0, PinNamesHelper.EO2);
+		final SWTBot4diacGefViewer viewer = connectBot.createConnection(UITestPinHelper.EO0, UITestPinHelper.EO2);
 		assertThrows(TimeoutException.class, viewer::waitForConnection);
 	}
 
@@ -835,7 +835,7 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_TABLE_CTRL_TREE_ITEM, new Point(100, 100));
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		final SWTBot4diacGefViewer viewer = connectBot.createConnection(PinNamesHelper.CLKO, PinNamesHelper.CV);
+		final SWTBot4diacGefViewer viewer = connectBot.createConnection(UITestPinHelper.CLKO, UITestPinHelper.CV);
 		assertThrows(TimeoutException.class, viewer::waitForConnection);
 	}
 
@@ -855,7 +855,7 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_TABLE_CTRL_TREE_ITEM, new Point(100, 100));
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		final SWTBot4diacGefViewer viewer = connectBot.createConnection(PinNamesHelper.CLKO, PinNamesHelper.DTO);
+		final SWTBot4diacGefViewer viewer = connectBot.createConnection(UITestPinHelper.CLKO, UITestPinHelper.DTO);
 		assertThrows(TimeoutException.class, viewer::waitForConnection);
 	}
 
@@ -875,7 +875,7 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_D_FF_TREE_ITEM, new Point(100, 100));
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		final SWTBot4diacGefViewer viewer = connectBot.createConnection(PinNamesHelper.EO, PinNamesHelper.Q);
+		final SWTBot4diacGefViewer viewer = connectBot.createConnection(UITestPinHelper.EO, UITestPinHelper.Q);
 		assertThrows(TimeoutException.class, viewer::waitForConnection);
 	}
 
@@ -895,7 +895,7 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_CTUD_TREE_ITEM, new Point(100, 100));
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		final SWTBot4diacGefViewer viewer = connectBot.createConnection(PinNamesHelper.QU, PinNamesHelper.QD);
+		final SWTBot4diacGefViewer viewer = connectBot.createConnection(UITestPinHelper.QU, UITestPinHelper.QD);
 		assertThrows(TimeoutException.class, viewer::waitForConnection);
 	}
 

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/networkediting/basicfb/Basic2FBNetworkEditingTests.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/networkediting/basicfb/Basic2FBNetworkEditingTests.java
@@ -25,7 +25,7 @@ import java.util.List;
 import org.eclipse.draw2d.PolylineConnection;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.fordiac.ide.test.ui.Abstract4diacUITests;
-import org.eclipse.fordiac.ide.test.ui.helpers.PinNamesHelper;
+import org.eclipse.fordiac.ide.test.ui.helpers.UITestPinHelper;
 import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotConnection;
 import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotFB;
 import org.eclipse.fordiac.ide.test.ui.helpers.UITestNamesHelper;
@@ -299,8 +299,8 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_CYCLE_TREE_ITEM, pos1);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_DEMUX_TREE_ITEM, new Point(300, 50));
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		connectBot.createConnection(PinNamesHelper.EO, PinNamesHelper.EI);
-		final ConnectionEditPart connection = connectBot.findConnection(PinNamesHelper.EO, PinNamesHelper.EI);
+		connectBot.createConnection(UITestPinHelper.EO, UITestPinHelper.EI);
+		final ConnectionEditPart connection = connectBot.findConnection(UITestPinHelper.EO, UITestPinHelper.EI);
 		assertNotNull(connection);
 
 		// select E_CYCLE
@@ -360,8 +360,8 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 		final Point pos2 = new Point(175, 125);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_CTUD_TREE_ITEM, pos2);
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		connectBot.createConnection(PinNamesHelper.QU, PinNamesHelper.G);
-		final ConnectionEditPart connection = connectBot.findConnection(PinNamesHelper.QU, PinNamesHelper.G);
+		connectBot.createConnection(UITestPinHelper.QU, UITestPinHelper.G);
+		final ConnectionEditPart connection = connectBot.findConnection(UITestPinHelper.QU, UITestPinHelper.G);
 		assertNotNull(connection);
 
 		// select E_SELECT
@@ -439,8 +439,8 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 		final Point pos2 = new Point(100, 275);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_SR_TREE_ITEM, pos2);
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		connectBot.createConnection(PinNamesHelper.EO1, PinNamesHelper.R);
-		ConnectionEditPart connection = connectBot.findConnection(PinNamesHelper.EO1, PinNamesHelper.R);
+		connectBot.createConnection(UITestPinHelper.EO1, UITestPinHelper.R);
+		ConnectionEditPart connection = connectBot.findConnection(UITestPinHelper.EO1, UITestPinHelper.R);
 		assertNotNull(connection);
 		final SWTBot4diacGefEditor editor = (SWTBot4diacGefEditor) bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
 
@@ -473,7 +473,7 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 		final int translationY = pointTo.y - pointFrom.y;
 
 		// check if connection has been moved
-		connection = connectBot.findConnection(PinNamesHelper.EO1, PinNamesHelper.R);
+		connection = connectBot.findConnection(UITestPinHelper.EO1, UITestPinHelper.R);
 		assertNotNull(connection);
 		final org.eclipse.draw2d.geometry.Point newStartPointConnection = polyLineConnection.getPoints()
 				.getFirstPoint();

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/networkediting/subapp_compsite/CompositeInstanceViewerTests.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/networkediting/subapp_compsite/CompositeInstanceViewerTests.java
@@ -27,7 +27,7 @@ import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.fordiac.ide.fbtypeeditor.network.viewer.CompositeInstanceViewer;
 import org.eclipse.fordiac.ide.model.ui.editors.AbstractBreadCrumbEditor;
 import org.eclipse.fordiac.ide.test.ui.Abstract4diacUITests;
-import org.eclipse.fordiac.ide.test.ui.helpers.PinNamesHelper;
+import org.eclipse.fordiac.ide.test.ui.helpers.UITestPinHelper;
 import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotConnection;
 import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotFB;
 import org.eclipse.fordiac.ide.test.ui.helpers.UITestNamesHelper;
@@ -194,13 +194,13 @@ public class CompositeInstanceViewerTests extends Abstract4diacUITests {
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_N_TABLE_TREE_ITEM, new Point(200, 200));
 		goToCompositeInstanceViewer(UITestNamesHelper.E_N_TABLE_FB);
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		SWTBot4diacGefViewer viewer = connectBot.createConnection(PinNamesHelper.EO, PinNamesHelper.EI);
+		SWTBot4diacGefViewer viewer = connectBot.createConnection(UITestPinHelper.EO, UITestPinHelper.EI);
 		assertThrows(TimeoutException.class, viewer::waitForConnection);
-		viewer = connectBot.createConnection(PinNamesHelper.N, PinNamesHelper.CV);
+		viewer = connectBot.createConnection(UITestPinHelper.N, UITestPinHelper.CV);
 		assertThrows(TimeoutException.class, viewer::waitForConnection);
-		viewer = connectBot.createConnection(PinNamesHelper.START, PinNamesHelper.STOP);
+		viewer = connectBot.createConnection(UITestPinHelper.START, UITestPinHelper.STOP);
 		assertThrows(TimeoutException.class, viewer::waitForConnection);
-		viewer = connectBot.createConnection(PinNamesHelper.START, PinNamesHelper.EO0);
+		viewer = connectBot.createConnection(UITestPinHelper.START, UITestPinHelper.EO0);
 		assertThrows(TimeoutException.class, viewer::waitForConnection);
 		returnToEditingArea();
 	}
@@ -218,7 +218,7 @@ public class CompositeInstanceViewerTests extends Abstract4diacUITests {
 		final SWTBotGefEditor editor = bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
 		final SWTBot4diacGefViewer viewer = (SWTBot4diacGefViewer) editor.getSWTBotGefViewer();
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		final ConnectionEditPart connection = connectBot.findConnection(PinNamesHelper.EO, PinNamesHelper.REQ);
+		final ConnectionEditPart connection = connectBot.findConnection(UITestPinHelper.EO, UITestPinHelper.REQ);
 		final PolylineConnection figure = (PolylineConnection) connection.getFigure();
 		final PointList points = figure.getPoints();
 		final org.eclipse.draw2d.geometry.Point firstPoint = points.getFirstPoint();

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/networkediting/subapp_compsite/SubapplicationTests.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/networkediting/subapp_compsite/SubapplicationTests.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import org.eclipse.fordiac.ide.model.ui.editors.HandlerHelper;
 import org.eclipse.fordiac.ide.test.ui.Abstract4diacUITests;
-import org.eclipse.fordiac.ide.test.ui.helpers.PinNamesHelper;
+import org.eclipse.fordiac.ide.test.ui.helpers.UITestPinHelper;
 import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotConnection;
 import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotFB;
 import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotSubapp;
@@ -101,9 +101,9 @@ public class SubapplicationTests extends Abstract4diacUITests {
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_SWITCH_TREE_ITEM, new Point(100, 100));
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_SR_TREE_ITEM, new Point(300, 100));
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		assertNotNull(connectBot.createConnection(PinNamesHelper.EO0, PinNamesHelper.S));
-		assertNotNull(connectBot.createConnection(PinNamesHelper.EO1, PinNamesHelper.R));
-		assertNotNull(connectBot.createConnection(PinNamesHelper.Q, PinNamesHelper.G));
+		assertNotNull(connectBot.createConnection(UITestPinHelper.EO0, UITestPinHelper.S));
+		assertNotNull(connectBot.createConnection(UITestPinHelper.EO1, UITestPinHelper.R));
+		assertNotNull(connectBot.createConnection(UITestPinHelper.Q, UITestPinHelper.G));
 
 		// drag rectangle over to FB, therefore FB should be selected
 		final SWTBot4diacGefEditor editor = (SWTBot4diacGefEditor) bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
@@ -117,9 +117,9 @@ public class SubapplicationTests extends Abstract4diacUITests {
 		assertEquals(5, selectedEditParts.size());
 		assertTrue(fbBot.isFbSelected(selectedEditParts, UITestNamesHelper.E_SWITCH_FB));
 		assertTrue(fbBot.isFbSelected(selectedEditParts, UITestNamesHelper.E_SR_FB));
-		assertTrue(connectBot.checkIfConnectionCanBeFound(PinNamesHelper.EO0, PinNamesHelper.S));
-		assertTrue(connectBot.checkIfConnectionCanBeFound(PinNamesHelper.EO1, PinNamesHelper.R));
-		assertTrue(connectBot.checkIfConnectionCanBeFound(PinNamesHelper.Q, PinNamesHelper.G));
+		assertTrue(connectBot.checkIfConnectionCanBeFound(UITestPinHelper.EO0, UITestPinHelper.S));
+		assertTrue(connectBot.checkIfConnectionCanBeFound(UITestPinHelper.EO1, UITestPinHelper.R));
+		assertTrue(connectBot.checkIfConnectionCanBeFound(UITestPinHelper.Q, UITestPinHelper.G));
 
 		bot.menu(UITestNamesHelper.SOURCE).menu(UITestNamesHelper.NEW_SUBAPPLICATION).click();
 		// renew list of selectedEditParts and then check if SubApp was created
@@ -146,7 +146,7 @@ public class SubapplicationTests extends Abstract4diacUITests {
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_SWITCH_TREE_ITEM, new Point(300, 100));
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_SR_TREE_ITEM, new Point(500, 100));
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		assertNotNull(connectBot.createConnection(PinNamesHelper.EO, PinNamesHelper.EI));
+		assertNotNull(connectBot.createConnection(UITestPinHelper.EO, UITestPinHelper.EI));
 
 		// drag rectangle over to FBs E_SWITCH and E_SR, therefore FBs should be
 		// selected
@@ -159,7 +159,7 @@ public class SubapplicationTests extends Abstract4diacUITests {
 		assertTrue(fbBot.isFbSelected(selectedEditParts, UITestNamesHelper.E_SWITCH_FB));
 		assertTrue(fbBot.isFbSelected(selectedEditParts, UITestNamesHelper.E_SR_FB));
 		assertFalse(fbBot.isFbSelected(selectedEditParts, UITestNamesHelper.E_CYCLE_TREE_ITEM));
-		assertTrue(connectBot.checkIfConnectionCanBeFound(PinNamesHelper.EO, PinNamesHelper.EI));
+		assertTrue(connectBot.checkIfConnectionCanBeFound(UITestPinHelper.EO, UITestPinHelper.EI));
 
 		bot.menu(UITestNamesHelper.SOURCE).menu(UITestNamesHelper.NEW_SUBAPPLICATION).click();
 		// renew list of selectedEditParts and then check if SubApp was created
@@ -167,7 +167,7 @@ public class SubapplicationTests extends Abstract4diacUITests {
 		assertEquals(1, selectedEditParts.size());
 		final SWTBotSubapp subappBot = new SWTBotSubapp(bot);
 		assertTrue(subappBot.isSubappSelected(selectedEditParts, UITestNamesHelper.SUBAPP));
-		assertTrue(connectBot.checkIfConnectionCanBeFound(PinNamesHelper.EO, PinNamesHelper.EO));
+		assertTrue(connectBot.checkIfConnectionCanBeFound(UITestPinHelper.EO, UITestPinHelper.EO));
 	}
 
 	/**
@@ -200,9 +200,9 @@ public class SubapplicationTests extends Abstract4diacUITests {
 		// in UI thread. Without this, the connections are not created correctly
 		UIThreadRunnable.syncExec(() -> HandlerHelper.selectEditPart(viewer.getGraphicalViewer(), editPart.part()));
 		final SWTBotConnection connectBot = new SWTBotConnection(bot);
-		assertNotNull(connectBot.createConnection(PinNamesHelper.EO0, PinNamesHelper.S));
-		assertNotNull(connectBot.createConnection(PinNamesHelper.EO1, PinNamesHelper.R));
-		assertNotNull(connectBot.createConnection(PinNamesHelper.Q, PinNamesHelper.G));
+		assertNotNull(connectBot.createConnection(UITestPinHelper.EO0, UITestPinHelper.S));
+		assertNotNull(connectBot.createConnection(UITestPinHelper.EO1, UITestPinHelper.R));
+		assertNotNull(connectBot.createConnection(UITestPinHelper.Q, UITestPinHelper.G));
 	}
 
 }


### PR DESCRIPTION
The helper classes have been renamed so that they match the naming conventions of the other helper classes.
- Class PinNameHelper is now UITestPinHelper 
- Class PropertySheetHelper is now SWTBotPropertySheet.