### PR TITLE
Only Process Outline Selections in Type Editor

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.typeeditor/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.typeeditor/META-INF/MANIFEST.MF
@@ -45,6 +45,7 @@ Import-Package: org.eclipse.core.commands.common,
  org.eclipse.ui.ide,
  org.eclipse.ui.part,
  org.eclipse.ui.texteditor,
+ org.eclipse.ui.views.contentoutline,
  org.eclipse.ui.views.properties,
  org.eclipse.ui.views.properties.tabbed,
  org.eclipse.xtext.ui.editor

--- a/plugins/org.eclipse.fordiac.ide.typeeditor/src/org/eclipse/fordiac/ide/typeeditor/AbstractTypeEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.typeeditor/src/org/eclipse/fordiac/ide/typeeditor/AbstractTypeEditor.java
@@ -77,6 +77,7 @@ import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.actions.WorkspaceModifyOperation;
 import org.eclipse.ui.ide.IGotoMarker;
 import org.eclipse.ui.texteditor.ITextEditor;
+import org.eclipse.ui.views.contentoutline.ContentOutline;
 import org.eclipse.ui.views.properties.IPropertySheetPage;
 import org.eclipse.ui.views.properties.PropertySheet;
 import org.eclipse.ui.views.properties.tabbed.ITabbedPropertySheetPageContributor;
@@ -391,7 +392,8 @@ public abstract class AbstractTypeEditor extends AbstractCloseAbleFormEditor imp
 						|| selectedElement instanceof Method || selectedElement instanceof VarDeclaration) {
 					handleContentOutlineSelection(new StructuredSelection(selectedElement));
 				}
-			} else {
+			} else if (part instanceof ContentOutline) {
+				// only update selection if it comes from the outline
 				handleContentOutlineSelection(selection);
 			}
 		}


### PR DESCRIPTION
The selectionChangedHandler was forwarding all selections to the handleOutlineSelectionChanged handler. This is now only done for URIs and for outline selections. This leads to a more predictable ui.