### PR TITLE
Add event type to exporter

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteFBTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteFBTemplate.xtend
@@ -233,8 +233,8 @@ abstract class ForteFBTemplate<T extends FBType> extends ForteLibraryElementTemp
 	// as there this code is duplicated
 	def protected generateFBInterfaceSpecDefinition() '''
 		const SFBInterfaceSpec «FBClassName»::scmFBInterfaceSpec = {
-		  «type.interfaceList.eventInputs.size», «IF type.interfaceList.eventInputs.empty»nullptr, nullptr, nullptr, nullptr«ELSE»scmEventInputNames,«IF type.interfaceList.eventInputs.containsOnlyBasicEventType» nullptr,«ELSE» scmEventInputTypeIds,«ENDIF»«IF hasInputWith»scmEIWith«ELSE»nullptr«ENDIF», scmEIWithIndexes«ENDIF»,
-		  «type.interfaceList.eventOutputs.size», «IF type.interfaceList.eventOutputs.empty»nullptr, nullptr, nullptr, nullptr«ELSE»scmEventOutputNames,«IF type.interfaceList.eventOutputs.containsOnlyBasicEventType» nullptr,«ELSE» scmEventOutputTypeIds,«ENDIF»«IF hasOutputWith»scmEOWith«ELSE»nullptr«ENDIF», scmEOWithIndexes«ENDIF»,
+		  «type.interfaceList.eventInputs.size», «IF type.interfaceList.eventInputs.empty»nullptr, nullptr, nullptr, nullptr«ELSE»scmEventInputNames, «IF type.interfaceList.eventInputs.containsOnlyBasicEventType»nullptr«ELSE»scmEventInputTypeIds«ENDIF», «IF hasInputWith»scmEIWith«ELSE»nullptr«ENDIF», scmEIWithIndexes«ENDIF»,
+		  «type.interfaceList.eventOutputs.size», «IF type.interfaceList.eventOutputs.empty»nullptr, nullptr, nullptr, nullptr«ELSE»scmEventOutputNames, «IF type.interfaceList.eventOutputs.containsOnlyBasicEventType»nullptr«ELSE»scmEventOutputTypeIds«ENDIF», «IF hasOutputWith»scmEOWith«ELSE»nullptr«ENDIF», scmEOWithIndexes«ENDIF»,
 		  «type.interfaceList.inputVars.size», «IF type.interfaceList.inputVars.empty»nullptr, nullptr«ELSE»scmDataInputNames, scmDataInputTypeIds«ENDIF»,
 		  «type.interfaceList.outputVars.size», «IF type.interfaceList.outputVars.empty»nullptr, nullptr«ELSE»scmDataOutputNames, scmDataOutputTypeIds«ENDIF»,
 		  «type.interfaceList.inOutVars.size», «IF type.interfaceList.inOutVars.empty»nullptr«ELSE»scmDataInOutNames«ENDIF»,

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteFBTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteFBTemplate.xtend
@@ -42,6 +42,9 @@ import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration
 import org.eclipse.fordiac.ide.model.libraryElement.With
 
 import static extension org.eclipse.fordiac.ide.export.forte_ng.util.ForteNgExportUtil.*
+import org.eclipse.emf.common.util.EList
+import org.eclipse.fordiac.ide.model.data.EventType
+import org.eclipse.fordiac.ide.model.typelibrary.EventTypeLibrary
 
 abstract class ForteFBTemplate<T extends FBType> extends ForteLibraryElementTemplate<T> {
 
@@ -119,7 +122,9 @@ abstract class ForteFBTemplate<T extends FBType> extends ForteLibraryElementTemp
 			«IF hasOutputWith»static const TDataIOID scmEOWith[];«ENDIF»
 			static const TForteInt16 scmEOWithIndexes[];
 			static const CStringDictionary::TStringId scmEventOutputNames[];
-			static const CStringDictionary::TStringId scmEventOutputTypeIds[]; 
+			«IF !type.interfaceList.eventOutputs.containsOnlyBasicEventType»
+				static const CStringDictionary::TStringId scmEventOutputTypeIds[]; 
+			«ENDIF»
 		«ENDIF»'''
 
 	def protected generateFBEventInputInterfaceDecl() '''«IF !type.interfaceList.eventInputs.empty»
@@ -127,7 +132,9 @@ abstract class ForteFBTemplate<T extends FBType> extends ForteLibraryElementTemp
 			«IF hasInputWith»static const TDataIOID scmEIWith[];«ENDIF»
 			static const TForteInt16 scmEIWithIndexes[];
 			static const CStringDictionary::TStringId scmEventInputNames[];
-			static const CStringDictionary::TStringId scmEventInputTypeIds[]; 
+			«IF !type.interfaceList.eventInputs.containsOnlyBasicEventType»
+				static const CStringDictionary::TStringId scmEventInputTypeIds[]; 
+			«ENDIF»
 		«ENDIF»'''
 
 	def protected generateEventConstants(List<Event> events) '''«FOR event : events»
@@ -184,7 +191,9 @@ abstract class ForteFBTemplate<T extends FBType> extends ForteLibraryElementTemp
 				«ENDIF»
 				const TForteInt16 «FBClassName»::scmEIWithIndexes[] = {«inputWithIndexes.join(", ")»};
 				const CStringDictionary::TStringId «FBClassName»::scmEventInputNames[] = {«type.interfaceList.eventInputs.FORTENameList»};
-				const CStringDictionary::TStringId «FBClassName»::scmEventInputTypeIds[] = {«type.interfaceList.eventInputs.FORTEEventTypeList»};
+				«IF !type.interfaceList.eventInputs.containsOnlyBasicEventType»
+					const CStringDictionary::TStringId «FBClassName»::scmEventInputTypeIds[] = {«type.interfaceList.eventInputs.FORTEEventTypeList»};
+				«ENDIF»
 			«ENDIF»
 			«IF !type.interfaceList.eventOutputs.empty»
 				«IF !outputWith.empty»
@@ -192,7 +201,9 @@ abstract class ForteFBTemplate<T extends FBType> extends ForteLibraryElementTemp
 				«ENDIF»
 				const TForteInt16 «FBClassName»::scmEOWithIndexes[] = {«outputWithIndexes.join(", ")»};
 				const CStringDictionary::TStringId «FBClassName»::scmEventOutputNames[] = {«type.interfaceList.eventOutputs.FORTENameList»};
-				const CStringDictionary::TStringId «FBClassName»::scmEventOutputTypeIds[] = {«type.interfaceList.eventOutputs.FORTEEventTypeList»};
+				«IF !type.interfaceList.eventOutputs.containsOnlyBasicEventType»
+						const CStringDictionary::TStringId «FBClassName»::scmEventOutputTypeIds[] = {«type.interfaceList.eventOutputs.FORTEEventTypeList»};
+				«ENDIF»
 			«ENDIF»
 			«IF !type.interfaceList.sockets.empty || !type.interfaceList.plugs.empty»
 				const SAdapterInstanceDef «FBClassName»::scmAdapterInstances[] = {
@@ -214,12 +225,16 @@ abstract class ForteFBTemplate<T extends FBType> extends ForteLibraryElementTemp
 		!type.interfaceList.eventOutputs.flatMap[it.with].filter[!it.variables.inOutVar].empty
 	}
 
+	def containsOnlyBasicEventType(EList<Event> events) {
+		events.findFirst[!it.typeName.contentEquals(EventTypeLibrary.EVENT)] === null
+	}
+	
 	// changes to this method require a recheck of the two methods generateFBInterfaceSpecSocket, generateFBInterfaceSpecPlug of AdapterFBImplTemplate
 	// as there this code is duplicated
 	def protected generateFBInterfaceSpecDefinition() '''
 		const SFBInterfaceSpec «FBClassName»::scmFBInterfaceSpec = {
-		  «type.interfaceList.eventInputs.size», «IF type.interfaceList.eventInputs.empty»nullptr, nullptr, nullptr, nullptr«ELSE»scmEventInputNames, scmEventInputTypeIds,  «IF hasInputWith»scmEIWith«ELSE»nullptr«ENDIF», scmEIWithIndexes«ENDIF»,
-		  «type.interfaceList.eventOutputs.size», «IF type.interfaceList.eventOutputs.empty»nullptr, nullptr, nullptr, nullptr«ELSE»scmEventOutputNames, scmEventOutputTypeIds, «IF hasOutputWith»scmEOWith«ELSE»nullptr«ENDIF», scmEOWithIndexes«ENDIF»,
+		  «type.interfaceList.eventInputs.size», «IF type.interfaceList.eventInputs.empty»nullptr, nullptr, nullptr, nullptr«ELSE»scmEventInputNames,«IF type.interfaceList.eventInputs.containsOnlyBasicEventType» nullptr,«ELSE» scmEventInputTypeIds,«ENDIF»«IF hasInputWith»scmEIWith«ELSE»nullptr«ENDIF», scmEIWithIndexes«ENDIF»,
+		  «type.interfaceList.eventOutputs.size», «IF type.interfaceList.eventOutputs.empty»nullptr, nullptr, nullptr, nullptr«ELSE»scmEventOutputNames,«IF type.interfaceList.eventOutputs.containsOnlyBasicEventType» nullptr,«ELSE» scmEventOutputTypeIds,«ENDIF»«IF hasOutputWith»scmEOWith«ELSE»nullptr«ENDIF», scmEOWithIndexes«ENDIF»,
 		  «type.interfaceList.inputVars.size», «IF type.interfaceList.inputVars.empty»nullptr, nullptr«ELSE»scmDataInputNames, scmDataInputTypeIds«ENDIF»,
 		  «type.interfaceList.outputVars.size», «IF type.interfaceList.outputVars.empty»nullptr, nullptr«ELSE»scmDataOutputNames, scmDataOutputTypeIds«ENDIF»,
 		  «type.interfaceList.inOutVars.size», «IF type.interfaceList.inOutVars.empty»nullptr«ELSE»scmDataInOutNames«ENDIF»,

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteFBTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteFBTemplate.xtend
@@ -119,6 +119,7 @@ abstract class ForteFBTemplate<T extends FBType> extends ForteLibraryElementTemp
 			«IF hasOutputWith»static const TDataIOID scmEOWith[];«ENDIF»
 			static const TForteInt16 scmEOWithIndexes[];
 			static const CStringDictionary::TStringId scmEventOutputNames[];
+			static const CStringDictionary::TStringId scmEventOutputTypeIds[]; 
 		«ENDIF»'''
 
 	def protected generateFBEventInputInterfaceDecl() '''«IF !type.interfaceList.eventInputs.empty»
@@ -126,6 +127,7 @@ abstract class ForteFBTemplate<T extends FBType> extends ForteLibraryElementTemp
 			«IF hasInputWith»static const TDataIOID scmEIWith[];«ENDIF»
 			static const TForteInt16 scmEIWithIndexes[];
 			static const CStringDictionary::TStringId scmEventInputNames[];
+			static const CStringDictionary::TStringId scmEventInputTypeIds[]; 
 		«ENDIF»'''
 
 	def protected generateEventConstants(List<Event> events) '''«FOR event : events»
@@ -182,6 +184,7 @@ abstract class ForteFBTemplate<T extends FBType> extends ForteLibraryElementTemp
 				«ENDIF»
 				const TForteInt16 «FBClassName»::scmEIWithIndexes[] = {«inputWithIndexes.join(", ")»};
 				const CStringDictionary::TStringId «FBClassName»::scmEventInputNames[] = {«type.interfaceList.eventInputs.FORTENameList»};
+				const CStringDictionary::TStringId «FBClassName»::scmEventInputTypeIds[] = {«type.interfaceList.eventInputs.FORTEEventTypeList»};
 			«ENDIF»
 			«IF !type.interfaceList.eventOutputs.empty»
 				«IF !outputWith.empty»
@@ -189,6 +192,7 @@ abstract class ForteFBTemplate<T extends FBType> extends ForteLibraryElementTemp
 				«ENDIF»
 				const TForteInt16 «FBClassName»::scmEOWithIndexes[] = {«outputWithIndexes.join(", ")»};
 				const CStringDictionary::TStringId «FBClassName»::scmEventOutputNames[] = {«type.interfaceList.eventOutputs.FORTENameList»};
+				const CStringDictionary::TStringId «FBClassName»::scmEventOutputTypeIds[] = {«type.interfaceList.eventOutputs.FORTEEventTypeList»};
 			«ENDIF»
 			«IF !type.interfaceList.sockets.empty || !type.interfaceList.plugs.empty»
 				const SAdapterInstanceDef «FBClassName»::scmAdapterInstances[] = {
@@ -214,8 +218,8 @@ abstract class ForteFBTemplate<T extends FBType> extends ForteLibraryElementTemp
 	// as there this code is duplicated
 	def protected generateFBInterfaceSpecDefinition() '''
 		const SFBInterfaceSpec «FBClassName»::scmFBInterfaceSpec = {
-		  «type.interfaceList.eventInputs.size», «IF type.interfaceList.eventInputs.empty»nullptr, nullptr, nullptr«ELSE»scmEventInputNames, «IF hasInputWith»scmEIWith«ELSE»nullptr«ENDIF», scmEIWithIndexes«ENDIF»,
-		  «type.interfaceList.eventOutputs.size», «IF type.interfaceList.eventOutputs.empty»nullptr, nullptr, nullptr«ELSE»scmEventOutputNames, «IF hasOutputWith»scmEOWith«ELSE»nullptr«ENDIF», scmEOWithIndexes«ENDIF»,
+		  «type.interfaceList.eventInputs.size», «IF type.interfaceList.eventInputs.empty»nullptr, nullptr, nullptr, nullptr«ELSE»scmEventInputNames, scmEventInputTypeIds,  «IF hasInputWith»scmEIWith«ELSE»nullptr«ENDIF», scmEIWithIndexes«ENDIF»,
+		  «type.interfaceList.eventOutputs.size», «IF type.interfaceList.eventOutputs.empty»nullptr, nullptr, nullptr, nullptr«ELSE»scmEventOutputNames, scmEventOutputTypeIds, «IF hasOutputWith»scmEOWith«ELSE»nullptr«ENDIF», scmEOWithIndexes«ENDIF»,
 		  «type.interfaceList.inputVars.size», «IF type.interfaceList.inputVars.empty»nullptr, nullptr«ELSE»scmDataInputNames, scmDataInputTypeIds«ENDIF»,
 		  «type.interfaceList.outputVars.size», «IF type.interfaceList.outputVars.empty»nullptr, nullptr«ELSE»scmDataOutputNames, scmDataOutputTypeIds«ENDIF»,
 		  «type.interfaceList.inOutVars.size», «IF type.interfaceList.inOutVars.empty»nullptr«ELSE»scmDataInOutNames«ENDIF»,

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteLibraryElementTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteLibraryElementTemplate.xtend
@@ -32,6 +32,8 @@ import org.eclipse.xtend.lib.annotations.Accessors
 
 import static extension org.eclipse.fordiac.ide.export.forte_ng.util.ForteNgExportUtil.*
 import static extension org.eclipse.xtext.EcoreUtil2.*
+import org.eclipse.fordiac.ide.model.libraryElement.Event
+import org.eclipse.emf.common.util.EList
 
 abstract class ForteLibraryElementTemplate<T extends LibraryElement> extends ForteNgExportTemplate {
 
@@ -151,7 +153,11 @@ abstract class ForteLibraryElementTemplate<T extends LibraryElement> extends For
 	}
 
 	def protected getFORTETypeList(List<? extends VarDeclaration> elements) {
-		elements.map [generateVariableTypeSpec].join(", ")
+		elements.map[generateVariableTypeSpec].join(", ")
+	}
+	
+	def protected getFORTEEventTypeList(List<? extends Event> elements) {
+		elements.map[it.typeName.FORTEStringId].join(", ")
 	}
 
 	override getErrors() {

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/adapter/AdapterFBImplTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/adapter/AdapterFBImplTemplate.xtend
@@ -54,8 +54,8 @@ class AdapterFBImplTemplate extends ForteFBTemplate<AdapterType> {
 
 	def generateFBInterfaceSpecSocket() '''
 		const SFBInterfaceSpec «FBClassName»::scmFBInterfaceSpecSocket = {
-		  «type.interfaceList.eventInputs.size», «IF type.interfaceList.eventInputs.empty»nullptr, nullptr, nullptr«ELSE»scmEventInputNames, «IF hasInputWith»scmEIWith«ELSE»nullptr«ENDIF», scmEIWithIndexes«ENDIF»,
-		  «type.interfaceList.eventOutputs.size», «IF type.interfaceList.eventOutputs.empty»nullptr, nullptr, nullptr«ELSE»scmEventOutputNames, «IF hasOutputWith»scmEOWith«ELSE»nullptr«ENDIF», scmEOWithIndexes«ENDIF»,
+		  «type.interfaceList.eventInputs.size», «IF type.interfaceList.eventInputs.empty»nullptr, nullptr, nullptr, nullptr«ELSE»scmEventInputNames, scmEventInputTypeIds, «IF hasInputWith»scmEIWith«ELSE»nullptr«ENDIF», scmEIWithIndexes«ENDIF»,
+		  «type.interfaceList.eventOutputs.size», «IF type.interfaceList.eventOutputs.empty»nullptr, nullptr, nullptr, nullptr«ELSE»scmEventOutputNames, scmEventOutputTypeIds, «IF hasOutputWith»scmEOWith«ELSE»nullptr«ENDIF», scmEOWithIndexes«ENDIF»,
 		  «type.interfaceList.inputVars.size», «IF type.interfaceList.inputVars.empty»nullptr, nullptr«ELSE»scmDataInputNames, scmDataInputTypeIds«ENDIF»,
 		  «type.interfaceList.outputVars.size», «IF type.interfaceList.outputVars.empty»nullptr, nullptr«ELSE»scmDataOutputNames, scmDataOutputTypeIds«ENDIF»,
 		  «type.interfaceList.inOutVars.size», «IF type.interfaceList.inOutVars.empty»nullptr«ELSE»scmDataInOutNames«ENDIF»,
@@ -65,8 +65,8 @@ class AdapterFBImplTemplate extends ForteFBTemplate<AdapterType> {
 
 	def generateFBInterfaceSpecPlug() '''
 		const SFBInterfaceSpec «FBClassName»::scmFBInterfaceSpecPlug = {
-		  «type.interfaceList.eventOutputs.size», «IF type.interfaceList.eventOutputs.empty»nullptr, nullptr, nullptr«ELSE»scmEventOutputNames, «IF hasOutputWith»scmEOWith«ELSE»nullptr«ENDIF», scmEOWithIndexes«ENDIF»,
-		  «type.interfaceList.eventInputs.size», «IF type.interfaceList.eventInputs.empty»nullptr, nullptr, nullptr«ELSE»scmEventInputNames, «IF hasInputWith»scmEIWith«ELSE»nullptr«ENDIF», scmEIWithIndexes«ENDIF»,
+		  «type.interfaceList.eventOutputs.size», «IF type.interfaceList.eventOutputs.empty»nullptr, nullptr, nullptr, nullptr«ELSE»scmEventOutputNames, scmEventOutputTypeIds, «IF hasOutputWith»scmEOWith«ELSE»nullptr«ENDIF», scmEOWithIndexes«ENDIF»,
+		  «type.interfaceList.eventInputs.size», «IF type.interfaceList.eventInputs.empty»nullptr, nullptr, nullptr, nullptr«ELSE»scmEventInputNames, scmEventInputTypeIds, «IF hasInputWith»scmEIWith«ELSE»nullptr«ENDIF», scmEIWithIndexes«ENDIF»,
 		  «type.interfaceList.outputVars.size», «IF type.interfaceList.outputVars.empty»nullptr, nullptr«ELSE»scmDataOutputNames, scmDataOutputTypeIds«ENDIF»,
 		  «type.interfaceList.inputVars.size», «IF type.interfaceList.inputVars.empty»nullptr, nullptr«ELSE»scmDataInputNames, scmDataInputTypeIds«ENDIF»,
 		  «type.interfaceList.inOutVars.size», «IF type.interfaceList.inOutVars.empty»nullptr«ELSE»scmDataInOutNames«ENDIF»,

--- a/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/forte_ng/ForteNgBasicFBTest.xtend
+++ b/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/forte_ng/ForteNgBasicFBTest.xtend
@@ -127,8 +127,8 @@ class ForteNgBasicFBTest extends ExporterTestBasicFBTypeBase {
 						DEFINE_FIRMWARE_FB(«EXPORTED_FUNCTIONBLOCK_NAME», g_nStringId«ExporterTestBase.BASICFUNCTIONBLOCK_NAME»)
 						
 						const SFBInterfaceSpec «EXPORTED_FUNCTIONBLOCK_NAME»::scmFBInterfaceSpec = {
-						  0, nullptr, nullptr, nullptr,
-						  0, nullptr, nullptr, nullptr,
+						  0, nullptr, nullptr, nullptr, nullptr,
+						  0, nullptr, nullptr, nullptr, nullptr,
 						  0, nullptr, nullptr,
 						  0, nullptr, nullptr,
 						  0, nullptr,

--- a/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/forte_ng/ForteNgTest.xtend
+++ b/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/forte_ng/ForteNgTest.xtend
@@ -310,8 +310,8 @@ class ForteNgTest extends ExporterTestBasicFBTypeBase {
 						DEFINE_FIRMWARE_FB(«EXPORTED_FUNCTIONBLOCK_NAME», g_nStringIdfunctionblock)
 						
 						const SFBInterfaceSpec «EXPORTED_FUNCTIONBLOCK_NAME»::scmFBInterfaceSpec = {
-						  0, nullptr, nullptr, nullptr,
-						  0, nullptr, nullptr, nullptr,
+						  0, nullptr, nullptr, nullptr, nullptr,
+						  0, nullptr, nullptr, nullptr, nullptr,
 						  0, nullptr, nullptr,
 						  0, nullptr, nullptr,
 						  0, nullptr,


### PR DESCRIPTION
Adds a event type list to the exporter. If there is only the basic event type (Event) present in the interface, no event list will be exported. 