### PR TITLE
removed target branch from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "develop"
     labels:
       - "Github Action Dependencies"
   - package-ecosystem: maven
@@ -15,6 +14,5 @@ updates:
       prefix: fix
       prefix-development: chore
       include: scope
-    target-branch: "develop"
     labels:
       - dependencies


### PR DESCRIPTION
Dependabot should update the workflows wich are currently run from release. So the target branch as develop was not the right place.