### PR TITLE
FB Network Grid Now Follows IEC 61499 Coordinate System Resolution

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editors/FBNetworkEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editors/FBNetworkEditor.java
@@ -23,6 +23,7 @@ package org.eclipse.fordiac.ide.application.editors;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.fordiac.ide.application.actions.CopyEditPartsAction;
 import org.eclipse.fordiac.ide.application.actions.CutEditPartsAction;
 import org.eclipse.fordiac.ide.application.actions.DeleteFBNetworkAction;
@@ -39,6 +40,7 @@ import org.eclipse.fordiac.ide.application.utilities.FbTypeTemplateTransferDropT
 import org.eclipse.fordiac.ide.gef.DiagramEditorWithFlyoutPalette;
 import org.eclipse.fordiac.ide.gef.preferences.PaletteFlyoutPreferences;
 import org.eclipse.fordiac.ide.gef.tools.AdvancedPanningSelectionTool;
+import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
@@ -48,6 +50,7 @@ import org.eclipse.gef.ContextMenuProvider;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartFactory;
 import org.eclipse.gef.LayerConstants;
+import org.eclipse.gef.SnapToGrid;
 import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.gef.editparts.ScalableFreeformRootEditPart;
 import org.eclipse.gef.editparts.ZoomManager;
@@ -136,6 +139,10 @@ public class FBNetworkEditor extends DiagramEditorWithFlyoutPalette implements I
 				.getRootEditPart();
 		final IFigure connectionLayer = rootEP.getLayer(LayerConstants.CONNECTION_LAYER);
 		connectionLayer.setClippingStrategy(new FBNetworkConnectionLayerClippingStrategy(getGraphicalViewer()));
+
+		getGraphicalViewer().setProperty(SnapToGrid.PROPERTY_GRID_SPACING,
+				new Dimension((int) CoordinateConverter.INSTANCE.getLineHeight(),
+						(int) CoordinateConverter.INSTANCE.getLineHeight()));
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/GroupContentEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/GroupContentEditPart.java
@@ -14,9 +14,13 @@ package org.eclipse.fordiac.ide.application.editparts;
 
 import java.util.List;
 
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.MarginBorder;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.fordiac.ide.application.commands.ResizeGroupOrSubappCommand;
 import org.eclipse.fordiac.ide.application.policies.GroupXYLayoutPolicy;
+import org.eclipse.fordiac.ide.gef.figures.AbstractShadowBorder;
+import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.commands.create.CreateFBElementInGroupCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.Group;
@@ -33,7 +37,8 @@ public class GroupContentEditPart extends AbstractContainerContentEditPart {
 
 	@Override
 	protected List<FBNetworkElement> getNetworkElements() {
-		// our model is the group and the getNetworkElements all elements in the group we want to show as children
+		// our model is the group and the getNetworkElements all elements in the group
+		// we want to show as children
 		return getModel().getNetworkElements();
 	}
 
@@ -45,12 +50,19 @@ public class GroupContentEditPart extends AbstractContainerContentEditPart {
 			@Override
 			public Command getElementCreateCommand(final TypeEntry type, final Point refPoint) {
 				return new ResizeGroupOrSubappCommand(this.getHost(),
-						new CreateFBElementInGroupCommand(type, getModel().getGroup(), refPoint.x,
-								refPoint.y));
+						new CreateFBElementInGroupCommand(type, getModel().getGroup(), refPoint.x, refPoint.y));
 			}
 		});
 	}
 
+	@Override
+	protected IFigure createFigure() {
+		final IFigure newGroupContentFigure = super.createFigure();
+		final int lrBorder = (int) CoordinateConverter.INSTANCE.getLineHeight()
+				- AbstractShadowBorder.SHADOW_INSETS.left;
+		newGroupContentFigure.setBorder(new MarginBorder(0, lrBorder, 5, lrBorder));
+		return newGroupContentFigure;
+	}
 
 	@Override
 	public <T> T getAdapter(final Class<T> key) {
@@ -64,6 +76,5 @@ public class GroupContentEditPart extends AbstractContainerContentEditPart {
 	public Group getContainerElement() {
 		return getModel().getGroup();
 	}
-
 
 }

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/GroupEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/GroupEditPart.java
@@ -43,6 +43,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.libraryElement.Position;
 import org.eclipse.fordiac.ide.model.libraryElement.PositionableElement;
+import org.eclipse.gef.ConnectionEditPart;
 import org.eclipse.gef.DragTracker;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPolicy;
@@ -68,11 +69,10 @@ public class GroupEditPart extends AbstractPositionableElementEditPart
 	private class GroupCommentRenameEditPolicy extends AbstractViewRenameEditPolicy {
 		@Override
 		protected Command getDirectEditCommand(final DirectEditRequest request) {
-			if (getHost() instanceof GroupEditPart) {
+			if (getHost() instanceof final GroupEditPart gEP) {
 				final String str = (String) request.getCellEditor().getValue();
 				if (!InstanceCommentFigure.EMPTY_COMMENT.equals(str)) {
-					return new ResizeGroupOrSubappCommand(getHost(),
-							new ChangeCommentCommand(((GroupEditPart) getHost()).getModel(), str));
+					return new ResizeGroupOrSubappCommand(getHost(), new ChangeCommentCommand(gEP.getModel(), str));
 				}
 			}
 			return null;
@@ -130,7 +130,7 @@ public class GroupEditPart extends AbstractPositionableElementEditPart
 			if (ep instanceof final AbstractFBNElementEditPart fbEp) {
 				fbEp.getChildren().forEach(pinEp -> {
 					if (pinEp instanceof InterfaceEditPartForFBNetwork) {
-						pinEp.getSourceConnections().forEach(conn -> ((EditPart) conn).refresh());
+						pinEp.getSourceConnections().forEach(ConnectionEditPart::refresh);
 					}
 				});
 			}
@@ -143,7 +143,7 @@ public class GroupEditPart extends AbstractPositionableElementEditPart
 			if (ep instanceof final AbstractFBNElementEditPart fbEp) {
 				fbEp.getChildren().forEach(pinEp -> {
 					if (pinEp instanceof InterfaceEditPartForFBNetwork) {
-						pinEp.getTargetConnections().forEach(conn -> ((EditPart) conn).refresh());
+						pinEp.getTargetConnections().forEach(ConnectionEditPart::refresh);
 					}
 				});
 			}
@@ -191,14 +191,14 @@ public class GroupEditPart extends AbstractPositionableElementEditPart
 
 	@Override
 	protected void addChildVisual(final EditPart childEditPart, final int index) {
-		final GridData layoutConstraint = new GridData(GridData.HORIZONTAL_ALIGN_FILL | GridData.GRAB_HORIZONTAL
-				| GridData.VERTICAL_ALIGN_FILL | GridData.GRAB_VERTICAL);
 		final IFigure child = ((GraphicalEditPart) childEditPart).getFigure();
 
 		if (child instanceof InstanceNameFigure) {
 			getFigure().getNameFigure().add(child,
 					new GridData(GridData.HORIZONTAL_ALIGN_BEGINNING | GridData.GRAB_HORIZONTAL));
 		} else {
+			final GridData layoutConstraint = new GridData(GridData.HORIZONTAL_ALIGN_FILL | GridData.GRAB_HORIZONTAL
+					| GridData.VERTICAL_ALIGN_FILL | GridData.GRAB_VERTICAL);
 			getFigure().getMainFigure().add(child, layoutConstraint);
 		}
 	}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/UnfoldedSubappContentEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/UnfoldedSubappContentEditPart.java
@@ -20,7 +20,6 @@ package org.eclipse.fordiac.ide.application.editparts;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.emf.common.notify.Adapter;
 import org.eclipse.emf.common.notify.Notification;
-import org.eclipse.emf.common.notify.Notifier;
 import org.eclipse.emf.ecore.util.EContentAdapter;
 import org.eclipse.fordiac.ide.application.commands.ResizeGroupOrSubappCommand;
 import org.eclipse.fordiac.ide.application.policies.SubAppContentLayoutEditPolicy;
@@ -50,7 +49,7 @@ public class UnfoldedSubappContentEditPart extends AbstractContainerContentEditP
 	public void activate() {
 		if (!isActive()) {
 			super.activate();
-			((Notifier) getModel()).eAdapters().add(adapter);
+			getModel().eAdapters().add(adapter);
 		}
 	}
 
@@ -58,7 +57,7 @@ public class UnfoldedSubappContentEditPart extends AbstractContainerContentEditP
 	public void deactivate() {
 		if (isActive()) {
 			super.deactivate();
-			((Notifier) getModel()).eAdapters().remove(adapter);
+			getModel().eAdapters().remove(adapter);
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/GroupFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/GroupFigure.java
@@ -20,8 +20,10 @@ import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.GridData;
 import org.eclipse.draw2d.GridLayout;
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.MarginBorder;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.RoundedRectangle;
+import org.eclipse.draw2d.ToolbarLayout;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -29,6 +31,7 @@ import org.eclipse.fordiac.ide.gef.draw2d.AdvancedLineBorder;
 import org.eclipse.fordiac.ide.gef.figures.AbstractShadowBorder;
 import org.eclipse.fordiac.ide.gef.figures.BorderedRoundedRectangle;
 import org.eclipse.fordiac.ide.gef.preferences.DiagramPreferences;
+import org.eclipse.fordiac.ide.model.CoordinateConverter;
 
 public class GroupFigure extends Figure {
 
@@ -42,9 +45,8 @@ public class GroupFigure extends Figure {
 
 	private void createFigure() {
 		createMainFigure();
-		createCommentFigure();
 
-		mainFigure.add(commentFigure, new GridData(GridData.HORIZONTAL_ALIGN_FILL | GridData.GRAB_HORIZONTAL));
+		mainFigure.add(createCommentFigure(), new GridData(GridData.HORIZONTAL_ALIGN_FILL | GridData.GRAB_HORIZONTAL));
 
 		final GridLayout rootLayout = new GridLayout(1, false);
 		rootLayout.verticalSpacing = -1; // this brings a slight overlap between name and main area to avoid drawing
@@ -68,16 +70,32 @@ public class GroupFigure extends Figure {
 		mainFigure.setOpaque(false);
 
 		final GridLayout mainLayout = new GridLayout(1, true);
+		mainLayout.marginHeight = 0;
+		mainLayout.marginWidth = 0;
 		mainLayout.verticalSpacing = 0;
 		mainLayout.horizontalSpacing = 0;
 		mainFigure.setLayoutManager(mainLayout);
 	}
 
-	private void createCommentFigure() {
+	private IFigure createCommentFigure() {
 		commentFigure = new InstanceCommentFigure();
 		commentFigure.setCursor(Cursors.SIZEALL);
 		final AdvancedLineBorder commentBorder = new AdvancedLineBorder(PositionConstants.SOUTH);
 		commentFigure.setBorder(commentBorder);
+
+		final Figure commentContainer = new Figure();
+		commentContainer.setLayoutManager(new ToolbarLayout());
+
+		final int lineHeight = (int) CoordinateConverter.INSTANCE.getLineHeight();
+		int top = lineHeight / 2;
+		final int bottom = top;
+		if (top + bottom != lineHeight) {
+			// we have a rounding error
+			top += lineHeight - (top + bottom);
+		}
+		commentContainer.setBorder(new MarginBorder(top, 5, bottom, 5));
+		commentContainer.add(commentFigure);
+		return commentContainer;
 	}
 
 	private void createNameFigure() {

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/InstanceNameFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/InstanceNameFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Johannes Kepler University Linz
+ * Copyright (c) 2019, 2024 Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,6 +15,7 @@ package org.eclipse.fordiac.ide.application.figures;
 import org.eclipse.draw2d.Label;
 import org.eclipse.draw2d.MarginBorder;
 import org.eclipse.draw2d.PositionConstants;
+import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.fordiac.ide.gef.figures.AbstractShadowBorder;
 import org.eclipse.fordiac.ide.gef.listeners.IFontUpdateListener;
 import org.eclipse.fordiac.ide.ui.preferences.PreferenceConstants;
@@ -22,14 +23,13 @@ import org.eclipse.jface.resource.JFaceResources;
 
 public class InstanceNameFigure extends Label implements IFontUpdateListener {
 
-	public static final int INSTANCE_LABEL_MARGIN = AbstractShadowBorder.SHADOW_INSETS.top + 2;
+	public static final int INSTANCE_LABEL_MARGIN = -AbstractShadowBorder.SHADOW_INSETS.top;
 
 	public InstanceNameFigure() {
-		super();
 		setFont();
 		setTextAlignment(PositionConstants.CENTER);
 		setLabelAlignment(PositionConstants.CENTER);
-		setBorder(new MarginBorder(0, 0, INSTANCE_LABEL_MARGIN, 0));
+		setBorder(new MarginBorder(INSTANCE_LABEL_MARGIN, 0, 0, 0));
 	}
 
 	private void setFont() {
@@ -41,5 +41,11 @@ public class InstanceNameFigure extends Label implements IFontUpdateListener {
 		setFont();
 		invalidateTree();
 		revalidate();
+	}
+
+	@Override
+	protected Point getTextLocation() {
+		// compensate for the shadow border negative inset
+		return super.getTextLocation().getTranslated(0, INSTANCE_LABEL_MARGIN);
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/SubAppForFbNetworkFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/SubAppForFbNetworkFigure.java
@@ -49,6 +49,7 @@ import org.eclipse.fordiac.ide.gef.figures.BorderedRoundedRectangle;
 import org.eclipse.fordiac.ide.gef.figures.FBShapeShadowBorder;
 import org.eclipse.fordiac.ide.gef.figures.RoundedRectangleShadowBorder;
 import org.eclipse.fordiac.ide.gef.preferences.DiagramPreferences;
+import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
 import org.eclipse.fordiac.ide.ui.imageprovider.FordiacImage;
 import org.eclipse.swt.SWT;
@@ -196,6 +197,7 @@ public class SubAppForFbNetworkFigure extends FBNetworkElementFigure {
 	private void createContentContainer() {
 		expandedContentArea = new Figure();
 		final GridLayout expContentLayout = new GridLayout();
+		expContentLayout.marginHeight = 0;
 		expContentLayout.marginWidth = 0;
 		expContentLayout.verticalSpacing = 0;
 		expContentLayout.horizontalSpacing = 0;
@@ -247,15 +249,22 @@ public class SubAppForFbNetworkFigure extends FBNetworkElementFigure {
 		final Figure commentContainer = new Figure();
 		commentContainer.setLayoutManager(new ToolbarLayout());
 		expandedMainFigure.add(commentContainer, createCommentLayoutData(), 0);
-		// create a grid layout to get the default margin which is also used in groups
-		final GridLayout marginGetter = new GridLayout();
-		commentContainer.setBorder(new MarginBorder(marginGetter.marginHeight));
 
 		commentFigure = new InstanceCommentFigure();
-		commentFigure.setBorder(new AdvancedLineBorder(PositionConstants.SOUTH));
+		final AdvancedLineBorder commentLineSeperator = new AdvancedLineBorder(PositionConstants.SOUTH);
+		commentFigure.setBorder(commentLineSeperator);
 		commentFigure.setCursor(Cursors.SIZEALL);
 		commentContainer.add(commentFigure);
 		refreshComment();
+
+		final int lineHeight = (int) CoordinateConverter.INSTANCE.getLineHeight();
+		int top = lineHeight / 2;
+		final int bottom = top;
+		if (top + bottom != lineHeight) {
+			// we have a rounding error
+			top += lineHeight - (top + bottom);
+		}
+		commentContainer.setBorder(new MarginBorder(top, 5, bottom, 5));
 	}
 
 	private static GridData createCommentLayoutData() {
@@ -283,7 +292,7 @@ public class SubAppForFbNetworkFigure extends FBNetworkElementFigure {
 
 	protected static GridLayout createExpandedMainFigureLayout() {
 		final GridLayout topLayout = new GridLayout(3, false);
-		topLayout.marginHeight = 1;
+		topLayout.marginHeight = 0;
 		topLayout.marginWidth = 0;
 		topLayout.verticalSpacing = 0;
 		topLayout.horizontalSpacing = 0;

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/SubAppForFbNetworkFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/SubAppForFbNetworkFigure.java
@@ -195,7 +195,20 @@ public class SubAppForFbNetworkFigure extends FBNetworkElementFigure {
 	}
 
 	private void createContentContainer() {
-		expandedContentArea = new Figure();
+		expandedContentArea = new Figure() {
+			@Override
+			public void setBounds(final Rectangle rect) {
+				final Rectangle copy = rect.getCopy();
+				final int lineHeight = (int) CoordinateConverter.INSTANCE.getLineHeight();
+				// ensure that the content is aligned on the grid in x direction. We have to do
+				// that here to compensate for different interface bar widths and also to
+				// compensate changing interface bar widths.
+				final int offset = lineHeight - copy.x % lineHeight;
+				copy.x += offset;
+				copy.width -= offset;
+				super.setBounds(copy);
+			}
+		};
 		final GridLayout expContentLayout = new GridLayout();
 		expContentLayout.marginHeight = 0;
 		expContentLayout.marginWidth = 0;

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/Activator.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/Activator.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.gef;
 
-import org.eclipse.fordiac.ide.gef.preferences.DiagramPreferences;
 import org.eclipse.fordiac.ide.ui.Abstract4DIACUIPlugin;
 import org.osgi.framework.BundleContext;
 
@@ -46,7 +45,6 @@ public class Activator extends Abstract4DIACUIPlugin {
 		// were used, the grid spacing is set to a default
 		if (getPreferenceStore().contains(RULER_UNITS)
 				&& org.eclipse.gef.rulers.RulerProvider.UNIT_PIXELS != getPreferenceStore().getInt(RULER_UNITS)) {
-			getPreferenceStore().setValue(DiagramPreferences.GRID_SPACING, 20);
 			getPreferenceStore().setValue(RULER_UNITS, org.eclipse.gef.rulers.RulerProvider.UNIT_PIXELS);
 			// thre's no way to delete a key. See
 			// https://bugs.eclipse.org/bugs/show_bug.cgi?id=279774
@@ -66,7 +64,7 @@ public class Activator extends Abstract4DIACUIPlugin {
 		super.stop(context);
 	}
 
-	private static synchronized void setPlugin(Activator newPlugin) {
+	private static synchronized void setPlugin(final Activator newPlugin) {
 		plugin = newPlugin;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/AbstractDiagramEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/AbstractDiagramEditPart.java
@@ -23,7 +23,6 @@ import org.eclipse.draw2d.FreeformLayer;
 import org.eclipse.draw2d.FreeformLayout;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.MarginBorder;
-import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.fordiac.ide.gef.Activator;
 import org.eclipse.fordiac.ide.gef.preferences.DiagramPreferences;
 import org.eclipse.gef.CompoundSnapToHelper;
@@ -70,7 +69,6 @@ public abstract class AbstractDiagramEditPart extends AbstractGraphicalEditPart 
 	@Override
 	public void refresh() {
 		super.refresh();
-		updateGrid();
 		showGrid();
 		updateRuler();
 	}
@@ -128,9 +126,6 @@ public abstract class AbstractDiagramEditPart extends AbstractGraphicalEditPart 
 				if (event.getProperty().equals(DiagramPreferences.SHOW_GRID)) {
 					showGrid();
 				}
-				if (event.getProperty().equals(DiagramPreferences.GRID_SPACING)) {
-					updateGrid();
-				}
 				if (event.getProperty().equals(DiagramPreferences.SHOW_RULERS)) {
 					updateRuler();
 				}
@@ -139,15 +134,9 @@ public abstract class AbstractDiagramEditPart extends AbstractGraphicalEditPart 
 		return listener;
 	}
 
-	@SuppressWarnings("static-method")  // allow children to overwrite and create a different router
+	@SuppressWarnings("static-method") // allow children to overwrite and create a different router
 	protected ConnectionRouter createConnectionRouter(final IFigure figure) {
 		return new BendpointConnectionRouter();
-	}
-
-	protected void updateGrid() {
-		final int gridSpacing = Activator.getDefault().getPreferenceStore().getInt(DiagramPreferences.GRID_SPACING);
-
-		getViewer().setProperty(SnapToGrid.PROPERTY_GRID_SPACING, new Dimension(gridSpacing, gridSpacing));
 	}
 
 	/*

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/figures/FBShape.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/figures/FBShape.java
@@ -391,7 +391,6 @@ public class FBShape extends Figure implements IFontUpdateListener, ITransparenc
 
 	private static ToolbarLayout createInputContainerLayout() {
 		final ToolbarLayout toolbarLayout = new ToolbarLayout(false);
-		toolbarLayout.setSpacing(2);
 		toolbarLayout.setStretchMinorAxis(true);
 		return toolbarLayout;
 	}
@@ -399,7 +398,6 @@ public class FBShape extends Figure implements IFontUpdateListener, ITransparenc
 	private static ToolbarLayout createOutputContainerLayout() {
 		final ToolbarLayout layout = new ToolbarLayout(false);
 		layout.setStretchMinorAxis(true);
-		layout.setSpacing(2);
 		layout.setMinorAlignment(OrderedLayout.ALIGN_BOTTOMRIGHT);
 
 		return layout;
@@ -430,8 +428,8 @@ public class FBShape extends Figure implements IFontUpdateListener, ITransparenc
 		container.add(middle, BorderLayout.CENTER);
 
 		final GridLayout middleLayout = new GridLayout(1, true);
-		middleLayout.marginHeight = 1;
-		middleLayout.verticalSpacing = 1;
+		middleLayout.marginHeight = 0;
+		middleLayout.verticalSpacing = 0;
 		middleLayout.marginWidth = 3;
 
 		middle.setLayoutManager(middleLayout);

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/preferences/DiagramPreferences.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/preferences/DiagramPreferences.java
@@ -52,8 +52,6 @@ public class DiagramPreferences extends FieldEditorPreferencePage implements IWo
 	public static final int CORNER_DIM = 6;
 	public static final int CORNER_DIM_HALF = CORNER_DIM / 2;
 
-	public static final String GRID_SPACING = "GridSpacing"; //$NON-NLS-1$
-
 	public static final String SNAP_TO_GRID = "SnapToGrid"; //$NON-NLS-1$
 
 	public static final String SHOW_GRID = "ShowGrid"; //$NON-NLS-1$
@@ -255,10 +253,6 @@ public class DiagramPreferences extends FieldEditorPreferencePage implements IWo
 				Messages.DiagramPreferences_FieldEditors_SnapToGrid, group);
 		addField(snapToGrid);
 
-		final IntegerFieldEditor gridSpacing = new IntegerFieldEditor(GRID_SPACING,
-				Messages.DiagramPreferences_FieldEditors_GridSpacingInPixels, group);
-		gridSpacing.setTextLimit(10);
-		addField(gridSpacing);
 		configGroup(group);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/preferences/PreferenceInitializer.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/preferences/PreferenceInitializer.java
@@ -28,7 +28,6 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 		final IPreferenceStore store = Activator.getDefault().getPreferenceStore();
 		store.setDefault(DiagramPreferences.SNAP_TO_GRID, true);
 		store.setDefault(DiagramPreferences.SHOW_GRID, true);
-		store.setDefault(DiagramPreferences.GRID_SPACING, 20);
 
 		store.setDefault(DiagramPreferences.PIN_LABEL_STYLE, DiagramPreferences.PIN_LABEL_STYLE_PIN_NAME);
 

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/SetPositionCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/SetPositionCommand.java
@@ -24,8 +24,8 @@ import org.eclipse.gef.commands.Command;
 
 public class SetPositionCommand extends Command {
 	private final PositionableElement positionableElement;
-	private final double dx;
-	private final double dy;
+//	private final double dx;
+//	private final double dy;
 	private Position oldPos;
 	private Position newPos;
 
@@ -33,16 +33,25 @@ public class SetPositionCommand extends Command {
 		return positionableElement;
 	}
 
-	public SetPositionCommand(final PositionableElement positionableElement, final double dx, final double dy) {
+	private SetPositionCommand(final PositionableElement positionableElement) {
 		this.positionableElement = positionableElement;
-		this.dx = dx;
-		this.dy = dy;
 		setLabel(Messages.ViewSetPositionCommand_LABEL_Move);
 	}
 
+	public SetPositionCommand(final PositionableElement positionableElement, final double dx, final double dy) {
+		this(positionableElement);
+		if (positionableElement != null) {
+			oldPos = getPositionableElement().getPosition();
+			newPos = createNewPosition(oldPos, dx, dy);
+		}
+	}
+
 	public SetPositionCommand(final PositionableElement positionableElement, final int dx, final int dy) {
-		this(positionableElement, CoordinateConverter.INSTANCE.screenToIEC61499(dx),
-				CoordinateConverter.INSTANCE.screenToIEC61499(dy));
+		this(positionableElement);
+		if (positionableElement != null) {
+			oldPos = getPositionableElement().getPosition();
+			newPos = createNewPosition(oldPos, dx, dy);
+		}
 	}
 
 	@Override
@@ -52,8 +61,6 @@ public class SetPositionCommand extends Command {
 
 	@Override
 	public void execute() {
-		oldPos = getPositionableElement().getPosition();
-		newPos = createNewPosition();
 		setPosition(newPos);
 	}
 
@@ -67,11 +74,23 @@ public class SetPositionCommand extends Command {
 		setPosition(oldPos);
 	}
 
-	private Position createNewPosition() {
+	private static Position createNewPosition(final Position oldPos, final double dx, final double dy) {
 		final Position pos = LibraryElementFactory.eINSTANCE.createPosition();
 		pos.setX(oldPos.getX() + dx);
 		pos.setY(oldPos.getY() + dy);
 		return pos;
+	}
+
+	private static Position createNewPosition(final Position oldPos, final int dx, final int dy) {
+		final Position pos = LibraryElementFactory.eINSTANCE.createPosition();
+		pos.setX(newPosFromScreenDelta(dx, oldPos.getX()));
+		pos.setY(newPosFromScreenDelta(dy, oldPos.getY()));
+		return pos;
+	}
+
+	private static double newPosFromScreenDelta(final int delta, final double oldPos) {
+		final int oldPosScreen = CoordinateConverter.INSTANCE.iec61499ToScreen(oldPos);
+		return CoordinateConverter.INSTANCE.screenToIEC61499(oldPosScreen + delta);
 	}
 
 	protected void setPosition(final Position pos) {


### PR DESCRIPTION
With this change the grid resolution can not be changed anymore but is the same size as the difference between to pins of a FB. This results in cleaner drawings and with snap to grid positions of FBs are always in 100 IEC 61499-2 units. To get that also in expanded subapps and groups the top part of them is adjust to use a multiple of the grid size.