### PR TITLE
Changed FORTE Exporter Name to `4diac FORTE 3.x`

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/plugin.xml
@@ -5,8 +5,8 @@
          point="org.eclipse.fordiac.ide.export.exportFilter">
       <ExportFilter
             class="org.eclipse.fordiac.ide.export.forte_ng.ForteNgExportFilter"
-            description="FORTE Export New Generation for FORTE 1.x"
-            name="FORTE 1.x NG"
+            description="Export type files to be added to 4diac FORTE"
+            name="4diac FORTE 3.x"
             sortIndex="10">
       </ExportFilter>
    </extension>


### PR DESCRIPTION
In order to indicate the target 4diac FORTE version and to comply with our CI the name and description of the 4diac FORTE export filter where updated.