### PR TITLE
Workaround for issue : Copying structs to other folder creates 2 identical structs

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/Messages.java
@@ -24,6 +24,8 @@ public final class Messages extends NLS {
 	public static String FordiacResourceChangeListener_4;
 	public static String FordiacResourceChangeListener_7;
 	public static String FordiacResourceChangeListener_UpdateTypeLibForNewProject;
+	public static String FordiacResourceChangeListener_CopyConflictTitle;
+	public static String FordiacResourceChangeListener_CopyConflictBody;
 	public static String ValidateTypeLibrary;
 
 	static {

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/changelistener/ExcludedElements.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/changelistener/ExcludedElements.java
@@ -1,0 +1,19 @@
+package org.eclipse.fordiac.ide.systemmanagement.changelistener;
+
+import java.util.List;
+
+public class ExcludedElements {
+	private static final List<String> paths = List.of("MANIFEST.MF"); //$NON-NLS-1$
+
+	public static boolean contains(final String pathToString) {
+		if (paths.contains(pathToString)) {
+			return true;
+		}
+		return false;
+	}
+
+	public static String stringRep() {
+		return paths.toString();
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/changelistener/ExcludedElements.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/changelistener/ExcludedElements.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Johannes Kepler University Linz
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Paul Stemmer - initial API and implementation and/or initial documentation
+ *******************************************************************************/
 package org.eclipse.fordiac.ide.systemmanagement.changelistener;
 
 import java.util.List;

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/changelistener/FordiacResourceChangeListener.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/changelistener/FordiacResourceChangeListener.java
@@ -271,7 +271,7 @@ public class FordiacResourceChangeListener implements IResourceChangeListener {
 			if (typeEntryForFile == null) {
 				final TypeEntry entry = typeLib.createTypeEntry(file);
 
-				if (fileExists(file, delta) && file.getName().endsWith(".dtp")) { //$NON-NLS-1$
+				if (file.getName().endsWith(".dtp") && file.exists()) { //$NON-NLS-1$
 					Display.getDefault().asyncExec(() -> {
 						final Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
 						final InputDialog renameDialog = new InputDialog(shell,
@@ -317,13 +317,6 @@ public class FordiacResourceChangeListener implements IResourceChangeListener {
 				filesToRename.add(new FileToRenameEntry(file, typeEntryForFile));
 			}
 		}
-	}
-
-	private static boolean fileExists(final IFile file, final IResourceDelta delta) {
-		if (delta.getResource().getName().equals(file.getName())) {
-			return true;
-		}
-		return false;
 	}
 
 	private static void autoRenameExistingType(final FileToRenameEntry entry) {

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/changelistener/FordiacResourceChangeListener.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/changelistener/FordiacResourceChangeListener.java
@@ -319,16 +319,9 @@ public class FordiacResourceChangeListener implements IResourceChangeListener {
 		}
 	}
 
-	private boolean fileExists(final IFile file, final IResourceDelta delta) {
+	private static boolean fileExists(final IFile file, final IResourceDelta delta) {
 		if (delta.getResource().getName().equals(file.getName())) {
 			return true;
-		}
-
-		final IResourceDelta[] affectedChildren = delta.getAffectedChildren();
-		for (final IResourceDelta childDelta : affectedChildren) {
-			if (fileExists(file, childDelta)) {
-				return true;
-			}
 		}
 		return false;
 	}

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/messages.properties
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/messages.properties
@@ -19,5 +19,7 @@ AutomationSystemEditor_Overwrite_Changes=Overwrite local changes with "my" chang
 FordiacResourceChangeListener_4=Check copied type file:  
 FordiacResourceChangeListener_7=Save renamed system:
 FordiacResourceChangeListener_UpdateTypeLibForNewProject=Update type library for project {0}
+FordiacResourceChangeListener_CopyConflictTitle=Name Conflict
+FordiacResourceChangeListener_CopyConflictBody=Enter a new name for '
 ValidateTypeLibrary=Validate Type Library 
 


### PR DESCRIPTION
This workaround creates a separate window, when a struct is copied and pasted with the same name. If the window gets closed without changes, the copied file will get deleted.