### PR TITLE
[Fix] Use Insets for Expanded SubappApp Content

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/UnfoldedSubappContentEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/UnfoldedSubappContentEditPart.java
@@ -17,12 +17,18 @@
 
 package org.eclipse.fordiac.ide.application.editparts;
 
+import org.eclipse.draw2d.Figure;
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.XYLayout;
+import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.emf.common.notify.Adapter;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.ecore.util.EContentAdapter;
 import org.eclipse.fordiac.ide.application.commands.ResizeGroupOrSubappCommand;
 import org.eclipse.fordiac.ide.application.policies.SubAppContentLayoutEditPolicy;
+import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.commands.create.AbstractCreateFBNetworkElementCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
@@ -78,6 +84,40 @@ public class UnfoldedSubappContentEditPart extends AbstractContainerContentEditP
 						.createCreateCommand(value, getModel(), refPoint.x, refPoint.y));
 			}
 		});
+	}
+
+	@Override
+	protected IFigure createFigure() {
+		final IFigure figure = new Figure() {
+			Insets offsetInset = new Insets();
+
+			@Override
+			public void setBounds(final Rectangle rect) {
+				final Rectangle copy = rect.getCopy();
+				final Rectangle clientArea = getParent().getClientArea();
+				final int maxAvailableHeight = clientArea.height - (rect.y - clientArea.y);
+				// expand content to the available subapp size
+				copy.height = Math.max(rect.height, maxAvailableHeight);
+
+				final int lineHeight = (int) CoordinateConverter.INSTANCE.getLineHeight();
+				// ensure that the content is aligned on the grid in x direction. We have to do
+				// that here to compensate for different interface bar widths and also to
+				// compensate changing interface bar widths.
+				final int offset = lineHeight - copy.x % lineHeight;
+				offsetInset.left = offset;
+				offsetInset.right = offset;
+				super.setBounds(copy);
+			}
+
+			@Override
+			public Insets getInsets() {
+				return offsetInset;
+			}
+		};
+
+		figure.setOpaque(true);
+		figure.setLayoutManager(new XYLayout());
+		return figure;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/SubAppForFbNetworkFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/SubAppForFbNetworkFigure.java
@@ -195,20 +195,7 @@ public class SubAppForFbNetworkFigure extends FBNetworkElementFigure {
 	}
 
 	private void createContentContainer() {
-		expandedContentArea = new Figure() {
-			@Override
-			public void setBounds(final Rectangle rect) {
-				final Rectangle copy = rect.getCopy();
-				final int lineHeight = (int) CoordinateConverter.INSTANCE.getLineHeight();
-				// ensure that the content is aligned on the grid in x direction. We have to do
-				// that here to compensate for different interface bar widths and also to
-				// compensate changing interface bar widths.
-				final int offset = lineHeight - copy.x % lineHeight;
-				copy.x += offset;
-				copy.width -= offset;
-				super.setBounds(copy);
-			}
-		};
+		expandedContentArea = new Figure();
 		final GridLayout expContentLayout = new GridLayout();
 		expContentLayout.marginHeight = 0;
 		expContentLayout.marginWidth = 0;


### PR DESCRIPTION
While the expanded subapp content offset calculation for grid alignment worked it broke the connection clipping. The result was that connections where not ending at the interface bar. With this change now the offset is applied as insets to expanded SubApp content figure, which fixes the connection clipping and provides the right offset.