### PR TITLE
Add functions F_NOW and F_NOW_MONOTONIC for time retrieval

### DIFF
--- a/data/typelibrary/utils-1.0.0/typelib/timing/F_NOW.fct
+++ b/data/typelibrary/utils-1.0.0/typelib/timing/F_NOW.fct
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Function Name="F_NOW" Comment="returns current local date and time">
+	<Identification Standard="61499-1" Description="Copyright (c) 2024 HR Agrartechnik GmbH   &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0&#10;&#10;returns current local date and time&#10;This may be affect to step changes (e.g., adjusting winter/summer time).&#10;&#10;(This is only a Wrapper around the ST Function NOW)" >
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH   " Version="1.0" Author="Franz Höpfinger" Date="2024-10-01">
+	</VersionInfo>
+	<CompilerInfo packageName="utils::timing">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="">
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="">
+				<With Var=""/>
+			</Event>
+		</EventOutputs>
+		<OutputVars>
+			<VarDeclaration Name="" Type="DATE_AND_TIME" Comment=""/>
+		</OutputVars>
+	</InterfaceList>
+	<FunctionBody>
+		<ST><![CDATA[PACKAGE utils::timing;
+
+(* returns current local date and time *)
+FUNCTION F_NOW : DATE_AND_TIME
+F_NOW := NOW();
+END_FUNCTION
+
+]]></ST>
+	</FunctionBody>
+</Function>

--- a/data/typelibrary/utils-1.0.0/typelib/timing/F_NOW_MONOTONIC.fct
+++ b/data/typelibrary/utils-1.0.0/typelib/timing/F_NOW_MONOTONIC.fct
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Function Name="F_NOW_MONOTONIC" Comment="returns current monotonic clock value">
+	<Identification Standard="61499-1" Description="Copyright (c) 2024 HR Agrartechnik GmbH   &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0&#10;&#10;return a clear monotonic time&#10;&#10;monotonic time from a specified point of time (depending on OS and hardware) which has no direct correlation to the current time.&#10;&#10;(This is only a Wrapper around the ST Function NOW_MONOTONIC)" >
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH   " Version="1.0" Author="Franz Höpfinger" Date="2024-10-01">
+	</VersionInfo>
+	<CompilerInfo packageName="utils::timing">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="">
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="">
+				<With Var=""/>
+			</Event>
+		</EventOutputs>
+		<OutputVars>
+			<VarDeclaration Name="" Type="TIME" Comment=""/>
+		</OutputVars>
+	</InterfaceList>
+	<FunctionBody>
+		<ST><![CDATA[PACKAGE utils::timing;
+
+(* returns current monotonic clock value *)
+FUNCTION F_NOW_MONOTONIC : TIME
+F_NOW_MONOTONIC := NOW_MONOTONIC();
+END_FUNCTION
+
+]]></ST>
+	</FunctionBody>
+</Function>


### PR DESCRIPTION
Two new functions, F_NOW and F_NOW_MONOTONIC, have been added to retrieve the current time and a clear monotonic time respectively. These functions are wrappers around ST Functions NOW and NOW_MONOTONIC.