### PR TITLE
For correct VarInOut visibility saves, Importer and Exporter were changed

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/LibraryElementTags.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/LibraryElementTags.java
@@ -196,6 +196,7 @@ public final class LibraryElementTags {
 	public static final String DIRECTLY_DERIVED_TYPE = "DirectlyDerivedType"; //$NON-NLS-1$
 	public static final String BASE_TYPE_ATTRIBUTE = "BaseType"; //$NON-NLS-1$
 	public static final String TARGET_ATTRIBUTE_DEFINITION = "TARGET"; //$NON-NLS-1$
+	public static final String ELEMENT_INOUTVISIBLEOUT = "VisibleOutSide"; //$NON-NLS-1$
 
 	private LibraryElementTags() {
 		throw new UnsupportedOperationException("Class should not be instantiated!"); //$NON-NLS-1$

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/AbstractTypeExporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/AbstractTypeExporter.java
@@ -198,7 +198,7 @@ public abstract class AbstractTypeExporter extends CommonElementExporter {
 		final boolean hasAttributes = !varDecl.getAttributes().isEmpty()
 				|| (varDecl.isInOutVar() && !varDecl.getInOutVarOpposite().getAttributes().isEmpty());
 		final boolean hasOutAttributes = varDecl.getAttributes().stream().map(Attribute::getName).toList()
-				.contains("VisibleOutSide"); //$NON-NLS-1$
+				.contains(LibraryElementTags.ELEMENT_INOUTVISIBLEOUT);
 		if (hasAttributes) {
 			addStartElement(LibraryElementTags.VAR_DECLARATION_ELEMENT);
 		} else {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/SubAppNetworkImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/SubAppNetworkImporter.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.model.dataimport;
 
+import java.util.List;
 import java.util.Map;
 
 import javax.xml.stream.XMLStreamException;
@@ -21,6 +22,7 @@ import javax.xml.stream.XMLStreamException;
 import org.eclipse.fordiac.ide.model.LibraryElementTags;
 import org.eclipse.fordiac.ide.model.dataimport.exceptions.TypeImportException;
 import org.eclipse.fordiac.ide.model.errormarker.FordiacMarkerHelper;
+import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
@@ -85,6 +87,14 @@ class SubAppNetworkImporter extends FBNetworkImporter {
 				inVar.setValue(LibraryElementFactory.eINSTANCE.createValue());
 			}
 		}
+		for (final VarDeclaration inOutVar : subApp.getInterface().getInOutVars()) {
+			final List<String> attributeList = inOutVar.getAttributes().stream().map(Attribute::getName).toList();
+			if (attributeList.contains(LibraryElementTags.ELEMENT_INOUTVISIBLEOUT)
+					&& inOutVar.getInOutVarOpposite().isVisible()) {
+				inOutVar.getInOutVarOpposite().setVisible(false);
+			}
+		}
+
 	}
 
 	public FBNetworkElement createTypedSubapp(final String type) {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/SubAppNetworkImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/SubAppNetworkImporter.java
@@ -14,7 +14,6 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.model.dataimport;
 
-import java.util.List;
 import java.util.Map;
 
 import javax.xml.stream.XMLStreamException;
@@ -88,9 +87,8 @@ class SubAppNetworkImporter extends FBNetworkImporter {
 			}
 		}
 		for (final VarDeclaration inOutVar : subApp.getInterface().getInOutVars()) {
-			final List<String> attributeList = inOutVar.getAttributes().stream().map(Attribute::getName).toList();
-			if (attributeList.contains(LibraryElementTags.ELEMENT_INOUTVISIBLEOUT)
-					&& inOutVar.getInOutVarOpposite().isVisible()) {
+			if (inOutVar.getAttributes().stream().map(Attribute::getName).anyMatch(
+					LibraryElementTags.ELEMENT_INOUTVISIBLEOUT::equals) && inOutVar.getInOutVarOpposite().isVisible()) {
 				inOutVar.getInOutVarOpposite().setVisible(false);
 			}
 		}


### PR DESCRIPTION
With this update, the varinout attributes are correctly stored in the xml file, and also correctly imported from that file.