### PR TITLE
Impoved SWTBot BasicFBNetwork Tests and all are running again

### DIFF
--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/helpers/SWTBotFB.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/helpers/SWTBotFB.java
@@ -178,6 +178,16 @@ public class SWTBotFB {
 	}
 
 	/**
+	 *
+	 * @param editor
+	 * @param fBname
+	 * @return
+	 */
+	public Rectangle getBoundsOfFBWithTolerance(final SWTBotGefEditor editor, final String fBname) {
+		return getBoundsOfFB(editor, fBname).expand(new Insets(TOLERANCE_SNAP_TO_GRID));
+	}
+
+	/**
 	 * Moves a Function Block to the given position
 	 *
 	 * @param editor
@@ -246,6 +256,11 @@ public class SWTBotFB {
 		return this;
 	}
 
+	/**
+	 *
+	 * @param editor
+	 * @return
+	 */
 	private static List<org.eclipse.draw2d.geometry.Point> getPositionOfSelectedElements(
 			final SWTBot4diacGefEditor editor) {
 		return editor.selectedEditParts().stream() //

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/helpers/SWTBotFB.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/helpers/SWTBotFB.java
@@ -25,12 +25,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.PolylineConnection;
 import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.fordiac.ide.application.editparts.FBEditPart;
 import org.eclipse.fordiac.ide.test.ui.swtbot.SWT4diacGefBot;
 import org.eclipse.fordiac.ide.test.ui.swtbot.SWTBot4diacGefEditor;
 import org.eclipse.fordiac.ide.test.ui.swtbot.SWTBot4diacGefViewer;
+import org.eclipse.gef.ConnectionEditPart;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.swt.graphics.Point;
@@ -272,6 +274,38 @@ public class SWTBotFB {
 					figure.translateToAbsolute(topLeft);
 					return topLeft;
 				}).toList();
+	}
+
+	public void checkIfMovingFBWasCorrect(final SWTBot4diacGefEditor editor, final String fbName,
+			final Point originalPos, final Point translation) {
+		final Rectangle fbBounds = getBoundsOfFBWithTolerance(editor, fbName);
+		final int absPos2Fb2X = originalPos.x + translation.x;
+		final int absPos2Fb2Y = originalPos.y + translation.y;
+		assertTrue(fbBounds.contains(absPos2Fb2X, absPos2Fb2Y));
+	}
+
+	@SuppressWarnings("static-method")
+	public void checkIfMovingConnectionWasCorrect(final SWTBot4diacGefEditor editor,
+			final org.eclipse.draw2d.geometry.Point origStartPointConnection,
+			final org.eclipse.draw2d.geometry.Point origEndPointConnection, final ConnectionEditPart connection,
+			final Point translation) {
+
+		final PolylineConnection polyLineConnection = (PolylineConnection) connection.getFigure();
+
+		assertNotNull(connection);
+		final org.eclipse.draw2d.geometry.Point newStartPointConnection = polyLineConnection.getPoints()
+				.getFirstPoint();
+		final org.eclipse.draw2d.geometry.Point newEndPointConnection = polyLineConnection.getPoints().getLastPoint();
+
+		assertTrue(Math.abs(origStartPointConnection.x) - Math.abs(newStartPointConnection.x)
+				- Math.abs(translation.x) <= TOLERANCE_SNAP_TO_GRID);
+		assertTrue(Math.abs(origStartPointConnection.y) - Math.abs(newStartPointConnection.y)
+				- Math.abs(translation.y) <= TOLERANCE_SNAP_TO_GRID);
+		assertTrue(Math.abs(origEndPointConnection.x) - Math.abs(newEndPointConnection.x)
+				- Math.abs(translation.x) <= TOLERANCE_SNAP_TO_GRID);
+		assertTrue(Math.abs(origEndPointConnection.y) - Math.abs(newEndPointConnection.y)
+				- Math.abs(translation.y) <= TOLERANCE_SNAP_TO_GRID);
+
 	}
 
 }

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/networkediting/basicfb/Basic1FBNetworkEditingTests.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/networkediting/basicfb/Basic1FBNetworkEditingTests.java
@@ -25,16 +25,18 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.PolylineConnection;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.fordiac.ide.application.editparts.InstanceNameEditPart;
 import org.eclipse.fordiac.ide.application.figures.InstanceNameFigure;
 import org.eclipse.fordiac.ide.test.ui.Abstract4diacUITests;
-import org.eclipse.fordiac.ide.test.ui.helpers.UITestPinHelper;
 import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotConnection;
 import org.eclipse.fordiac.ide.test.ui.helpers.SWTBotFB;
 import org.eclipse.fordiac.ide.test.ui.helpers.UITestNamesHelper;
+import org.eclipse.fordiac.ide.test.ui.helpers.UITestPinHelper;
 import org.eclipse.fordiac.ide.test.ui.swtbot.SWTBot4diacGefEditor;
 import org.eclipse.fordiac.ide.test.ui.swtbot.SWTBot4diacGefViewer;
+import org.eclipse.gef.ConnectionEditPart;
 import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.GraphicalViewer;
@@ -167,7 +169,7 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 	public void selectFbViaMouseLeftClickRectangleOverFB() {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_D_FF_TREE_ITEM, new Point(200, 200));
-		final SWTBot4diacGefEditor editor = (SWTBot4diacGefEditor) bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
+		final SWTBot4diacGefEditor editor = bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
 
 		// drag rectangle next to FB, therefore FB should not be selected
 		editor.drag(40, 40, 80, 80);
@@ -195,7 +197,7 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 	public void selectFbViaMouseLeftClickOnFB() {
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_SWITCH_TREE_ITEM, new Point(150, 250));
-		final SWTBot4diacGefEditor editor = (SWTBot4diacGefEditor) bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
+		final SWTBot4diacGefEditor editor = bot.gefEditor(UITestNamesHelper.PROJECT_NAME);
 
 		// check bounds of FB
 		editor.getEditPart(UITestNamesHelper.E_SWITCH_FB);
@@ -268,12 +270,12 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		assertNotNull(editor);
 		assertNotNull(editor.getEditPart(UITestNamesHelper.E_CYCLE_FB));
 		editor.click(UITestNamesHelper.E_CYCLE_FB);
-		SWTBotGefEditPart parent = editor.getEditPart(UITestNamesHelper.E_CYCLE_FB).parent();
+		final SWTBotGefEditPart parent = editor.getEditPart(UITestNamesHelper.E_CYCLE_FB).parent();
 		assertNotNull(parent);
 
-		IFigure figure = ((GraphicalEditPart) parent.part()).getFigure();
+		final IFigure figure = ((GraphicalEditPart) parent.part()).getFigure();
 		assertNotNull(figure);
-		Rectangle fbBounds = figure.getBounds().getCopy();
+		final Rectangle fbBounds = figure.getBounds().getCopy();
 		assertNotNull(fbBounds);
 		figure.translateToAbsolute(fbBounds);
 		assertEquals(pos1.x, fbBounds.x);
@@ -285,15 +287,7 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		parent.click();
 
 		final Point pos2 = new Point(85, 85);
-		editor.drag(parent, pos2.x, pos2.y);
-		final org.eclipse.draw2d.geometry.Point posToCheck2 = new org.eclipse.draw2d.geometry.Point(pos2);
-
-		parent = editor.getEditPart(UITestNamesHelper.E_CYCLE_FB).parent();
-		figure = ((GraphicalEditPart) parent.part()).getFigure();
-		fbBounds = figure.getBounds().getCopy();
-		figure.translateToAbsolute(fbBounds);
-		assertEquals(posToCheck2.x, fbBounds.x);
-		assertEquals(posToCheck2.y, fbBounds.y);
+		fbBot.moveSingleFB(editor, UITestNamesHelper.E_CYCLE_FB, pos2);
 	}
 
 	/**
@@ -487,7 +481,6 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 	@SuppressWarnings({ "static-method", "static-access" })
 	@Test
 	public void connectionCanBeFoundAfterMovingFB() {
-		// in progress
 		final Point pos1 = new Point(100, 150);
 		final SWTBotFB fbBot = new SWTBotFB(bot);
 		fbBot.dragAndDropEventsFB(UITestNamesHelper.E_TABLE_CTRL_TREE_ITEM, pos1);
@@ -505,38 +498,27 @@ public class Basic1FBNetworkEditingTests extends Abstract4diacUITests {
 		assertTrue(connectBot.checkIfConnectionCanBeFound(UITestPinHelper.CLKO, UITestPinHelper.INIT));
 		assertTrue(connectBot.checkIfConnectionCanBeFound(UITestPinHelper.CV, UITestPinHelper.N));
 
-		assertNotNull(editor);
-		assertNotNull(editor.getEditPart(UITestNamesHelper.E_TABLE_CTRL_FB));
-		editor.click(UITestNamesHelper.E_TABLE_CTRL_FB);
-		SWTBotGefEditPart parent = editor.getEditPart(UITestNamesHelper.E_TABLE_CTRL_FB).parent();
-		assertNotNull(parent);
-
-		IFigure figure = ((GraphicalEditPart) parent.part()).getFigure();
-		assertNotNull(figure);
-		Rectangle fbBounds = figure.getBounds().getCopy();
-		assertNotNull(fbBounds);
-		figure.translateToAbsolute(fbBounds);
-		assertEquals(pos1.x, fbBounds.x);
-		assertEquals(pos1.y, fbBounds.y);
-
-		final org.eclipse.draw2d.geometry.Point posToCheck1 = new org.eclipse.draw2d.geometry.Point(pos1);
-		assertEquals(posToCheck1.x, fbBounds.x);
-		assertEquals(posToCheck1.y, fbBounds.y);
-		parent.click();
-
 		final Point pos2 = new Point(85, 85);
-		editor.drag(parent, pos2.x, pos2.y);
-		final org.eclipse.draw2d.geometry.Point posToCheck2 = new org.eclipse.draw2d.geometry.Point(pos2);
+		fbBot.moveSingleFB(editor, UITestNamesHelper.E_TABLE_CTRL_FB, pos2);
 
-		parent = editor.getEditPart(UITestNamesHelper.E_TABLE_CTRL_FB).parent();
-		figure = ((GraphicalEditPart) parent.part()).getFigure();
-		fbBounds = figure.getBounds().getCopy();
-		figure.translateToAbsolute(fbBounds);
-		assertEquals(posToCheck2.x, fbBounds.x);
-		assertEquals(posToCheck2.y, fbBounds.y);
-
+		// check if moving has worked correctly
 		assertTrue(connectBot.checkIfConnectionCanBeFound(UITestPinHelper.CLKO, UITestPinHelper.INIT));
 		assertTrue(connectBot.checkIfConnectionCanBeFound(UITestPinHelper.CV, UITestPinHelper.N));
+
+		final Point translation = new Point(pos1.x - pos2.x, pos1.y - pos2.y);
+		fbBot.selectFBWithFBNameInEditor((SWTBot4diacGefEditor) editor, UITestNamesHelper.E_TABLE_CTRL_FB);
+		final ConnectionEditPart connection1 = connectBot.findConnection(UITestPinHelper.CLKO, UITestPinHelper.INIT);
+		assertNotNull(connection1);
+		final ConnectionEditPart connection2 = connectBot.findConnection(UITestPinHelper.CV, UITestPinHelper.N);
+
+		final PolylineConnection polyLineConnection = (PolylineConnection) connection1.getFigure();
+		final org.eclipse.draw2d.geometry.Point origStartPointConnection = polyLineConnection.getPoints()
+				.getFirstPoint();
+		final org.eclipse.draw2d.geometry.Point origEndPointConnection = polyLineConnection.getPoints().getLastPoint();
+		fbBot.checkIfMovingConnectionWasCorrect((SWTBot4diacGefEditor) editor, origStartPointConnection,
+				origEndPointConnection, connection1, translation);
+		fbBot.checkIfMovingConnectionWasCorrect((SWTBot4diacGefEditor) editor, origStartPointConnection,
+				origEndPointConnection, connection2, translation);
 	}
 
 	/**

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/networkediting/basicfb/Basic2FBNetworkEditingTests.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/networkediting/basicfb/Basic2FBNetworkEditingTests.java
@@ -214,20 +214,13 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 		assertTrue(fbBot.isFbSelected(selectedEditParts, UITestNamesHelper.E_CYCLE_FB));
 		assertTrue(fbBot.isFbSelected(selectedEditParts, UITestNamesHelper.E_SR_FB));
 
-		// move Fbs to new position by selecting them with a rectangle
+		// move FBs to new position by selecting them with a rectangle
 		final Point translation = new Point(130, -40);
 		fbBot.moveViaRectangle(editor, new Rectangle(50, 50, 400, 300), translation);
 
 		// check if translation was correct
-		final Rectangle fb1Bounds2 = fbBot.getBoundsOfFBWithTolerance(editor, UITestNamesHelper.E_CYCLE_FB);
-		final int absPos2Fb1X = absPos1Fb1.x + translation.x;
-		final int absPos2Fb1Y = absPos1Fb1.y + translation.y;
-		assertTrue(fb1Bounds2.contains(absPos2Fb1X, absPos2Fb1Y));
-
-		final Rectangle fb2Bounds2 = fbBot.getBoundsOfFBWithTolerance(editor, UITestNamesHelper.E_SR_FB);
-		final int absPos2Fb2X = absPos1Fb2.x + translation.x;
-		final int absPos2Fb2Y = absPos1Fb2.y + translation.y;
-		assertTrue(fb2Bounds2.contains(absPos2Fb2X, absPos2Fb2Y));
+		fbBot.checkIfMovingFBWasCorrect(editor, UITestNamesHelper.E_CYCLE_FB, absPos1Fb1, translation);
+		fbBot.checkIfMovingFBWasCorrect(editor, UITestNamesHelper.E_SR_FB, absPos1Fb2, translation);
 	}
 
 	/**
@@ -285,26 +278,18 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 
 		// get connection start and end point
 		final PolylineConnection polyLineConnection = (PolylineConnection) connection.getFigure();
-		final org.eclipse.draw2d.geometry.Point startPointConnection = polyLineConnection.getPoints().getFirstPoint();
-		final org.eclipse.draw2d.geometry.Point endPointConnection = polyLineConnection.getPoints().getLastPoint();
+		final org.eclipse.draw2d.geometry.Point origStartPointConnection = polyLineConnection.getPoints()
+				.getFirstPoint();
+		final org.eclipse.draw2d.geometry.Point origEndPointConnection = polyLineConnection.getPoints().getLastPoint();
 
 		// calculate deltas of translation
 		final Point pos2 = new Point(305, 245);
-		final int deltaX = pos2.x - pos1.x;
-		final int deltaY = pos2.y - pos1.y;
+		final Point translation = new Point(pos2.x - pos1.x, pos2.y - pos1.y);
 
 		// move E_CYCLE
 		editor.drag(fb1, pos2.x, pos2.y);
-		final Rectangle fb1Bounds2 = fbBot.getBoundsOfFB(editor, UITestNamesHelper.E_CYCLE_FB);
-		assertTrue(fb1Bounds2.contains(pos2.x, pos2.y));
-		assertNotNull(connection);
-		final org.eclipse.draw2d.geometry.Point newStartPointConnection = polyLineConnection.getPoints()
-				.getFirstPoint();
-		final org.eclipse.draw2d.geometry.Point newEndPointConnection = polyLineConnection.getPoints().getLastPoint();
-
-		assertEquals(startPointConnection.x + (long) deltaX, newStartPointConnection.x);
-		assertEquals(startPointConnection.y + (long) deltaY, newStartPointConnection.y);
-		assertEquals(endPointConnection, newEndPointConnection);
+		fbBot.checkIfMovingConnectionWasCorrect(editor, origStartPointConnection, origEndPointConnection, connection,
+				translation);
 	}
 
 	/**
@@ -417,8 +402,9 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 
 		// get connection start and end point
 		final PolylineConnection polyLineConnection = (PolylineConnection) connection.getFigure();
-		final org.eclipse.draw2d.geometry.Point startPointConnection = polyLineConnection.getPoints().getFirstPoint();
-		final org.eclipse.draw2d.geometry.Point endPointConnection = polyLineConnection.getPoints().getLastPoint();
+		final org.eclipse.draw2d.geometry.Point origStartPointConnection = polyLineConnection.getPoints()
+				.getFirstPoint();
+		final org.eclipse.draw2d.geometry.Point origEndPointConnection = polyLineConnection.getPoints().getLastPoint();
 
 		// drag rectangle over FBs, therefore FBs should be selected
 		editor.drag(30, 30, 400, 400);
@@ -440,20 +426,12 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 		assertTrue(fbBot.isFbSelected(selectedEditParts, UITestNamesHelper.E_SR_FB));
 
 		// calculation of translation
-		final int translationX = pointTo.x - pointFrom.x;
-		final int translationY = pointTo.y - pointFrom.y;
+		final Point translation = new Point(pointTo.x - pointFrom.x, pointTo.y - pointFrom.y);
 
 		// check if connection has been moved
 		connection = connectBot.findConnection(UITestPinHelper.EO1, UITestPinHelper.R);
-		assertNotNull(connection);
-		final org.eclipse.draw2d.geometry.Point newStartPointConnection = polyLineConnection.getPoints()
-				.getFirstPoint();
-		final org.eclipse.draw2d.geometry.Point newEndPointConnection = polyLineConnection.getPoints().getLastPoint();
-
-		assertEquals(startPointConnection.x + (long) translationX, newStartPointConnection.x);
-		assertEquals(startPointConnection.y + (long) translationY, newStartPointConnection.y);
-		assertEquals(endPointConnection.x + (long) translationX, newEndPointConnection.x);
-		assertEquals(endPointConnection.y + (long) translationY, newEndPointConnection.y);
+		fbBot.checkIfMovingConnectionWasCorrect(editor, origStartPointConnection, origEndPointConnection, connection,
+				translation);
 
 	}
 }

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/networkediting/basicfb/Basic2FBNetworkEditingTests.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/networkediting/basicfb/Basic2FBNetworkEditingTests.java
@@ -209,37 +209,24 @@ public class Basic2FBNetworkEditingTests extends Abstract4diacUITests {
 		// drag rectangle over FBs, therefore FBs should be selected
 		editor.drag(50, 50, 400, 300);
 		assertDoesNotThrow(editor::waitForSelectedFBEditPart);
-		List<SWTBotGefEditPart> selectedEditParts = editor.selectedEditParts();
+		final List<SWTBotGefEditPart> selectedEditParts = editor.selectedEditParts();
 		assertFalse(selectedEditParts.isEmpty());
 		assertTrue(fbBot.isFbSelected(selectedEditParts, UITestNamesHelper.E_CYCLE_FB));
 		assertTrue(fbBot.isFbSelected(selectedEditParts, UITestNamesHelper.E_SR_FB));
 
-		// move selection by clicking on point within selection (120, 120) and drag to
-		// new Point (285, 85)
-		final Point pointFrom = new Point(120, 120);
-		final Point pointTo = new Point(250, 80);
-		editor.drag(pointFrom.x, pointFrom.y, pointTo.x, pointTo.y);
+		// move Fbs to new position by selecting them with a rectangle
+		final Point translation = new Point(130, -40);
+		fbBot.moveViaRectangle(editor, new Rectangle(50, 50, 400, 300), translation);
 
-		assertDoesNotThrow(editor::waitForSelectedFBEditPart);
-		selectedEditParts = editor.selectedEditParts();
-		assertFalse(selectedEditParts.isEmpty());
-		assertTrue(fbBot.isFbSelected(selectedEditParts, UITestNamesHelper.E_CYCLE_FB));
-		assertTrue(fbBot.isFbSelected(selectedEditParts, UITestNamesHelper.E_SR_FB));
-
-		// Calculation of translation
-		final int translationX = pointTo.x - pointFrom.x;
-		final int translationY = pointTo.y - pointFrom.y;
-
-		// Calculation of new Position of E_CYCLEs
-		final int absPos2Fb1X = absPos1Fb1.x + translationX + TOLERANCE_SNAP_TO_GRID;
-		final int absPos2Fb1Y = absPos1Fb1.y + translationY + TOLERANCE_SNAP_TO_GRID;
-		final Rectangle fb1Bounds2 = fbBot.getBoundsOfFB(editor, UITestNamesHelper.E_CYCLE_FB);
+		// check if translation was correct
+		final Rectangle fb1Bounds2 = fbBot.getBoundsOfFBWithTolerance(editor, UITestNamesHelper.E_CYCLE_FB);
+		final int absPos2Fb1X = absPos1Fb1.x + translation.x;
+		final int absPos2Fb1Y = absPos1Fb1.y + translation.y;
 		assertTrue(fb1Bounds2.contains(absPos2Fb1X, absPos2Fb1Y));
 
-		// Calculation of new Position of E_SR
-		final int absPos2Fb2X = absPos1Fb2.x + translationX + TOLERANCE_SNAP_TO_GRID;
-		final int absPos2Fb2Y = absPos1Fb2.y + translationY + TOLERANCE_SNAP_TO_GRID;
-		final Rectangle fb2Bounds2 = fbBot.getBoundsOfFB(editor, UITestNamesHelper.E_SR_FB);
+		final Rectangle fb2Bounds2 = fbBot.getBoundsOfFBWithTolerance(editor, UITestNamesHelper.E_SR_FB);
+		final int absPos2Fb2X = absPos1Fb2.x + translation.x;
+		final int absPos2Fb2Y = absPos1Fb2.y + translation.y;
 		assertTrue(fb2Bounds2.contains(absPos2Fb2X, absPos2Fb2Y));
 	}
 


### PR DESCRIPTION
Due to the snap to grid feature of 4diac, all tests that query the exact position did not run anymore. Especially tests that move FBs were affected. To counteract this, there is now a small tolerance in which the FB or connection may be located.
In addition, separate auxiliary methods have been created in the SWTBotFB class for easier and faster test creation.