### PR TITLE
Create Mapping Target FBs if not Present

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/MapCommunicationCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/MapCommunicationCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Johannes Kepler University Linz
+ * Copyright (c) 2023, 2024 Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,6 +13,7 @@
 package org.eclipse.fordiac.ide.model.commands.change;
 
 import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.fordiac.ide.model.dataimport.MappingTargetCreator;
 import org.eclipse.fordiac.ide.model.libraryElement.CommunicationChannel;
 import org.eclipse.fordiac.ide.model.libraryElement.CommunicationMappingTarget;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
@@ -44,7 +45,7 @@ public class MapCommunicationCommand extends MapToCommand {
 		comm.setPosition(EcoreUtil.copy(srcElement.getPosition()));
 		comm.setTypeEntry(srcElement.getTypeEntry());
 		comm.setInterface(srcElement.getType().getInterfaceList().copy());
-		transferFBParams(srcElement, comm);
+		MappingTargetCreator.transferFBParams(srcElement, comm);
 		target.getMappedElements().add(comm);
 		return comm;
 	}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/MappingTargetCreator.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/MappingTargetCreator.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Alois Zoitl - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.model.dataimport;
+
+import java.util.List;
+
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.fordiac.ide.model.helpers.BlockInstanceFactory;
+import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableFB;
+import org.eclipse.fordiac.ide.model.libraryElement.FB;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
+import org.eclipse.fordiac.ide.model.libraryElement.Resource;
+import org.eclipse.fordiac.ide.model.libraryElement.TypedSubApp;
+import org.eclipse.fordiac.ide.model.libraryElement.UntypedSubApp;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.typelibrary.FBTypeEntry;
+import org.eclipse.jdt.annotation.NonNull;
+
+public final class MappingTargetCreator {
+
+	private MappingTargetCreator() {
+		throw new UnsupportedOperationException("Utility class shall not be instantated!"); //$NON-NLS-1$
+	}
+
+	public static FBNetworkElement createMappingTarget(final Resource res, final FBNetworkElement srcElement,
+			final String targetFBName) {
+		final FBNetworkElement created = createFBNetworkElement(srcElement);
+
+		if (created != null) {
+			if (srcElement.getTypeEntry() != null) {
+				created.setTypeEntry(srcElement.getTypeEntry());
+			}
+			created.setInterface(srcElement.getInterface().copy()); // use the src interface to get all parameters
+			created.setPosition(EcoreUtil.copy(srcElement.getPosition()));
+			if (srcElement instanceof final ConfigurableFB srcConfFB) {
+				setupConfigureableFB(srcConfFB, (ConfigurableFB) created);
+			}
+			created.setName(extractTargetFBName(targetFBName));
+			res.getFBNetwork().getNetworkElements().add(created);
+		}
+		return created;
+	}
+
+	public static void transferFBParams(@NonNull final FBNetworkElement srcElement,
+			@NonNull final FBNetworkElement targetElement) {
+		final List<VarDeclaration> destInputs = targetElement.getInterface().getInputVars();
+		final List<VarDeclaration> srcInputs = srcElement.getInterface().getInputVars();
+
+		for (int i = 0; i < destInputs.size(); i++) {
+			final VarDeclaration srcVar = srcInputs.get(i);
+			final VarDeclaration dstVar = destInputs.get(i);
+
+			if ((srcVar.getValue() != null) && (!srcVar.getValue().getValue().isEmpty())) {
+				if (dstVar.getValue() == null) {
+					dstVar.setValue(LibraryElementFactory.eINSTANCE.createValue());
+				}
+				dstVar.getValue().setValue(srcVar.getValue().getValue());
+			}
+		}
+	}
+
+	private static FBNetworkElement createFBNetworkElement(final FBNetworkElement srcElement) {
+		return switch (srcElement) {
+		case final FB fb -> BlockInstanceFactory.createFBInstanceForTypeEntry((FBTypeEntry) fb.getTypeEntry());
+		case final TypedSubApp typedSubapp -> LibraryElementFactory.eINSTANCE.createTypedSubApp();
+		case final UntypedSubApp untypedSubapp -> LibraryElementFactory.eINSTANCE.createUntypedSubApp();
+		default -> null;
+		};
+	}
+
+	private static void setupConfigureableFB(final ConfigurableFB srcConfFB, final ConfigurableFB targetConfFB) {
+		targetConfFB.setDataType(srcConfFB.getDataType());
+		targetConfFB.updateConfiguration();
+	}
+
+	private static String extractTargetFBName(final String targetFBName) {
+		final var separator = targetFBName.lastIndexOf('.');
+		if (separator != -1) {
+			return targetFBName.substring(separator + 1);
+		}
+		return targetFBName;
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/SystemImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/SystemImporter.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2016 - 2017 fortiss GmbH
- * 				 2018 - 2020 Johannes Kepler University, Linz
+ * Copyright (c) 2016, 2024 fortiss GmbH, Johannes Kepler University, Linz,
+ *                          Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -260,7 +260,7 @@ public class SystemImporter extends CommonElementImporter {
 		final FBNetworkElement fromElement = findMappingTargetFromName(fromValue);
 		final FBNetworkElement toElement = (fromElement instanceof CommunicationChannel)
 				? findMappingTargetFromName(toValue, fromElement)
-				: findMappingToElement(fromValue, toValue);
+				: findMappingToElement(fromValue, toValue, fromElement);
 
 		if ((null != fromElement) && (null != toElement)) {
 			getElement().getMapping().add(createMappingEntry(toElement, fromElement));
@@ -270,7 +270,8 @@ public class SystemImporter extends CommonElementImporter {
 		proceedToEndElementNamed(LibraryElementTags.MAPPING_ELEMENT);
 	}
 
-	private FBNetworkElement findMappingToElement(final String fromValue, final String toValue) {
+	private FBNetworkElement findMappingToElement(final String fromValue, final String toValue,
+			final FBNetworkElement fromElement) {
 		final var devResSeperator = toValue.indexOf('.');
 		if (devResSeperator == -1) {
 			getErrors().add(
@@ -298,7 +299,12 @@ public class SystemImporter extends CommonElementImporter {
 
 		final String targetFBName = (resFBSeperator == -1) ? fromValue : toValue.substring(resFBSeperator + 1);
 
-		return resFBNElementMapping.getOrDefault(res, Collections.emptyMap()).get(targetFBName);
+		final FBNetworkElement fbNetworkElement = resFBNElementMapping.getOrDefault(res, Collections.emptyMap())
+				.get(targetFBName);
+		if (fbNetworkElement == null && fromElement != null) {
+			return MappingTargetCreator.createMappingTarget(res, fromElement, targetFBName);
+		}
+		return fbNetworkElement;
 	}
 
 	private static Mapping createMappingEntry(final FBNetworkElement toElement, final FBNetworkElement fromElement) {


### PR DESCRIPTION
Based on the mapping source the target FB is created inside of the resource. This is the starting point of not requiring to store mapped information as part of the resource.