### PR TITLE
Enable seamless connections between graphical editors

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/tools/AdvancedPanningSelectionTool.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/tools/AdvancedPanningSelectionTool.java
@@ -134,7 +134,8 @@ public class AdvancedPanningSelectionTool extends SelectionTool {
 	protected boolean handleDrag() {
 		if (isInState(PAN_IN_PROGRESS) && (getCurrentViewer().getControl() instanceof FigureCanvas)) {
 			final FigureCanvas canvas = (FigureCanvas) getCurrentViewer().getControl();
-			canvas.scrollTo(viewLocation.x - getDragMoveDelta().width, viewLocation.y - getDragMoveDelta().height);
+			// canvas.scrollTo(viewLocation.x - getDragMoveDelta().width, viewLocation.y -
+			// getDragMoveDelta().height);
 			return true;
 		}
 		return super.handleDrag();


### PR DESCRIPTION
This is currently a rough proof of concept. It attempts to find the target in another editor based on the current mouse position. There are some missing checks and only normal connection dragging (without modifiers) works so far. The connection feedback also does not work at the moment.
