### PR TITLE
Do not react to outline selection changes in FB type Xtext editor tab

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editors/FBTypeXtextEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editors/FBTypeXtextEditor.java
@@ -120,7 +120,11 @@ public abstract class FBTypeXtextEditor extends XtextEditor implements IFBTEdito
 
 	@Override
 	public boolean outlineSelectionChanged(final Object selectedElement) {
-		return selectAndReveal(selectedElement, false);
+		// do not react to selection changes from the FB type editor, until we can
+		// determine the text position for the selected element without:
+		// - blocking the UI thread waiting for a lock on the Xtext document,
+		// - interrupting the Xtext validation job when executed with priority.
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
Do not react to outline selection changes in FB type Xtext editor tab, until we can determine the text position for the selected element without:
 - blocking the UI thread waiting for a lock on the Xtext document,
 - interrupting the Xtext validation job when executed with priority, potentially resulting in stale or missing annotations, 

which is both made worse since the FB type editor currently forwards all kinds of selections, including completely unrelated ones.