### PR TITLE
Fix watches for interal variables and FBs in monitoring

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/AbstractRuntimeWatch.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/AbstractRuntimeWatch.java
@@ -36,6 +36,12 @@ public abstract class AbstractRuntimeWatch extends AbstractVariableWatch {
 		resourceRelativeName = DeploymentDebugWatchUtils.getResourceRelativeName(element, getResource());
 	}
 
+	protected AbstractRuntimeWatch(final Variable<?> variable, final ITypedElement element, final Resource resource,
+			final String resourceRelativeName, final DeploymentDebugDevice debugTarget) throws EvaluatorException {
+		super(variable, element, resource, debugTarget);
+		this.resourceRelativeName = resourceRelativeName;
+	}
+
 	@Override
 	public void addWatch() throws DebugException {
 		final Resource resource = getResource();

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/AbstractVariableWatch.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/AbstractVariableWatch.java
@@ -35,8 +35,13 @@ public abstract class AbstractVariableWatch extends DeploymentDebugVariable impl
 
 	protected AbstractVariableWatch(final Variable<?> variable, final ITypedElement element,
 			final DeploymentDebugDevice debugTarget) throws EvaluatorException {
+		this(variable, element, DeploymentDebugWatchUtils.getResource(element), debugTarget);
+	}
+
+	protected AbstractVariableWatch(final Variable<?> variable, final ITypedElement element, final Resource resource,
+			final DeploymentDebugDevice debugTarget) throws EvaluatorException {
 		super(variable, element.getQualifiedName(), debugTarget);
-		resource = DeploymentDebugWatchUtils.getResource(element);
+		this.resource = resource;
 		this.element = element;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/AdapterDeclarationWatch.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/AdapterDeclarationWatch.java
@@ -17,6 +17,7 @@ import java.util.List;
 import org.eclipse.fordiac.ide.deployment.debug.DeploymentDebugDevice;
 import org.eclipse.fordiac.ide.model.libraryElement.AdapterDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
+import org.eclipse.fordiac.ide.model.libraryElement.Resource;
 
 public class AdapterDeclarationWatch extends AbstractContainerWatch implements IAdapterDeclarationWatch {
 
@@ -26,6 +27,12 @@ public class AdapterDeclarationWatch extends AbstractContainerWatch implements I
 			final DeploymentDebugDevice target) {
 		super(name, element, target);
 		value = new FBNetworkElementValue(element.getAdapterFB(), target);
+	}
+
+	public AdapterDeclarationWatch(final String name, final AdapterDeclaration element, final Resource resource,
+			final String resourceRelativeName, final DeploymentDebugDevice target) {
+		super(name, element, target);
+		value = new FBNetworkElementValue(element.getAdapterFB(), resource, resourceRelativeName, target);
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/EventWatch.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/EventWatch.java
@@ -27,11 +27,17 @@ import org.eclipse.fordiac.ide.model.eval.value.EventValue;
 import org.eclipse.fordiac.ide.model.eval.variable.EventVariable;
 import org.eclipse.fordiac.ide.model.libraryElement.Event;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
+import org.eclipse.fordiac.ide.model.libraryElement.Resource;
 
 public class EventWatch extends AbstractRuntimeWatch implements IEventWatch {
 
 	public EventWatch(final String name, final Event event, final DeploymentDebugDevice debugTarget) {
 		super(new EventVariable(name, (EventType) event.getType()), event, debugTarget);
+	}
+
+	public EventWatch(final String name, final Event event, final Resource resource, final String resourceRelativeName,
+			final DeploymentDebugDevice debugTarget) {
+		super(new EventVariable(name, (EventType) event.getType()), event, resource, resourceRelativeName, debugTarget);
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/FBNetworkElementWatch.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/FBNetworkElementWatch.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.eclipse.fordiac.ide.deployment.debug.DeploymentDebugDevice;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.Resource;
 
 public class FBNetworkElementWatch extends AbstractContainerWatch {
 
@@ -25,6 +26,12 @@ public class FBNetworkElementWatch extends AbstractContainerWatch {
 			final DeploymentDebugDevice target) {
 		super(name, element, target);
 		value = new FBNetworkElementValue(element, target);
+	}
+
+	public FBNetworkElementWatch(final String name, final FBNetworkElement element, final Resource resource,
+			final String resourceRelativeName, final DeploymentDebugDevice target) {
+		super(name, element, target);
+		value = new FBNetworkElementValue(element, resource, resourceRelativeName, target);
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/IWatch.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/IWatch.java
@@ -20,6 +20,7 @@ import org.eclipse.fordiac.ide.model.eval.EvaluatorException;
 import org.eclipse.fordiac.ide.model.libraryElement.AdapterDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.Event;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.Resource;
@@ -112,6 +113,37 @@ public interface IWatch extends IVariable, IDeploymentDebugElement {
 		case final AdapterDeclaration adapterDeclaration ->
 			new AdapterDeclarationWatch(name, adapterDeclaration, debugTarget);
 		case final FBNetworkElement networkElement -> new FBNetworkElementWatch(name, networkElement, debugTarget);
+		default -> throw new UnsupportedOperationException("Unsupported element: " + element.eClass().getName()); //$NON-NLS-1$
+		};
+	}
+
+	/**
+	 * Create a new watch for an element
+	 *
+	 * @param name                 The name of the watch
+	 * @param element              The element
+	 * @param resource             The resource of the element
+	 * @param resourceRelativeName The resource-relative name of the element
+	 * @param debugTarget          The debug target
+	 * @return The created watch
+	 * @throws EvaluatorException            if there is a problem creating the
+	 *                                       watch
+	 * @throws UnsupportedOperationException if the element is not supported
+	 */
+	static IWatch watchFor(final String name, final INamedElement element, final Resource resource,
+			final String resourceRelativeName, final DeploymentDebugDevice debugTarget)
+			throws EvaluatorException, UnsupportedOperationException {
+		return switch (element) {
+		case final IInterfaceElement interfaceElement when DeploymentDebugWatchUtils
+				.isSubAppInterfaceElement(interfaceElement) ->
+			throw new UnsupportedOperationException("Unsupported element: " + element.eClass().getName()); //$NON-NLS-1$
+		case final Event event -> new EventWatch(name, event, resource, resourceRelativeName, debugTarget);
+		case final VarDeclaration varDeclaration ->
+			new VarDeclarationWatch(name, varDeclaration, resource, resourceRelativeName, debugTarget);
+		case final AdapterDeclaration adapterDeclaration ->
+			new AdapterDeclarationWatch(name, adapterDeclaration, resource, resourceRelativeName, debugTarget);
+		case final FBNetworkElement networkElement ->
+			new FBNetworkElementWatch(name, networkElement, resource, resourceRelativeName, debugTarget);
 		default -> throw new UnsupportedOperationException("Unsupported element: " + element.eClass().getName()); //$NON-NLS-1$
 		};
 	}

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/VarDeclarationWatch.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/VarDeclarationWatch.java
@@ -26,6 +26,7 @@ import org.eclipse.fordiac.ide.model.eval.value.AnyValue;
 import org.eclipse.fordiac.ide.model.eval.value.Value;
 import org.eclipse.fordiac.ide.model.eval.variable.VariableOperations;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
+import org.eclipse.fordiac.ide.model.libraryElement.Resource;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 
 public class VarDeclarationWatch extends AbstractRuntimeWatch implements IVarDeclarationWatch {
@@ -36,6 +37,12 @@ public class VarDeclarationWatch extends AbstractRuntimeWatch implements IVarDec
 			final DeploymentDebugDevice debugTarget) throws EvaluatorException {
 		super(VariableOperations.newVariable(name, VariableOperations.evaluateResultType(varDeclaration)),
 				varDeclaration, debugTarget);
+	}
+
+	public VarDeclarationWatch(final String name, final VarDeclaration varDeclaration, final Resource resource,
+			final String resourceRelativeName, final DeploymentDebugDevice debugTarget) throws EvaluatorException {
+		super(VariableOperations.newVariable(name, VariableOperations.evaluateResultType(varDeclaration)),
+				varDeclaration, resource, resourceRelativeName, debugTarget);
 	}
 
 	@Override


### PR DESCRIPTION
The watches for internal variables and FBs need the resource and resource-relative name from the instance, since the respective elements are part of the type and not the instance hierarchy.