### PR TITLE
Fix System Navigator sorting

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/plugin.xml
@@ -594,7 +594,7 @@
          <navigatorContent
                activeByDefault="true"
                id="org.eclipse.fordiac.ide.systemmanagement.ui.systemexplorer.sortOnly"
-               name="name"
+               name="System Sort Override"
                priority="normal"
                sortOnly="true">
             <commonSorter

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/plugin.xml
@@ -588,7 +588,28 @@
             </instanceof>
          </filterExpression>
       </commonFilter>
-  </extension>  
+  </extension>
+      <extension
+            point="org.eclipse.ui.navigator.navigatorContent">
+         <navigatorContent
+               activeByDefault="true"
+               id="org.eclipse.fordiac.ide.systemmanagement.ui.systemexplorer.sortOnly"
+               name="name"
+               priority="normal"
+               sortOnly="true">
+            <commonSorter
+                  class="org.eclipse.jface.viewers.ViewerSorter"
+                  id="org.eclipse.fordiac.ide.systemmanagement.ui.systemexplorer.IFolderSorter">
+               <parentExpression>
+                  <or>
+                     <instanceof
+                           value="org.eclipse.core.resources.IFolder">
+                     </instanceof>
+                  </or>
+               </parentExpression>
+            </commonSorter>
+         </navigatorContent>
+      </extension>  
     <extension point="org.eclipse.ui.navigator.linkHelper">    
        <linkHelper
              class="org.eclipse.fordiac.ide.systemmanagement.ui.linkhelpers.SystemExplorerLinkHelper"


### PR DESCRIPTION
added sortOnly NavigationContent for IFolders
-> this fixes folders collapsing on file rename