### PR TITLE
ignore non-type files while manually creating type entries

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/LibraryManager.java
+++ b/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/LibraryManager.java
@@ -499,12 +499,14 @@ public enum LibraryManager {
 		case final IFolder f -> true;
 		case final IFile file -> {
 			final TypeEntry entry = TypeEntryFactory.INSTANCE.createTypeEntry(file);
-			final TypeEntry oldEntry = cachedTypes.get(entry.getFullTypeName());
-			if (oldEntry != null) {
-				FordiacResourceChangeListener.updateTypeEntry(file, oldEntry);
-				cachedTypes.remove(entry.getFullTypeName());
-			} else {
-				typeLibrary.createTypeEntry(file);
+			if (entry != null) {
+				final TypeEntry oldEntry = cachedTypes.get(entry.getFullTypeName());
+				if (oldEntry != null) {
+					FordiacResourceChangeListener.updateTypeEntry(file, oldEntry);
+					cachedTypes.remove(entry.getFullTypeName());
+				} else {
+					typeLibrary.createTypeEntry(file);
+				}
 			}
 			yield false;
 		}


### PR DESCRIPTION
loading libraries containing files that were not part of the type library (e.g. addtional CSV, PDF,...) failed