### PR TITLE
Maintain the Expanded State of Demuxer Property Sheet Tree Viewer

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/StructManipulatorSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/StructManipulatorSection.java
@@ -59,6 +59,7 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.ITreeSelection;
 import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.TreePath;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.viewers.TreeViewerColumn;
 import org.eclipse.swt.SWT;
@@ -122,7 +123,11 @@ public abstract class StructManipulatorSection extends AbstractSection implement
 	}
 
 	protected void refreshStructTypeTable() {
+		final Object[] expandedElements = memberVarViewer.getExpandedElements();
+		final TreePath[] expandedTreePaths = memberVarViewer.getExpandedTreePaths();
 		memberVarViewer.setInput(getType());
+		memberVarViewer.setExpandedElements(expandedElements);
+		memberVarViewer.setExpandedTreePaths(expandedTreePaths);
 	}
 
 	protected void handleStructSelectionChanged(final String newStructName) {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/CheckableStructTreeNode.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/CheckableStructTreeNode.java
@@ -211,4 +211,31 @@ public class CheckableStructTreeNode extends AbstractStructTreeNode {
 		return vars;
 	}
 
+	// equals and hash code are used by the treeviewer to maintain the expanded
+	// state on updates. For us currently the pinname which contains the full
+	// hierarchical name are the main equality criteria.
+	@Override
+	public int hashCode() {
+		return (getPinName() != null) ? getPinName().hashCode() : super.hashCode();
+	}
+
+	@Override
+	public boolean equals(final Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		final CheckableStructTreeNode other = (CheckableStructTreeNode) obj;
+		if (getPinName() != null && other.getPinName() != null) {
+			return getPinName().equals(other.getPinName());
+		}
+
+		return super.equals(obj);
+	}
+
 }


### PR DESCRIPTION
When changing the visibility flag of demuxer output pins the tree viewer always collapsed because of the required update of the viewer. With this fix the tree items use an own equals and hash method to indicate if they are the same. With that the state can be restored.