### PR TITLE
[Fix] Reconnect Pin change didn't correctly check on old and new pins

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractUpdateFBNElementCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractUpdateFBNElementCommand.java
@@ -328,13 +328,15 @@ public abstract class AbstractUpdateFBNElementCommand extends Command implements
 	protected void handleParameters() {
 		for (final VarDeclaration input : oldElement.getInterface().getInputVars()) {
 			// No outside connections to a pin in oldElement and it has an initial value
-			if (input.getInputConnections().isEmpty() && hasValue(input.getValue())) {
+			if (input.getInputConnections().isEmpty()
+					&& (hasValue(input.getValue()) || !input.getAttributes().isEmpty())) {
 				updateSelectedInterface(input, newElement);
 			}
 		}
 
 		for (final VarDeclaration output : oldElement.getInterface().getOutputVars()) {
-			if (output.getOutputConnections().isEmpty() && hasValue(output.getValue())) {
+			if (output.getOutputConnections().isEmpty()
+					&& (hasValue(output.getValue()) || !output.getAttributes().isEmpty())) {
 				updateSelectedInterface(output, newElement);
 			}
 		}

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/ReconnectPinChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/ReconnectPinChange.java
@@ -105,15 +105,19 @@ class ReconnectPinByName extends Command {
 	public void execute() {
 		final IInterfaceElement interfaceElement = element.getInterfaceElement(newName);
 		final IInterfaceElement oldinterfaceElement = element.getInterfaceElement(oldName);
-		propagateInitialValue(interfaceElement, oldinterfaceElement);
 
-		for (final Attribute attribute : oldinterfaceElement.getAttributes()) {
-			interfaceElement.setAttribute(attribute.getName(), attribute.getType(), attribute.getValue(),
-					attribute.getComment());
-		}
-		interfaceElement.setComment(oldinterfaceElement.getComment());
+		if (interfaceElement != null
+				&& oldinterfaceElement instanceof final ErrorMarkerInterface errorMarkerInterface) {
+			// only if we have a new interface element and the old one is an error marker
+			// interface we need to transfer things
+			propagateInitialValue(interfaceElement, oldinterfaceElement);
 
-		if (oldinterfaceElement instanceof final ErrorMarkerInterface errorMarkerInterface) {
+			for (final Attribute attribute : oldinterfaceElement.getAttributes()) {
+				interfaceElement.setAttribute(attribute.getName(), attribute.getType(), attribute.getValue(),
+						attribute.getComment());
+			}
+			interfaceElement.setComment(oldinterfaceElement.getComment());
+
 			final EList<Connection> inputConnections = getConnection(errorMarkerInterface);
 			if (inputConnections.isEmpty()) {
 				cmds.add(new DeleteInterfaceCommand(oldinterfaceElement));
@@ -122,10 +126,8 @@ class ReconnectPinByName extends Command {
 			} else if (state.contains(ChangeState.DELETE)) {
 				deleteConnection(inputConnections);
 			}
-
 		}
 		cmds.execute();
-
 	}
 
 	private void propagateInitialValue(final IInterfaceElement interfaceElement,


### PR DESCRIPTION
In the reconnection pin change it can be that there is no old or no new pin. Both cases where not handled in the ReconnectionPinChange.

Furthermore not connected pins would have lost their attributes. This is fixed as well.