### PR TITLE
Divided Update Changes into separate rename/delete changes

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.typemanagement/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/plugin.xml
@@ -704,8 +704,8 @@
             id="org.eclipse.fordiac.ide.typemanagement.wizards.DeleteStructChangeViewer">
          <enablement>
          <or>
-         <instanceof value="org.eclipse.fordiac.ide.typemanagement.refactoring.UpdateFBTypeInterfaceChange"/>
-		 <instanceof value="org.eclipse.fordiac.ide.typemanagement.refactoring.delete.UpdateStructDataTypeMemberVariableChange"/>
+         <instanceof value="org.eclipse.fordiac.ide.typemanagement.refactoring.delete.DeleteUpdateFBTypeInterfaceChange"/>
+		 <instanceof value="org.eclipse.fordiac.ide.typemanagement.refactoring.delete.DeleteUpdateStructDataTypeMemberVariableChange"/>
 		 <instanceof value="org.eclipse.fordiac.ide.typemanagement.refactoring.delete.SafeFBTypeDeletionChange$DeleteInternalFBChange"/>
 		 <instanceof value="org.eclipse.fordiac.ide.typemanagement.refactoring.delete.UpdateUntypedSubappPinChange"/>
 		 <instanceof value="org.eclipse.fordiac.ide.typemanagement.refactoring.ReconnectPinChange"/>

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/Messages.java
@@ -114,6 +114,7 @@ public final class Messages extends NLS {
 	public static String DeleteFBTypeParticipant_Change_UpdateSubappPins;
 	public static String FBTypeComposedAdapterFactory_FBTypecomposedAdapterFactoryShouldNotBeInsantiated;
 	public static String IFordiacPreviewChange_Reconnect0;
+	public static String ConfigurableChange_noChangeErrorMessage;
 
 	public static String ImportChange_ImportedNamespaceChanged;
 

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/messages.properties
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/messages.properties
@@ -128,3 +128,4 @@ DeleteLibraryParticipant_Change_Title=Removing Library Dependency
 AddLibraryDependency_Change_Title=Adding Library Dependency
 SafeStructDeletionChange_RootNodeChangeText=Changes for occurrence: {0}{1}
 UpdateUntypedSubappPinChange_0=Pin is not part of untyped subapp
+ConfigurableChange_noChangeErrorMessage0=NO_CHANGE is selected

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/ConfigurableChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/ConfigurableChange.java
@@ -15,13 +15,28 @@ package org.eclipse.fordiac.ide.typemanagement.refactoring;
 
 import java.util.EnumSet;
 
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.fordiac.ide.typemanagement.Messages;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 
 public abstract class ConfigurableChange<T extends EObject> extends AbstractCommandChange<T>
 		implements IFordiacPreviewChange {
 
 	private final EnumSet<ChangeState> state;
+
+	@Override
+	public RefactoringStatus isValid(final T element, final IProgressMonitor pm)
+			throws CoreException, OperationCanceledException {
+		final RefactoringStatus status = new RefactoringStatus();
+		if (getState().contains(ChangeState.NO_CHANGE)) {
+			status.addFatalError(Messages.ConfigurableChange_noChangeErrorMessage);
+		}
+		return status;
+	}
 
 	protected ConfigurableChange(final String name, final URI elementURI, final Class elementClass) {
 		super(name, elementURI, elementClass);

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/ReconnectPinChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/ReconnectPinChange.java
@@ -71,7 +71,7 @@ public class ReconnectPinChange extends ConfigurableChange<FBNetworkElement> {
 	@Override
 	public RefactoringStatus isValid(final FBNetworkElement element, final IProgressMonitor pm)
 			throws CoreException, OperationCanceledException {
-		return null;
+		return super.isValid(element, pm);
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/UpdateManipulatorChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/UpdateManipulatorChange.java
@@ -46,7 +46,7 @@ public class UpdateManipulatorChange extends ConfigurableChange<StructManipulato
 	@Override
 	public RefactoringStatus isValid(final StructManipulator manipulator, final IProgressMonitor pm)
 			throws CoreException, OperationCanceledException {
-		final RefactoringStatus status = new RefactoringStatus();
+		final RefactoringStatus status = super.isValid(manipulator, pm);
 		if (manipulator.eContainer() == null) {
 			status.addError(getName() + " invalid element");
 		}

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/delete/DeleteInternalFBChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/delete/DeleteInternalFBChange.java
@@ -61,7 +61,7 @@ public class DeleteInternalFBChange extends ConfigurableChange<FB> {
 	@Override
 	public RefactoringStatus isValid(final FB element, final IProgressMonitor pm)
 			throws CoreException, OperationCanceledException {
-		final RefactoringStatus status = new RefactoringStatus();
+		final RefactoringStatus status = super.isValid(element, pm);
 		if (element.eContainer() == null) {
 			status.addError(element.getQualifiedName() + " is null");
 		}

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/delete/DeleteUpdateFBTypeInterfaceChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/delete/DeleteUpdateFBTypeInterfaceChange.java
@@ -12,7 +12,7 @@
  *     - initial API and implementation and/or initial documentation
  *   Michael Oberlehner - outsourced inner class to own file
  *******************************************************************************/
-package org.eclipse.fordiac.ide.typemanagement.refactoring;
+package org.eclipse.fordiac.ide.typemanagement.refactoring.delete;
 
 import java.text.MessageFormat;
 import java.util.EnumSet;
@@ -30,15 +30,16 @@ import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.typemanagement.Messages;
+import org.eclipse.fordiac.ide.typemanagement.refactoring.ConfigurableChange;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.commands.CompoundCommand;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 
-public class UpdateFBTypeInterfaceChange extends ConfigurableChange<FBType> {
+public class DeleteUpdateFBTypeInterfaceChange extends ConfigurableChange<FBType> {
 
 	final StructuredType struct;
 
-	public UpdateFBTypeInterfaceChange(final FBType type, final StructuredType struct) {
+	public DeleteUpdateFBTypeInterfaceChange(final FBType type, final StructuredType struct) {
 		super(MessageFormat.format(Messages.DeleteFBTypeParticipant_Change_DeleteFBTypeInterface, type.getName(),
 				struct.getName()), EcoreUtil.getURI(type), FBType.class);
 		this.struct = struct;
@@ -62,7 +63,7 @@ public class UpdateFBTypeInterfaceChange extends ConfigurableChange<FBType> {
 	@Override
 	public RefactoringStatus isValid(final FBType element, final IProgressMonitor pm)
 			throws CoreException, OperationCanceledException {
-		final RefactoringStatus status = new RefactoringStatus();
+		final RefactoringStatus status = super.isValid(element, pm);
 
 		final List<VarDeclaration> varDeclaration = getVarDeclarationsForStruct(element);
 

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/delete/SafeStructDeletionChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/delete/SafeStructDeletionChange.java
@@ -32,7 +32,6 @@ import org.eclipse.fordiac.ide.model.search.types.DataTypeInstanceSearch;
 import org.eclipse.fordiac.ide.model.typelibrary.DataTypeEntry;
 import org.eclipse.fordiac.ide.typemanagement.Messages;
 import org.eclipse.fordiac.ide.typemanagement.refactoring.UpdateFBInstanceChange;
-import org.eclipse.fordiac.ide.typemanagement.refactoring.UpdateFBTypeInterfaceChange;
 import org.eclipse.fordiac.ide.typemanagement.refactoring.UpdateManipulatorChange;
 import org.eclipse.ltk.core.refactoring.CompositeChange;
 
@@ -55,7 +54,7 @@ public class SafeStructDeletionChange extends CompositeChange {
 				final RootNodeChange rootChange = getOrCreateRootChange(eObject);
 				if (eObject instanceof final VarDeclaration varDecl && doneElements.add(varDecl)) {
 					if (varDecl.eContainer() instanceof StructuredType) {
-						rootChange.add(new UpdateStructDataTypeMemberVariableChange(varDecl));
+						rootChange.add(new DeleteUpdateStructDataTypeMemberVariableChange(varDecl));
 						handleTransitiveRefactoring(varDecl, rootChange, doneElements);
 					} else if (isUntypedSubappPin(varDecl)) {
 						rootChange.add(new UpdateUntypedSubappPinChange(varDecl));
@@ -106,7 +105,7 @@ public class SafeStructDeletionChange extends CompositeChange {
 				createChanges((DataTypeEntry) stElement.getTypeEntry());
 			} else if (rootContainer instanceof final FBType fbType
 					&& dataTypeEntry.getType() instanceof final StructuredType type) {
-				rootChange.add(new UpdateFBTypeInterfaceChange(fbType, type));
+				rootChange.add(new DeleteUpdateFBTypeInterfaceChange(fbType, type));
 			}
 		}
 	}

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/rename/RenameTypeRefactoringParticipant.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/rename/RenameTypeRefactoringParticipant.java
@@ -39,9 +39,7 @@ import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
 import org.eclipse.fordiac.ide.typemanagement.Messages;
 import org.eclipse.fordiac.ide.typemanagement.refactoring.UpdateFBInstanceChange;
-import org.eclipse.fordiac.ide.typemanagement.refactoring.UpdateFBTypeInterfaceChange;
 import org.eclipse.fordiac.ide.typemanagement.refactoring.UpdateTypeEntryChange;
-import org.eclipse.fordiac.ide.typemanagement.refactoring.delete.UpdateStructDataTypeMemberVariableChange;
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.CompositeChange;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
@@ -186,13 +184,13 @@ public class RenameTypeRefactoringParticipant extends RenameParticipant {
 				if (rootContainer instanceof final StructuredType stElement) {
 					final CompositeChange change = new CompositeChange(MessageFormat.format(
 							Messages.Refactoring_AffectedStruct, stElement.getName(), dataTypeEntry.getTypeName()));
-					change.add(new UpdateStructDataTypeMemberVariableChange(varDecl));
+					change.add(new RenameUpdateStructDataTypeMemberVariableChange(varDecl));
 					createStructChanges((DataTypeEntry) stElement.getTypeEntry(), change);
 					return change;
 				}
 				if (rootContainer instanceof final FBType fbType
 						&& dataTypeEntry.getType() instanceof final StructuredType type) {
-					return new UpdateFBTypeInterfaceChange(fbType, type);
+					return new RenameUpdateFBTypeInterfaceChange(fbType, type);
 				}
 			}
 		}

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/rename/RenameUpdateFBTypeInterfaceChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/rename/RenameUpdateFBTypeInterfaceChange.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Daniel Lindhuber
+ *     - initial API and implementation and/or initial documentation
+ *   Michael Oberlehner - outsourced inner class to own file
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.refactoring.rename;
+
+import java.text.MessageFormat;
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.fordiac.ide.model.commands.change.ChangeDataTypeCommand;
+import org.eclipse.fordiac.ide.model.data.StructuredType;
+import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
+import org.eclipse.fordiac.ide.model.libraryElement.FBType;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.typemanagement.Messages;
+import org.eclipse.fordiac.ide.typemanagement.refactoring.AbstractCommandChange;
+import org.eclipse.gef.commands.Command;
+import org.eclipse.gef.commands.CompoundCommand;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+
+public class RenameUpdateFBTypeInterfaceChange extends AbstractCommandChange<FBType> {
+
+	final StructuredType struct;
+
+	public RenameUpdateFBTypeInterfaceChange(final FBType type, final StructuredType struct) {
+		super(MessageFormat.format(Messages.DeleteFBTypeParticipant_Change_DeleteFBTypeInterface, type.getName(),
+				struct.getName()), EcoreUtil.getURI(type), FBType.class);
+		this.struct = struct;
+	}
+
+	@Override
+	public void initializeValidationData(final FBType element, final IProgressMonitor pm) {
+		// nothing to do here
+	}
+
+	@Override
+	public RefactoringStatus isValid(final FBType element, final IProgressMonitor pm)
+			throws CoreException, OperationCanceledException {
+		final RefactoringStatus status = new RefactoringStatus();
+
+		final List<VarDeclaration> varDeclaration = getVarDeclarationsForStruct(element);
+
+		if (varDeclaration.isEmpty()) {
+			status.addError(struct.getQualifiedName() + " is not part of the interface of " + getName());
+		}
+
+		if (element.getTypeLibrary() == null || element.getTypeLibrary().getDataTypeLibrary() == null) {
+			status.addError("Type Library is null");
+		}
+
+		return status;
+	}
+
+	@Override
+	protected Command createCommand(final FBType type) {
+
+		final List<VarDeclaration> varDeclarations = getVarDeclarationsForStruct(type);
+		final CompoundCommand cmd = new CompoundCommand();
+
+		for (final VarDeclaration varDec : varDeclarations) {
+			cmd.add(ChangeDataTypeCommand.forDataType(varDec, struct));
+		}
+
+		return cmd;
+	}
+
+	private List<VarDeclaration> getVarDeclarationsForStruct(final FBType element) {
+		return element.getInterfaceList().getAllInterfaceElements().stream().filter(VarDeclaration.class::isInstance)
+				.map(VarDeclaration.class::cast).filter(decl -> PackageNameHelper.getFullTypeName(decl.getType())
+						.equalsIgnoreCase(PackageNameHelper.getFullTypeName(struct)))
+				.toList();
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/rename/RenameUpdateStructDataTypeMemberVariableChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/rename/RenameUpdateStructDataTypeMemberVariableChange.java
@@ -8,46 +8,33 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *   Michael Oberleh
+ *   Michael Oberlehner
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-package org.eclipse.fordiac.ide.typemanagement.refactoring.delete;
+package org.eclipse.fordiac.ide.typemanagement.refactoring.rename;
 
 import java.text.MessageFormat;
-import java.util.EnumSet;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeDataTypeCommand;
-import org.eclipse.fordiac.ide.model.commands.delete.DeleteMemberVariableCommand;
 import org.eclipse.fordiac.ide.model.data.StructuredType;
-import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.typemanagement.Messages;
-import org.eclipse.fordiac.ide.typemanagement.refactoring.ConfigurableChange;
+import org.eclipse.fordiac.ide.typemanagement.refactoring.AbstractCommandChange;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 
-public class UpdateStructDataTypeMemberVariableChange extends ConfigurableChange<VarDeclaration> {
+public class RenameUpdateStructDataTypeMemberVariableChange extends AbstractCommandChange<VarDeclaration> {
 
-	public UpdateStructDataTypeMemberVariableChange(final VarDeclaration varDeclaration) {
+	public RenameUpdateStructDataTypeMemberVariableChange(final VarDeclaration varDeclaration) {
 		super(MessageFormat.format(Messages.DeleteFBTypeParticipant_Change_UpdateMemberVariable,
 				varDeclaration.getName(), varDeclaration.getTypeName(),
 				((INamedElement) varDeclaration.eContainer()).getName()), EcoreUtil.getURI(varDeclaration),
 				VarDeclaration.class);
-	}
-
-	@Override
-	public EnumSet<ChangeState> getAllowedChoices() {
-		return EnumSet.of(ChangeState.DELETE, ChangeState.CHANGE_TO_ANY, ChangeState.NO_CHANGE);
-	}
-
-	@Override
-	public EnumSet<ChangeState> getDefaultSelection() {
-		return EnumSet.of(ChangeState.NO_CHANGE);
 	}
 
 	@Override
@@ -69,19 +56,7 @@ public class UpdateStructDataTypeMemberVariableChange extends ConfigurableChange
 
 	@Override
 	protected Command createCommand(final VarDeclaration varDeclaration) {
-		if (getState().contains(ChangeState.DELETE)
-				&& varDeclaration.eContainer() instanceof final StructuredType type) {
-			return new DeleteMemberVariableCommand(type, varDeclaration);
-		}
-		if (getState().contains(ChangeState.CHANGE_TO_ANY)) {
-			return ChangeDataTypeCommand.forDataType(varDeclaration, IecTypes.GenericTypes.ANY_STRUCT);
-		}
-
-		if (getState().contains(ChangeState.NO_CHANGE)) {
-			return ChangeDataTypeCommand.forDataType(varDeclaration, varDeclaration.getType());
-		}
-
-		return null;
+		return ChangeDataTypeCommand.forDataType(varDeclaration, varDeclaration.getType());
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/wizards/ChangeConfigurationViewer.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/wizards/ChangeConfigurationViewer.java
@@ -15,8 +15,7 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.typemanagement.wizards;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.LinkedHashMap;
 
 import org.eclipse.fordiac.ide.typemanagement.refactoring.IFordiacPreviewChange;
 import org.eclipse.fordiac.ide.typemanagement.refactoring.IFordiacPreviewChange.ChangeState;
@@ -36,7 +35,7 @@ public class ChangeConfigurationViewer implements IChangePreviewViewer {
 	private IFordiacPreviewChange change;
 
 	private Table table;
-	private final Map<TableItem, ChangeState> choices = new HashMap<>();
+	private final LinkedHashMap<TableItem, ChangeState> choices = new LinkedHashMap<>();
 
 	@Override
 	public void createControl(final Composite parent) {
@@ -91,6 +90,11 @@ public class ChangeConfigurationViewer implements IChangePreviewViewer {
 		// initialize UI from change state
 		choices.entrySet().stream().filter(entry -> delChange.getState().contains(entry.getValue()))
 				.forEach(entry -> entry.getKey().setChecked(true));
+
+		if (choices.keySet().stream().filter(TableItem::getChecked).toList().isEmpty()) {
+			choices.firstEntry().getKey().setChecked(true);
+		}
+
 	}
 
 	private void initializeChoices(final ChangePreviewViewerInput input) {


### PR DESCRIPTION
Delete Changes should not change anything, therefore they are disabled per default.
Rename Changes need to actually rename the regarding element as default option, so it is not possible to use the same changes for both refactorings.
Therefore, they are splitted up which also gives the benefits to provide more specific repair options.

Furthermore, if a change is enabled, there will be always a selection in the viewer, so it is not possible for the user to enable a change without a corresponding operation that needs to exectuted