### PR TITLE
Struct Manipulator property sheet threw exceptions on updates

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/StructManipulatorSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/StructManipulatorSection.java
@@ -130,7 +130,9 @@ public abstract class StructManipulatorSection extends AbstractSection implement
 		memberVarViewer.setInput(getType());
 		memberVarViewer.setExpandedElements(expandedElements);
 		memberVarViewer.setExpandedTreePaths(expandedTreePaths);
-		memberVarViewer.getTree().setTopItem(topItem);
+		if (topItem != null && !topItem.isDisposed()) {
+			memberVarViewer.getTree().setTopItem(topItem);
+		}
 	}
 
 	protected void handleStructSelectionChanged(final String newStructName) {


### PR DESCRIPTION
When the struct type is changed manipulator inputs didn't fit and setTopItem was throwing exceptions resulting in bad states of your application.