### PR TITLE
add buttons for "Cancel All" and "Overwrite All" to the export

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/ExportException.java
+++ b/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/ExportException.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2009 Profactor GmbH
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -23,11 +23,41 @@ public class ExportException extends Exception {
 
 	/**
 	 * Instantiates a new export exception.
-	 * 
+	 *
 	 * @param message the message
 	 */
 	public ExportException(final String message) {
 		super(message);
+	}
+
+	public static class UserInteraction extends ExportException {
+
+		private static final long serialVersionUID = 1L;
+
+		public UserInteraction(final String message) {
+			super(message);
+		}
+
+	}
+
+	public static class OverwriteAll extends UserInteraction {
+
+		private static final long serialVersionUID = 1L;
+
+		public OverwriteAll() {
+			super(Messages.TemplateExportFilter_OVERWRITE_ALL_LABEL_STRING);
+		}
+
+	}
+
+	public static class CancelAll extends UserInteraction {
+
+		private static final long serialVersionUID = 1L;
+
+		public CancelAll() {
+			super(Messages.TemplateExportFilter_OVERWRITE_ALL_LABEL_STRING);
+		}
+
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/Messages.java
@@ -26,6 +26,8 @@ public final class Messages extends NLS {
 
 	public static String ExportTemplate_ExportTemplate;
 
+	public static String TemplateExportFilter_CANCEL_ALL_LABEL_STRING;
+
 	public static String TemplateExportFilter_ErrorDuringTemplateGeneration;
 
 	public static String TemplateExportFilter_FILE_EXISTS;
@@ -49,6 +51,8 @@ public final class Messages extends NLS {
 	public static String TemplateExportFilter_OVERWRITE_REQUEST;
 
 	public static String TemplateExportFilter_PREFIX_ERRORMESSAGE_WITH_TYPENAME;
+
+	public static String TemplateExportFilter_OVERWRITE_ALL_LABEL_STRING;
 
 	static {
 		// initialize resource bundle

--- a/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/messages.properties
+++ b/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/messages.properties
@@ -14,6 +14,7 @@
  
 ExportTemplate_ExportTemplate=ExportTemplate [{0}]
 
+TemplateExportFilter_CANCEL_ALL_LABEL_STRING=Cancel All
 TemplateExportFilter_ErrorDuringTemplateGeneration=Error during template generation
 TemplateExportFilter_FILE_EXISTS=File Exists
 TemplateExportFilter_FILE_IGNORED=File was ignored during export.
@@ -26,3 +27,4 @@ TemplateExportFilter_MERGE_LABEL_STRING=Merge
 TemplateExportFilter_OVERWRITE_LABEL_STRING=Overwrite
 TemplateExportFilter_OVERWRITE_REQUEST=Overwrite {0}?\nMerge will create a backup of the original file and open an editor to merge the files manually\!
 TemplateExportFilter_PREFIX_ERRORMESSAGE_WITH_TYPENAME={0}: {1}
+TemplateExportFilter_OVERWRITE_ALL_LABEL_STRING=Overwrite All


### PR DESCRIPTION
When exporting big projects and the checkbox for overwriting without asking is not selected a dialog is opened for every exported type without a quick way to abort