### PR TITLE
Added check to prevent ClassCastException

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/handlers/RemoveAllWatchesHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.monitoring/src/org/eclipse/fordiac/ide/monitoring/handlers/RemoveAllWatchesHandler.java
@@ -126,8 +126,8 @@ public class RemoveAllWatchesHandler extends AbstractMonitoringHandler {
 			final FBNetworkElement fbnElement) {
 		final Set<IInterfaceElement> foundElements = new HashSet<>();
 		foundElements.addAll(getWatchedIfElementsForFB(manager, fbnElement));
-		if (fbnElement.getType() instanceof BaseFBType) {
-			foundElements.addAll(getWatchedInternalVars(manager, (FB) fbnElement));
+		if (fbnElement.getType() instanceof BaseFBType && fbnElement instanceof final FB fb) {
+			foundElements.addAll(getWatchedInternalVars(manager, fb));
 		} else if (fbnElement instanceof final SubApp subapp && subapp.getSubAppNetwork() != null) {
 			foundElements.addAll(getWatchedElementsFromFBNetwork(manager, subapp.getSubAppNetwork()));
 		}


### PR DESCRIPTION
ClassCastException could be thrown when opening the ContextMenu on an errorMarker