### PR TITLE
Avoid reacting to file changes in FB type Xtext editor

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editors/FBTypeXtextEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editors/FBTypeXtextEditor.java
@@ -20,10 +20,8 @@ import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IEditorInput;
-import org.eclipse.ui.IEditorSite;
 import org.eclipse.ui.INavigationLocation;
 import org.eclipse.ui.IWorkbenchPart;
-import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.part.MultiPageEditorPart;
 import org.eclipse.ui.part.MultiPageEditorSite;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
@@ -37,11 +35,6 @@ public abstract class FBTypeXtextEditor extends XtextEditor implements IFBTEdito
 	private AbstractUIPlugin languageUIPlugin;
 
 	private boolean restoringSelection;
-
-	@Override
-	public void init(final IEditorSite site, final IEditorInput input) throws PartInitException {
-		super.init(site, input);
-	}
 
 	@Override
 	public void createPartControl(final Composite parent) {
@@ -149,6 +142,12 @@ public abstract class FBTypeXtextEditor extends XtextEditor implements IFBTEdito
 	@Override
 	public void reloadType() {
 		doRevertToSaved();
+	}
+
+	@Override
+	protected void handleEditorInputChanged() {
+		// avoid asking the user for a refresh or save as
+		// and leave updates to the enclosing FB type editor
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/document/LibraryElementXtextDocumentProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/document/LibraryElementXtextDocumentProvider.java
@@ -93,6 +93,14 @@ public abstract class LibraryElementXtextDocumentProvider extends XtextDocumentP
 	}
 
 	@Override
+	public boolean isSynchronized(final Object element) {
+		if (element instanceof ITypeEditorInput) {
+			return true; // always consider synchronized if in an FB type editor
+		}
+		return super.isSynchronized(element);
+	}
+
+	@Override
 	protected void handleElementContentChanged(final IFileEditorInput fileEditorInput) {
 		if (fileEditorInput instanceof ITypeEditorInput) {
 			return; // update only if opened directly from a file and not in an FB type editor


### PR DESCRIPTION
Avoid reacting to file changes in the FB type Xtext editor, since that is already taken care of by the FB type editor.