### PR TITLE
Created Participant class for copying Structs.

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.typemanagement/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/META-INF/MANIFEST.MF
@@ -32,6 +32,7 @@ Export-Package: org.eclipse.fordiac.ide.typemanagement,
  org.eclipse.fordiac.ide.typemanagement.navigator,
  org.eclipse.fordiac.ide.typemanagement.preferences,
  org.eclipse.fordiac.ide.typemanagement.refactoring,
+ org.eclipse.fordiac.ide.typemanagement.refactoring.copy,
  org.eclipse.fordiac.ide.typemanagement.refactoring.rename,
  org.eclipse.fordiac.ide.typemanagement.util,
  org.eclipse.fordiac.ide.typemanagement.wizards

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/plugin.xml
@@ -769,7 +769,65 @@
          </command>
       </menuContribution>
    </extension>
-       <extension
+<!--	<extension point="org.eclipse.ltk.core.refactoring.copyParticipants">
+    <copyParticipant
+          class="org.eclipse.fordiac.ide.typemanagement.refactoring.copy.CopyStructRefactoringParticipant"
+          id="org.eclipse.fordiac.ide.typemanagement.copyStruct"
+          name="Rename Structs handler">
+    	<enablement>
+            <and>
+				<instanceof 
+					value="org.eclipse.core.resources.IFile">
+                </instanceof>
+                <test
+					forcePluginActivation="true"
+                    property="org.eclipse.core.resources.extension"
+                    value="dtp">
+				</test>
+			</and>
+		</enablement>
+	</copyParticipant>
+	</extension>-->
+ <extension
+       point="org.eclipse.ltk.core.refactoring.copyParticipants">
+    <copyParticipant
+          class="org.eclipse.fordiac.ide.typemanagement.refactoring.copy.CopyStructRefactoringParticipant"
+          id="org.eclipse.fordiac.ide.typemanagement.copyStruct"
+          name="Copy Structs (.dtp) handler">
+       <enablement>
+          <and>
+             <instanceof
+                   value="org.eclipse.core.resources.IFile">
+             </instanceof>
+             <test
+                   forcePluginActivation="true"
+                   property="org.eclipse.core.resources.extension"
+                   value="dtp">
+             </test>
+          </and>
+       </enablement>
+    </copyParticipant>
+ </extension>
+ <extension
+       point="org.eclipse.ltk.core.refactoring.deleteParticipants">
+    <deleteParticipant
+          class="org.eclipse.fordiac.ide.typemanagement.refactoring.delete.TestDeleteParticipant"
+          id="org.eclipse.fordiac.ide.typemanagement.testDeleteX"
+          name="This a TeSt">
+       <enablement>
+          <and>
+             <instanceof
+                   value="org.eclipse.core.resources.IFile">
+             </instanceof>
+             <test
+                   forcePluginActivation="true"
+                   property="org.eclipse.core.resources.extension"
+                   value="dtp">
+             </test>
+          </and></enablement>
+    </deleteParticipant>
+ </extension>
+        <extension
              point="org.eclipse.ltk.core.refactoring.refactoringContributions">
-       </extension>   
+       </extension>>
 </plugin>

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/Messages.java
@@ -172,6 +172,8 @@ public final class Messages extends NLS {
 
 	public static String UpdateUntypedSubappPinChange_0;
 
+	public static String CopyStruct_Change_Name;
+
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/messages.properties
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/messages.properties
@@ -128,3 +128,4 @@ DeleteLibraryParticipant_Change_Title=Removing Library Dependency
 AddLibraryDependency_Change_Title=Adding Library Dependency
 SafeStructDeletionChange_RootNodeChangeText=Changes for occurrence: {0}{1}
 UpdateUntypedSubappPinChange_0=Pin is not part of untyped subapp
+CopyStruct_Change_Name=Change the name for a copied Struct with the same name

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/copy/CopyStructRefactoringParticipant.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/copy/CopyStructRefactoringParticipant.java
@@ -1,0 +1,45 @@
+package org.eclipse.fordiac.ide.typemanagement.refactoring.copy;
+
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.fordiac.ide.typemanagement.Messages;
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+import org.eclipse.ltk.core.refactoring.participants.CheckConditionsContext;
+import org.eclipse.ltk.core.refactoring.participants.CopyParticipant;
+
+public class CopyStructRefactoringParticipant extends CopyParticipant {
+
+	@Override
+	protected boolean initialize(final Object element) {
+		if (element instanceof final IFolder folder && ((IFolder) element).getName().endsWith(".dtp")) { //$NON-NLS-1$
+			System.out.println("True!");
+			return true;
+		}
+		System.out.println("False!");
+		return false;
+	}
+
+	@Override
+	public String getName() {
+		System.out.println("getName");
+		return Messages.CopyStruct_Change_Name;
+	}
+
+	@Override
+	public RefactoringStatus checkConditions(final IProgressMonitor pm, final CheckConditionsContext context)
+			throws OperationCanceledException {
+		System.out.println("checkConditions");
+		return null;
+	}
+
+	@Override
+	public Change createChange(final IProgressMonitor pm) throws CoreException, OperationCanceledException {
+		// TODO Auto-generated method stub
+		System.out.println("createChange");
+		return null;
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/delete/TestDeleteParticipant.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/delete/TestDeleteParticipant.java
@@ -1,0 +1,37 @@
+package org.eclipse.fordiac.ide.typemanagement.refactoring.delete;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+import org.eclipse.ltk.core.refactoring.participants.CheckConditionsContext;
+import org.eclipse.ltk.core.refactoring.participants.DeleteParticipant;
+
+public class TestDeleteParticipant extends DeleteParticipant {
+
+	@Override
+	protected boolean initialize(final Object element) {
+		return false;
+	}
+
+	@Override
+	public String getName() {
+		// TODO Auto-generated method stub
+		return "";
+	}
+
+	@Override
+	public RefactoringStatus checkConditions(final IProgressMonitor pm, final CheckConditionsContext context)
+			throws OperationCanceledException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Change createChange(final IProgressMonitor pm) throws CoreException, OperationCanceledException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+}


### PR DESCRIPTION
Changed Manifest (since my participant did not work (added the path))
Created second, deleteParticipant for testing, which worked Edited Messages and its properties for getName() (ignore that) All in All CopyStructRefactoringParticipant is not really implemented, but 1 of the 2 sysouts should trigger, which doesn't