### PR TITLE
Fixed Exception in Pin Refactoring for non connection change

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/ReconnectPinChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/ReconnectPinChange.java
@@ -50,8 +50,12 @@ public class ReconnectPinChange extends AbstractCommandChange<FBNetworkElement> 
 
 	@Override
 	protected Command createCommand(final FBNetworkElement element) {
+		if (state.size() == 1 && state.contains(ChangeState.NO_CHANGE)) {
+			return new Command() {
+				// empty command that is not doing any change
+			};
+		}
 		return new ReconnectPinByName(oldName, newName, element, state);
-
 	}
 
 	@Override


### PR DESCRIPTION
Selecting No Change for connection updates in pin rename refactorings resulted in an exception.