### PR TITLE
Fixed System Explorer Label Providers

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/plugin.xml
@@ -391,11 +391,11 @@
             activeByDefault="true"
             contentProvider="org.eclipse.fordiac.ide.systemmanagement.ui.providers.SystemExplorerRootContentProvider"
             id="org.eclipse.fordiac.ide.systemmanagement.ui.systemexplorer.rootcontent"
-            labelProvider="org.eclipse.fordiac.ide.systemmanagement.ui.systemexplorer.SystemLabelProvider"
+            labelProvider="org.eclipse.fordiac.ide.systemmanagement.ui.systemexplorer.SystemExplorerLabelProvider"
             name="System Content"
             priority="high">
             <possibleChildren>
-                 <instanceof value="org.eclipse.core.resources.IProject"/>
+                 <instanceof value="org.eclipse.core.resources.IProject"/>                 
 	        </possibleChildren> 
        </navigatorContent>
         <navigatorContent
@@ -407,19 +407,16 @@
               priority="high">
            <possibleChildren>
               <or>
-                 <instanceof
-                       value="org.eclipse.emf.ecore.EObject">
-                 </instanceof>
-                 <instanceof
-                       value="org.eclipse.emf.edit.provider.ItemProviderAdapter">
-                 </instanceof>
+                 <!-- this possible child flag is need so that our label provider is styling the icon and text of sys files and the typeLib -->
+              	 <instanceof value="org.eclipse.core.resources.IFile" />
+              	 <instanceof value="org.eclipse.core.resources.IFolder"/> 
+                 <instanceof value="org.eclipse.emf.ecore.EObject" />
+                 <instanceof value="org.eclipse.emf.edit.provider.ItemProviderAdapter" />
               </or>
            </possibleChildren>
            <triggerPoints>
               <and>
-                 <instanceof
-                       value="org.eclipse.core.resources.IFile">
-                 </instanceof>
+                 <instanceof value="org.eclipse.core.resources.IFile" />
                  <test
                        forcePluginActivation="true"
                        property="org.eclipse.core.resources.extension"

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/systemexplorer/FordiacProjectSorter.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/systemexplorer/FordiacProjectSorter.java
@@ -54,7 +54,7 @@ public class FordiacProjectSorter extends ViewerComparator {
 	}
 
 	public static boolean isTypeLibFolder(final Object entry) {
-		return ((entry instanceof IFolder) && SystemManager.TYPE_LIB_FOLDER_NAME.equals(((IFolder) entry).getName()));
+		return ((entry instanceof final IFolder folder) && SystemManager.TYPE_LIB_FOLDER_NAME.equals(folder.getName()));
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/systemexplorer/SystemLabelProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/systemexplorer/SystemLabelProvider.java
@@ -1,6 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 fortiss GmbH
- * 				 2020 Johannes Kepler University Linz
+ * Copyright (c) 2015, 2024 fortiss GmbH, Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -23,16 +22,16 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
-import org.eclipse.emf.edit.ui.provider.AdapterFactoryLabelProvider;
 import org.eclipse.fordiac.ide.model.data.provider.DataItemProviderAdapterFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.provider.LibraryElementItemProviderAdapterFactory;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
+import org.eclipse.fordiac.ide.typemanagement.navigator.LibraryElementLabelProvider;
 import org.eclipse.fordiac.ide.ui.imageprovider.FordiacImage;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.navigator.IDescriptionProvider;
 
-public class SystemLabelProvider extends AdapterFactoryLabelProvider implements IDescriptionProvider {
+public class SystemLabelProvider extends LibraryElementLabelProvider implements IDescriptionProvider {
 
 	private static ComposedAdapterFactory systemAdapterFactory = new ComposedAdapterFactory(createFactoryList());
 
@@ -42,8 +41,8 @@ public class SystemLabelProvider extends AdapterFactoryLabelProvider implements 
 
 	@Override
 	public String getText(final Object object) {
-		if (object instanceof IFile) {
-			return getTextForFiles((IFile) object);
+		if (object instanceof final IFile file) {
+			return getTextForFiles(file);
 		}
 		if (object instanceof IResource) {
 			return null;
@@ -65,17 +64,16 @@ public class SystemLabelProvider extends AdapterFactoryLabelProvider implements 
 
 	@Override
 	public Image getImage(final Object object) {
-		if (object instanceof IResource) {
-			return getImageForResource((IResource) object);
+		if (object instanceof final IResource res) {
+			return getImageForResource(res);
 		}
 		return super.getImage(object);
 	}
 
-	private static Image getImageForResource(final IResource resource) {
+	private Image getImageForResource(final IResource resource) {
 		if (FordiacProjectSorter.isTypeLibFolder(resource)) {
-			return FordiacImage.ICON_TYPE_NAVIGATOR.getImage();
+			return getDecoratedImage(resource, FordiacImage.ICON_TYPE_NAVIGATOR.getImageDescriptor());
 		}
-
 		return null;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/plugin.xml
@@ -376,7 +376,8 @@
             labelProvider="org.eclipse.fordiac.ide.typemanagement.navigator.FBTypeLabelProvider"
             name="FB Type Content">
             <possibleChildren>
-	           <or>         
+	           <or>     
+	              <!-- this possible child flag is need so that our lable provider is styling the icon and text of FB type files -->    
 	              <instanceof value="org.eclipse.core.resources.IFile" /> 
 	              <instanceof value="org.eclipse.emf.ecore.EObject"/>
 	              <instanceof value="org.eclipse.emf.edit.provider.ItemProviderAdapter"/>

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/navigator/FBTypeLabelProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/navigator/FBTypeLabelProvider.java
@@ -15,36 +15,21 @@
  *                 palette, some code cleanup
  *   Martin Erich Jobst
  *               - avoid loading type by using cached meta-information from type entry
+ *   Alois Zoitl - extracted error overlay handling into new base class
  *******************************************************************************/
 package org.eclipse.fordiac.ide.typemanagement.navigator;
 
-import java.util.Arrays;
-
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IMarker;
-import org.eclipse.core.resources.IResource;
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.emf.edit.ui.provider.AdapterFactoryLabelProvider;
 import org.eclipse.fordiac.ide.model.edit.providers.TypeImageProvider;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
-import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 import org.eclipse.fordiac.ide.ui.imageprovider.FordiacImage;
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.jface.resource.JFaceResources;
-import org.eclipse.jface.resource.LocalResourceManager;
-import org.eclipse.jface.resource.ResourceManager;
-import org.eclipse.jface.viewers.DecorationOverlayIcon;
-import org.eclipse.jface.viewers.IDecoration;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.ui.ISharedImages;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.navigator.IDescriptionProvider;
 
-public class FBTypeLabelProvider extends AdapterFactoryLabelProvider implements IDescriptionProvider {
-
-	ResourceManager resourceManager = new LocalResourceManager(JFaceResources.getResources());
+public class FBTypeLabelProvider extends LibraryElementLabelProvider implements IDescriptionProvider {
 
 	public FBTypeLabelProvider() {
 		super(FBTypeComposedAdapterFactory.getAdapterFactory());
@@ -53,12 +38,7 @@ public class FBTypeLabelProvider extends AdapterFactoryLabelProvider implements 
 	@Override
 	public Image getImage(final Object element) {
 		if (element instanceof final IFile file && file.exists()) {
-			ImageDescriptor imageDescriptor = getImageForFile(file);
-			if (imageDescriptor != null) {
-				imageDescriptor = decorateImage(file, imageDescriptor);
-				return resourceManager.get(imageDescriptor);
-			}
-			return null;
+			return getDecoratedImage(file, getImageForFile(file));
 		}
 		return super.getImage(element);
 	}
@@ -72,47 +52,6 @@ public class FBTypeLabelProvider extends AdapterFactoryLabelProvider implements 
 			}
 		}
 		return null;
-	}
-
-	/**
-	 * If the file has a problem an error/warning overlay is created
-	 *
-	 * This code is based on
-	 * org.eclipse.ui.internal.navigator.resources.workbench.ResourceExtensionLabelProvider,
-	 * which can not directly be used as this class is an Eclipse internal class.
-	 */
-	private static ImageDescriptor decorateImage(final IResource element, final ImageDescriptor imageDescriptor) {
-		final ImageDescriptor overlay = getErrorOverlay(element);
-		if (overlay != null) {
-			return new DecorationOverlayIcon(imageDescriptor, overlay, IDecoration.BOTTOM_LEFT);
-		}
-		return imageDescriptor;
-	}
-
-	private static ImageDescriptor getErrorOverlay(final IResource element) {
-		ImageDescriptor overlay = null;
-		try {
-			final IMarker[] problems = element.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE);
-			if (problems.length > 0) {
-				final int problemSeverity = Arrays.stream(problems).mapToInt(p -> p.getAttribute(IMarker.SEVERITY, -1))
-						.max().orElse(-1);
-				switch (problemSeverity) {
-				case IMarker.SEVERITY_ERROR:
-					overlay = PlatformUI.getWorkbench().getSharedImages()
-							.getImageDescriptor(ISharedImages.IMG_DEC_FIELD_ERROR);
-					break;
-				case IMarker.SEVERITY_WARNING:
-					overlay = PlatformUI.getWorkbench().getSharedImages()
-							.getImageDescriptor(ISharedImages.IMG_DEC_FIELD_WARNING);
-					break;
-				default:
-					break;
-				}
-			}
-		} catch (final CoreException e) {
-			FordiacLogHelper.logError(e.getMessage(), e);
-		}
-		return overlay;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/navigator/LibraryElementLabelProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/navigator/LibraryElementLabelProvider.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2024 TU Wien ACIN, fortiss GmbH,
+ * 							Johannes Kepler University Linz
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Alois Zoitl - initial API and implementation and/or initial documentation
+ *   			 - cleaned up issues reported by sonarlint
+ *   			 - made the getImageForFile public so it can be used by the
+ *                 palette, some code cleanup
+ *   Martin Erich Jobst
+ *               - avoid loading type by using cached meta-information from type entry
+ *   Alois Zoitl - extracted from FBType LabelProvider
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.navigator;
+
+import java.util.Arrays;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.emf.common.notify.AdapterFactory;
+import org.eclipse.emf.edit.ui.provider.AdapterFactoryLabelProvider;
+import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.resource.LocalResourceManager;
+import org.eclipse.jface.resource.ResourceManager;
+import org.eclipse.jface.viewers.DecorationOverlayIcon;
+import org.eclipse.jface.viewers.IDecoration;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.ui.ISharedImages;
+import org.eclipse.ui.PlatformUI;
+
+public class LibraryElementLabelProvider extends AdapterFactoryLabelProvider {
+
+	private final ResourceManager resourceManager = new LocalResourceManager(JFaceResources.getResources());
+
+	protected Image getDecoratedImage(final IResource element, final ImageDescriptor imageDescriptor) {
+		if (imageDescriptor != null) {
+			return resourceManager.get(decorateImage(element, imageDescriptor));
+		}
+		return null;
+	}
+
+	/**
+	 * If the file has a problem an error/warning overlay is created
+	 *
+	 * This code is based on
+	 * org.eclipse.ui.internal.navigator.resources.workbench.ResourceExtensionLabelProvider,
+	 * which can not directly be used as this class is an Eclipse internal class.
+	 */
+	private static ImageDescriptor decorateImage(final IResource element, final ImageDescriptor imageDescriptor) {
+		final ImageDescriptor overlay = getErrorOverlay(element);
+		if (overlay != null) {
+			return new DecorationOverlayIcon(imageDescriptor, overlay, IDecoration.BOTTOM_LEFT);
+		}
+		return imageDescriptor;
+	}
+
+	private static ImageDescriptor getErrorOverlay(final IResource element) {
+		ImageDescriptor overlay = null;
+		try {
+			final IMarker[] problems = element.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE);
+			if (problems.length > 0) {
+				final int problemSeverity = Arrays.stream(problems).mapToInt(p -> p.getAttribute(IMarker.SEVERITY, -1))
+						.max().orElse(-1);
+				switch (problemSeverity) {
+				case IMarker.SEVERITY_ERROR:
+					overlay = PlatformUI.getWorkbench().getSharedImages()
+							.getImageDescriptor(ISharedImages.IMG_DEC_FIELD_ERROR);
+					break;
+				case IMarker.SEVERITY_WARNING:
+					overlay = PlatformUI.getWorkbench().getSharedImages()
+							.getImageDescriptor(ISharedImages.IMG_DEC_FIELD_WARNING);
+					break;
+				default:
+					break;
+				}
+			}
+		} catch (final CoreException e) {
+			FordiacLogHelper.logError(e.getMessage(), e);
+		}
+		return overlay;
+	}
+
+	public LibraryElementLabelProvider(final AdapterFactory adapterFactory) {
+		super(adapterFactory);
+	}
+
+}


### PR DESCRIPTION
The system explorer label providers didn't correctly show system names and the type lib icon.

Furthermore now the type lib icon is also showing error and warning feedback if children have errors or warnings.