### PR TITLE
Fix missing editor input in instance viewers

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/DiagramEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/DiagramEditor.java
@@ -290,6 +290,7 @@ public abstract class DiagramEditor extends GraphicalEditor
 			annotationModel = multiPageEditorSite.getMultiPageEditor().getAdapter(GraphicalAnnotationModel.class);
 			addAnnotationModelDispatcher();
 		}
+		super.setInputWithNotify(input);
 	}
 
 	protected DefaultEditDomain createEditDomain() {


### PR DESCRIPTION
This add a missing call to actually set the editor input in instance viewers, which would otherwise cause an NPE when opening the context menu.