### PR TITLE
Update GitHub Workflow Actions to Their Latest Versions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,25 +16,25 @@ jobs:
     runs-on: ${{ matrix.os }} 
     name: OS ${{ matrix.os }} Java ${{ matrix.java }} compile
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
     - name: Set up Java
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@2dfa2011c5b2a0f1489bf9e433881c92c1631f88 # v4.3.0
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}
         cache: 'maven'
     - name: Set up Maven
-      uses: stCarolas/setup-maven@v4.5
+      uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
       with:
         maven-version: 3.9.3
     - name: Build with Maven
-      uses: coactions/setup-xvfb@v1
+      uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
       with:
        run: >- 
         mvn -V -B -fae -ntp clean verify
     - name: Upload Test Results for Java-${{ matrix.java }}
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       with:
         name: test-results-${{ matrix.os }}-java${{ matrix.java }}
         if-no-files-found: error

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -36,7 +36,7 @@ jobs:
            done
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@82082dac68ad6a19d980f8ce817e108b9f496c2a # v2.17.1
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/event_file/event.json


### PR DESCRIPTION
Dependabot is rather picky with version names, also using the commit hash instead of the version is better for reducing supply-chain attacks. See https://github.com/eclipse/gef-classic/issues/471 for more details.