### PR TITLE
Update Type Preserves also Pin Attributes

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractUpdateFBNElementCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractUpdateFBNElementCommand.java
@@ -480,6 +480,13 @@ public abstract class AbstractUpdateFBNElementCommand extends Command implements
 
 	private void copyAttributes() {
 		newElement.getAttributes().addAll(EcoreUtil.copyAll(oldElement.getAttributes()));
+		oldElement.getInterface().getAllInterfaceElements().stream().filter(ie -> !ie.getAttributes().isEmpty())
+				.forEach(ie -> {
+					final IInterfaceElement newIE = newElement.getInterfaceElement(ie.getName());
+					if (newIE != null) {
+						newIE.getAttributes().addAll(EcoreUtil.copyAll(ie.getAttributes()));
+					}
+				});
 	}
 
 	protected abstract FBNetworkElement createCopiedFBEntry(final FBNetworkElement srcElement);


### PR DESCRIPTION
When updating a type any pin attributes where lost. This is fixed now.