### PR TITLE
Reconnect Connection Preserves Connection in XML File

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractReconnectConnectionCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractReconnectConnectionCommand.java
@@ -97,6 +97,7 @@ public abstract class AbstractReconnectConnectionCommand extends Command impleme
 		connectionCreateCmd.setDestination(getNewDestination());
 		connectionCreateCmd.setArrangementConstraints(con.getRoutingData());
 		connectionCreateCmd.setVisible(con.isVisible());
+		connectionCreateCmd.setElementIndex(parent.getConnectionIndex(con));
 		connectionCreateCmd.execute(); // perform adding the connection first to preserve any error markers
 		deleteConnectionCmd.execute();
 		copyAttributes(connectionCreateCmd.getConnection(), deleteConnectionCmd.getConnection());

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractUpdateFBNElementCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractUpdateFBNElementCommand.java
@@ -426,6 +426,7 @@ public abstract class AbstractUpdateFBNElementCommand extends Command implements
 			cmd.setDestination(dest);
 			cmd.setVisible(oldConn.isVisible());
 			cmd.setArrangementConstraints(oldConn.getRoutingData());
+			cmd.setElementIndex(fbn.getConnectionIndex(oldConn));
 			reconnCmds.add(cmd);
 		}
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/AbstractConnectionCreateCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/AbstractConnectionCreateCommand.java
@@ -70,6 +70,8 @@ public abstract class AbstractConnectionCreateCommand extends Command implements
 
 	private boolean visible = true;
 
+	private int elementIndex = -1;
+
 	protected AbstractConnectionCreateCommand(final FBNetwork parent) {
 		// initialize values
 		this.parent = parent;
@@ -125,7 +127,7 @@ public abstract class AbstractConnectionCreateCommand extends Command implements
 		connection.setDestination(destination);
 		connection.setRoutingData(routingData);
 
-		parent.addConnection(connection);
+		parent.addConnectionWithIndex(connection, elementIndex);
 		// visible needs to be setup after the connection is added to correctly update
 		// ui
 		connection.setVisible(visible);
@@ -153,7 +155,7 @@ public abstract class AbstractConnectionCreateCommand extends Command implements
 	public void redo() {
 		connection.setSource(source);
 		connection.setDestination(destination);
-		parent.addConnection(connection);
+		parent.addConnectionWithIndex(connection, elementIndex);
 
 		if (null != mirroredConnection) {
 			mirroredConnection.redo();
@@ -309,5 +311,9 @@ public abstract class AbstractConnectionCreateCommand extends Command implements
 	public Set<EObject> getAffectedObjects() {
 		return Stream.of(parent, connection, source, destination).filter(Objects::nonNull)
 				.collect(Collectors.toUnmodifiableSet());
+	}
+
+	public void setElementIndex(final int elementIndex) {
+		this.elementIndex = elementIndex;
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/delete/DeleteConnectionCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/delete/DeleteConnectionCommand.java
@@ -176,4 +176,8 @@ public class DeleteConnectionCommand extends Command implements ScopedCommand {
 		return Stream.of(connectionParent, connection, source, destination).filter(Objects::nonNull)
 				.collect(Collectors.toUnmodifiableSet());
 	}
+
+	public int getElementIndex() {
+		return elementIndex;
+	}
 }


### PR DESCRIPTION
In order to reduce the amount of changed lines in the XML file this change ensures that reconnect connection will use the same places as the old one. In the best case this means only source or target entry and bendpoints are changed and such the changes are within one XML file line. This should reduce chances for conflicts when mutliple people work on one file via version control.