### PR TITLE
Fixed Adapter creation for untyped subapps #794

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/CreateInterfaceElementCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/CreateInterfaceElementCommand.java
@@ -31,7 +31,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
-import org.eclipse.fordiac.ide.model.libraryElement.SubAppType;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.ui.providers.CreationCommand;
 
@@ -217,11 +216,10 @@ public class CreateInterfaceElementCommand extends CreationCommand implements Sc
 	}
 
 	private void createAdapterFBCreateCommand() {
-		if (dataType instanceof AdapterType && targetInterfaceList.eContainer() instanceof final FBType fbType
-				&& !(fbType instanceof SubAppType)) {
+		if (dataType instanceof AdapterType) {
 			final int xyPos = 10;
 			adapterCreateCmd = new AdapterFBCreateCommand(xyPos, xyPos, (AdapterDeclaration) newInterfaceElement,
-					fbType);
+					(targetInterfaceList.eContainer() instanceof final FBType fbType) ? fbType : null);
 		}
 	}
 


### PR DESCRIPTION
For untyped subapps no adapter fb was created which is needed for certain checks for saving and managing adapters.

https://github.com/eclipse-4diac/4diac-ide/issues/794