### PR TITLE
Fix attribute lookup in FB networks

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/CommonElementImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/CommonElementImporter.java
@@ -184,6 +184,7 @@ public abstract class CommonElementImporter {
 		reader = importer.reader;
 		file = importer.file;
 		typeLibrary = importer.typeLibrary;
+		element = importer.element;
 		errors = importer.errors;
 		warnings = importer.warnings;
 		dependencies = importer.dependencies;


### PR DESCRIPTION
Fix attribute lookup in FB networks by passing the imported element to sub-importers.