### PR TITLE
Show Attribute Property Sheet for Pin Type Sel. in Interface Editor

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editparts/CommentField.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editparts/CommentField.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2011 - 2017 Profactor GmbH, fortiss GmbH
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -24,14 +24,15 @@ class CommentField {
 
 	/**
 	 * Helper object to display comment of an in/output.
-	 * 
+	 *
 	 * @param referencedElement the referenced element
 	 */
-	CommentField(IInterfaceElement referencedElement) {
+	CommentField(final IInterfaceElement referencedElement) {
 		this.referencedElement = referencedElement;
 	}
 
 	public String getLabel() {
 		return getReferencedElement().getComment();
 	}
+
 }

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editparts/TypeField.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editparts/TypeField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Profactor GmbH, fortiss GmbH,
+ * Copyright (c) 2011, 2024 Profactor GmbH, fortiss GmbH,
  *                          Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
@@ -14,9 +14,11 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.fbtypeeditor.editparts;
 
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableObject;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 
-public class TypeField {
+public class TypeField implements IAdaptable {
 	private final IInterfaceElement referencedElement;
 
 	public IInterfaceElement getReferencedElement() {
@@ -31,4 +33,11 @@ public class TypeField {
 		return getReferencedElement().getFullTypeName();
 	}
 
+	@Override
+	public <T> T getAdapter(final Class<T> adapter) {
+		if (adapter == ConfigurableObject.class) {
+			return adapter.cast(referencedElement);
+		}
+		return null;
+	}
 }

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/filters/AttributeFilter.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/filters/AttributeFilter.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.fordiac.ide.gef.filters;
 
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
 import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableObject;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
@@ -31,7 +33,11 @@ public class AttributeFilter implements IFilter {
 
 	public static Object parseObject(final Object input) {
 		if (input instanceof final EditPart editpart) {
-			final Object inputHelper = editpart.getModel();
+			Object inputHelper = editpart.getModel();
+
+			if (!(inputHelper instanceof EObject) && inputHelper instanceof final IAdaptable adaptable) {
+				inputHelper = adaptable.getAdapter(ConfigurableObject.class);
+			}
 
 			// handle exception: interface elements of functions
 			if (inputHelper instanceof final IInterfaceElement interfaceElement


### PR DESCRIPTION
When the type field of a pin is selected in the interface editor the same property sheets as for the pin selection is shown.