### PR TITLE
AdapterFB Events Where Wrongly Prefixed with AdapterName

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/FBNetworkHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/FBNetworkHelper.java
@@ -123,6 +123,7 @@ public final class FBNetworkHelper {
 				final AdapterDeclaration adapter = destInterface.getAdapter(elem.getName());
 				if (null != adapter) {
 					adapterfb.setAdapterDecl(adapter);
+					adapter.setAdapterNetworkFB(adapterfb);
 				}
 			}
 		}
@@ -154,11 +155,11 @@ public final class FBNetworkHelper {
 		return newConn;
 	}
 
-	private static IInterfaceElement getInterfaceElement(final IInterfaceElement ie, final InterfaceList typeInterface,
+	private static IInterfaceElement getInterfaceElement(final IInterfaceElement ie, final InterfaceList destInterface,
 			final FBNetwork dstNetwork, final FBNetwork srcNetwork) {
 		final IInterfaceElement interfaceElement;
 		if (ie.getFBNetworkElement() == null || srcNetwork != ie.getFBNetworkElement().getFbNetwork()) {
-			interfaceElement = typeInterface.getInterfaceElement(ie.getName());
+			interfaceElement = destInterface.getInterfaceElement(ie.getName());
 		} else {
 			final FBNetworkElement element = dstNetwork.getElementNamed(ie.getFBNetworkElement().getName());
 			if (null == element) {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/InterfaceListAnnotations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/InterfaceListAnnotations.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
+ * Copyright (c) 2008, 2024 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
  *                          Johannes Kepler University
  *
  * This program and the accompanying materials are made available under the
@@ -23,7 +23,6 @@ import java.util.stream.Stream;
 
 import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.EList;
-import org.eclipse.fordiac.ide.model.Annotations;
 import org.eclipse.fordiac.ide.model.libraryElement.AdapterDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.Event;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
@@ -53,12 +52,12 @@ final class InterfaceListAnnotations {
 
 	public static Event getEvent(final InterfaceList il, final String name) {
 		for (final Event event : il.getEventInputs()) {
-			if (Annotations.getTransitionEventName(event).equals(name)) {
+			if (event.getName().equals(name)) {
 				return event;
 			}
 		}
 		for (final Event event : il.getEventOutputs()) {
-			if (Annotations.getTransitionEventName(event).equals(name)) {
+			if (event.getName().equals(name)) {
 				return event;
 			}
 		}


### PR DESCRIPTION
With the rework of the AdapterFB model we never search with the full name for adapter events. However the getEvent method always prefixed ApdaterFB events with the adapter name.