### PR TITLE
Clean-up of Show FB in Application

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.resourceediting/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.resourceediting/plugin.xml
@@ -50,15 +50,6 @@
       </handler>
    </extension>
    <extension
-         point="org.eclipse.ui.bindings">
-      <key
-            commandId="org.eclipse.fordiac.ide.resourceediting.commands.ShowFBInAppCommand"
-            contextId="org.eclipse.ui.contexts.window"
-            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-            sequence="M1+8">
-      </key>
-   </extension>
-   <extension
          point="org.eclipse.ui.menus">
       <menuContribution
             locationURI="menu:navigate?after=additions">
@@ -71,18 +62,6 @@
 		</command>
       </menuContribution>
       <menuContribution
-            locationURI="toolbar:org.eclipse.ui.main.toolbar?after=additions">
-         <toolbar
-               id="org.eclipse.fordiac.ide.application.toolbars.fordiacToolbar">
-            <command
-                  commandId="org.eclipse.fordiac.ide.resourceediting.commands.ShowFBInAppCommand"
-                  icon="fordiacimage://ICON_APPLICATION"
-                  id="org.eclipse.fordiac.ide.resourceediting.toolbars.ShowFBInAppCommand"
-                  tooltip="Show FB in Application">
-            </command>
-         </toolbar>
-      </menuContribution>
-      <menuContribution
             locationURI="popup:org.eclipse.ui.popup.any?after=additions">
          <command
                commandId="org.eclipse.fordiac.ide.resourceediting.commands.ShowFBInAppCommand"
@@ -91,9 +70,7 @@
             <visibleWhen checkEnabled="true">
             	<and>
 	               <with variable="activeEditor">
-	                  <instanceof
-	                        value="org.eclipse.fordiac.ide.resourceediting.editors.ResourceDiagramEditor">
-	                  </instanceof>
+	                  <adapt type="org.eclipse.fordiac.ide.model.libraryElement.Resource" />
 	               </with>
 	               <iterate ifEmpty="false">
 	                  <instanceof

--- a/plugins/org.eclipse.fordiac.ide.resourceediting/src/org/eclipse/fordiac/ide/resourceediting/editors/ResourceDiagramEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.resourceediting/src/org/eclipse/fordiac/ide/resourceediting/editors/ResourceDiagramEditor.java
@@ -63,6 +63,14 @@ public class ResourceDiagramEditor extends FBNetworkEditor {
 		}
 	};
 
+	@Override
+	public <T> T getAdapter(final Class<T> adapter) {
+		if (adapter == Resource.class) {
+			return adapter.cast(getResource());
+		}
+		return super.getAdapter(adapter);
+	}
+
 	private Resource getResource() {
 		return (Resource) getModel().eContainer();
 	}


### PR DESCRIPTION
This rarely needed command was using unnecessarily toolbar space. Furthermore it didn't show up the context menu in the resource editor anymore. Therefore it is removed from the toolbar and the context menu is fixed.