### PR TITLE
Fixed construction of subchanges from  RenameTypeRefactoringParticipant

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/rename/RenameTypeRefactoringParticipant.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/rename/RenameTypeRefactoringParticipant.java
@@ -191,7 +191,7 @@ public class RenameTypeRefactoringParticipant extends RenameParticipant {
 					return change;
 				}
 				if (rootContainer instanceof final FBType fbType
-						&& dataTypeEntry instanceof final StructuredType type) {
+						&& dataTypeEntry.getType() instanceof final StructuredType type) {
 					return new UpdateFBTypeInterfaceChange(fbType, type);
 				}
 			}


### PR DESCRIPTION
Fixed a condition that always returns false and is therefore useless.