### PR TITLE
Errormessage for canceled export

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.export.ui/src/org/eclipse/fordiac/ide/export/ui/wizard/FordiacExportWizard.java
+++ b/plugins/org.eclipse.fordiac.ide.export.ui/src/org/eclipse/fordiac/ide/export/ui/wizard/FordiacExportWizard.java
@@ -153,6 +153,7 @@ public class FordiacExportWizard extends Wizard implements IExportWizard {
 						overwriteWithoutWarning = true;
 					} catch (final ExportException.CancelAll e) {
 						enableCMakeLists = false;
+						filter.getWarnings().add(Messages.FordiacExportWizard_EXPORT_CANCELED);
 						break;
 					} catch (final ExportException.UserInteraction e) {
 						// noop

--- a/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/Messages.java
@@ -30,6 +30,8 @@ public final class Messages extends NLS {
 
 	public static String TemplateExportFilter_ErrorDuringTemplateGeneration;
 
+	public static String TemplateExportFilter_EXPORT_CANCELED;
+
 	public static String TemplateExportFilter_FILE_EXISTS;
 
 	public static String TemplateExportFilter_FILE_IGNORED;

--- a/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/TemplateExportFilter.java
+++ b/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/TemplateExportFilter.java
@@ -163,13 +163,14 @@ public abstract class TemplateExportFilter extends ExportFilter {
 				if (!overwrite) {
 					openMergeEditor(writtenFiles);
 				}
-			}
-
-			if (res == BUTTON_OVERWRITE_ALL) {
+			} else if (res == BUTTON_OVERWRITE_ALL) {
 				throw (new ExportException.OverwriteAll());
-			}
-			if (res == BUTTON_CANCEL_ALL) {
+			} else if (res == BUTTON_CANCEL_ALL) {
 				throw (new ExportException.CancelAll());
+			} else { // the cancel button was selected / ESC pressed
+				getWarnings().add(MessageFormat.format(Messages.TemplateExportFilter_PREFIX_ERRORMESSAGE_WITH_TYPENAME,
+						typeFile != null ? typeFile.getFullPath() : name,
+						Messages.TemplateExportFilter_EXPORT_CANCELED));
 			}
 
 		} catch (final ExportException.UserInteraction e) {

--- a/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/messages.properties
+++ b/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/messages.properties
@@ -16,6 +16,7 @@ ExportTemplate_ExportTemplate=ExportTemplate [{0}]
 
 TemplateExportFilter_CANCEL_ALL_LABEL_STRING=Cancel All
 TemplateExportFilter_ErrorDuringTemplateGeneration=Error during template generation
+TemplateExportFilter_EXPORT_CANCELED=Export was canceled\!
 TemplateExportFilter_FILE_EXISTS=File Exists
 TemplateExportFilter_FILE_IGNORED=File was ignored during export.
 TemplateExportFilter_LIST_FOUR_OR_MORE_ELEMENTS={0}, {1}, {2}, ...


### PR DESCRIPTION
In #507 new buttons for canceling exports were added. To allow the user to verify their actions this introduces entries in the export log when the export was canceled.