### PR TITLE
Avoid removing and re-adding annotations during live validation

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/InstancePropertySection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/InstancePropertySection.java
@@ -126,6 +126,12 @@ public class InstancePropertySection extends AbstractSection {
 		}
 	}
 
+	@Override
+	protected void performRefreshAnnotations() {
+		inputTable.refresh(false);
+		outputTable.refresh(false);
+	}
+
 	protected void createTableSection(final Composite parent) {
 		final Composite tableSectionComposite = getWidgetFactory().createComposite(parent);
 		GridLayoutFactory.fillDefaults().numColumns(TWO_COLUMNS).applyTo(tableSectionComposite);

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/VarConfigurationSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/VarConfigurationSection.java
@@ -147,7 +147,12 @@ public class VarConfigurationSection extends AbstractSection {
 
 	@Override
 	protected void performRefresh() {
-		// currently nothing to do
+		inputTable.refresh();
+	}
+
+	@Override
+	protected void performRefreshAnnotations() {
+		inputTable.refresh(false);
 	}
 
 	private List<VarDeclaration> collectVarConfigs() {

--- a/plugins/org.eclipse.fordiac.ide.datatypeeditor/src/org/eclipse/fordiac/ide/datatypeeditor/properties/DataTypeInfoSection.java
+++ b/plugins/org.eclipse.fordiac.ide.datatypeeditor/src/org/eclipse/fordiac/ide/datatypeeditor/properties/DataTypeInfoSection.java
@@ -19,7 +19,6 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.gef.properties.AbstractSection;
 import org.eclipse.fordiac.ide.gef.widgets.PackageInfoWidget;
-import org.eclipse.fordiac.ide.gef.widgets.TypeInfoWidget;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeCommentCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.ui.FordiacMessages;
@@ -32,7 +31,7 @@ import org.eclipse.ui.views.properties.tabbed.TabbedPropertySheetPage;
 
 public class DataTypeInfoSection extends AbstractSection {
 
-	private TypeInfoWidget typeInfoWidget;
+	private PackageInfoWidget typeInfoWidget;
 	private Text commentText;
 
 	@Override
@@ -97,6 +96,11 @@ public class DataTypeInfoSection extends AbstractSection {
 	protected void performRefresh() {
 		commentText.setText((null != getType().getComment()) ? getType().getComment() : ""); //$NON-NLS-1$
 		typeInfoWidget.refresh();
+	}
+
+	@Override
+	protected void performRefreshAnnotations() {
+		typeInfoWidget.refreshAnnotations();
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AbstractEditInterfaceSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AbstractEditInterfaceSection.java
@@ -164,6 +164,12 @@ public abstract class AbstractEditInterfaceSection<T extends IInterfaceElement> 
 		outputTable.refresh();
 	}
 
+	@Override
+	protected void performRefreshAnnotations() {
+		inputTable.refresh(false);
+		outputTable.refresh(false);
+	}
+
 	protected void setTableInput() {
 		setTableInput(getInterface());
 		if (isShowTableEditButtons()) {

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AbstractEditVarInOutSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AbstractEditVarInOutSection.java
@@ -133,6 +133,11 @@ public abstract class AbstractEditVarInOutSection extends AbstractSection
 		inputTable.refresh();
 	}
 
+	@Override
+	protected void performRefreshAnnotations() {
+		inputTable.refresh(false);
+	}
+
 	protected abstract void setTableInput();
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AbstractInternalVarsSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AbstractInternalVarsSection.java
@@ -193,6 +193,11 @@ public abstract class AbstractInternalVarsSection extends AbstractSection
 	}
 
 	@Override
+	protected void performRefreshAnnotations() {
+		table.refresh(false);
+	}
+
+	@Override
 	public void executeCompoundCommand(final CompoundCommand cmd) {
 		executeCommand(cmd);
 		table.refresh();

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AbstractSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AbstractSection.java
@@ -74,6 +74,10 @@ public abstract class AbstractSection extends AbstractPropertySection implements
 	 */
 	protected abstract void performRefresh();
 
+	protected void performRefreshAnnotations() {
+		// empty default
+	}
+
 	protected void setType(final Object input) {
 		// as the property sheet is reused for different selection first remove
 		// listening to the old element
@@ -150,12 +154,31 @@ public abstract class AbstractSection extends AbstractPropertySection implements
 		}
 	}
 
+	protected final void notifiyRefreshAnnotations() {
+		if (shouldRefresh()) {
+			parent.getDisplay().asyncExec(() -> {
+				if (!parent.isDisposed()) {
+					refreshAnnotations();
+				}
+			});
+		}
+	}
+
 	@Override
 	public final void refresh() {
 		if (getType() != null) {
 			final CommandStack commandStackBuffer = commandStack;
 			commandStack = null;
 			performRefresh();
+			commandStack = commandStackBuffer;
+		}
+	}
+
+	public final void refreshAnnotations() {
+		if (getType() != null) {
+			final CommandStack commandStackBuffer = commandStack;
+			commandStack = null;
+			performRefreshAnnotations();
 			commandStack = commandStackBuffer;
 		}
 	}
@@ -183,7 +206,7 @@ public abstract class AbstractSection extends AbstractPropertySection implements
 		}
 	}
 
-	private final GraphicalAnnotationModelListener annotationModelListener = event -> notifiyRefresh();
+	private final GraphicalAnnotationModelListener annotationModelListener = event -> notifiyRefreshAnnotations();
 
 	protected void removeAnnotationModelListener() {
 		if (annotationModel != null) {

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AttributeSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AttributeSection.java
@@ -180,6 +180,11 @@ public class AttributeSection extends AbstractSection implements I4diacNatTableU
 	}
 
 	@Override
+	protected void performRefreshAnnotations() {
+		table.refresh(false);
+	}
+
+	@Override
 	public void executeCommand(final Command cmd) {
 		super.executeCommand(cmd);
 		provider.setInput(getFilteredAttributeList());

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/InternalFbsSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/InternalFbsSection.java
@@ -143,6 +143,11 @@ public class InternalFbsSection extends AbstractSection implements I4diacNatTabl
 	}
 
 	@Override
+	protected void performRefreshAnnotations() {
+		table.refresh(false);
+	}
+
+	@Override
 	public void executeCompoundCommand(final CompoundCommand cmd) {
 		executeCommand(cmd);
 		table.refresh();

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/TypeInfoSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/TypeInfoSection.java
@@ -90,6 +90,11 @@ public abstract class TypeInfoSection extends AbstractDoubleColumnSection {
 	}
 
 	@Override
+	protected void performRefreshAnnotations() {
+		typeInfo.refreshAnnotations();
+	}
+
+	@Override
 	protected void addContentAdapter() {
 		super.addContentAdapter();
 		if (getType() != null) {

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/validation/ValidationJob.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/validation/ValidationJob.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.Spliterators;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -99,7 +100,8 @@ public class ValidationJob extends UIJob {
 				.stream(Spliterators.spliteratorUnknownSize(EcoreUtil.getAllContents(
 						diagnostics.stream().map(FordiacMarkerHelper::getDiagnosticTarget).toList(), true), 0), false)
 				.map(annotationModel::getAnnotations).flatMap(Collection::stream)
-				.filter(ValidationJob::isValidationAnnotation).collect(Collectors.toSet());
+				.filter(ValidationJob::isValidationAnnotation).filter(Predicate.not(add::contains))
+				.collect(Collectors.toSet());
 		if (monitor.isCanceled()) {
 			throw new OperationCanceledException();
 		}

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/widgets/PackageInfoWidget.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/widgets/PackageInfoWidget.java
@@ -155,7 +155,6 @@ public class PackageInfoWidget extends TypeInfoWidget {
 	public void refresh() {
 		super.refresh();
 		if (packageViewer != null && !packageViewer.getControl().isDisposed()) {
-			final GraphicalAnnotationModel annotationModel = annotationModelSupplier.get();
 			final Consumer<Command> commandExecutorBuffer = getCommandExecutor();
 			setCommandExecutor(null);
 			if ((getType() != null)) {
@@ -165,22 +164,28 @@ public class PackageInfoWidget extends TypeInfoWidget {
 				buttons.setEnabled(!isReadonly());
 				organizeImportsButton.setEnabled(!isReadonly());
 				packageViewer.getTable().setEnabled(!isReadonly());
-
-				final CompilerInfo compilerInfo = getType().getCompilerInfo();
-				final StyledString nameStyledString = new StyledString(PackageNameHelper.getPackageName(getType()),
-						annotationModel != null && compilerInfo != null
-								? GraphicalAnnotationStyles
-										.getAnnotationStyle(annotationModel.getAnnotations(compilerInfo))
-								: null);
-
-				final Point nameTextSelection = nameText.getSelection();
-				nameText.setText(nameStyledString.toString());
-				nameText.setStyleRanges(nameStyledString.getStyleRanges());
-				nameText.setSelection(nameTextSelection);
 				packageViewer.setInput(getType());
+				refreshAnnotations();
 			}
 			setCommandExecutor(commandExecutorBuffer);
 		}
+	}
+
+	public void refreshAnnotations() {
+		final GraphicalAnnotationModel annotationModel = annotationModelSupplier.get();
+		final CompilerInfo compilerInfo = getType().getCompilerInfo();
+		final StyledString nameStyledString = new StyledString(PackageNameHelper.getPackageName(getType()),
+				annotationModel != null && compilerInfo != null
+						? GraphicalAnnotationStyles.getAnnotationStyle(annotationModel.getAnnotations(compilerInfo))
+						: null);
+
+		final int caretOffset = nameText.getCaretOffset();
+		final Point nameTextSelection = nameText.getSelection();
+		nameText.setText(nameStyledString.toString());
+		nameText.setStyleRanges(nameStyledString.getStyleRanges());
+		nameText.setSelection(nameTextSelection);
+		nameText.setCaretOffset(caretOffset);
+		packageViewer.refresh();
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/src/org/eclipse/fordiac/ide/globalconstantseditor/ui/properties/GlobalConstantsTypeInfoSection.java
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/src/org/eclipse/fordiac/ide/globalconstantseditor/ui/properties/GlobalConstantsTypeInfoSection.java
@@ -19,7 +19,6 @@ package org.eclipse.fordiac.ide.globalconstantseditor.ui.properties;
 
 import org.eclipse.fordiac.ide.gef.properties.AbstractSection;
 import org.eclipse.fordiac.ide.gef.widgets.PackageInfoWidget;
-import org.eclipse.fordiac.ide.gef.widgets.TypeInfoWidget;
 import org.eclipse.fordiac.ide.globalconstantseditor.ui.document.GlobalConstantsDocument;
 import org.eclipse.fordiac.ide.globalconstantseditor.ui.editor.GlobalConstantsEditor;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeCommentCommand;
@@ -36,7 +35,7 @@ import org.eclipse.ui.views.properties.tabbed.TabbedPropertySheetPage;
 
 public class GlobalConstantsTypeInfoSection extends AbstractSection {
 
-	private TypeInfoWidget typeInfoWidget;
+	private PackageInfoWidget typeInfoWidget;
 	private Text commentText;
 
 	@Override
@@ -112,6 +111,11 @@ public class GlobalConstantsTypeInfoSection extends AbstractSection {
 	protected void performRefresh() {
 		commentText.setText((null != getType().getComment()) ? getType().getComment() : ""); //$NON-NLS-1$
 		typeInfoWidget.refresh();
+	}
+
+	@Override
+	protected void performRefreshAnnotations() {
+		typeInfoWidget.refreshAnnotations();
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/editors/SystemEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/editors/SystemEditor.java
@@ -112,7 +112,7 @@ public class SystemEditor extends EditorPart
 
 	private final GraphicalAnnotationModelListener annotationModelListener = event -> {
 		if (typeInfo != null && !form.isDisposed()) {
-			form.getDisplay().asyncExec(typeInfo::refresh);
+			form.getDisplay().asyncExec(typeInfo::refreshAnnotations);
 		}
 	};
 


### PR DESCRIPTION
Avoid removing and re-adding annotations during live validation, including resulting superfluous notifications to listeners.