### PR TITLE
Preserve Mapping Order

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractUpdateFBNElementCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractUpdateFBNElementCommand.java
@@ -142,6 +142,10 @@ public abstract class AbstractUpdateFBNElementCommand extends Command implements
 		// Map FB
 		if (resource != null) {
 			mapCmd = MapToCommand.createMapToCommand(newElement, resource);
+			if (mapCmd instanceof final MapToCommand mapToCommand) {
+				mapToCommand.setElementIndex(unmapCmd.getElementIndex());
+			}
+
 			if (mapCmd.canExecute()) {
 				mapCmd.execute();
 				recreateResourceConns(resourceConns);

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/MapToCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/MapToCommand.java
@@ -62,6 +62,7 @@ public class MapToCommand extends Command implements ScopedCommand {
 	protected FBNetworkElement targetElement;
 	private final Mapping mapping = LibraryElementFactory.eINSTANCE.createMapping();
 	private final CompoundCommand createdConnections = new CompoundCommand();
+	private int elementIndex = -1;
 
 	protected MapToCommand(final FBNetworkElement srcElement, final MappingTarget resource) {
 		this.srcElement = srcElement;
@@ -100,7 +101,7 @@ public class MapToCommand extends Command implements ScopedCommand {
 		mapping.setTo(targetElement);
 		srcElement.setMapping(mapping);
 		targetElement.setMapping(mapping);
-		getAutomationSystem().getMapping().add(mapping);
+		addMapping();
 
 		checkConnections();
 
@@ -152,7 +153,7 @@ public class MapToCommand extends Command implements ScopedCommand {
 		addMappedElements();
 		srcElement.setMapping(mapping);
 		targetElement.setMapping(mapping);
-		getAutomationSystem().getMapping().add(mapping);
+		addMapping();
 		createdConnections.redo();
 	}
 
@@ -409,11 +410,23 @@ public class MapToCommand extends Command implements ScopedCommand {
 		return null;
 	}
 
+	private void addMapping() {
+		if (elementIndex == -1) {
+			getAutomationSystem().getMapping().add(mapping);
+		} else {
+			getAutomationSystem().getMapping().add(elementIndex, mapping);
+		}
+	}
+
 	@Override
 	public Set<EObject> getAffectedObjects() {
 		if (srcElement != null && resource != null) {
 			return Set.of(srcElement, resource);
 		}
 		return Set.of();
+	}
+
+	public void setElementIndex(final int elementIndex) {
+		this.elementIndex = elementIndex;
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/UnmapCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/UnmapCommand.java
@@ -31,6 +31,7 @@ import org.eclipse.gef.commands.Command;
 public class UnmapCommand extends Command implements ScopedCommand {
 	private final Mapping mapping;
 	private final AutomationSystem system;
+	private int elementIndex;
 
 	private final DeleteFBNetworkElementCommand deleteMappedFBCmd;
 
@@ -50,6 +51,7 @@ public class UnmapCommand extends Command implements ScopedCommand {
 	public void execute() {
 		mapping.getFrom().setMapping(null);
 		mapping.getTo().setMapping(null);
+		elementIndex = system.getMapping().indexOf(mapping);
 		system.getMapping().remove(mapping);
 		deleteMappedFBCmd.execute();
 	}
@@ -59,7 +61,7 @@ public class UnmapCommand extends Command implements ScopedCommand {
 		deleteMappedFBCmd.undo();
 		mapping.getFrom().setMapping(mapping);
 		mapping.getTo().setMapping(mapping);
-		system.getMapping().add(mapping);
+		system.getMapping().add(elementIndex, mapping);
 	}
 
 	@Override
@@ -84,5 +86,9 @@ public class UnmapCommand extends Command implements ScopedCommand {
 	@Override
 	public Set<EObject> getAffectedObjects() {
 		return Set.of(mapping.getFrom(), deleteMappedFBCmd.getFbParent().eContainer());
+	}
+
+	public int getElementIndex() {
+		return elementIndex;
 	}
 }


### PR DESCRIPTION
Undo of unmapping or update types is preserving to order of the mapping entries in the XML file.