### PR TITLE
Disable editing of the Message-Textfield of the export

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.export.ui/src/org/eclipse/fordiac/ide/export/ui/wizard/ExportStatusMessageDialog.java
+++ b/plugins/org.eclipse.fordiac.ide.export.ui/src/org/eclipse/fordiac/ide/export/ui/wizard/ExportStatusMessageDialog.java
@@ -65,6 +65,7 @@ public class ExportStatusMessageDialog extends ErrorDialog {
 
 		text = new StyledText(parent, SWT.MULTI | SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL);
 		GridDataFactory.fillDefaults().grab(true, true).applyTo(text);
+		text.setEditable(false);
 
 		printMessages();
 


### PR DESCRIPTION
User was able to edit the error messages of the exporter by typing

This also disables the context-menu for copying; shortcuts still work