### PR TITLE
Fixed FBNetwork Viewer Position after Type updates

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/DiagramEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/DiagramEditor.java
@@ -59,7 +59,6 @@ import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IReusableEditor;
@@ -122,7 +121,7 @@ public abstract class DiagramEditor extends GraphicalEditor
 
 		final AdvancedScrollingGraphicalViewer viewer = getGraphicalViewer();
 		if (viewer.getControl() instanceof FigureCanvas) {
-			Display.getDefault().asyncExec(() -> performInitialsationScroll(viewer));
+			performInitialsationScroll(viewer);
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/DiagramEditorWithFlyoutPalette.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/DiagramEditorWithFlyoutPalette.java
@@ -75,7 +75,6 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IActionBars;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
@@ -145,11 +144,11 @@ public abstract class DiagramEditorWithFlyoutPalette extends GraphicalEditorWith
 
 		final AdvancedScrollingGraphicalViewer viewer = getGraphicalViewer();
 		if (viewer.getControl() instanceof FigureCanvas) {
-			Display.getDefault().asyncExec(() -> performInitialsationScroll(viewer));
+			performInitialsationScroll(viewer);
 		}
 	}
 
-	public void performInitialsationScroll(final AdvancedScrollingGraphicalViewer viewer) {
+	protected void performInitialsationScroll(final AdvancedScrollingGraphicalViewer viewer) {
 		final FigureCanvas canvas = (FigureCanvas) viewer.getControl();
 		if (canvas != null && !canvas.isDisposed()) {
 			viewer.flush();

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/GraphicalViewerNavigationLocationData.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/GraphicalViewerNavigationLocationData.java
@@ -38,8 +38,9 @@ public class GraphicalViewerNavigationLocationData {
 		// we have to wait to set the scroll position until the editor is drawn and the
 		// canvas is setup
 		if ((viewer.getControl() instanceof final FigureCanvas canvas) && !canvas.isDisposed()) {
-			Display.getDefault().asyncExec(() -> {
+			Display.getDefault().syncExec(() -> {
 				if (!canvas.isDisposed()) {
+					viewer.flush();
 					canvas.scrollTo(location.x, location.y);
 				}
 			});


### PR DESCRIPTION
As FBNetwork viewers (i.e., for CFB and typed subapp content) have to be purged and reloaded on type updates any asynchronous editor behavior my hinder correct restoration of positions and zoom settings. With this change most async behavior could be removed.