### PR TITLE
Removed the check to prevented automation system from reloading to ensure safe type update

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
@@ -48,7 +48,6 @@ import org.eclipse.fordiac.ide.model.dataimport.CommonElementImporter;
 import org.eclipse.fordiac.ide.model.dataimport.exceptions.TypeImportException;
 import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
-import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.resource.FordiacTypeResource;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
@@ -430,14 +429,8 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 
 			NotificationChain notifications = null;
 			synchronized (this) {
-				if (!getTypeEClass().equals(LibraryElementPackage.Literals.AUTOMATION_SYSTEM)) {
-					// currently we only want to purge the models if it is not an automation system,
-					// as it is used as identification in system explorer and monitoring
-					// FIXME remove if when monitoring is fixed
-					notifications = basicSetType(null, notifications);
-					notifications = basicSetTypeEditable(null, notifications);
-				}
-
+				notifications = basicSetType(null, notifications);
+				notifications = basicSetTypeEditable(null, notifications);
 				// if there is an editor opened then this notification will be delegated to the
 				// corresponding editor.
 				// If not, then nothing will happen


### PR DESCRIPTION
In order to ensure that refactoring operations are working correct, this check needs to be removed. 
Especially refactorings are behaving strange sometimes when the editor is closed