### PR TITLE
add scrolling info to keep table stable when refreshing

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/StructManipulatorSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/StructManipulatorSection.java
@@ -76,6 +76,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
+import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.EditorPart;
@@ -125,9 +126,11 @@ public abstract class StructManipulatorSection extends AbstractSection implement
 	protected void refreshStructTypeTable() {
 		final Object[] expandedElements = memberVarViewer.getExpandedElements();
 		final TreePath[] expandedTreePaths = memberVarViewer.getExpandedTreePaths();
+		final TreeItem topItem = memberVarViewer.getTree().getTopItem();
 		memberVarViewer.setInput(getType());
 		memberVarViewer.setExpandedElements(expandedElements);
 		memberVarViewer.setExpandedTreePaths(expandedTreePaths);
+		memberVarViewer.getTree().setTopItem(topItem);
 	}
 
 	protected void handleStructSelectionChanged(final String newStructName) {


### PR DESCRIPTION
Previously, when selecting/deselecting elements the instance was updated (replaced), so a new type is coming into the section. This leads to the tree jumping upwards everytime, which is really unpleasant (esp. when you want to edit multiple elements or verify that the correct element was checked). So this fix sets the top element back, leading to a stable appearance in the tool.