### PR TITLE
Fix attribute lookup in importer

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/CommonElementImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/CommonElementImporter.java
@@ -435,7 +435,9 @@ public abstract class CommonElementImporter {
 				}
 			} else {
 				// AttributeDeclarations
-				final AttributeTypeEntry entry = ImportHelper.resolveImport(attribute.getName(), confObject,
+				// use element for resolving import since confObject may not have been added to
+				// enclosing type yet
+				final AttributeTypeEntry entry = ImportHelper.resolveImport(attribute.getName(), getElement(),
 						name -> getTypeLibrary().getAttributeTypeEntry(name), name -> null);
 				final AttributeTypeEntry attributeTypeEntry = addDependency(entry);
 				if (attributeTypeEntry != null && attributeTypeEntry.getType() != null) {


### PR DESCRIPTION
Fix attribute lookup in importer to use the element as context instead of the current object, since the current object may not have been added to the enclosing type yet.