### PR TITLE
Enable seamless drag-and-drop between graphical editors

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/dnd/CustomDragSourceListener.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/dnd/CustomDragSourceListener.java
@@ -50,7 +50,7 @@ public class CustomDragSourceListener extends AbstractTransferDragSourceListener
 	public void dragStart(final DragSourceEvent event) {
 		final Request req = createRequest(new Point(event.x, event.y));
 
-		if (!isAltKeyPressed() || req == null) {
+		if (req == null) {
 			event.doit = false;
 			lastReq = null;
 			return;
@@ -69,13 +69,6 @@ public class CustomDragSourceListener extends AbstractTransferDragSourceListener
 		super.dragFinished(event);
 		CustomSourceTransfer.getInstance().setObject(null);
 		lastReq = null;
-	}
-
-	private boolean isAltKeyPressed() {
-		final AdvancedGraphicalViewerKeyHandler keyHandler = (AdvancedGraphicalViewerKeyHandler) getViewer()
-				.getKeyHandler();
-
-		return (keyHandler.getCurrentStateMask() & SWT.ALT) != 0;
 	}
 
 	private boolean isCtrlKeyPressed() {

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/dnd/CustomDragTargetListener.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/dnd/CustomDragTargetListener.java
@@ -24,12 +24,40 @@ import org.eclipse.gef.dnd.AbstractTransferDropTargetListener;
 import org.eclipse.gef.requests.ChangeBoundsRequest;
 import org.eclipse.gef.requests.CreateConnectionRequest;
 import org.eclipse.gef.requests.ReconnectRequest;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.dnd.DND;
+import org.eclipse.swt.dnd.DropTarget;
+import org.eclipse.swt.dnd.DropTargetEvent;
+import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.widgets.Event;
 
 public class CustomDragTargetListener extends AbstractTransferDropTargetListener {
 
 	public CustomDragTargetListener(final EditPartViewer viewer) {
 		super(viewer, CustomSourceTransfer.getInstance());
-		setEnablementDeterminedByCommand(true);
+	}
+
+	@Override
+	public void handleDragOver() {
+		super.handleDragOver();
+		// forward dragOver events as mouse events to enable tool movement
+		getViewer().getEditDomain().mouseDrag(toMouseEvent(getCurrentEvent()), getViewer());
+	}
+
+	@Override
+	protected void handleDrop() {
+		super.handleDrop();
+		if (getCurrentEvent().detail == DND.DROP_NONE) {
+			// if no drop is possible
+			// forward drop events as mouse events to enable tool execution
+			getViewer().getEditDomain().mouseUp(toMouseEvent(getCurrentEvent()), getViewer());
+		}
+	}
+
+	@Override
+	public boolean isEnabled(final DropTargetEvent event) {
+		return true; // always enabled to get dragOver events
 	}
 
 	@Override
@@ -74,4 +102,15 @@ public class CustomDragTargetListener extends AbstractTransferDropTargetListener
 		}
 	}
 
+	protected static MouseEvent toMouseEvent(final DropTargetEvent event) {
+		final Event swtEvent = new Event();
+		swtEvent.display = event.display;
+		swtEvent.widget = event.widget;
+		swtEvent.type = SWT.MouseMove;
+		swtEvent.item = event.item;
+		final Point relativePoint = ((DropTarget) event.widget).getControl().toControl(new Point(event.x, event.y));
+		swtEvent.x = relativePoint.x;
+		swtEvent.y = relativePoint.y;
+		return new MouseEvent(swtEvent);
+	}
 }


### PR DESCRIPTION
This is currently a rough proof of concept. It is based on the idea of always performing drag-and-drop and forwarding `DragOver` events as `MouseEvent`s to GEF to enable the GEF tools to work correctly when inside the current editor.