### PR TITLE
Use internal typed attribute for INOUT_VISIBLE_OUT

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/AbstractTypeExporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/AbstractTypeExporter.java
@@ -29,7 +29,6 @@ import java.io.OutputStream;
 import javax.xml.stream.XMLStreamException;
 
 import org.eclipse.fordiac.ide.model.LibraryElementTags;
-import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes;
 import org.eclipse.fordiac.ide.model.libraryElement.CompilerInfo;
 import org.eclipse.fordiac.ide.model.libraryElement.Import;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
@@ -212,8 +211,7 @@ public abstract class AbstractTypeExporter extends CommonElementExporter {
 
 		if (hasAttributes) {
 			if (varDecl.isInOutVar() && !varDecl.getInOutVarOpposite().isVisible()) {
-				addAttributeElement(LibraryElementTags.ELEMENT_INOUTVISIBLEOUT, IecTypes.ElementaryTypes.BOOL, "false", //$NON-NLS-1$
-						null);
+				addAttributeElement(LibraryElementTags.ELEMENT_INOUTVISIBLEOUT, null, "false", null); //$NON-NLS-1$
 			}
 			addAttributes(varDecl.getAttributes());
 			addEndElement();

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/datatype/helper/InternalAttributeDeclarations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/datatype/helper/InternalAttributeDeclarations.java
@@ -49,14 +49,16 @@ public final class InternalAttributeDeclarations {
 			ElementaryTypes.BOOL);
 	public static final AttributeDeclaration VISIBLE = createAttributeDeclaration(LibraryElementTags.ELEMENT_VISIBLE,
 			ElementaryTypes.BOOL);
+	public static final AttributeDeclaration INOUT_VISIBLE_OUT = createAttributeDeclaration(
+			LibraryElementTags.ELEMENT_INOUTVISIBLEOUT, ElementaryTypes.BOOL);
 	public static final AttributeDeclaration UNFOLDED = createAttributeDeclaration(
 			LibraryElementTags.SUBAPP_REPRESENTATION_ATTRIBUTE, ElementaryTypes.BOOL);
 	public static final AttributeDeclaration RETAIN = createAttributeDeclaration(LibraryElementTags.RETAIN_ATTRIBUTE,
 			ElementaryTypes.USINT);
 	public static final AttributeDeclaration TARGET = createTargetAttributeDeclaration();
 
-	private static final List<AttributeDeclaration> allAttributes = List.of(VAR_CONFIG, VISIBLE, UNFOLDED, RETAIN,
-			TARGET);
+	private static final List<AttributeDeclaration> allAttributes = List.of(VAR_CONFIG, VISIBLE, INOUT_VISIBLE_OUT,
+			UNFOLDED, RETAIN, TARGET);
 
 	private static AttributeDeclaration createAttributeDeclaration(final String name, final DataType type) {
 		final AttributeDeclaration declaration = LibraryElementFactory.eINSTANCE.createAttributeDeclaration();


### PR DESCRIPTION
In order to reduce and harmonize XML output the Visible out attribute is now also stored as typed attribute.