### PR TITLE
Fixed Broken Connection Checking for CFB and Typed Subapp Instances

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/annotations/FBAnnotations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/annotations/FBAnnotations.java
@@ -17,7 +17,10 @@ package org.eclipse.fordiac.ide.model.annotations;
 import java.util.stream.Stream;
 
 import org.eclipse.fordiac.ide.model.helpers.FBNetworkHelper;
+import org.eclipse.fordiac.ide.model.libraryElement.AdapterConnection;
 import org.eclipse.fordiac.ide.model.libraryElement.CFBInstance;
+import org.eclipse.fordiac.ide.model.libraryElement.DataConnection;
+import org.eclipse.fordiac.ide.model.libraryElement.EventConnection;
 import org.eclipse.fordiac.ide.model.libraryElement.FB;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
@@ -41,6 +44,9 @@ public final class FBAnnotations {
 		if (null == fbNetwork) {
 			fbNetwork = FBNetworkHelper.copyCFBNetWork(cfb.getType().getFBNetwork(), cfb.getInterface());
 			cfb.setCfbNetwork(fbNetwork);
+			fbNetwork.getEventConnections().forEach(EventConnection::checkIfConnectionBroken);
+			fbNetwork.getDataConnections().forEach(DataConnection::checkIfConnectionBroken);
+			fbNetwork.getAdapterConnections().forEach(AdapterConnection::checkIfConnectionBroken);
 		}
 		return fbNetwork;
 	}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/annotations/SubAppAnnotations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/annotations/SubAppAnnotations.java
@@ -17,6 +17,9 @@ package org.eclipse.fordiac.ide.model.annotations;
 import java.util.stream.Stream;
 
 import org.eclipse.fordiac.ide.model.helpers.FBNetworkHelper;
+import org.eclipse.fordiac.ide.model.libraryElement.AdapterConnection;
+import org.eclipse.fordiac.ide.model.libraryElement.DataConnection;
+import org.eclipse.fordiac.ide.model.libraryElement.EventConnection;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.TypedSubApp;
@@ -29,6 +32,9 @@ public final class SubAppAnnotations {
 		if (null == subAppNetwork) {
 			subAppNetwork = FBNetworkHelper.copyFBNetWork(subApp.getType().getFBNetwork(), subApp.getInterface());
 			subApp.setSubAppNetwork(subAppNetwork);
+			subAppNetwork.getEventConnections().forEach(EventConnection::checkIfConnectionBroken);
+			subAppNetwork.getDataConnections().forEach(DataConnection::checkIfConnectionBroken);
+			subAppNetwork.getAdapterConnections().forEach(AdapterConnection::checkIfConnectionBroken);
 		}
 		return subAppNetwork;
 	}


### PR DESCRIPTION
When creating the network for CFB Typed SubApp instances the broken connection checking was done before the network was added to the instance. Therefore connections to the instance border where in some cases dashed.