### PR TITLE
Remove check for connected subapp pin in change data type command

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeDataTypeCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeDataTypeCommand.java
@@ -44,12 +44,9 @@ public final class ChangeDataTypeCommand extends AbstractChangeInterfaceElementC
 	private DataType oldDataType;
 	private final CompoundCommand additionalCommands = new CompoundCommand();
 
-	private boolean ignoreConnections;
-
 	private ChangeDataTypeCommand(final IInterfaceElement interfaceElement, final DataType dataType) {
 		super(interfaceElement);
 		this.dataType = dataType;
-		ignoreConnections = false;
 	}
 
 	public static ChangeDataTypeCommand forTypeName(final IInterfaceElement interfaceElement, final String typeName) {
@@ -104,11 +101,6 @@ public final class ChangeDataTypeCommand extends AbstractChangeInterfaceElementC
 	}
 
 	@Override
-	public boolean canExecute() {
-		return super.canExecute() && (ignoreConnections || !isSubAppPinAndConnected());
-	}
-
-	@Override
 	protected void doExecute() {
 		oldDataType = getInterfaceElement().getType();
 		setNewType();
@@ -133,13 +125,5 @@ public final class ChangeDataTypeCommand extends AbstractChangeInterfaceElementC
 
 	public CompoundCommand getAdditionalCommands() {
 		return additionalCommands;
-	}
-
-	public boolean isIgnoreConnections() {
-		return ignoreConnections;
-	}
-
-	public void setIgnoreConnections(final boolean ignoreConnections) {
-		this.ignoreConnections = ignoreConnections;
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/delete/UpdateUntypedSubappPinChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/delete/UpdateUntypedSubappPinChange.java
@@ -75,18 +75,12 @@ public class UpdateUntypedSubappPinChange extends AbstractCommandChange<VarDecla
 	protected Command createCommand(final VarDeclaration varDecl) {
 		if (state.contains(ChangeState.DELETE)) {
 			return new DeleteSubAppInterfaceElementCommand(varDecl);
-
 		}
 		if (state.contains(ChangeState.CHANGE_TO_ANY)) {
-			final var cmd = ChangeDataTypeCommand.forDataType(varDecl, IecTypes.GenericTypes.ANY_STRUCT);
-			cmd.setIgnoreConnections(true);
-			return cmd;
+			return ChangeDataTypeCommand.forDataType(varDecl, IecTypes.GenericTypes.ANY_STRUCT);
 		}
-
 		if (state.contains(ChangeState.NO_CHANGE)) {
-			final var cmd = ChangeDataTypeCommand.forDataType(varDecl, varDecl.getType());
-			cmd.setIgnoreConnections(true);
-			return cmd;
+			return ChangeDataTypeCommand.forDataType(varDecl, varDecl.getType());
 		}
 		return null;
 	}


### PR DESCRIPTION
The check for disallowing to change the type of a connected subapp pin in the change data type command is frequently causing problems for refactorings or quickfixes. The option to skip the check is often forgotten.

This change removes the check entirely, while the checks in the UI that prevent the user from changing the type still remain in place.