### PR TITLE
Add the Properties View to the Debug Perspective

### DIFF
--- a/plugins/org.eclipse.fordiac.ide/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide/plugin.xml
@@ -24,6 +24,12 @@
          	<perspectiveShortcut
 				id="org.eclipse.fordiac.ide.SystemPerspective">
 			</perspectiveShortcut>
+			<view
+               id="org.eclipse.ui.views.PropertySheet"
+               minimized="false"
+               relationship="stack"
+               relative="org.eclipse.ui.console.ConsoleView">
+         	</view>
 		</perspectiveExtension>
 		<perspectiveExtension
         		editorOnboardingImage="$nl$/icons/sys_onboarding.png"


### PR DESCRIPTION
During debugging it is also necessary to inspect properties of elements in the graphical editors.