### PR TITLE
Fix duplicate watches when using multiple devices in monitoring

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/DeploymentDebugDevice.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/DeploymentDebugDevice.java
@@ -248,7 +248,7 @@ public class DeploymentDebugDevice extends DeploymentDebugElement implements IDe
 	}
 
 	protected void addWatch(final DeploymentWatchpoint watchpoint) {
-		final Optional<INamedElement> element = watchpoint.getTarget(getSystem());
+		final Optional<INamedElement> element = watchpoint.getTarget(device);
 		if (element.isPresent()) {
 			try {
 				final IWatch watch = watches.computeIfAbsent(element.get().getQualifiedName(),

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/breakpoint/DeploymentWatchpoint.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/breakpoint/DeploymentWatchpoint.java
@@ -14,6 +14,7 @@ package org.eclipse.fordiac.ide.deployment.debug.breakpoint;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
@@ -24,9 +25,11 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.model.Breakpoint;
 import org.eclipse.debug.core.model.IBreakpoint;
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.fordiac.ide.deployment.debug.watch.DeploymentDebugWatchUtils;
 import org.eclipse.fordiac.ide.model.errormarker.ErrorMarkerBuilder;
 import org.eclipse.fordiac.ide.model.errormarker.FordiacErrorMarker;
 import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
+import org.eclipse.fordiac.ide.model.libraryElement.Device;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.typelibrary.SystemEntry;
@@ -76,13 +79,21 @@ public class DeploymentWatchpoint extends Breakpoint {
 	}
 
 	public Optional<INamedElement> getTarget(final AutomationSystem system) {
+		return getTargets(system).findFirst();
+	}
+
+	public Optional<INamedElement> getTarget(final Device device) {
+		return getTargets(device.getAutomationSystem())
+				.filter(target -> device.equals(DeploymentDebugWatchUtils.getDevice(target))).findFirst();
+	}
+
+	public Stream<INamedElement> getTargets(final AutomationSystem system) {
 		final String location = getLocation();
 		final Optional<EClass> targetType = getTargetType();
 		if (location.isEmpty() || targetType.isEmpty()) {
-			return Optional.empty();
+			return Stream.empty();
 		}
-		return system.findByQualifiedName(location).filter(element -> targetType.get().equals(element.eClass()))
-				.findFirst();
+		return system.findByQualifiedName(location).filter(element -> targetType.get().equals(element.eClass()));
 	}
 
 	public Optional<EClass> getTargetType() {

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/DeploymentDebugWatchUtils.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/DeploymentDebugWatchUtils.java
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
 import org.eclipse.fordiac.ide.model.libraryElement.AdapterDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.AdapterFB;
 import org.eclipse.fordiac.ide.model.libraryElement.Connection;
+import org.eclipse.fordiac.ide.model.libraryElement.Device;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
@@ -34,6 +35,11 @@ public final class DeploymentDebugWatchUtils {
 		case final FBNetworkElement networkElement -> networkElement.getResource();
 		case null, default -> null;
 		};
+	}
+
+	public static Device getDevice(final INamedElement element) {
+		final Resource resource = getResource(element);
+		return resource != null ? resource.getDevice() : null;
 	}
 
 	public static String getResourceRelativeName(final INamedElement element, final Resource resource) {


### PR DESCRIPTION
There were duplicate watches added to each device when using multiple devices. This filters the target element according to the device.

Closes https://github.com/eclipse-4diac/4diac-ide/issues/799