### PR TITLE
Fix result type of comparison with missing operand types in ST editor

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/ExpressionAnnotations.xtend
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/ExpressionAnnotations.xtend
@@ -76,39 +76,41 @@ final package class ExpressionAnnotations {
 	def package static INamedElement getDeclaredResultType(STBinaryExpression expr) { getResultType(expr, true) }
 
 	def package static INamedElement getResultType(STBinaryExpression expr, boolean declared) {
-		val left = declared ? expr.left?.declaredResultType : expr.left?.resultType
-		val right = declared ? expr.right?.declaredResultType : expr.right?.resultType
-		if (left instanceof DataType) {
-			if (right instanceof DataType) {
-				if (expr.op.arithmetic || expr.op.logical) {
-					if (left instanceof AnyDurationType && right instanceof AnyNumType)
-						left
-					else if (left instanceof AnyDateType && right instanceof TimeType)
-						left
-					else if (left instanceof AnyDateType && right instanceof LtimeType)
-						left.equivalentAnyLDateType
-					else if (left.instanceofAnySDateType && right.instanceofAnySDateType)
-						ElementaryTypes.TIME
-					else if (left instanceof AnyDateType && right instanceof AnyDateType)
-						ElementaryTypes.LTIME
-					else if (left.isAssignableFrom(right))
-						left
-					else if (right.isAssignableFrom(left))
-						right
-					else
+		if (expr.op.comparison)
+			ElementaryTypes.BOOL // always return BOOL for comparison
+		else {
+			val left = declared ? expr.left?.declaredResultType : expr.left?.resultType
+			val right = declared ? expr.right?.declaredResultType : expr.right?.resultType
+			if (left instanceof DataType) {
+				if (right instanceof DataType) {
+					if (expr.op.arithmetic || expr.op.logical) {
+						if (left instanceof AnyDurationType && right instanceof AnyNumType)
+							left
+						else if (left instanceof AnyDateType && right instanceof TimeType)
+							left
+						else if (left instanceof AnyDateType && right instanceof LtimeType)
+							left.equivalentAnyLDateType
+						else if (left.instanceofAnySDateType && right.instanceofAnySDateType)
+							ElementaryTypes.TIME
+						else if (left instanceof AnyDateType && right instanceof AnyDateType)
+							ElementaryTypes.LTIME
+						else if (left.isAssignableFrom(right))
+							left
+						else if (right.isAssignableFrom(left))
+							right
+						else
+							null
+					} else
 						null
-				} else if (expr.op.comparison)
-					ElementaryTypes.BOOL
+				} else if (declared)
+					left // if looking for declared result type and right is null/invalid, propagate left
 				else
 					null
-			} else if (declared)
-				left // if looking for declared result type and right is null/invalid, propagate left
+			} else if (declared && right instanceof DataType)
+				right // if looking for declared result type and left is null/invalid, propagate right
 			else
 				null
-		} else if (declared && right instanceof DataType)
-			right // if looking for declared result type and left is null/invalid, propagate right
-		else
-			null
+		}
 	}
 
 	def package static INamedElement getResultType(STUnaryExpression expr) { expr.expression?.resultType }

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.tests/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/ui/tests/STFunctionQuickfixTest.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.tests/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/ui/tests/STFunctionQuickfixTest.java
@@ -119,4 +119,58 @@ class STFunctionQuickfixTest extends AbstractQuickfixTest {
 
 						"""));
 	}
+
+	@Test
+	void fixMissingVariableExpression() {
+		testQuickfixesOn("""
+				FUNCTION TEST
+				X := DINT#17 = 4; // test comment
+				END_FUNCTION
+
+				""", Diagnostic.LINKING_DIAGNOSTIC,
+				// INPUT
+				new Quickfix("Create missing INPUT variable", "Create missing INPUT variable", """
+						FUNCTION TEST
+						VAR_INPUT
+							X : BOOL;
+						END_VAR
+
+						X := DINT#17 = 4; // test comment
+						END_FUNCTION
+
+						"""),
+				// IN_OUT
+				new Quickfix("Create missing IN_OUT variable", "Create missing IN_OUT variable", """
+						FUNCTION TEST
+						VAR_IN_OUT
+							X : BOOL;
+						END_VAR
+
+						X := DINT#17 = 4; // test comment
+						END_FUNCTION
+
+						"""),
+				// OUTPUT
+				new Quickfix("Create missing OUTPUT variable", "Create missing OUTPUT variable", """
+						FUNCTION TEST
+						VAR_OUTPUT
+							X : BOOL;
+						END_VAR
+
+						X := DINT#17 = 4; // test comment
+						END_FUNCTION
+
+						"""),
+				// TEMP
+				new Quickfix("Create missing TEMP variable", "Create missing TEMP variable", """
+						FUNCTION TEST
+						VAR_TEMP
+							X : BOOL;
+						END_VAR
+
+						X := DINT#17 = 4; // test comment
+						END_FUNCTION
+
+						"""));
+	}
 }


### PR DESCRIPTION
Always return BOOL as result type of comparison regardless of missing/invalid operand types.