### PR TITLE
Improve UX of 2 pin contract dialog

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.contracts/src/org/eclipse/fordiac/ide/contracts/DefineFBDecisionTwoPinDialog.java
+++ b/plugins/org.eclipse.fordiac.ide.contracts/src/org/eclipse/fordiac/ide/contracts/DefineFBDecisionTwoPinDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Paul Pavlicek
+ * Copyright (c) 2023, 2024 Paul Pavlicek and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/plugins/org.eclipse.fordiac.ide.contracts/src/org/eclipse/fordiac/ide/contracts/DefineFBDecisionTwoPinDialog.java
+++ b/plugins/org.eclipse.fordiac.ide.contracts/src/org/eclipse/fordiac/ide/contracts/DefineFBDecisionTwoPinDialog.java
@@ -10,94 +10,40 @@
  * Contributors:
  *   Paul Pavlicek
  *     - initial API and implementation and/or initial documentation
+ *   Felix Schmid
+ *     - improved UX by replacing checkboxes with buttons
  *******************************************************************************/
 package org.eclipse.fordiac.ide.contracts;
 
 import org.eclipse.jface.dialogs.MessageDialog;
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.events.SelectionListener;
-import org.eclipse.swt.layout.FillLayout;
-import org.eclipse.swt.layout.GridData;
-import org.eclipse.swt.layout.GridLayout;
-import org.eclipse.swt.widgets.Button;
-import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 
 public class DefineFBDecisionTwoPinDialog extends MessageDialog {
-	private static final int NUM_COLUMNS = 3;
-	private boolean isReaction;
-	private Button reactionCheckbox;
-	private Button guaranteeCheckbox;
+
+	private static final int CREATE_REACTION = 0;
+	private static final int CREATE_GUARANTEE = 1;
+
+	private int pressedButtonId = -1;
 
 	public DefineFBDecisionTwoPinDialog(final Shell parentShell) {
 		super(parentShell, Messages.DefineFBReactionOnePinDialog_Title, null,
 				Messages.DefineFBDecisionTwoPinDialog_Info, MessageDialog.INFORMATION, 0,
-				Messages.DefineFBReactionOnePinDialog_Button);
+				Messages.DefineFBDecisionTwoPinDialog_CreateReaction,
+				Messages.DefineFBDecisionTwoPinDialog_CreateGuarantee);
 	}
 
 	public boolean isReaction() {
-		return isReaction;
+		return pressedButtonId == CREATE_REACTION;
 	}
 
-	@Override
-	protected Control createCustomArea(final Composite parent) {
-		parent.setLayout(new FillLayout());
-		final Composite dialogArea = new Composite(parent, SWT.FILL);
-		dialogArea.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, true, true));
-		dialogArea.setLayout(new GridLayout(2, false));
-
-		final Composite dialog = new Composite(dialogArea, SWT.NONE);
-		dialog.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, true, true));
-		dialog.setLayout(new GridLayout(NUM_COLUMNS, false));
-
-		reactionCheckbox = new Button(dialog, SWT.CHECK);
-		reactionCheckbox.setText(Messages.DefineFBDecisionTwoPinDialog_CreateReaction);
-		reactionCheckbox.setLayoutData(new GridData(SWT.BEGINNING, SWT.CENTER, false, false));
-		reactionCheckbox.addSelectionListener(new SelectionListener() {
-
-			@Override
-			public void widgetSelected(final SelectionEvent e) {
-				guaranteeCheckbox.setEnabled(!reactionCheckbox.getSelection());
-
-			}
-
-			@Override
-			public void widgetDefaultSelected(final SelectionEvent e) {
-				// is never called
-			}
-		});
-
-		guaranteeCheckbox = new Button(dialog, SWT.CHECK);
-		guaranteeCheckbox.setText(Messages.DefineFBDecisionTwoPinDialog_CreateGuarantee);
-		guaranteeCheckbox.setLayoutData(new GridData(SWT.BEGINNING, SWT.CENTER, false, false));
-		guaranteeCheckbox.addSelectionListener(new SelectionListener() {
-
-			@Override
-			public void widgetSelected(final SelectionEvent e) {
-				reactionCheckbox.setEnabled(!guaranteeCheckbox.getSelection());
-
-			}
-
-			@Override
-			public void widgetDefaultSelected(final SelectionEvent e) {
-				// is never called
-			}
-		});
-
-		return dialogArea;
+	public boolean isGuarantee() {
+		return pressedButtonId == CREATE_GUARANTEE;
 	}
 
 	@Override
 	protected void buttonPressed(final int buttonId) {
-		isReaction = reactionCheckbox.getSelection();
-		if (reactionCheckbox.getSelection() == guaranteeCheckbox.getSelection()) {
-			MessageDialog.openError(this.getShell(), Messages.DefineFBDecisionTwoPinDialog_Error,
-					Messages.DefineFBDecisionTwoPinDialog_ErrorInfo);
-		} else {
-			super.buttonPressed(buttonId);
-		}
+		pressedButtonId = buttonId;
+		super.buttonPressed(buttonId);
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.contracts/src/org/eclipse/fordiac/ide/contracts/DefineFbInterfaceConstraintHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.contracts/src/org/eclipse/fordiac/ide/contracts/DefineFbInterfaceConstraintHandler.java
@@ -50,14 +50,11 @@ public class DefineFbInterfaceConstraintHandler extends AbstractHandler {
 		} else if (eventPins.size() == 2) {
 			final DefineFBDecisionTwoPinDialog dialog = new DefineFBDecisionTwoPinDialog(
 					HandlerUtil.getActiveShell(event));
-			boolean isReaction = true;
-			if (dialog.open() != CANCEL) {
-				isReaction = dialog.isReaction();
 
-			}
-			if (isReaction) {
+			dialog.open();
+			if (dialog.isReaction()) {
 				makeTwoPinReaction(event, eventPins);
-			} else {
+			} else if (dialog.isGuarantee()) {
 				makeTwoPinGuarantee(event, eventPins);
 			}
 


### PR DESCRIPTION
Selecting 2 pins and choosing “Source>Define Contract for FB Interface Pins” brings up a dialog where a choice can be made via checkboxes. By replacing those with buttons, the user saves one click while having the same functionality.
Using buttons also avoids the error dialog when the user clicks OK without selecting an option.
Furthermore, this PR contains a bug fix, that when the user closes the dialog box without making a choice, it acted as if the first option was chosen. Now it correctly cancels the operation.

P.S.: I am new to contributing to this project, so this PR also has the purpose of making sure that my workflow is set up correctly.
