### PR TITLE
Added a temporary flag for disabling the rename dialog

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/changelistener/FordiacResourceChangeListener.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/changelistener/FordiacResourceChangeListener.java
@@ -72,6 +72,8 @@ import com.google.common.base.Objects;
 
 public class FordiacResourceChangeListener implements IResourceChangeListener {
 
+	private static final boolean ENABLE_COPY_DIALOG = false;
+
 	private static class FileToRenameEntry {
 
 		private final IFile filetoRename;
@@ -277,7 +279,7 @@ public class FordiacResourceChangeListener implements IResourceChangeListener {
 					updateTypeEntry(file, entry);
 					return;
 				}
-				if (fileExists(file, delta)) {
+				if (ENABLE_COPY_DIALOG && fileExists(file, delta)) {
 					Display.getDefault().syncExec(() -> {
 						openRenameDialog(file, entry);
 					});


### PR DESCRIPTION
Currently the rename dialog has to many problems to be activated:
- Git reset can trigger the dialog
- Copy between projects has problems
- The recursive search has the danger of slowing down project opening after switching branch