### PR TITLE
Merge 3.0.x in freeze

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/LibraryManager.java
+++ b/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/LibraryManager.java
@@ -940,7 +940,8 @@ public enum LibraryManager {
 	 */
 	private static LibraryRecord getLibraryRecord(final Map<String, List<LibraryRecord>> libs,
 			final String symbolicName, final Version version) {
-		return libs.get(symbolicName).stream().filter(l -> l.version().equals(version)).findFirst().orElse(null);
+		return libs.getOrDefault(symbolicName, Collections.emptyList()).stream()
+				.filter(l -> l.version().equals(version)).findFirst().orElse(null);
 	}
 
 	/**


### PR DESCRIPTION
Fix null pointer caused by non-existing library
The case of a fixed version also needs to be considered