### PR TITLE
Fix race condition with built-in data types in ST editor

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm/src/org/eclipse/fordiac/ide/structuredtextalgorithm/scoping/STAlgorithmScopeProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm/src/org/eclipse/fordiac/ide/structuredtextalgorithm/scoping/STAlgorithmScopeProvider.java
@@ -18,7 +18,6 @@ import org.eclipse.emf.ecore.EReference;
 import org.eclipse.fordiac.ide.model.libraryElement.FB;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
-import org.eclipse.fordiac.ide.model.typelibrary.DataTypeLibrary;
 import org.eclipse.fordiac.ide.structuredtextalgorithm.stalgorithm.STAlgorithmPackage;
 import org.eclipse.fordiac.ide.structuredtextalgorithm.stalgorithm.STAlgorithmSource;
 import org.eclipse.fordiac.ide.structuredtextalgorithm.stalgorithm.STMethod;
@@ -43,7 +42,7 @@ public class STAlgorithmScopeProvider extends AbstractSTAlgorithmScopeProvider {
 	public IScope getScope(final EObject context, final EReference reference) {
 		if (reference == STAlgorithmPackage.Literals.ST_METHOD__RETURN_TYPE) {
 			final IScope globalScope = this.delegateGetScope(context, reference);
-			return STCoreScopeProvider.scopeFor(DataTypeLibrary.getNonUserDefinedDataTypes(), globalScope);
+			return scopeForNonUserDefinedDataTypes(globalScope);
 		}
 		if (reference == STCorePackage.Literals.ST_FEATURE_EXPRESSION__FEATURE) {
 			final STExpression receiver = STCoreScopeProvider.getReceiver(context);
@@ -52,9 +51,8 @@ public class STAlgorithmScopeProvider extends AbstractSTAlgorithmScopeProvider {
 				if (feature == STBuiltinFeature.THIS) {
 					final STAlgorithmSource source = EcoreUtil2.getContainerOfType(context, STAlgorithmSource.class);
 					if (source != null) {
-						return STCoreScopeProvider.scopeFor(
-								source.getElements().stream().filter(STMethod.class::isInstance).toList(),
-								super.getScope(context, reference));
+						return qualifiedScope(source.getElements().stream().filter(STMethod.class::isInstance).toList(),
+								reference, super.getScope(context, reference));
 					}
 				}
 			}

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/scoping/STCoreScopeProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/scoping/STCoreScopeProvider.java
@@ -25,6 +25,7 @@ package org.eclipse.fordiac.ide.structuredtextcore.scoping;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -58,7 +59,6 @@ import org.eclipse.xtext.scoping.impl.ImportNormalizer;
 import org.eclipse.xtext.scoping.impl.ImportScope;
 import org.eclipse.xtext.scoping.impl.ScopeBasedSelectable;
 import org.eclipse.xtext.scoping.impl.SimpleScope;
-import org.eclipse.xtext.util.SimpleAttributeResolver;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
@@ -72,21 +72,21 @@ import com.google.inject.Inject;
  * on how and when to use it.
  */
 public class STCoreScopeProvider extends AbstractSTCoreScopeProvider {
-	protected static final EObjectDescription[] ADDITIONAL_LITERAL_TYPES = {
-			descriptionForType("D", ElementaryTypes.DATE), //$NON-NLS-1$
-			descriptionForType("LD", ElementaryTypes.LDATE), //$NON-NLS-1$
-			descriptionForType("T", ElementaryTypes.TIME), //$NON-NLS-1$
-			descriptionForType("LT", ElementaryTypes.LTIME) //$NON-NLS-1$
-	};
+	private static final List<IEObjectDescription> NON_USER_DEFINED_TYPES_DESCRIPTIONS = DataTypeLibrary
+			.getNonUserDefinedDataTypes().stream().map(STCoreScopeProvider::descriptionForType).toList();
 
-	protected static boolean isAnyElementaryLiteral(final EReference reference) {
-		return (reference == STCorePackage.Literals.ST_NUMERIC_LITERAL__TYPE
-				|| reference == STCorePackage.Literals.ST_DATE_LITERAL__TYPE
-				|| reference == STCorePackage.Literals.ST_TIME_LITERAL__TYPE
-				|| reference == STCorePackage.Literals.ST_TIME_OF_DAY_LITERAL__TYPE
-				|| reference == STCorePackage.Literals.ST_DATE_AND_TIME_LITERAL__TYPE
-				|| reference == STCorePackage.Literals.ST_STRING_LITERAL__TYPE);
-	}
+	private static final List<IEObjectDescription> LITERAL_TYPES_DESCRIPTIONS = Stream
+			.concat(NON_USER_DEFINED_TYPES_DESCRIPTIONS.stream(), Stream.of(//
+					descriptionForType("D", ElementaryTypes.DATE), //$NON-NLS-1$
+					descriptionForType("LD", ElementaryTypes.LDATE), //$NON-NLS-1$
+					descriptionForType("T", ElementaryTypes.TIME), //$NON-NLS-1$
+					descriptionForType("LT", ElementaryTypes.LTIME) //$NON-NLS-1$
+			)).toList();
+
+	private static final Set<EReference> ANY_ELEMENTARY_LITERAL_REFERENCES = Set.of(
+			STCorePackage.Literals.ST_NUMERIC_LITERAL__TYPE, STCorePackage.Literals.ST_DATE_LITERAL__TYPE,
+			STCorePackage.Literals.ST_TIME_LITERAL__TYPE, STCorePackage.Literals.ST_TIME_OF_DAY_LITERAL__TYPE,
+			STCorePackage.Literals.ST_DATE_AND_TIME_LITERAL__TYPE, STCorePackage.Literals.ST_STRING_LITERAL__TYPE);
 
 	@Inject
 	IQualifiedNameProvider qualifiedNameProvider;
@@ -100,19 +100,14 @@ public class STCoreScopeProvider extends AbstractSTCoreScopeProvider {
 	public IScope getScope(final EObject context, final EReference reference) {
 		if (reference == STCorePackage.Literals.ST_VAR_DECLARATION__TYPE) {
 			final IScope globalScope = super.getScope(context, reference);
-			return scopeFor(DataTypeLibrary.getNonUserDefinedDataTypes(),
-					filterScope(globalScope, this::isApplicableForVariableType));
+			return scopeForNonUserDefinedDataTypes(filterScope(globalScope, this::isApplicableForVariableType));
 		}
 		if (reference == STCorePackage.Literals.ST_TYPE_DECLARATION__TYPE) {
 			final IScope globalScope = super.getScope(context, reference);
-			return scopeFor(DataTypeLibrary.getNonUserDefinedDataTypes(),
-					filterScope(globalScope, this::isApplicableForTypeDeclaration));
+			return scopeForNonUserDefinedDataTypes(filterScope(globalScope, this::isApplicableForTypeDeclaration));
 		}
 		if (isAnyElementaryLiteral(reference)) {
-			return new SimpleScope(Stream.concat(
-					StreamSupport.stream(Scopes.scopedElementsFor(DataTypeLibrary.getNonUserDefinedDataTypes(),
-							QualifiedName.wrapper(SimpleAttributeResolver.NAME_RESOLVER)).spliterator(), false),
-					Stream.of(ADDITIONAL_LITERAL_TYPES)).toList(), true);
+			return new SimpleScope(LITERAL_TYPES_DESCRIPTIONS, true);
 		}
 		if (reference == STCorePackage.Literals.ST_FEATURE_EXPRESSION__FEATURE) {
 			final var receiver = getReceiver(context);
@@ -168,12 +163,8 @@ public class STCoreScopeProvider extends AbstractSTCoreScopeProvider {
 		return super.getScope(context, reference);
 	}
 
-	protected static IScope scopeFor(final Iterable<? extends EObject> elements) {
-		return scopeFor(elements, IScope.NULLSCOPE);
-	}
-
-	protected static IScope scopeFor(final Iterable<? extends EObject> elements, final IScope parent) {
-		return new SimpleScope(parent, Scopes.scopedElementsFor(elements), true);
+	protected static IScope scopeForNonUserDefinedDataTypes(final IScope parent) {
+		return new SimpleScope(parent, NON_USER_DEFINED_TYPES_DESCRIPTIONS, true);
 	}
 
 	protected IScope qualifiedScope(final Iterable<? extends EObject> elements, final EReference reference) {
@@ -232,6 +223,10 @@ public class STCoreScopeProvider extends AbstractSTCoreScopeProvider {
 						&& !LibraryElementPackage.eINSTANCE.getEvent().isSuperTypeOf(clazz));
 	}
 
+	protected static boolean isAnyElementaryLiteral(final EReference reference) {
+		return ANY_ELEMENTARY_LITERAL_REFERENCES.contains(reference);
+	}
+
 	protected static STExpression getReceiver(final EObject context) {
 		if (context instanceof STFeatureExpression) {
 			return getReceiver(context.eContainer());
@@ -252,7 +247,11 @@ public class STCoreScopeProvider extends AbstractSTCoreScopeProvider {
 		return null;
 	}
 
-	protected static EObjectDescription descriptionForType(final String name, final DataType type) {
+	protected static IEObjectDescription descriptionForType(final DataType type) {
+		return new EObjectDescription(QualifiedName.create(type.getName()), type, null);
+	}
+
+	protected static IEObjectDescription descriptionForType(final String name, final DataType type) {
 		return new EObjectDescription(QualifiedName.create(name), type, null);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/scoping/STFunctionScopeProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/scoping/STFunctionScopeProvider.java
@@ -19,20 +19,23 @@ package org.eclipse.fordiac.ide.structuredtextfunctioneditor.scoping;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
-import org.eclipse.fordiac.ide.model.typelibrary.DataTypeLibrary;
 import org.eclipse.fordiac.ide.structuredtextfunctioneditor.stfunction.STFunction;
 import org.eclipse.fordiac.ide.structuredtextfunctioneditor.stfunction.STFunctionPackage;
 import org.eclipse.xtext.scoping.IScope;
 
-/** This class contains custom scoping description.
+/**
+ * This class contains custom scoping description.
  *
- * See https://www.eclipse.org/Xtext/documentation/303_runtime_concepts.html#scoping on how and when to use it. */
+ * See
+ * https://www.eclipse.org/Xtext/documentation/303_runtime_concepts.html#scoping
+ * on how and when to use it.
+ */
 public class STFunctionScopeProvider extends AbstractSTFunctionScopeProvider {
 	@Override
 	public IScope getScope(final EObject context, final EReference reference) {
 		if (reference == STFunctionPackage.Literals.ST_FUNCTION__RETURN_TYPE) {
 			final IScope globalScope = delegateGetScope(context, reference);
-			return scopeFor(DataTypeLibrary.getNonUserDefinedDataTypes(), globalScope);
+			return scopeForNonUserDefinedDataTypes(globalScope);
 		}
 		return super.getScope(context, reference);
 	}
@@ -40,7 +43,8 @@ public class STFunctionScopeProvider extends AbstractSTFunctionScopeProvider {
 	protected STFunction getFunction(final EObject context) {
 		if (context instanceof STFunction) {
 			return (STFunction) context;
-		} else if (context != null) {
+		}
+		if (context != null) {
 			return getFunction(context.eContainer());
 		}
 		return null;


### PR DESCRIPTION
The Xtext framework installs an adapter when getting qualified names of elements via the qualified name provider. This causes a race condition with the list of adapters for built-in data types in the ST editor.

This commit addresses the problem by directly providing the (qualified) name without going through the qualified name provider for global data types.