### PR TITLE
Enable seamless connections between graphical editors

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editors/FBNetworkEditDomain.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editors/FBNetworkEditDomain.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Martin Erich Jobst
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Martin Jobst - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.application.editors;
+
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import org.eclipse.gef.DefaultEditDomain;
+import org.eclipse.gef.EditPartViewer;
+import org.eclipse.gef.GraphicalViewer;
+import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.PlatformUI;
+
+public class FBNetworkEditDomain extends DefaultEditDomain {
+
+	public FBNetworkEditDomain(final IEditorPart editorPart) {
+		super(editorPart);
+	}
+
+	@Override
+	public void mouseUp(final MouseEvent me, final EditPartViewer viewer) {
+		final EditPartViewer actualViewer = findViewer(new Point(me.x, me.y), viewer);
+		final MouseEvent convertedEvent = convertMouseEventCoordinates(me, viewer, actualViewer);
+		super.mouseUp(convertedEvent, actualViewer);
+	}
+
+	@Override
+	public void mouseMove(final MouseEvent me, final EditPartViewer viewer) {
+		final EditPartViewer actualViewer = findViewer(new Point(me.x, me.y), viewer);
+		final MouseEvent convertedEvent = convertMouseEventCoordinates(me, viewer, actualViewer);
+		super.mouseMove(convertedEvent, actualViewer);
+	}
+
+	@Override
+	public void mouseDrag(final MouseEvent me, final EditPartViewer viewer) {
+		final EditPartViewer actualViewer = findViewer(new Point(me.x, me.y), viewer);
+		final MouseEvent convertedEvent = convertMouseEventCoordinates(me, viewer, actualViewer);
+		super.mouseDrag(convertedEvent, actualViewer);
+	}
+
+	private static EditPartViewer findViewer(final Point point, final EditPartViewer viewer) {
+		if (viewer.getControl().getBounds().contains(point)) {
+			return viewer;
+		}
+		final Point absolute = viewer.getControl().toDisplay(point);
+		return Stream.of(PlatformUI.getWorkbench().getWorkbenchWindows())
+				.flatMap(window -> Stream.of(window.getPages())).flatMap(page -> Stream.of(page.getEditorReferences()))
+				.map(ref -> ref.getEditor(false)).filter(Objects::nonNull)
+				.<EditPartViewer>map(editor -> editor.getAdapter(GraphicalViewer.class)).filter(Objects::nonNull)
+				.filter(candidate -> containsAbsolutePoint(candidate, absolute)).findAny().orElse(viewer);
+	}
+
+	private static boolean containsAbsolutePoint(final EditPartViewer viewer, final Point point) {
+		final Control control = viewer.getControl();
+		if (control.getParent() != null) {
+			return control.getBounds().contains(control.getParent().toControl(point));
+		}
+		return control.getBounds().contains(point);
+	}
+
+	private static MouseEvent convertMouseEventCoordinates(final MouseEvent event, final EditPartViewer from,
+			final EditPartViewer to) {
+		if (from == to) {
+			return event;
+		}
+		final Point converted = to.getControl().toControl(from.getControl().toDisplay(event.x, event.y));
+		final Event swtEvent = new Event();
+		swtEvent.display = event.display;
+		swtEvent.widget = event.widget;
+		swtEvent.time = event.time;
+		swtEvent.data = event.data;
+		swtEvent.x = converted.x;
+		swtEvent.y = converted.y;
+		swtEvent.button = event.button;
+		swtEvent.stateMask = event.stateMask;
+		swtEvent.count = event.count;
+		return new MouseEvent(swtEvent);
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editors/FBNetworkEditDomain.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editors/FBNetworkEditDomain.java
@@ -46,6 +46,13 @@ public class FBNetworkEditDomain extends DefaultEditDomain {
 	}
 
 	@Override
+	public void mouseHover(final MouseEvent me, final EditPartViewer viewer) {
+		final EditPartViewer actualViewer = findViewer(new Point(me.x, me.y), viewer);
+		final MouseEvent convertedEvent = convertMouseEventCoordinates(me, viewer, actualViewer);
+		super.mouseHover(convertedEvent, actualViewer);
+	}
+
+	@Override
 	public void mouseDrag(final MouseEvent me, final EditPartViewer viewer) {
 		final EditPartViewer actualViewer = findViewer(new Point(me.x, me.y), viewer);
 		final MouseEvent convertedEvent = convertMouseEventCoordinates(me, viewer, actualViewer);

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editors/FBNetworkEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editors/FBNetworkEditor.java
@@ -46,6 +46,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
 import org.eclipse.fordiac.ide.model.ui.actions.Open4DIACElementAction;
 import org.eclipse.gef.ContextMenuProvider;
+import org.eclipse.gef.DefaultEditDomain;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartFactory;
 import org.eclipse.gef.LayerConstants;
@@ -119,6 +120,11 @@ public class FBNetworkEditor extends DiagramEditorWithFlyoutPalette {
 
 	protected TypeLibrary getTypeLibrary() {
 		return getSystem().getTypeLibrary();
+	}
+
+	@Override
+	protected DefaultEditDomain createEditDomain() {
+		return new FBNetworkEditDomain(this);
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/FBNetworkRootEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/FBNetworkRootEditPart.java
@@ -23,8 +23,10 @@ import java.util.stream.Collectors;
 
 import org.eclipse.fordiac.ide.gef.editparts.ZoomScalableFreeformRootEditPart;
 import org.eclipse.fordiac.ide.gef.tools.AdvancedMarqueeDragTracker;
+import org.eclipse.fordiac.ide.gef.tools.FordiacViewportAutoexposeHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
+import org.eclipse.gef.AutoexposeHelper;
 import org.eclipse.gef.DragTracker;
 import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.Request;
@@ -64,6 +66,9 @@ public class FBNetworkRootEditPart extends ZoomScalableFreeformRootEditPart {
 
 	@Override
 	public <T> T getAdapter(final Class<T> adapter) {
+		if (adapter == AutoexposeHelper.class) {
+			return adapter.cast(new FordiacViewportAutoexposeHelper(this));
+		}
 		if (adapter == FBNetwork.class) {
 			return adapter.cast(fbNetwork);
 		}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/tools/FBNetworkPanningSelectionTool.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/tools/FBNetworkPanningSelectionTool.java
@@ -29,6 +29,8 @@ package org.eclipse.fordiac.ide.application.tools;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 import org.eclipse.fordiac.ide.application.editparts.ConnectionEditPart;
 import org.eclipse.fordiac.ide.gef.editparts.InterfaceEditPart;
@@ -37,11 +39,16 @@ import org.eclipse.fordiac.ide.gef.tools.InlineConnectionCreationTool;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartViewer;
+import org.eclipse.gef.GraphicalViewer;
 import org.eclipse.gef.RequestConstants;
 import org.eclipse.gef.requests.SelectionRequest;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.ui.PlatformUI;
 
 public class FBNetworkPanningSelectionTool extends AdvancedPanningSelectionTool {
 
@@ -67,13 +74,15 @@ public class FBNetworkPanningSelectionTool extends AdvancedPanningSelectionTool 
 
 	@Override
 	public void mouseUp(final MouseEvent me, final EditPartViewer viewer) {
+		final EditPartViewer actualViewer = findViewer(new Point(me.x, me.y), viewer);
+		final MouseEvent convertedEvent = convertMouseEventCoordinates(me, viewer, actualViewer);
 		if (checkConnCreationState(me.stateMask)) {
-			connectionCreationTool.mouseUp(me, viewer);
+			connectionCreationTool.mouseUp(convertedEvent, actualViewer);
 		} else {
 			if (LEFT_MOUSE == me.button) {
 				lastLeftClick = getLocation();
 			}
-			super.mouseUp(me, viewer);
+			super.mouseUp(convertedEvent, actualViewer);
 		}
 	}
 
@@ -100,9 +109,23 @@ public class FBNetworkPanningSelectionTool extends AdvancedPanningSelectionTool 
 	public void mouseMove(final MouseEvent me, final EditPartViewer viewer) {
 		// the super call has to be first so that the target editpart is updated
 		// accordingly
-		super.mouseMove(me, viewer);
+		final EditPartViewer actualViewer = findViewer(new Point(me.x, me.y), viewer);
+		final MouseEvent convertedEvent = convertMouseEventCoordinates(me, viewer, actualViewer);
+		super.mouseMove(convertedEvent, actualViewer);
 		if (checkConnCreationState(me.stateMask)) {
-			connectionCreationTool.mouseDrag(me, viewer);
+			connectionCreationTool.mouseMove(convertedEvent, actualViewer);
+		}
+	}
+
+	@Override
+	public void mouseDrag(final MouseEvent me, final EditPartViewer viewer) {
+		// the super call has to be first so that the target editpart is updated
+		// accordingly
+		final EditPartViewer actualViewer = findViewer(new Point(me.x, me.y), viewer);
+		final MouseEvent convertedEvent = convertMouseEventCoordinates(me, viewer, actualViewer);
+		super.mouseDrag(convertedEvent, actualViewer);
+		if (checkConnCreationState(me.stateMask)) {
+			connectionCreationTool.mouseDrag(convertedEvent, actualViewer);
 		}
 	}
 
@@ -174,4 +197,42 @@ public class FBNetworkPanningSelectionTool extends AdvancedPanningSelectionTool 
 		return (targetEditPart != null) && (targetEditPart.getModel() instanceof IInterfaceElement);
 	}
 
+	private static EditPartViewer findViewer(final Point point, final EditPartViewer viewer) {
+		if (viewer.getControl().getBounds().contains(point)) {
+			return viewer;
+		}
+		final Point absolute = viewer.getControl().toDisplay(point);
+		return Stream.of(PlatformUI.getWorkbench().getWorkbenchWindows())
+				.flatMap(window -> Stream.of(window.getPages())).flatMap(page -> Stream.of(page.getEditorReferences()))
+				.map(ref -> ref.getEditor(false)).filter(Objects::nonNull)
+				.<EditPartViewer>map(editor -> editor.getAdapter(GraphicalViewer.class)).filter(Objects::nonNull)
+				.filter(candidate -> containsAbsolutePoint(candidate, absolute)).findAny().orElse(viewer);
+	}
+
+	private static boolean containsAbsolutePoint(final EditPartViewer viewer, final Point point) {
+		final Control control = viewer.getControl();
+		if (control.getParent() != null) {
+			return control.getBounds().contains(control.getParent().toControl(point));
+		}
+		return control.getBounds().contains(point);
+	}
+
+	private static MouseEvent convertMouseEventCoordinates(final MouseEvent event, final EditPartViewer from,
+			final EditPartViewer to) {
+		if (from == to) {
+			return event;
+		}
+		final Point converted = to.getControl().toControl(from.getControl().toDisplay(event.x, event.y));
+		final Event swtEvent = new Event();
+		swtEvent.display = event.display;
+		swtEvent.widget = event.widget;
+		swtEvent.time = event.time;
+		swtEvent.data = event.data;
+		swtEvent.x = converted.x;
+		swtEvent.y = converted.y;
+		swtEvent.button = event.button;
+		swtEvent.stateMask = event.stateMask;
+		swtEvent.count = event.count;
+		return new MouseEvent(swtEvent);
+	}
 }

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editparts/ECCRootEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editparts/ECCRootEditPart.java
@@ -22,8 +22,10 @@ import org.eclipse.emf.common.notify.Notifier;
 import org.eclipse.emf.common.notify.impl.AdapterImpl;
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.policies.ECCXYLayoutEditPolicy;
 import org.eclipse.fordiac.ide.gef.editparts.AbstractDiagramEditPart;
+import org.eclipse.fordiac.ide.gef.tools.FordiacViewportAutoexposeHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.ECC;
 import org.eclipse.fordiac.ide.model.libraryElement.ECState;
+import org.eclipse.gef.AutoexposeHelper;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.editpolicies.RootComponentEditPolicy;
 
@@ -54,6 +56,14 @@ public class ECCRootEditPart extends AbstractDiagramEditPart {
 			super.deactivate();
 			((Notifier) getModel()).eAdapters().remove(getContentAdapter());
 		}
+	}
+
+	@Override
+	public <T> T getAdapter(final Class<T> key) {
+		if (key == AutoexposeHelper.class) {
+			return key.cast(new FordiacViewportAutoexposeHelper(this));
+		}
+		return super.getAdapter(key);
 	}
 
 	/**

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/tools/AdvancedMarqueeDragTracker.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/tools/AdvancedMarqueeDragTracker.java
@@ -59,6 +59,8 @@ public class AdvancedMarqueeDragTracker extends MarqueeDragTracker {
 		}
 	}
 
+	private EditPartViewer startingViewer;
+
 	@Override
 	protected boolean handleButtonDown(final int button) {
 		if (3 == button && getCurrentViewer() != null) {
@@ -74,11 +76,28 @@ public class AdvancedMarqueeDragTracker extends MarqueeDragTracker {
 	}
 
 	@Override
+	protected EditPartViewer getCurrentViewer() {
+		// use the viewer in which the selection started as this is where the feedback
+		// figure is located
+		if (startingViewer != null) {
+			return startingViewer;
+		}
+		return super.getCurrentViewer();
+	}
+
+	@Override
 	public void mouseDown(final MouseEvent me, final EditPartViewer viewer) {
 		if (viewer instanceof final AdvancedScrollingGraphicalViewer advScrollingGraphicalViewer) {
 			CanvasHelper.bindToContentPane(me, advScrollingGraphicalViewer, MARQUEE_DRAG_BORDER);
 		}
+		startingViewer = viewer;
 		super.mouseDown(me, viewer);
+	}
+
+	@Override
+	public void mouseUp(final MouseEvent me, final EditPartViewer viewer) {
+		super.mouseUp(me, startingViewer);
+		startingViewer = null;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/tools/AdvancedPanningSelectionTool.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/tools/AdvancedPanningSelectionTool.java
@@ -135,7 +135,8 @@ public class AdvancedPanningSelectionTool extends SelectionTool {
 	protected boolean handleDrag() {
 		if (isInState(PAN_IN_PROGRESS) && (getCurrentViewer().getControl() instanceof FigureCanvas)) {
 			final FigureCanvas canvas = (FigureCanvas) getCurrentViewer().getControl();
-			canvas.scrollTo(viewLocation.x - getDragMoveDelta().width, viewLocation.y - getDragMoveDelta().height);
+			// canvas.scrollTo(viewLocation.x - getDragMoveDelta().width, viewLocation.y -
+			// getDragMoveDelta().height);
 			return true;
 		}
 		return super.handleDrag();

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/tools/FordiacConnectionDragCreationTool.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/tools/FordiacConnectionDragCreationTool.java
@@ -15,13 +15,11 @@
 package org.eclipse.fordiac.ide.gef.tools;
 
 import org.eclipse.draw2d.geometry.Insets;
-import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.fordiac.ide.gef.figures.HideableConnection;
 import org.eclipse.fordiac.ide.gef.router.MoveableRouter;
 import org.eclipse.fordiac.ide.model.commands.create.AbstractConnectionCreateCommand;
 import org.eclipse.fordiac.ide.model.ui.editors.AdvancedScrollingGraphicalViewer;
 import org.eclipse.fordiac.ide.ui.UIPlugin;
-import org.eclipse.fordiac.ide.ui.preferences.ConnectionPreferenceValues;
 import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.tools.ConnectionDragCreationTool;
@@ -51,13 +49,26 @@ public class FordiacConnectionDragCreationTool extends ConnectionDragCreationToo
 	@Override
 	public void mouseDrag(final MouseEvent me, final EditPartViewer viewer) {
 		if (isActive() && viewer instanceof final AdvancedScrollingGraphicalViewer advViewer) {
-			advViewer.checkScrollPositionDuringDragBounded(me,
-					new Point(MoveableRouter.MIN_CONNECTION_FB_DISTANCE_SCREEN
-							+ HideableConnection.BEND_POINT_BEVEL_SIZE + ConnectionPreferenceValues.HANDLE_SIZE,
-							ConnectionPreferenceValues.HANDLE_SIZE));
-			CanvasHelper.bindToContentPane(me, advViewer, NEW_CONNECTION_CANVAS_BORDER);
+//			advViewer.checkScrollPositionDuringDragBounded(me,
+//					new Point(MoveableRouter.MIN_CONNECTION_FB_DISTANCE_SCREEN
+//							+ HideableConnection.BEND_POINT_BEVEL_SIZE + ConnectionPreferenceValues.HANDLE_SIZE,
+//							ConnectionPreferenceValues.HANDLE_SIZE));
+//			CanvasHelper.bindToContentPane(me, advViewer, NEW_CONNECTION_CANVAS_BORDER);
 		}
 		super.mouseDrag(me, viewer);
+	}
+
+	@Override
+	protected boolean handleMove() {
+		// overwritten to disable viewer check
+		if (isInState(STATE_CONNECTION_STARTED | STATE_INITIAL | STATE_ACCESSIBLE_DRAG_IN_PROGRESS)) {
+			updateTargetRequest();
+			updateTargetUnderMouse();
+			showSourceFeedback();
+			showTargetFeedback();
+			setCurrentCommand(getCommand());
+		}
+		return true;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/tools/FordiacViewportAutoexposeHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/tools/FordiacViewportAutoexposeHelper.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Martin Erich Jobst
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Martin Jobst - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.gef.tools;
+
+import org.eclipse.draw2d.PositionConstants;
+import org.eclipse.draw2d.Viewport;
+import org.eclipse.draw2d.geometry.Insets;
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.GraphicalEditPart;
+import org.eclipse.gef.editparts.ViewportAutoexposeHelper;
+
+public class FordiacViewportAutoexposeHelper extends ViewportAutoexposeHelper {
+
+	private static final Insets DEFAULT_EXPOSE_THRESHOLD = new Insets(100);
+
+	private long lastStepTime = 0;
+
+	private final Insets threshold;
+
+	public FordiacViewportAutoexposeHelper(final GraphicalEditPart owner) {
+		this(owner, DEFAULT_EXPOSE_THRESHOLD);
+	}
+
+	public FordiacViewportAutoexposeHelper(final GraphicalEditPart owner, final Insets threshold) {
+		super(owner, threshold);
+		this.threshold = threshold;
+	}
+
+	@Override
+	public boolean step(final Point where) {
+		final Viewport port = findViewport(owner);
+
+		final Rectangle rect = Rectangle.SINGLETON;
+		port.getClientArea(rect);
+		port.translateToParent(rect);
+		port.translateToAbsolute(rect);
+		if (!rect.contains(where)) {
+			return false;
+		}
+
+		rect.shrink(threshold);
+
+		if (rect.contains(where)) {
+			return false;
+		}
+
+		if (lastStepTime == 0) {
+			lastStepTime = System.currentTimeMillis();
+		}
+
+		final long difference = System.currentTimeMillis() - lastStepTime;
+
+		if (difference < 0) {
+			return true;
+		}
+
+		lastStepTime = System.currentTimeMillis();
+
+		final int region = rect.getPosition(where);
+		final Point loc = port.getViewLocation();
+
+		if ((region & PositionConstants.SOUTH) != 0) {
+			loc.y += (int) difference * (where.y() - rect.bottom()) / threshold.bottom;
+		} else if ((region & PositionConstants.NORTH) != 0) {
+			loc.y += (int) difference * (where.y() - rect.top()) / threshold.top;
+		}
+
+		if ((region & PositionConstants.EAST) != 0) {
+			loc.x += (int) difference * (where.x() - rect.right()) / threshold.right;
+		} else if ((region & PositionConstants.WEST) != 0) {
+			loc.x += (int) difference * (where.x() - rect.left()) / threshold.left;
+		}
+
+		port.setViewLocation(loc);
+		return true;
+	}
+}


### PR DESCRIPTION
This is currently a rough proof of concept. It attempts to find the target in another editor based on the current mouse position and then feed that as a converted mouse event to the tool implementation. There are some missing checks and connection feedback does not work at the moment.
