### PR TITLE
Fix type entry subclasses

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractCheckedTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractCheckedTypeEntryImpl.java
@@ -27,7 +27,7 @@ abstract class AbstractCheckedTypeEntryImpl<T extends LibraryElement> extends Ab
 	}
 
 	@Override
-	public synchronized T getType() {
+	public T getType() {
 		final LibraryElement type = super.getType();
 		if (typeClass.isInstance(type)) {
 			return typeClass.cast(type);
@@ -36,7 +36,7 @@ abstract class AbstractCheckedTypeEntryImpl<T extends LibraryElement> extends Ab
 	}
 
 	@Override
-	public synchronized T getTypeEditable() {
+	public T getTypeEditable() {
 		final LibraryElement type = super.getTypeEditable();
 		if (typeClass.isInstance(type)) {
 			return typeClass.cast(type);
@@ -45,7 +45,7 @@ abstract class AbstractCheckedTypeEntryImpl<T extends LibraryElement> extends Ab
 	}
 
 	@Override
-	public synchronized T copyType() {
+	public T copyType() {
 		final LibraryElement type = super.copyType();
 		if (typeClass.isInstance(type)) {
 			return typeClass.cast(type);
@@ -63,7 +63,7 @@ abstract class AbstractCheckedTypeEntryImpl<T extends LibraryElement> extends Ab
 	}
 
 	@Override
-	public synchronized void setType(final LibraryElement type) {
+	public void setType(final LibraryElement type) {
 		if (typeClass.isInstance(type)) {
 			super.setType(type);
 		} else {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
@@ -247,7 +247,8 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 		}
 	}
 
-	private synchronized NotificationChain basicSetType(final LibraryElement newType, NotificationChain notifications) {
+	protected synchronized NotificationChain basicSetType(final LibraryElement newType,
+			NotificationChain notifications) {
 		final LibraryElement oldType = (typeRef != null) ? typeRef.get() : null;
 		if (newType != null) {
 			Objects.requireNonNull(newType.getName(), "No name in new type"); //$NON-NLS-1$

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AdapterTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AdapterTypeEntryImpl.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.eclipse.emf.common.notify.NotificationChain;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.model.dataexport.AbstractTypeExporter;
@@ -54,12 +55,13 @@ public class AdapterTypeEntryImpl extends AbstractCheckedTypeEntryImpl<AdapterTy
 	}
 
 	@Override
-	public synchronized void setType(final LibraryElement type) {
+	protected synchronized NotificationChain basicSetType(final LibraryElement type,
+			final NotificationChain notifications) {
 		if (type instanceof final AdapterType adpType) {
-			// wenn we get a new type ensure that the plug is the mirror of the socket
+			// ensure that the plug is the mirror of the socket
 			adpType.setPlugType(createPlugType(adpType));
 		}
-		super.setType(type);
+		return super.basicSetType(type, notifications);
 	}
 
 	public static AdapterType createPlugType(final AdapterType adapterType) {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/FBTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/FBTypeEntryImpl.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.emf.common.notify.NotificationChain;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.fordiac.ide.model.LibraryElementTags;
 import org.eclipse.fordiac.ide.model.dataexport.AbstractTypeExporter;
@@ -56,11 +57,12 @@ public class FBTypeEntryImpl extends AbstractCheckedTypeEntryImpl<FBType> implem
 	}
 
 	@Override
-	public synchronized void setType(final LibraryElement type) {
-		super.setType(type);
-		if (type != null) {
+	protected synchronized NotificationChain basicSetType(final LibraryElement type,
+			final NotificationChain notifications) {
+		if (type instanceof FBType) {
 			typeEClass.set(type.eClass());
 		}
+		return super.basicSetType(type, notifications);
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/SystemEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/SystemEntryImpl.java
@@ -44,14 +44,14 @@ public class SystemEntryImpl extends AbstractCheckedTypeEntryImpl<AutomationSyst
 	}
 
 	@Override
-	public synchronized AutomationSystem getTypeEditable() {
+	public AutomationSystem getTypeEditable() {
 		// for performance reasons the systemEntry uses only the type and not the type
 		// editable
 		return getSystem();
 	}
 
 	@Override
-	public synchronized void setTypeEditable(final LibraryElement newTypeEditable) {
+	public void setTypeEditable(final LibraryElement newTypeEditable) {
 		// for performance reasons the systemEntry uses only the type and not the type
 		// editable
 		setSystem(newTypeEditable);


### PR DESCRIPTION
Fix type entry subclasses after https://github.com/eclipse-4diac/4diac-ide/pull/545:
- plug type creation in adapter entry,
- type class caching in FB type entry,
- remove extra synchronized in subclasses that could still cause deadlocks.

Fixes https://github.com/eclipse-4diac/4diac-ide/issues/562, https://github.com/eclipse-4diac/4diac-ide/issues/564