### PR TITLE
Fix editor updates for transitive notifications in type entry

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
@@ -320,22 +320,18 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 					setTypeEditable(null);
 				}
 
-				if (notification.getNewValue() != null && notification.getOldValue() != null) {
-					// if there is an editor opened then this notification will be delegated to the
-					// corresponding editor.
-					// If not, then nothing will happen
-					delagateNotifiactionToEditor(notification);
-				}
-
+				// if there is an editor opened then this notification will be delegated to the
+				// corresponding editor.
+				// If not, then nothing will happen
+				delegateNotificationToEditor(notification);
 			}
 		}
 	}
 
-	private void delagateNotifiactionToEditor(final Notification notification) {
-		if (eNotificationRequired() && notification.getNewValue() instanceof final LibraryElement element) {
+	private void delegateNotificationToEditor(final Notification notification) {
+		if (eNotificationRequired()) {
 			eNotify(new TypeEntryNotificationImpl(this, Notification.SET,
-					TypeEntry.TYPE_ENTRY_EDITOR_INSTANCE_UPDATE_FEATURE, notification.getOldValue(),
-					element.getTypeEntry()));
+					TypeEntry.TYPE_ENTRY_EDITOR_INSTANCE_UPDATE_FEATURE, null, notification.getNotifier()));
 		}
 	}
 


### PR DESCRIPTION
For transitive notifications of changed types, either the old or new value is usually null. This resulted in no notification being sent to the editor. The editor update should also get the changed type entry from the notification instead of indirectly via the type entry of the new value.