### PR TITLE
Updated plugin.xml to new name of EditUntypedSubappInterfaceEventSection

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.subapptypeeditor/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.subapptypeeditor/plugin.xml
@@ -210,7 +210,7 @@
                tab="org.eclipse.fordiac.ide.application.property.tab.ShowAdapter">
          </propertySection>
          <propertySection
-               class="org.eclipse.fordiac.ide.application.properties.EditInterfaceEventSection"
+               class="org.eclipse.fordiac.ide.application.properties.EditUntypedSubappInterfaceEventSection"
                id="org.eclipse.fordiac.ide.application.properties.section.EditEvents"
                filter="org.eclipse.fordiac.ide.application.properties.SubappInterfaceEditingFilter"
                tab="org.eclipse.fordiac.ide.application.property.tab.EditEvents">


### PR DESCRIPTION
Property sheets for types have separate definitions. Therefore any class name changes need to be reflected on two places. This was forgotten for EditUntypedSubappInterfaceEventSection.