### PR TITLE
Fix marker update when holding resource lock

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/errormarker/FordiacMarkerHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/errormarker/FordiacMarkerHelper.java
@@ -263,7 +263,7 @@ public final class FordiacMarkerHelper {
 				&& (force || errorMarkersNeedsUpdate(resource, type, builders))) {
 			final ISchedulingRule currentRule = Job.getJobManager().currentRule();
 			if (currentRule != null && currentRule.contains(resource)) {
-				createMarkersInWorkspace(resource, builders);
+				updateMarkersInWorkspace(resource, type, builders);
 			} else {
 				final WorkspaceJob job = new WorkspaceJob("Update error markers on resource: " + resource.getName()) { //$NON-NLS-1$
 					@Override


### PR DESCRIPTION
The helper method to update markers was calling the wrong internal method when already holding the necessary resource lock.