### PR TITLE
Use a fresh CompareEditor for every file

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/TemplateExportFilter.java
+++ b/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/TemplateExportFilter.java
@@ -206,13 +206,12 @@ public abstract class TemplateExportFilter extends ExportFilter {
 	}
 
 	private static void openMergeEditor(final Iterable<StoredFiles> writtenFiles) throws ExportException {
-		final ICompareEditorOpener opener = CompareEditorOpenerUtil.getOpener();
-		if (null == opener) {
-			throw new ExportException(Messages.TemplateExportFilter_MERGE_EDITOR_FAILED);
-		}
-
 		for (final StoredFiles sf : writtenFiles) {
 			if ((null != sf.newFile()) && (null != sf.oldFile())) {
+				final ICompareEditorOpener opener = CompareEditorOpenerUtil.getOpener();
+				if (null == opener) {
+					throw new ExportException(Messages.TemplateExportFilter_MERGE_EDITOR_FAILED);
+				}
 				opener.setName(sf.newFile().getName());
 				opener.setTitle(sf.newFile().getName());
 				opener.setNewFile(sf.newFile());


### PR DESCRIPTION
Only the last file (the .cpp file) passed to the reused opener was shown in the merge editor