### PR TITLE
Improved the SWTBot tests with moving FBs

### DIFF
--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/fbtype/ECCEditorTests.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/fbtype/ECCEditorTests.java
@@ -56,7 +56,7 @@ public class ECCEditorTests extends Abstract4diacUITests {
 		eccTab.setFocus();
 
 		bot.editorByTitle(UITestNamesHelper.FBT_TEST_PROJECT2).show();
-		editor = (SWTBot4diacGefEditor) bot.gefEditor(UITestNamesHelper.FBT_TEST_PROJECT2);
+		editor = bot.gefEditor(UITestNamesHelper.FBT_TEST_PROJECT2);
 	}
 
 	/**
@@ -125,6 +125,7 @@ public class ECCEditorTests extends Abstract4diacUITests {
 	@Test
 	@Order(4)
 	public void createAlgorithm() {
+
 		new SWTBotECC(bot).changeAlgorithmAndEventValue(editor, UITestNamesHelper.TESTSTATE,
 				UITestNamesHelper.DEINITIALIZE, 0);
 	}

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/helpers/SWTBotFB.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/helpers/SWTBotFB.java
@@ -19,10 +19,12 @@ package org.eclipse.fordiac.ide.test.ui.helpers;
 import static org.eclipse.swtbot.swt.finder.waits.Conditions.treeItemHasNode;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.fordiac.ide.application.editparts.FBEditPart;
 import org.eclipse.fordiac.ide.test.ui.swtbot.SWT4diacGefBot;
@@ -169,6 +171,28 @@ public class SWTBotFB {
 		assertNotNull(fbBounds);
 		figure.translateToAbsolute(fbBounds);
 		return fbBounds;
+	}
+
+	/**
+	 * Moves a Function Block to the given position
+	 *
+	 * @param editor
+	 * @param fBname  The FB that should be moved
+	 * @param toPoint The new position of the FB
+	 */
+	public void moveSingleFB(SWTBotGefEditor editor, final String fBname, final Point toPoint) {
+		assertNotNull(editor);
+		assertNotNull(editor.getEditPart(fBname));
+		editor = selectFBWithFBNameInEditor((SWTBot4diacGefEditor) editor, fBname);
+		final SWTBotGefEditPart fbEditPart = editor.getEditPart(fBname).parent();
+		assertNotNull(fbEditPart);
+
+		// move FB, get bounds of FB and expand bounds to have a tolerance for the grid
+		// alignment when checking the new position
+		editor.drag(fbEditPart, toPoint.x, toPoint.y);
+		final Rectangle toPosition = getBoundsOfFB(editor, fBname);
+		final Rectangle expandedBounds = toPosition.expand(new Insets(2));
+		assertTrue(expandedBounds.contains(toPoint.x, toPoint.y));
 	}
 
 }

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/networkediting/basicfb/Basic2FBNetworkEditingTests.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/networkediting/basicfb/Basic2FBNetworkEditingTests.java
@@ -39,6 +39,8 @@ import org.junit.jupiter.api.Test;
 
 public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 
+	static final int TOLERANCE_SNAP_TO_GRID = 15;
+
 	/**
 	 * Drags and Drops two Function Blocks onto the canvas.
 	 *
@@ -195,7 +197,7 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 		final Point absPos1Fb1 = new Point(100, 100);
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_CYCLE_TREE_ITEM, absPos1Fb1);
-		final Point absPos1Fb2 = new Point(100, 220);
+		final Point absPos1Fb2 = new Point(250, 150);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_SR_TREE_ITEM, absPos1Fb2);
 		final SWTBot4diacGefEditor editor = bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
 
@@ -205,18 +207,17 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 		assertTrue(fb2Bounds1.contains(absPos1Fb2.x, absPos1Fb2.y));
 
 		// drag rectangle over FBs, therefore FBs should be selected
-		editor.drag(50, 50, 400, 400);
+		editor.drag(50, 50, 400, 300);
 		assertDoesNotThrow(editor::waitForSelectedFBEditPart);
 		List<SWTBotGefEditPart> selectedEditParts = editor.selectedEditParts();
 		assertFalse(selectedEditParts.isEmpty());
-		fbBot.moveViaRectangle(editor, new Rectangle(50, 50, 400, 400), new Point(75, 125));
 		assertTrue(fbBot.isFbSelected(selectedEditParts, UITestNamesHelper.E_CYCLE_FB));
 		assertTrue(fbBot.isFbSelected(selectedEditParts, UITestNamesHelper.E_SR_FB));
 
 		// move selection by clicking on point within selection (120, 120) and drag to
 		// new Point (285, 85)
 		final Point pointFrom = new Point(120, 120);
-		final Point pointTo = new Point(285, 85);
+		final Point pointTo = new Point(250, 80);
 		editor.drag(pointFrom.x, pointFrom.y, pointTo.x, pointTo.y);
 
 		assertDoesNotThrow(editor::waitForSelectedFBEditPart);
@@ -230,31 +231,41 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 		final int translationY = pointTo.y - pointFrom.y;
 
 		// Calculation of new Position of E_CYCLEs
-		final int absPos2Fb1X = absPos1Fb1.x + translationX;
-		final int absPos2Fb1Y = absPos1Fb1.y + translationY;
+		final int absPos2Fb1X = absPos1Fb1.x + translationX + TOLERANCE_SNAP_TO_GRID;
+		final int absPos2Fb1Y = absPos1Fb1.y + translationY + TOLERANCE_SNAP_TO_GRID;
 		final Rectangle fb1Bounds2 = fbBot.getBoundsOfFB(editor, UITestNamesHelper.E_CYCLE_FB);
-		assertEquals(absPos2Fb1X, fb1Bounds2.x);
-		assertEquals(absPos2Fb1Y, fb1Bounds2.y);
 		assertTrue(fb1Bounds2.contains(absPos2Fb1X, absPos2Fb1Y));
 
 		// Calculation of new Position of E_SR
-		final int absPos2Fb2X = absPos1Fb2.x + translationX;
-		final int absPos2Fb2Y = absPos1Fb2.y + translationY;
+		final int absPos2Fb2X = absPos1Fb2.x + translationX + TOLERANCE_SNAP_TO_GRID;
+		final int absPos2Fb2Y = absPos1Fb2.y + translationY + TOLERANCE_SNAP_TO_GRID;
 		final Rectangle fb2Bounds2 = fbBot.getBoundsOfFB(editor, UITestNamesHelper.E_SR_FB);
-		assertEquals(absPos2Fb2X, fb2Bounds2.x);
-		assertEquals(absPos2Fb2Y, fb2Bounds2.y);
 		assertTrue(fb2Bounds2.contains(absPos2Fb2X, absPos2Fb2Y));
 	}
 
+	/**
+	 * Checks if Elements can be moved via selection with a rectangle
+	 *
+	 * First 3 FBs are dragged onto the editing area. Afterwards a rectangle is
+	 * drawn up to select them and to be moved to a new location with the given
+	 * translation.
+	 */
 	@SuppressWarnings("static-method")
 	@Test
 	public void moveFBsSelectedViaRectangle() {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
-		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_CYCLE_TREE_ITEM, new Point(100, 75));
-		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_CYCLE_TREE_ITEM, new Point(300, 75));
+		final Point posFB = new Point(100, 75);
+		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_CYCLE_TREE_ITEM, posFB);
+		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_SWITCH_TREE_ITEM, new Point(250, 75));
+		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_N_TABLE_TREE_ITEM, new Point(400, 100));
 		final SWTBot4diacGefEditor editor = bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
-		fbBot.moveViaRectangle(editor, new Rectangle(50, 50, 500, 200), new Point(75, 125));
-// TODO		assertFalse(selectedEditParts.isEmpty());
+		final Point translation = new Point(75, 125);
+		fbBot.moveViaRectangle(editor, new Rectangle(50, 50, 600, 300), translation);
+		// check first FB
+		final Rectangle endPosFB = fbBot.getBoundsOfFB(editor, UITestNamesHelper.E_CYCLE_FB);
+		final int expectedEndPosX = posFB.x + translation.x + TOLERANCE_SNAP_TO_GRID;
+		final int expectedEndPosY = posFB.y + translation.y + TOLERANCE_SNAP_TO_GRID;
+		assertTrue(endPosFB.contains(expectedEndPosX, expectedEndPosY));
 	}
 
 	/**
@@ -283,13 +294,7 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 		// select E_CYCLE
 		final SWTBot4diacGefEditor editor = bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
 		fbBot.selectFBWithFBNameInEditor(editor, UITestNamesHelper.E_CYCLE_FB);
-//		assertNotNull(editor);
-//		assertNotNull(editor.getEditPart(UITestNamesHelper.E_CYCLE_FB));
-//		editor.click(UITestNamesHelper.E_CYCLE_FB);
 		final SWTBotGefEditPart fb1 = editor.getEditPart(UITestNamesHelper.E_CYCLE_FB).parent();
-//		assertNotNull(fb1);
-//		final Rectangle fb1Bounds1 = fbBot.getBoundsOfFB(editor, UITestNamesHelper.E_CYCLE_FB);
-//		assertTrue(fb1Bounds1.contains(pos1.x, pos1.y));
 
 		// get connection start and end point
 		final PolylineConnection polyLineConnection = (PolylineConnection) connection.getFigure();
@@ -356,7 +361,7 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 		// get connection start and end point
 		final PolylineConnection polyLineConnection = (PolylineConnection) connection.getFigure();
 		final org.eclipse.draw2d.geometry.Point startPointConnection = polyLineConnection.getPoints().getFirstPoint();
-		final org.eclipse.draw2d.geometry.Point endPointConnection = polyLineConnection.getPoints().getLastPoint();
+		org.eclipse.draw2d.geometry.Point endPointConnection = polyLineConnection.getPoints().getLastPoint();
 
 		// calculate deltas of translation
 		final Point pos3 = new Point(45, 105);
@@ -368,16 +373,18 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 		final int fb2DeltaY = pos4.y - pos2.y;
 
 		// move E_SELECT
-		editor.drag(fb1, pos3.x, pos3.y);
-		final Rectangle fb1Bounds2 = fbBot.getBoundsOfFB(editor, UITestNamesHelper.E_SELECT_FB);
-		assertTrue(fb1Bounds2.contains(pos3.x, pos3.y));
+		fbBot.moveSingleFB(editor, UITestNamesHelper.E_SELECT_FB, pos3);
+
 		assertNotNull(connection);
 		org.eclipse.draw2d.geometry.Point newStartPointConnection = polyLineConnection.getPoints().getFirstPoint();
 		org.eclipse.draw2d.geometry.Point newEndPointConnection = polyLineConnection.getPoints().getLastPoint();
 
-		assertEquals(startPointConnection, newStartPointConnection);
-		assertEquals(endPointConnection.x + (long) fb1DeltaX, newEndPointConnection.x);
-		assertEquals(endPointConnection.y + (long) fb1DeltaY, newEndPointConnection.y);
+		double distance = startPointConnection.getDistance(newStartPointConnection);
+		assertTrue(distance <= TOLERANCE_SNAP_TO_GRID);
+		distance = endPointConnection.translate(fb1DeltaX, fb1DeltaY).getDistance(newEndPointConnection);
+		assertTrue(distance <= TOLERANCE_SNAP_TO_GRID);
+
+		endPointConnection = newEndPointConnection;
 
 		// select E_CTUD
 		editor.click(UITestNamesHelper.E_CTUD_FB);
@@ -386,17 +393,16 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 		final Rectangle fb2Bounds1 = fbBot.getBoundsOfFB(editor, UITestNamesHelper.E_CTUD_FB);
 		assertTrue(fb2Bounds1.contains(pos2.x, pos2.y));
 		// move E_CTUD
-		editor.drag(fb2, pos4.x, pos4.y);
+		fbBot.moveSingleFB(editor, UITestNamesHelper.E_CTUD_FB, pos4);
 		final Rectangle fb2Bounds2 = fbBot.getBoundsOfFB(editor, UITestNamesHelper.E_CTUD_FB);
 		assertTrue(fb2Bounds2.contains(pos4.x, pos4.y));
 		assertNotNull(connection);
 		newStartPointConnection = polyLineConnection.getPoints().getFirstPoint();
 		newEndPointConnection = polyLineConnection.getPoints().getLastPoint();
 
-		assertEquals(startPointConnection.x + (long) fb2DeltaX, newStartPointConnection.x);
-		assertEquals(startPointConnection.y + (long) fb2DeltaY, newStartPointConnection.y);
-		assertEquals(endPointConnection.x + (long) fb1DeltaX, newEndPointConnection.x);
-		assertEquals(endPointConnection.y + (long) fb1DeltaY, newEndPointConnection.y);
+		assertTrue(startPointConnection.translate(fb2DeltaX, fb2DeltaY)
+				.getDistance(newStartPointConnection) <= TOLERANCE_SNAP_TO_GRID);
+		assertTrue(endPointConnection.getDistance(newEndPointConnection) <= TOLERANCE_SNAP_TO_GRID);
 	}
 
 	/**

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/networkediting/basicfb/Basic2FBNetworkEditingTests.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/networkediting/basicfb/Basic2FBNetworkEditingTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Andrea Zoitl
+ * Copyright (c) 2023, 2024 Andrea Zoitl
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.test.ui.networkediting.basicfb;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -25,10 +25,10 @@ import java.util.List;
 import org.eclipse.draw2d.PolylineConnection;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.fordiac.ide.test.ui.Abstract4diacUITests;
-import org.eclipse.fordiac.ide.test.ui.helpers.UITestPinHelper;
 import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotConnection;
 import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotFB;
 import org.eclipse.fordiac.ide.test.ui.helpers.UITestNamesHelper;
+import org.eclipse.fordiac.ide.test.ui.helpers.UITestPinHelper;
 import org.eclipse.fordiac.ide.test.ui.swtbot.SWTBot4diacGefEditor;
 import org.eclipse.gef.ConnectionEditPart;
 import org.eclipse.swt.graphics.Point;
@@ -48,26 +48,26 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 	 * Then a second FB (E_SWITCH) is dragged onto the canvas and the check is the
 	 * same as above.
 	 */
-	@SuppressWarnings({ "static-method", "static-access" })
+	@SuppressWarnings("static-method")
 	@Test
 	public void dragAndDrop2FB() {
-		// select FB E_CYCLE
+		// drag&drop FB E_CYCLE and check if position is the given one
 		final SWTBot4diacGefEditor editor = (SWTBot4diacGefEditor) bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
 		final SWTBotFB fbBot = new SWTBotFB(bot);
-		final Point point1 = new Point(100, 100);
-		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_CYCLE_TREE_ITEM, point1);
+		final Point posECycle = new Point(100, 100);
+		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_CYCLE_TREE_ITEM, posECycle);
 		assertNotNull(editor.getEditPart(UITestNamesHelper.E_CYCLE_FB));
-		final Rectangle absPos1 = fbBot.getBoundsOfFB(editor, UITestNamesHelper.E_CYCLE_FB);
-		assertEquals(point1.x, absPos1.x);
-		assertEquals(point1.y, absPos1.y);
+		final Rectangle posFB = fbBot.getBoundsOfFB(editor, UITestNamesHelper.E_CYCLE_FB);
+		assertEquals(posECycle.x, posFB.x);
+		assertEquals(posECycle.y, posFB.y);
 
 		// select FB E_SWITCH
-		final Point point2 = new Point(300, 150);
-		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_SWITCH_TREE_ITEM, point2);
+		final Point posESwitch = new Point(300, 150);
+		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_SWITCH_TREE_ITEM, posESwitch);
 		assertNotNull(editor.getEditPart(UITestNamesHelper.E_SWITCH_FB));
-		final Rectangle absPos2 = fbBot.getBoundsOfFB(editor, UITestNamesHelper.E_SWITCH_FB);
-		assertEquals(point2.x, absPos2.x);
-		assertEquals(point2.y, absPos2.y);
+		final Rectangle absFB2 = fbBot.getBoundsOfFB(editor, UITestNamesHelper.E_SWITCH_FB);
+		assertEquals(posESwitch.x, absFB2.x);
+		assertEquals(posESwitch.y, absFB2.y);
 	}
 
 	/**
@@ -75,7 +75,7 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 	 * deleted and it is checked if the FB is no longer on the canvas after
 	 * deletion.
 	 */
-	@SuppressWarnings({ "static-method", "static-access" })
+	@SuppressWarnings("static-method")
 	@Test
 	public void delete1FB() {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
@@ -104,7 +104,7 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 	 * selected as expected. Then a rectangle is drawn over the FBs to check whether
 	 * the FBs are selected.
 	 */
-	@SuppressWarnings({ "static-method", "static-access" })
+	@SuppressWarnings("static-method")
 	@Test
 	public void select2FBsViaMouseLeftClickOnFB() {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
@@ -139,7 +139,7 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 	 * which is not expected. To achieve this it is necessary to create a
 	 * draw2d.geometry Point with the same coordinates of the swt.graphics Point.
 	 */
-	@SuppressWarnings({ "static-method", "static-access" })
+	@SuppressWarnings("static-method")
 	@Test
 	public void move1FB() {
 		final Point pos1 = new Point(100, 100);
@@ -148,28 +148,13 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 		final Point pos2 = new Point(350, 100);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_N_TABLE_TREE_ITEM, pos2);
 
-		// select E_CYCLE and check position of E_CYCLE
+		// select FB E_CYCLE and move it to new position of x=125, y=185
 		final SWTBotGefEditor editor = bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
-		assertNotNull(editor);
-		assertNotNull(editor.getEditPart(UITestNamesHelper.E_CYCLE_FB));
-		editor.click(UITestNamesHelper.E_CYCLE_FB);
-		final SWTBotGefEditPart fb1 = editor.getEditPart(UITestNamesHelper.E_CYCLE_FB).parent();
-		assertNotNull(fb1);
-		final Rectangle fb1Bounds1 = fbBot.getBoundsOfFB(editor, UITestNamesHelper.E_CYCLE_FB);
-		assertTrue(fb1Bounds1.contains(pos1.x, pos1.y));
+		fbBot.moveSingleFB(editor, UITestNamesHelper.E_CYCLE_FB, new Point(125, 185));
 
-		// check position of E_N_TABLE
-		final Rectangle fb2Bounds1 = fbBot.getBoundsOfFB(editor, UITestNamesHelper.E_N_TABLE_FB);
-		assertTrue(fb2Bounds1.contains(pos2.x, pos2.y));
-
-		// move E_CYCLE and check new position
-		final Point pos3 = new Point(125, 185);
-		editor.drag(fb1, pos3.x, pos3.y);
-		final Rectangle fb1Bounds2 = fbBot.getBoundsOfFB(editor, UITestNamesHelper.E_CYCLE_FB);
-		assertTrue(fb1Bounds2.contains(pos3.x, pos3.y));
-
-		// check if E_N_TABLE is still on same position
-		assertTrue(fb2Bounds1.contains(pos2.x, pos2.y));
+		// check position of E_N_TABLE to ensure that it unchanged
+		final Rectangle boundsENTable = fbBot.getBoundsOfFB(editor, UITestNamesHelper.E_N_TABLE_FB);
+		assertTrue(boundsENTable.contains(pos2.x, pos2.y));
 	}
 
 	/**
@@ -181,7 +166,7 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 	 * this position is also checked. To achieve this it is necessary to create a
 	 * draw2d.geometry Point with the same coordinates of the swt.graphics Point.
 	 */
-	@SuppressWarnings({ "static-method", "static-access" })
+	@SuppressWarnings("static-method")
 	@Test
 	public void moveBothFBOneAfterAnother() {
 		final Point pos1 = new Point(200, 200);
@@ -190,30 +175,10 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 		final Point pos2 = new Point(400, 200);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_SWITCH_TREE_ITEM, pos2);
 
-		// select and move E_CYCLE
+		// select and move E_CYCLE and E_SWITCH
 		final SWTBot4diacGefEditor editor = (SWTBot4diacGefEditor) bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
-		assertNotNull(editor);
-		assertNotNull(editor.getEditPart(UITestNamesHelper.E_CYCLE_FB));
-		editor.click(UITestNamesHelper.E_CYCLE_FB);
-		final SWTBotGefEditPart fb1 = editor.getEditPart(UITestNamesHelper.E_CYCLE_FB).parent();
-		assertNotNull(fb1);
-		final Rectangle fb1Bounds1 = fbBot.getBoundsOfFB(editor, UITestNamesHelper.E_CYCLE_FB);
-		assertTrue(fb1Bounds1.contains(pos1.x, pos1.y));
-		final Point pos3 = new Point(85, 85);
-		editor.drag(fb1, pos3.x, pos3.y);
-		final Rectangle fb1Bounds2 = fbBot.getBoundsOfFB(editor, UITestNamesHelper.E_CYCLE_FB);
-		assertTrue(fb1Bounds2.contains(pos3.x, pos3.y));
-
-		// select and move E_SWITCH
-		editor.click(UITestNamesHelper.E_SWITCH_FB);
-		final SWTBotGefEditPart fb2 = editor.getEditPart(UITestNamesHelper.E_SWITCH_FB).parent();
-		assertNotNull(fb2);
-		final Rectangle fb2Bounds1 = fbBot.getBoundsOfFB(editor, UITestNamesHelper.E_SWITCH_FB);
-		assertTrue(fb2Bounds1.contains(pos2.x, pos2.y));
-		final Point pos4 = new Point(285, 85);
-		editor.drag(fb2, pos4.x, pos4.y);
-		final Rectangle fb2Bounds2 = fbBot.getBoundsOfFB(editor, UITestNamesHelper.E_SWITCH_FB);
-		assertTrue(fb2Bounds2.contains(pos4.x, pos4.y));
+		fbBot.moveSingleFB(editor, UITestNamesHelper.E_CYCLE_FB, new Point(85, 85));
+		fbBot.moveSingleFB(editor, UITestNamesHelper.E_SWITCH_FB, new Point(285, 85));
 	}
 
 	/**
@@ -224,7 +189,7 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 	 * selected as expected. Then a rectangle is drawn over the FBs to check whether
 	 * the FBs are selected.
 	 */
-	@SuppressWarnings({ "static-method", "static-access" })
+	@SuppressWarnings("static-method")
 	@Test
 	public void moveBothFBTogether() {
 		final Point absPos1Fb1 = new Point(100, 100);
@@ -291,7 +256,7 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 	 * Then the E_CYCLE is moved and it is checked whether the start point of the
 	 * connection has also moved and whether the end point has remained unchanged.
 	 */
-	@SuppressWarnings({ "static-method", "static-access" })
+	@SuppressWarnings("static-method")
 	@Test
 	public void checkIfConnectionRemainsAfterMoving1FB() {
 		final Point pos1 = new Point(100, 50);
@@ -351,7 +316,7 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 	 * Afterwards, the E_SWITCH is also moved and checked whether the start point
 	 * and end point of the connection match the new positions of the FBs.
 	 */
-	@SuppressWarnings({ "static-method", "static-access" })
+	@SuppressWarnings("static-method")
 	@Test
 	public void checkIfConnectionRemainsAfterMovingBothFBsOneAfterAnother() {
 		final Point pos1 = new Point(375, 75);
@@ -430,7 +395,7 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 	 * FB and moved to a new position. The translation is calculated and compared
 	 * with the new values of the connection start and end point.
 	 */
-	@SuppressWarnings({ "static-method", "static-access" })
+	@SuppressWarnings("static-method")
 	@Test
 	public void checkIfConnectionRemainsAfterMovingBothFBsTogether() {
 		final Point pos1 = new Point(200, 100);

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/networkediting/basicfb/Basic2FBNetworkEditingTests.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/networkediting/basicfb/Basic2FBNetworkEditingTests.java
@@ -52,7 +52,7 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 	@Test
 	public void dragAndDrop2FB() {
 		// drag&drop FB E_CYCLE and check if position is the given one
-		final SWTBot4diacGefEditor editor = (SWTBot4diacGefEditor) bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
+		final SWTBot4diacGefEditor editor = bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		final Point posECycle = new Point(100, 100);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_CYCLE_TREE_ITEM, posECycle);
@@ -110,7 +110,7 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_N_TABLE_TREE_ITEM, new Point(100, 100));
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_CTUD_TREE_ITEM, new Point(300, 100));
-		final SWTBot4diacGefEditor editor = (SWTBot4diacGefEditor) bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
+		final SWTBot4diacGefEditor editor = bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
 
 		// drag rectangle next to FBs, therefore FBs should not be selected
 		editor.drag(40, 40, 200, 200);
@@ -176,7 +176,7 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_SWITCH_TREE_ITEM, pos2);
 
 		// select and move E_CYCLE and E_SWITCH
-		final SWTBot4diacGefEditor editor = (SWTBot4diacGefEditor) bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
+		final SWTBot4diacGefEditor editor = bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
 		fbBot.moveSingleFB(editor, UITestNamesHelper.E_CYCLE_FB, new Point(85, 85));
 		fbBot.moveSingleFB(editor, UITestNamesHelper.E_SWITCH_FB, new Point(285, 85));
 	}
@@ -197,7 +197,7 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_CYCLE_TREE_ITEM, absPos1Fb1);
 		final Point absPos1Fb2 = new Point(100, 220);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_SR_TREE_ITEM, absPos1Fb2);
-		final SWTBot4diacGefEditor editor = (SWTBot4diacGefEditor) bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
+		final SWTBot4diacGefEditor editor = bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
 
 		final Rectangle fb1Bounds1 = fbBot.getBoundsOfFB(editor, UITestNamesHelper.E_CYCLE_FB);
 		assertTrue(fb1Bounds1.contains(absPos1Fb1.x, absPos1Fb1.y));
@@ -209,6 +209,7 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 		assertDoesNotThrow(editor::waitForSelectedFBEditPart);
 		List<SWTBotGefEditPart> selectedEditParts = editor.selectedEditParts();
 		assertFalse(selectedEditParts.isEmpty());
+		fbBot.moveViaRectangle(editor, new Rectangle(50, 50, 400, 400), new Point(75, 125));
 		assertTrue(fbBot.isFbSelected(selectedEditParts, UITestNamesHelper.E_CYCLE_FB));
 		assertTrue(fbBot.isFbSelected(selectedEditParts, UITestNamesHelper.E_SR_FB));
 
@@ -245,6 +246,17 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 		assertTrue(fb2Bounds2.contains(absPos2Fb2X, absPos2Fb2Y));
 	}
 
+	@SuppressWarnings("static-method")
+	@Test
+	public void moveFBsSelectedViaRectangle() {
+		final SWTBotFB fbBot = new SWTBotFB(bot);
+		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_CYCLE_TREE_ITEM, new Point(100, 75));
+		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_CYCLE_TREE_ITEM, new Point(300, 75));
+		final SWTBot4diacGefEditor editor = bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
+		fbBot.moveViaRectangle(editor, new Rectangle(50, 50, 500, 200), new Point(75, 125));
+// TODO		assertFalse(selectedEditParts.isEmpty());
+	}
+
 	/**
 	 * Checks whether the connection remains and moves along with moving FB
 	 *
@@ -269,14 +281,15 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 		assertNotNull(connection);
 
 		// select E_CYCLE
-		final SWTBotGefEditor editor = bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
-		assertNotNull(editor);
-		assertNotNull(editor.getEditPart(UITestNamesHelper.E_CYCLE_FB));
-		editor.click(UITestNamesHelper.E_CYCLE_FB);
+		final SWTBot4diacGefEditor editor = bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
+		fbBot.selectFBWithFBNameInEditor(editor, UITestNamesHelper.E_CYCLE_FB);
+//		assertNotNull(editor);
+//		assertNotNull(editor.getEditPart(UITestNamesHelper.E_CYCLE_FB));
+//		editor.click(UITestNamesHelper.E_CYCLE_FB);
 		final SWTBotGefEditPart fb1 = editor.getEditPart(UITestNamesHelper.E_CYCLE_FB).parent();
-		assertNotNull(fb1);
-		final Rectangle fb1Bounds1 = fbBot.getBoundsOfFB(editor, UITestNamesHelper.E_CYCLE_FB);
-		assertTrue(fb1Bounds1.contains(pos1.x, pos1.y));
+//		assertNotNull(fb1);
+//		final Rectangle fb1Bounds1 = fbBot.getBoundsOfFB(editor, UITestNamesHelper.E_CYCLE_FB);
+//		assertTrue(fb1Bounds1.contains(pos1.x, pos1.y));
 
 		// get connection start and end point
 		final PolylineConnection polyLineConnection = (PolylineConnection) connection.getFigure();
@@ -407,7 +420,7 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 		connectBot.createConnection(UITestPinHelper.EO1, UITestPinHelper.R);
 		ConnectionEditPart connection = connectBot.findConnection(UITestPinHelper.EO1, UITestPinHelper.R);
 		assertNotNull(connection);
-		final SWTBot4diacGefEditor editor = (SWTBot4diacGefEditor) bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
+		final SWTBot4diacGefEditor editor = bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
 
 		// get connection start and end point
 		final PolylineConnection polyLineConnection = (PolylineConnection) connection.getFigure();

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/swtbot/SWT4diacGefBot.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/swtbot/SWT4diacGefBot.java
@@ -20,6 +20,11 @@ import org.eclipse.ui.IEditorReference;
 public class SWT4diacGefBot extends SWTGefBot {
 
 	@Override
+	public SWTBot4diacGefEditor gefEditor(final String fileName) throws WidgetNotFoundException {
+		return (SWTBot4diacGefEditor) super.gefEditor(fileName);
+	}
+
+	@Override
 	protected SWTBot4diacGefEditor createEditor(final IEditorReference reference, final SWTWorkbenchBot bot) {
 		return new SWTBot4diacGefEditor(reference, bot);
 	}


### PR DESCRIPTION
All tests that had to do with moving FB were no longer running. With the new methods and also taking into account the slightly changed position due to SnapToGrid, the tests of class Basic2FBNetwork are now running again.