### PR TITLE
Disable changed value detection for sub-variables in monitoring

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/DeploymentDebugVariable.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/DeploymentDebugVariable.java
@@ -57,6 +57,11 @@ public class DeploymentDebugVariable extends EvaluatorDebugVariable {
 	}
 
 	@Override
+	public boolean hasValueChanged() {
+		return false; // prevents annoying flickering in variables view
+	}
+
+	@Override
 	public String getModelIdentifier() {
 		return DeploymentDebugElement.MODEL_IDENTIFIER;
 	}

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/AbstractVariableWatch.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/AbstractVariableWatch.java
@@ -97,11 +97,6 @@ public abstract class AbstractVariableWatch extends DeploymentDebugVariable impl
 	}
 
 	@Override
-	public boolean hasValueChanged() {
-		return false; // prevents annoying flickering in variables view
-	}
-
-	@Override
 	public int hashCode() {
 		return getQualifiedName().hashCode();
 	}


### PR DESCRIPTION
The changed value detection produces spurious flickering in the Variables view during monitoring. This also disables changed value detection for sub-variables.