### PR TITLE
Fixed Quick-Fix to use the correct model-element from the editor

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/marker/resolution/ChangeDataTypeMarkerResolution.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/marker/resolution/ChangeDataTypeMarkerResolution.java
@@ -21,7 +21,6 @@ import org.eclipse.fordiac.ide.model.commands.change.ChangeStructCommand;
 import org.eclipse.fordiac.ide.model.commands.change.ConfigureFBCommand;
 import org.eclipse.fordiac.ide.model.data.DataType;
 import org.eclipse.fordiac.ide.model.data.StructuredType;
-import org.eclipse.fordiac.ide.model.errormarker.FordiacErrorMarker;
 import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableFB;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.StructManipulator;
@@ -53,7 +52,7 @@ public class ChangeDataTypeMarkerResolution extends AbstractErrorMarkerResolutio
 		}
 
 		if (selectedType != null) {
-			final EObject errorType = FordiacErrorMarker.getTarget(marker);
+			final EObject errorType = getTargetElement(marker);
 			if (errorType instanceof final IInterfaceElement interfaceElement) {
 				AbstractLiveSearchContext.executeAndSave(
 						ChangeDataTypeCommand.forDataType(interfaceElement, selectedType), interfaceElement,

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/marker/resolution/ChangeFBMarkerResolution.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/marker/resolution/ChangeFBMarkerResolution.java
@@ -18,15 +18,14 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.fordiac.ide.model.commands.change.UpdateFBTypeCommand;
 import org.eclipse.fordiac.ide.model.commands.change.UpdateInternalFBCommand;
-import org.eclipse.fordiac.ide.model.errormarker.FordiacErrorMarker;
 import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.FB;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.search.AbstractLiveSearchContext;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.model.ui.editors.DataTypeTreeSelectionDialog;
-import org.eclipse.fordiac.ide.model.ui.nat.FBTypeSelectionTreeContentProvider;
 import org.eclipse.fordiac.ide.model.ui.nat.FBTreeNodeLabelProvider;
+import org.eclipse.fordiac.ide.model.ui.nat.FBTypeSelectionTreeContentProvider;
 import org.eclipse.fordiac.ide.model.ui.nat.TypeNode;
 import org.eclipse.fordiac.ide.ui.FordiacMessages;
 import org.eclipse.jface.window.Window;
@@ -52,7 +51,8 @@ public class ChangeFBMarkerResolution extends AbstractErrorMarkerResolution {
 		}
 
 		if (selectedEntry != null) {
-			final EObject target = FordiacErrorMarker.getTarget(marker);
+			final EObject target = getTargetElement(marker);
+
 			if (target instanceof final FB fb && fb.eContainer() instanceof final BaseFBType base
 					&& base.getInternalFbs().contains(fb)) {
 				AbstractLiveSearchContext.executeAndSave(new UpdateInternalFBCommand(fb, selectedEntry), fb,

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/marker/resolution/CreateDataTypeMarkerResolution.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/marker/resolution/CreateDataTypeMarkerResolution.java
@@ -57,7 +57,7 @@ public class CreateDataTypeMarkerResolution extends AbstractErrorMarkerResolutio
 		}
 
 		if (newEntry != null) {
-			final EObject errorType = FordiacErrorMarker.getTarget(marker);
+			final EObject errorType = getTargetElement(marker);
 			if (errorType instanceof final IInterfaceElement target) {
 				AbstractLiveSearchContext.executeAndSave(ChangeDataTypeCommand.forDataType(target, newEntry.getType()),
 						target, new NullProgressMonitor());

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/marker/resolution/CreateMissingFBMarkerResolution.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/marker/resolution/CreateMissingFBMarkerResolution.java
@@ -67,7 +67,7 @@ public class CreateMissingFBMarkerResolution extends AbstractErrorMarkerResoluti
 	public void run(final IMarker[] markers, final IProgressMonitor monitor) {
 		// save Error-Objects for new Type has same name
 		for (final IMarker marker : markers) {
-			targets.add(FordiacErrorMarker.getTarget(marker));
+			targets.add(getTargetElement(marker));
 		}
 
 		final String errorName = FordiacErrorMarker.getData(this.marker)[0];


### PR DESCRIPTION
Quick-Fix now saves all unsaved changes instead of discarding them