### PR TITLE
Remove unnecessary Attribute from F_MOVE.fbt

### DIFF
--- a/data/typelibrary/iec61131-3-1.0.0/typelib/arithmetic/F_MOVE.fbt
+++ b/data/typelibrary/iec61131-3-1.0.0/typelib/arithmetic/F_MOVE.fbt
@@ -22,5 +22,4 @@
 			<VarDeclaration Name="OUT" Type="ANY" Comment="input = output"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="GenericClassName" Value="'GEN_FORTE_F_MOVE'"/>
 </FBType>


### PR DESCRIPTION
The commit removes an unnecessary Attribute from the F_MOVE.fbt file.
