### PR TITLE
Move interpreter contribution from Debug to Run menu

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/plugin.xml
@@ -55,7 +55,7 @@
    <extension
            point="org.eclipse.ui.menus">
 	<menuContribution
-         locationURI="menu:org.eclipse.4diac.ide.monitoring.menus.debug?after=org.eclipse.fordiac.ide.monitoring.monitoringAdditions">  
+         locationURI="menu:org.eclipse.ui.run">  
       <command
             commandId="org.eclipse.fordiac.ide.fb.interpreter.recordExecutionTrace"
             label="Record Execution Trace for Network"


### PR DESCRIPTION
Move interpreter contribution from Debug to Run menu, in anticipation of removal of the Debug menu.