### PR TITLE
Bugfix in remove watch handler

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/handlers/RemoveAllWatchesHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/handlers/RemoveAllWatchesHandler.java
@@ -126,7 +126,7 @@ public class RemoveAllWatchesHandler extends AbstractMonitoringHandler {
 			final FBNetworkElement fbnElement) {
 		final Set<IInterfaceElement> foundElements = new HashSet<>();
 		foundElements.addAll(getWatchedIfElementsForFB(manager, fbnElement));
-		if (fbnElement.getType() instanceof BaseFBType) {
+		if (fbnElement.getType() instanceof BaseFBType && fbnElement instanceof FB) {
 			foundElements.addAll(getWatchedInternalVars(manager, (FB) fbnElement));
 		} else if (fbnElement instanceof final SubApp subapp && subapp.getSubAppNetwork() != null) {
 			foundElements.addAll(getWatchedElementsFromFBNetwork(manager, subapp.getSubAppNetwork()));


### PR DESCRIPTION
right clicking on an error fbnetworkelement inside an editor of a baseFbType caused an type cast exception in the setEnabled method of the watches handler