### PR TITLE
Fix return type conversion in ST partitioner

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm/src/org/eclipse/fordiac/ide/structuredtextalgorithm/util/STAlgorithmPartitioner.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm/src/org/eclipse/fordiac/ide/structuredtextalgorithm/util/STAlgorithmPartitioner.java
@@ -166,7 +166,7 @@ public class STAlgorithmPartitioner extends STRecoveringPartitioner<ICallable> {
 		method.getInOutParameters().stream().map(STVarDeclaration.class::cast)
 				.filter(STAlgorithmPartitioner::isValidParameter).map(this::convertInOutParameter)
 				.forEachOrdered(result.getInOutParameters()::add);
-		result.setReturnType(resolveDataType(method.getReturnType(), method));
+		result.setReturnType(resolveDataType(method.getReturnType(), method, null));
 		result.setText(node.getText());
 		return result;
 	}

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/util/STAbstractCorePartitioner.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/util/STAbstractCorePartitioner.java
@@ -81,7 +81,7 @@ public abstract class STAbstractCorePartitioner<E extends INamedElement> impleme
 		if (comment != null) {
 			result.setComment(comment);
 		}
-		result.setType(resolveDataType(declaration.getType(), declaration));
+		result.setType(resolveDataType(declaration.getType(), declaration, GenericTypes.ANY));
 		if (declaration.isArray()) {
 			ArraySizeHelper.setArraySize(result, extractArraySize(declaration));
 		}
@@ -135,7 +135,8 @@ public abstract class STAbstractCorePartitioner<E extends INamedElement> impleme
 				.map(INode::getText).collect(Collectors.joining()).trim();
 	}
 
-	protected static DataType resolveDataType(final INamedElement type, final EObject context) {
+	protected static DataType resolveDataType(final INamedElement type, final EObject context,
+			final DataType defaultType) {
 		if (type != null && type.eIsProxy()) {
 			final String linkName = extractLinkName(type, context);
 			if (!linkName.isEmpty()) {
@@ -147,7 +148,7 @@ public abstract class STAbstractCorePartitioner<E extends INamedElement> impleme
 		} else if (type instanceof final DataType dataType) {
 			return dataType;
 		}
-		return GenericTypes.ANY;
+		return defaultType;
 	}
 
 	protected static String extractLinkName(final EObject proxy, final EObject context) {

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/util/STFunctionPartitioner.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/util/STFunctionPartitioner.java
@@ -143,7 +143,7 @@ public class STFunctionPartitioner
 		function.getInOutParameters().stream().map(STVarDeclaration.class::cast)
 				.filter(STFunctionPartitioner::isValidParameter).map(this::convertInOutParameter)
 				.forEachOrdered(result.getInOutParameters()::add);
-		result.setReturnType(resolveDataType(function.getReturnType(), function));
+		result.setReturnType(resolveDataType(function.getReturnType(), function, null));
 		result.setText(node.getText());
 		return result;
 	}


### PR DESCRIPTION
If there was no return type, the return type of the converted method or function was inadvertently set to ANY instead of null. This later led to problems during export and possibly other places.