### PR TITLE
When Invoking the New Instance Inserter via Typing Don't Select Char

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editors/NewInstanceDirectEditManager.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editors/NewInstanceDirectEditManager.java
@@ -94,9 +94,9 @@ public class NewInstanceDirectEditManager extends TextDirectEditManager {
 	public void show(final String initialValue) {
 		this.initialValue = initialValue;
 		super.show();
-		if (null != initialValue) {
+		if (initialValue != null) {
 			final Text text = getCellEditor().getText();
-			text.selectAll();
+			text.setSelection(text.getText().length());
 			setDirty(true);
 		}
 	}


### PR DESCRIPTION
When the new instance direct edit was invoked by clicking and just typing the first char was always selected and subsequent typing overwrote it. With this commit the caret is placed after the initial char so that users can continue typing.