### PR TITLE
add missing dependency to subapptypeeditor manifest

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.subapptypeeditor/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.subapptypeeditor/META-INF/MANIFEST.MF
@@ -23,7 +23,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.fordiac.ide.typemanagement,
  org.eclipse.fordiac.ide.util,
  org.eclipse.emf.edit.ui,
- org.eclipse.fordiac.ide.model.edit
+ org.eclipse.fordiac.ide.model.edit,
+ org.eclipse.fordiac.ide.model.search
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Eclipse 4diac
 Bundle-RequiredExecutionEnvironment: JavaSE-21


### PR DESCRIPTION
was missing a dependency to org.eclipse.fordiac.ide.model.search