### PR TITLE
add deprecated annotation for searchApplication wrapper in ModelSearch

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/ModelSearchQuery.java
+++ b/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/ModelSearchQuery.java
@@ -117,8 +117,12 @@ public class ModelSearchQuery implements ISearchQuery {
 	 * (mis)used for search in 4diac Analytics until this functionality is
 	 * refactored out of this class
 	 *
+	 * @deprecated searchApplication can take a long time and should not be used
+	 *             without considering use of a IProgressMonitor for cancellation
+	 *
 	 * @param app
 	 */
+	@Deprecated
 	public void searchApplication(final Application app) {
 		this.searchApplication(app, null);
 	}


### PR DESCRIPTION
In #505 a wrapper that hides the requirement for a IProgressMonitor was added to the searchApplication method of the ModelSearch to keep the API stable for a plugin using this method.

This adds a deprecation notice to make sure the depending plugin is aware of this change.