### PR TITLE
Fix update for terminated target in monitoring

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/DeploymentDebugTarget.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/DeploymentDebugTarget.java
@@ -211,7 +211,9 @@ public class DeploymentDebugTarget extends DeploymentDebugElement implements IDe
 			watches.keySet().retainAll(combinedWatches.keySet());
 			watches.putAll(combinedWatches);
 		}
-		thread.getTopStackFrame().fireChangeEvent(DebugEvent.CONTENT);
+		if (hasThreads()) {
+			thread.getTopStackFrame().fireChangeEvent(DebugEvent.CONTENT);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
There was a potential for watch updates sent after the debug target had already been terminated when under high load. This adds a check to prevent that.