### PR TITLE
Deprecate type editable in type entries

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/AdapterTypeEntry.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/AdapterTypeEntry.java
@@ -22,7 +22,11 @@ public interface AdapterTypeEntry extends FBTypeEntry {
 	@Override
 	AdapterType getType();
 
+	/**
+	 * @deprecated see {@link TypeEntry#getTypeEditable()}
+	 */
 	@Override
+	@Deprecated(since = "3.0.0", forRemoval = true)
 	AdapterType getTypeEditable();
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/AttributeTypeEntry.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/AttributeTypeEntry.java
@@ -19,7 +19,11 @@ public interface AttributeTypeEntry extends TypeEntry {
 	@Override
 	AttributeDeclaration getType();
 
+	/**
+	 * @deprecated see {@link TypeEntry#getTypeEditable()}
+	 */
 	@Override
+	@Deprecated(since = "3.0.0", forRemoval = true)
 	AttributeDeclaration getTypeEditable();
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/DataTypeEntry.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/DataTypeEntry.java
@@ -22,7 +22,11 @@ public interface DataTypeEntry extends TypeEntry {
 	@Override
 	AnyDerivedType getType();
 
+	/**
+	 * @deprecated see {@link TypeEntry#getTypeEditable()}
+	 */
 	@Override
+	@Deprecated(since = "3.0.0", forRemoval = true)
 	AnyDerivedType getTypeEditable();
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/DeviceTypeEntry.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/DeviceTypeEntry.java
@@ -22,7 +22,11 @@ public interface DeviceTypeEntry extends TypeEntry {
 	@Override
 	DeviceType getType();
 
+	/**
+	 * @deprecated see {@link TypeEntry#getTypeEditable()}
+	 */
 	@Override
+	@Deprecated(since = "3.0.0", forRemoval = true)
 	DeviceType getTypeEditable();
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/ErrorDataTypeEntry.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/ErrorDataTypeEntry.java
@@ -19,6 +19,10 @@ public interface ErrorDataTypeEntry extends ErrorTypeEntry {
 	@Override
 	ErrorMarkerDataType getType();
 
+	/**
+	 * @deprecated see {@link TypeEntry#getTypeEditable()}
+	 */
 	@Override
+	@Deprecated(since = "3.0.0", forRemoval = true)
 	ErrorMarkerDataType getTypeEditable();
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/FBTypeEntry.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/FBTypeEntry.java
@@ -22,7 +22,11 @@ public interface FBTypeEntry extends TypeEntry {
 	@Override
 	FBType getType();
 
+	/**
+	 * @deprecated see {@link TypeEntry#getTypeEditable()}
+	 */
 	@Override
+	@Deprecated(since = "3.0.0", forRemoval = true)
 	FBType getTypeEditable();
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/FunctionFBTypeEntry.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/FunctionFBTypeEntry.java
@@ -19,7 +19,11 @@ public interface FunctionFBTypeEntry extends FBTypeEntry {
 	@Override
 	FunctionFBType getType();
 
+	/**
+	 * @deprecated see {@link TypeEntry#getTypeEditable()}
+	 */
 	@Override
+	@Deprecated(since = "3.0.0", forRemoval = true)
 	FunctionFBType getTypeEditable();
 
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/GlobalConstantsEntry.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/GlobalConstantsEntry.java
@@ -18,7 +18,11 @@ public interface GlobalConstantsEntry extends TypeEntry {
 	@Override
 	GlobalConstants getType();
 
+	/**
+	 * @deprecated see {@link TypeEntry#getTypeEditable()}
+	 */
 	@Override
+	@Deprecated(since = "3.0.0", forRemoval = true)
 	GlobalConstants getTypeEditable();
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/ResourceTypeEntry.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/ResourceTypeEntry.java
@@ -22,7 +22,11 @@ public interface ResourceTypeEntry extends TypeEntry {
 	@Override
 	ResourceType getType();
 
+	/**
+	 * @deprecated see {@link TypeEntry#getTypeEditable()}
+	 */
 	@Override
+	@Deprecated(since = "3.0.0", forRemoval = true)
 	ResourceType getTypeEditable();
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/SegmentTypeEntry.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/SegmentTypeEntry.java
@@ -22,7 +22,11 @@ public interface SegmentTypeEntry extends TypeEntry {
 	@Override
 	SegmentType getType();
 
+	/**
+	 * @deprecated see {@link TypeEntry#getTypeEditable()}
+	 */
 	@Override
+	@Deprecated(since = "3.0.0", forRemoval = true)
 	SegmentType getTypeEditable();
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/SubAppTypeEntry.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/SubAppTypeEntry.java
@@ -22,7 +22,11 @@ public interface SubAppTypeEntry extends TypeEntry {
 	@Override
 	SubAppType getType();
 
+	/**
+	 * @deprecated see {@link TypeEntry#getTypeEditable()}
+	 */
 	@Override
+	@Deprecated(since = "3.0.0", forRemoval = true)
 	SubAppType getTypeEditable();
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/TypeEntry.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/TypeEntry.java
@@ -55,8 +55,25 @@ public interface TypeEntry extends Notifier {
 
 	void setType(LibraryElement value);
 
+	/**
+	 * @deprecated The "editable" type may not be identical to the type currently
+	 *             used in editors due to automatic reload from disk on changes.
+	 *             However, it was often used this way. In the future, either get a
+	 *             private copy to edit the type via {@link #copyType()} or get the
+	 *             type directly from an editor via
+	 *             {@code Adapters.adapt(editor, LibraryElement.class)}.
+	 */
+	@Deprecated(since = "3.0.0", forRemoval = true)
 	LibraryElement getTypeEditable();
 
+	/**
+	 * @deprecated The "editable" type may not be identical to the type currently
+	 *             used in editors due to automatic reload from disk on changes.
+	 *             However, it was often used this way. In the future, use
+	 *             {@link #save(LibraryElement, IProgressMonitor)} to save a
+	 *             modified type or update the type directly inside an editor.
+	 */
+	@Deprecated(since = "3.0.0", forRemoval = true)
 	void setTypeEditable(LibraryElement value);
 
 	TypeLibrary getTypeLibrary();

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractCheckedTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractCheckedTypeEntryImpl.java
@@ -16,6 +16,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.fordiac.ide.model.dataexport.AbstractTypeExporter;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 
 abstract class AbstractCheckedTypeEntryImpl<T extends LibraryElement> extends AbstractTypeEntryImpl {
@@ -35,7 +36,11 @@ abstract class AbstractCheckedTypeEntryImpl<T extends LibraryElement> extends Ab
 		return null;
 	}
 
+	/**
+	 * @deprecated see {@link TypeEntry#getTypeEditable()}
+	 */
 	@Override
+	@Deprecated(since = "3.0.0", forRemoval = true)
 	public T getTypeEditable() {
 		final LibraryElement type = super.getTypeEditable();
 		if (typeClass.isInstance(type)) {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
@@ -270,7 +270,11 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 		}
 	}
 
+	/**
+	 * @deprecated see {@link TypeEntry#getTypeEditable()}
+	 */
 	@Override
+	@Deprecated(since = "3.0.0", forRemoval = true)
 	public LibraryElement getTypeEditable() {
 		// check if type is present and current
 		LibraryElement typeEditable = basicGetTypeEditable();
@@ -342,7 +346,11 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 		return false;
 	}
 
+	/**
+	 * @deprecated see {@link TypeEntry#setTypeEditable(LibraryElement)}
+	 */
 	@Override
+	@Deprecated(since = "3.0.0", forRemoval = true)
 	public void setTypeEditable(final LibraryElement newTypeEditable) {
 		final NotificationChain notifications = basicSetTypeEditable(newTypeEditable, null);
 		if (notifications != null) {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/SystemEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/SystemEntryImpl.java
@@ -24,6 +24,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.typelibrary.SystemEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 
 public class SystemEntryImpl extends AbstractCheckedTypeEntryImpl<AutomationSystem> implements SystemEntry {
 
@@ -43,14 +44,22 @@ public class SystemEntryImpl extends AbstractCheckedTypeEntryImpl<AutomationSyst
 		setType(system);
 	}
 
+	/**
+	 * @deprecated see {@link TypeEntry#getTypeEditable()}
+	 */
 	@Override
+	@Deprecated(since = "3.0.0", forRemoval = true)
 	public AutomationSystem getTypeEditable() {
 		// for performance reasons the systemEntry uses only the type and not the type
 		// editable
 		return getSystem();
 	}
 
+	/**
+	 * @deprecated see {@link TypeEntry#setTypeEditable(LibraryElement)}
+	 */
 	@Override
+	@Deprecated(since = "3.0.0", forRemoval = true)
 	public void setTypeEditable(final LibraryElement newTypeEditable) {
 		// for performance reasons the systemEntry uses only the type and not the type
 		// editable

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/AttributeTypeEntryMock.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/AttributeTypeEntryMock.java
@@ -68,7 +68,11 @@ public class AttributeTypeEntryMock extends BasicNotifierImpl implements Attribu
 		attributeDeclaration = (AttributeDeclaration) value;
 	}
 
+	/**
+	 * @deprecated see {@link TypeEntry#setTypeEditable(LibraryElement)}
+	 */
 	@Override
+	@Deprecated(since = "3.0.0", forRemoval = true)
 	public void setTypeEditable(final LibraryElement value) {
 		// currently not needed in mock
 	}
@@ -88,7 +92,11 @@ public class AttributeTypeEntryMock extends BasicNotifierImpl implements Attribu
 		return attributeDeclaration;
 	}
 
+	/**
+	 * @deprecated see {@link TypeEntry#getTypeEditable()}
+	 */
 	@Override
+	@Deprecated(since = "3.0.0", forRemoval = true)
 	public AttributeDeclaration getTypeEditable() {
 		// currently not needed in mock
 		return null;

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/DataTypeEntryMock.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/DataTypeEntryMock.java
@@ -69,7 +69,11 @@ public final class DataTypeEntryMock extends BasicNotifierImpl implements DataTy
 		dataType = (AnyDerivedType) value;
 	}
 
+	/**
+	 * @deprecated see {@link TypeEntry#setTypeEditable(LibraryElement)}
+	 */
 	@Override
+	@Deprecated(since = "3.0.0", forRemoval = true)
 	public void setTypeEditable(final LibraryElement value) {
 		// currently not needed in mock
 	}
@@ -89,7 +93,11 @@ public final class DataTypeEntryMock extends BasicNotifierImpl implements DataTy
 		return dataType;
 	}
 
+	/**
+	 * @deprecated see {@link TypeEntry#getTypeEditable()}
+	 */
 	@Override
+	@Deprecated(since = "3.0.0", forRemoval = true)
 	public AnyDerivedType getTypeEditable() {
 		// currently not needed in mock
 		return null;

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/FBTypeEntryMock.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/FBTypeEntryMock.java
@@ -67,7 +67,11 @@ public class FBTypeEntryMock extends BasicNotifierImpl implements FBTypeEntry {
 		fbType = (FBType) value;
 	}
 
+	/**
+	 * @deprecated see {@link TypeEntry#setTypeEditable(LibraryElement)}
+	 */
 	@Override
+	@Deprecated(since = "3.0.0", forRemoval = true)
 	public void setTypeEditable(final LibraryElement value) {
 		// currently not needed in mock
 	}
@@ -87,7 +91,11 @@ public class FBTypeEntryMock extends BasicNotifierImpl implements FBTypeEntry {
 		return fbType;
 	}
 
+	/**
+	 * @deprecated see {@link TypeEntry#getTypeEditable()}
+	 */
 	@Override
+	@Deprecated(since = "3.0.0", forRemoval = true)
 	public FBType getTypeEditable() {
 		// currently not needed in mock
 		return null;

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/SubAppTypeEntryMock.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/SubAppTypeEntryMock.java
@@ -68,7 +68,11 @@ public final class SubAppTypeEntryMock extends BasicNotifierImpl implements SubA
 		subAppType = (SubAppType) value;
 	}
 
+	/**
+	 * @deprecated see {@link TypeEntry#setTypeEditable(LibraryElement)}
+	 */
 	@Override
+	@Deprecated(since = "3.0.0", forRemoval = true)
 	public void setTypeEditable(final LibraryElement value) {
 		// currently not needed in mock
 	}
@@ -88,7 +92,11 @@ public final class SubAppTypeEntryMock extends BasicNotifierImpl implements SubA
 		return subAppType;
 	}
 
+	/**
+	 * @deprecated see {@link TypeEntry#getTypeEditable()}
+	 */
 	@Override
+	@Deprecated(since = "3.0.0", forRemoval = true)
 	public SubAppType getTypeEditable() {
 		// currently not needed in mock
 		return null;


### PR DESCRIPTION
The "editable" type may not be identical to the type currently used in editors due to automatic reload from disk on changes. However, it was often used this way.

This deprecates the type editable in favor of either getting a private copy via `TypeEntry.copyType()` or getting the type directly from an editor via `Adapters.adapt(editor, LibraryElement.class)`.