### PR TITLE
Fix project configuration of ST parser meta-model

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor.model/.classpath
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor.model/.classpath
@@ -6,7 +6,6 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="xtend-gen"/>
 	<classpathentry kind="src" path="src-gen">
 		<attributes>
 			<attribute name="ignore_optional_problems" value="true"/>

--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor.model/build.properties
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor.model/build.properties
@@ -1,5 +1,4 @@
-source.. = src-gen/,\
-           xtend-gen/
+source.. = src-gen/
 bin.includes = .,\
                META-INF/,\
                plugin.xml,\

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.model/.project
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.model/.project
@@ -6,6 +6,11 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.jdt.core.javabuilder</name>
 			<arguments>
 			</arguments>
@@ -24,5 +29,6 @@
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
 </projectDescription>

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.model/.project
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.model/.project
@@ -6,6 +6,11 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.jdt.core.javabuilder</name>
 			<arguments>
 			</arguments>
@@ -24,5 +29,6 @@
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
 </projectDescription>


### PR DESCRIPTION
There were problems with resolving the EMF meta-model of Xtext grammars in the ST parser. The Xtext grammar seems to require that EMF meta-model projects also have the Xtext project nature and builder present, even though they themselves have no Xtext resources.

This adds back the required Xtext project nature to the ST algorithm and function projects. It also removes the obsolete xtend-gen folder in the global constants model project, which was causing warnings in the log.

Closes https://github.com/eclipse-4diac/4diac-ide/issues/802