### PR TITLE
Adjusted Adapter Type Parsing to new TypeLib Synchronization

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
@@ -247,7 +247,8 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 		}
 	}
 
-	private synchronized NotificationChain basicSetType(final LibraryElement newType, NotificationChain notifications) {
+	protected synchronized NotificationChain basicSetType(final LibraryElement newType,
+			NotificationChain notifications) {
 		final LibraryElement oldType = (typeRef != null) ? typeRef.get() : null;
 		if (newType != null) {
 			Objects.requireNonNull(newType.getName(), "No name in new type"); //$NON-NLS-1$

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AdapterTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AdapterTypeEntryImpl.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.eclipse.emf.common.notify.NotificationChain;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.model.dataexport.AbstractTypeExporter;
@@ -54,12 +55,13 @@ public class AdapterTypeEntryImpl extends AbstractCheckedTypeEntryImpl<AdapterTy
 	}
 
 	@Override
-	public synchronized void setType(final LibraryElement type) {
-		if (type instanceof final AdapterType adpType) {
-			// wenn we get a new type ensure that the plug is the mirror of the socket
+	protected synchronized NotificationChain basicSetType(final LibraryElement newType,
+			final NotificationChain notifications) {
+		if (newType instanceof final AdapterType adpType) {
+			// when we get a new type ensure that the plug is the mirror of the socket
 			adpType.setPlugType(createPlugType(adpType));
 		}
-		super.setType(type);
+		return super.basicSetType(newType, notifications);
 	}
 
 	public static AdapterType createPlugType(final AdapterType adapterType) {


### PR DESCRIPTION
On setType the AdpaterType entry generated also the Plug representation. With the update this has to be done in the basicSetType.