### PR TITLE
Override basicSetTypeEditable to update system entry after refactoring

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
@@ -229,7 +229,7 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 		return type;
 	}
 
-	private LibraryElement basicGetType() {
+	protected LibraryElement basicGetType() {
 		final SoftReference<LibraryElement> typeRefCached = typeRef;
 		return typeRefCached != null ? typeRefCached.get() : null;
 	}
@@ -339,7 +339,7 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 		return typeEditable;
 	}
 
-	private LibraryElement basicGetTypeEditable() {
+	protected LibraryElement basicGetTypeEditable() {
 		final SoftReference<LibraryElement> typeEditableRefCached = typeEditableRef;
 		return typeEditableRefCached != null ? typeEditableRefCached.get() : null;
 	}
@@ -366,7 +366,7 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 		}
 	}
 
-	private synchronized NotificationChain basicSetTypeEditable(final LibraryElement newTypeEditable,
+	protected synchronized NotificationChain basicSetTypeEditable(final LibraryElement newTypeEditable,
 			NotificationChain notifications) {
 		final LibraryElement oldTypeEditable = (typeEditableRef != null) ? typeEditableRef.get() : null;
 		if (newTypeEditable != null) {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/SystemEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/SystemEntryImpl.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package org.eclipse.fordiac.ide.model.typelibrary.impl;
 
+import org.eclipse.emf.common.notify.NotificationChain;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.fordiac.ide.model.dataexport.AbstractTypeExporter;
 import org.eclipse.fordiac.ide.model.dataexport.SystemExporter;
@@ -80,4 +81,16 @@ public class SystemEntryImpl extends AbstractCheckedTypeEntryImpl<AutomationSyst
 	public EClass getTypeEClass() {
 		return LibraryElementPackage.Literals.AUTOMATION_SYSTEM;
 	}
+
+	@Override
+	protected synchronized NotificationChain basicSetTypeEditable(final LibraryElement newTypeEditable,
+			final NotificationChain notifications) {
+		return super.basicSetType(newTypeEditable, notifications);
+	}
+
+	@Override
+	protected LibraryElement basicGetTypeEditable() {
+		return super.basicGetType();
+	}
+
 }


### PR DESCRIPTION
This fix solves the following problem:
On reopening the editor uses a different library element then the refactoring operation.
Therefore, the XML is not in sync with the library element. 

how to reproduce:
1) Rename Interfaceelement in an FBType Editor
2) Select reconnect (all connections of the block instances will be reconnected)
3) close the editor of the instance (e.g AutomationEditor)
4) reopen the editor after refactoring