### PR TITLE
Key bindings for graphical editors

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.application/META-INF/MANIFEST.MF
@@ -36,4 +36,5 @@ Bundle-Activator: org.eclipse.fordiac.ide.application.ApplicationPlugin
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.fordiac.ide.application;singleton:=true
 Bundle-RequiredExecutionEnvironment: JavaSE-21
+Bundle-Localization: plugin
 Automatic-Module-Name: org.eclipse.fordiac.ide.application

--- a/plugins/org.eclipse.fordiac.ide.application/build.properties
+++ b/plugins/org.eclipse.fordiac.ide.application/build.properties
@@ -2,4 +2,5 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               plugin.xml
+               plugin.xml,\
+               plugin.properties

--- a/plugins/org.eclipse.fordiac.ide.application/plugin.properties
+++ b/plugins/org.eclipse.fordiac.ide.application/plugin.properties
@@ -1,19 +1,19 @@
- ###############################################################################
- # Copyright (c) 2008 - 2017 Profactor GmbH, TU Wien ACIN, fortiss GmbH
- #				 2019 - 2020 Andrea Zoitl
- # 
- # This program and the accompanying materials are made available under the
- # terms of the Eclipse Public License 2.0 which is available at
- # http://www.eclipse.org/legal/epl-2.0.
- #
- # SPDX-License-Identifier: EPL-2.0
- #
- # Contributors:
- #   Gerhard Ebenhofer, Alois Zoitl, Monika Wenger
- #     - initial API and implementation and/or initial documentation
- #   Andrea Zoitl
- #     - Externalized all translatable strings 
- ###############################################################################
+###############################################################################
+# Copyright (c) 2008, 2024 Profactor GmbH, TU Wien ACIN, fortiss GmbH, 
+#                          Andrea Zoitl, Primetals Technologies Austria GmbH
+# 
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Gerhard Ebenhofer, Alois Zoitl, Monika Wenger
+#     - initial API and implementation and/or initial documentation
+#   Andrea Zoitl
+#     - Externalized all translatable strings 
+###############################################################################
 AbstractCommandMarkerResolution_CannotCreateCommand=Cannot create command for element ''{0}'' in ''{1}''
 AbstractCommandMarkerResolution_CannotExecuteCommand=Cannot execute command for element ''{0}'' in ''{1}''
 AbstractCommandMarkerResolution_CommitTask=Saving files
@@ -112,8 +112,6 @@ ToggleConnections_Hide=Hide All Connections
 ToggleConnections_Singular_Hide=Hide Connection
 ToggleConnections_Singular_Show=Show Connection
 ToggleConnections_Target_Show=Show Outside Connections
-Element=Element
-Location=Location
 VarConfigurationSection_VarConfigs=VAR Configs
 InfoPropertySection_SystemInfo=System Information
 InfoPropertySection_Number_Of_Connections_Label=Number of Connections:
@@ -136,3 +134,12 @@ QuickFixDialog_Resolutions_List_Title=Select a fix:
 QuickFixDialog_Problems_List_Title=Problems:
 QuickFixDialog_Problems_List_Location=Location
 QuickFixDialog_Problems_List_Resource=Resource
+
+command.followLeftConnection.name=Follow Left Connection
+command.followRightConnection.name=Follow Right Connection
+command.goToChild.name=Go To Child
+command.goToParent.name=Go To Parent
+command.goToPinAbove.name=Go To Pin Above
+command.goToPinBelow.name=Go To Pin Below
+context.fbnetworkEditing.description = 4diac IDE FB Network Editing Context 
+context.fbnetworkEditing.name = FB Network Editing	

--- a/plugins/org.eclipse.fordiac.ide.application/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.application/plugin.xml
@@ -418,28 +418,28 @@
     <command categoryId="org.eclipse.fordiac.ide.commands.category"
              defaultHandler="org.eclipse.fordiac.ide.application.handlers.GotoParentHandler"
              id="org.eclipse.fordiac.ide.application.commands.gotoparent"
-             name="Go To Parent">
+             name="%command.goToParent.name">
     </command>
     <command categoryId="org.eclipse.fordiac.ide.commands.category"
              defaultHandler="org.eclipse.fordiac.ide.application.handlers.GotoChildHandler"
              id="org.eclipse.fordiac.ide.application.commands.gotochild"
-             name="Go To Child">
+             name="%command.goToChild.name">
     </command>
     <command categoryId="org.eclipse.fordiac.ide.commands.category"
              id="org.eclipse.fordiac.ide.application.commands.gotopinunder"
-             name="Go To Pin Below">
+             name="%command.goToPinBelow.name">
     </command>
     <command categoryId="org.eclipse.fordiac.ide.commands.category"
              id="org.eclipse.fordiac.ide.application.commands.gotopinabove"
-             name="Go To Pin Below">
+             name="%command.goToPinAbove.name">
     </command>
     <command categoryId="org.eclipse.fordiac.ide.commands.category"
              id="org.eclipse.fordiac.ide.application.commands.followLeftConnection"
-             name="Follow Left Connection">
+             name="%command.followLeftConnection.name">
     </command>
     <command categoryId="org.eclipse.fordiac.ide.commands.category"
              id="org.eclipse.fordiac.ide.application.commands.followRightConnection"
-             name="Follow Right Connection">
+             name="%command.followRightConnection.name">
     </command>
     <command categoryId="org.eclipse.fordiac.ide.commands.category"
              id="org.eclipse.fordiac.ide.application.commands.createConnectionAtSubappInterface"
@@ -566,8 +566,6 @@
   </extension>
   
   <extension point="org.eclipse.ui.handlers">
-  
- <!-- HANDLER FOR FOLLOW LEFT CONNECTION, SECOND IS FOR OVERRIDING THE CONFLICTING SHORTCUT -->
     <handler class="org.eclipse.fordiac.ide.application.handlers.FollowLeftConnectionHandler"
              commandId="org.eclipse.fordiac.ide.application.commands.followLeftConnection">
 	  <activeWhen>
@@ -581,21 +579,6 @@
         </with>
       </activeWhen>
     </handler>
-    
-    <handler class="org.eclipse.fordiac.ide.application.handlers.FollowLeftConnectionHandler"
-             commandId="org.eclipse.ui.edit.text.goto.wordPrevious">
-	  <activeWhen>
-		<with variable="selection">
-			<count value="1"/>
-        	<iterate>
-            	<or>
-              		<instanceof value="org.eclipse.fordiac.ide.gef.editparts.InterfaceEditPart" />
-            	</or>
-          	</iterate>
-        </with>        	
-      </activeWhen>
-    </handler>
-    
     <handler class="org.eclipse.fordiac.ide.application.handlers.FollowLeftTargetPinConnectionHandler"
              commandId="org.eclipse.fordiac.ide.application.commands.followLeftConnection">
 	  <activeWhen>
@@ -610,22 +593,6 @@
       </activeWhen>
     </handler>
     
-    <handler class="org.eclipse.fordiac.ide.application.handlers.FollowLeftTargetPinConnectionHandler"
-             commandId="org.eclipse.ui.edit.text.goto.wordPrevious">
-	  <activeWhen>
-		<with variable="selection">
-			<count value="1"/>
-        	<iterate>
-            	<or>
-              		<instanceof value="org.eclipse.fordiac.ide.application.editparts.TargetInterfaceElementEditPart" />
-            	</or>
-          	</iterate>
-        </with>        	
-      </activeWhen>
-    </handler>
-    
-    
-<!-- HANDLER FOR FOLLOW RIGHT CONNECTION, SECOND IS FOR OVERRIDING THE CONFLICTING SHORTCUT -->
     <handler class="org.eclipse.fordiac.ide.application.handlers.FollowRightConnectionHandler"
              commandId="org.eclipse.fordiac.ide.application.commands.followRightConnection">
 	  <activeWhen>
@@ -639,22 +606,7 @@
         </with>
       </activeWhen>
     </handler>
-    
-    <handler class="org.eclipse.fordiac.ide.application.handlers.FollowRightConnectionHandler"
-             commandId="org.eclipse.ui.edit.text.goto.wordNext">
-	  <activeWhen>
-        <with variable="selection">
-			<count value="1"/>
-        	<iterate>
-            	<or>
-              		<instanceof value="org.eclipse.fordiac.ide.gef.editparts.InterfaceEditPart" />
-            	</or>
-          	</iterate>
-        </with>
-      </activeWhen>
-    </handler>
-    
-     <handler class="org.eclipse.fordiac.ide.application.handlers.FollowRightTargetPinConnectionHandler"
+	<handler class="org.eclipse.fordiac.ide.application.handlers.FollowRightTargetPinConnectionHandler"
              commandId="org.eclipse.fordiac.ide.application.commands.followRightConnection">
 	  <activeWhen>
         <with variable="selection">
@@ -666,24 +618,8 @@
           	</iterate>
         </with>
       </activeWhen>
-    </handler>
+    </handler>    
     
-    <handler class="org.eclipse.fordiac.ide.application.handlers.FollowRightTargetPinConnectionHandler"
-             commandId="org.eclipse.ui.edit.text.goto.wordNext">
-	  <activeWhen>
-		<with variable="selection">
-			<count value="1"/>
-        	<iterate>
-            	<or>
-              		<instanceof value="org.eclipse.fordiac.ide.application.editparts.TargetInterfaceElementEditPart" />
-            	</or>
-          	</iterate>
-        </with>        	
-      </activeWhen>
-    </handler>
-    
-    
-    <!-- HANDLER FOR Go TO PIN ABOVE, SECOND IS FOR OVERRIDING THE CONFLICTING SHORTCUT -->
     <handler class="org.eclipse.fordiac.ide.application.handlers.GotoPinAboveHandler"
              commandId="org.eclipse.fordiac.ide.application.commands.gotopinabove">
 	  <activeWhen>
@@ -691,23 +627,8 @@
       </activeWhen>
     </handler>
     
-    <handler class="org.eclipse.fordiac.ide.application.handlers.GotoPinAboveHandler"
-             commandId="org.eclipse.ui.edit.text.scroll.lineUp">
-	  <activeWhen>
-        <reference definitionId="org.eclipse.fordiac.ide.application.NavigrationInterfaceElementSelection" />
-      </activeWhen>
-    </handler>
-    
- 	<!-- HANDLER FOR Go TO PIN BELOW, SECOND IS FOR OVERRIDING THE CONFLICTING SHORTCUT -->
     <handler class="org.eclipse.fordiac.ide.application.handlers.GotoPinUnderHandler"
              commandId="org.eclipse.fordiac.ide.application.commands.gotopinunder">
-	  <activeWhen>
-        <reference definitionId="org.eclipse.fordiac.ide.application.NavigrationInterfaceElementSelection" />
-      </activeWhen>
-    </handler>
-    
-    <handler class="org.eclipse.fordiac.ide.application.handlers.GotoPinUnderHandler"
-             commandId="org.eclipse.ui.edit.text.scroll.lineDown">
 	  <activeWhen>
         <reference definitionId="org.eclipse.fordiac.ide.application.NavigrationInterfaceElementSelection" />
       </activeWhen>
@@ -909,70 +830,81 @@
 	</handler>
   </extension>
   
+  <extension
+		point="org.eclipse.ui.contexts">
+	<context
+		id="org.eclipse.fordiac.ide.fbnetwork"
+		description="%context.fbnetworkEditing.description"
+		name="%context.fbnetworkEditing.name"
+		parentId="org.eclipse.fordiac.ide.gef">
+	</context>
+  </extension> 
+  
   <extension point="org.eclipse.ui.bindings">
     <key commandId="org.eclipse.fordiac.ide.application.commands.clearFocusOn"
-         contextId="org.eclipse.ui.contexts.window"
+         contextId="org.eclipse.fordiac.ide.fbnetwork"
          schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-         sequence="M1+6">
-    </key>
+         sequence="M1+6"/>
     <key commandId="org.eclipse.fordiac.ide.application.commands.gotoparent"
-         contextId="org.eclipse.ui.contexts.window"
+         contextId="org.eclipse.fordiac.ide.fbnetwork"
          schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-         sequence="M1+M2+ARROW_UP">
-    </key>
+         sequence="M1+M2+ARROW_UP"/>
     <key commandId="org.eclipse.fordiac.ide.application.commands.gotochild"
-         contextId="org.eclipse.ui.contexts.window"
+         contextId="org.eclipse.fordiac.ide.fbnetwork"
          schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-         sequence="M1+M2+ARROW_DOWN">
-    </key>
+         sequence="M1+M2+ARROW_DOWN"/>
     <key commandId="org.eclipse.fordiac.ide.application.commands.gotopinunder"
-         contextId="org.eclipse.ui.contexts.window"
+         contextId="org.eclipse.fordiac.ide.fbnetwork"
          schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-         sequence="M1+ARROW_DOWN">
-    </key>
+         sequence="M1+ARROW_DOWN"/>
     <key commandId="org.eclipse.fordiac.ide.application.commands.gotopinabove"
-         contextId="org.eclipse.ui.contexts.window"
+         contextId="org.eclipse.fordiac.ide.fbnetwork"
          schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-         sequence="M1+ARROW_UP">
-    </key>
+         sequence="M1+ARROW_UP"/>
     <key commandId="org.eclipse.fordiac.ide.application.commands.followLeftConnection"
-         contextId="org.eclipse.ui.contexts.window"
+         contextId="org.eclipse.fordiac.ide.fbnetwork"
          schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-         sequence="M1+ARROW_LEFT">
-    </key>
+         sequence="M1+ARROW_LEFT"/>
     <key commandId="org.eclipse.fordiac.ide.application.commands.followRightConnection"
-         contextId="org.eclipse.ui.contexts.window"
+         contextId="org.eclipse.fordiac.ide.fbnetwork"
          schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-         sequence="M1+ARROW_RIGHT">
-    </key>
+         sequence="M1+ARROW_RIGHT"/>
     <key commandId="org.eclipse.fordiac.ide.application.commands.connectThrough"
-         contextId="org.eclipse.ui.contexts.window"
+         contextId="org.eclipse.fordiac.ide.fbnetwork"
          schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-         sequence="M1+B">
-    </key>
+         sequence="M1+B"/>
     <key commandId="org.eclipse.fordiac.ide.application.commands.toggleConnections"
-         contextId="org.eclipse.ui.contexts.window"
+         contextId="org.eclipse.fordiac.ide.fbnetwork"
          schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-         sequence="M1+T">
-    </key>
-    <key
-          commandId="org.eclipse.fordiac.ide.application.commands.mapTo"
-          contextId="org.eclipse.ui.contexts.window"
-          schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-          sequence="M1+M2+M">
-    </key>
-    <key
-          commandId="org.eclipse.fordiac.ide.application.commands.createConnectionAtSubappInterface"
-          contextId="org.eclipse.ui.contexts.window"
-          schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-          sequence="M1+M2+F">
-    </key>
-    <key
-          commandId="org.eclipse.fordiac.ide.application.commands.aggressiveConDelete"
-          contextId="org.eclipse.ui.contexts.window"
-          schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-          sequence="M2+DEL">
-    </key>
+         sequence="M1+T"/>
+    <key commandId="org.eclipse.fordiac.ide.application.commands.mapTo"
+		 contextId="org.eclipse.fordiac.ide.fbnetwork"
+		 schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+		 sequence="M1+M2+M"/>
+    <key commandId="org.eclipse.fordiac.ide.application.commands.createConnectionAtSubappInterface"
+         contextId="org.eclipse.fordiac.ide.fbnetwork"
+         schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+         sequence="M1+M2+F"/>
+    <key commandId="org.eclipse.fordiac.ide.application.commands.aggressiveConDelete"
+		 contextId="org.eclipse.fordiac.ide.fbnetwork"
+		 schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+		 sequence="M2+DEL"/>
+	<key commandId="org.eclipse.fordiac.ide.application.commands.followRightConnection"
+		 contextId="org.eclipse.fordiac.ide.fbnetwork"
+	     schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+	     sequence="M1+ARROW_RIGHT"/>	
+    <key contextId="org.eclipse.fordiac.ide.fbnetwork"
+	     commandId="org.eclipse.fordiac.ide.application.commands.followLeftConnection"
+	     schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+	     sequence="M1+ARROW_LEFT"/>
+	<key commandId="org.eclipse.fordiac.ide.application.commands.gotopinabove"
+         contextId="org.eclipse.fordiac.ide.fbnetwork"
+		 schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+         sequence="CTRL+ARROW_UP"/>
+    <key commandId="org.eclipse.fordiac.ide.application.commands.gotopinunder"
+         contextId="org.eclipse.fordiac.ide.fbnetwork"
+		 schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+         sequence="CTRL+ARROW_DOWN"/>    
   </extension>
   
   <extension point="org.eclipse.ui.menus">

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/Messages.java
@@ -21,7 +21,7 @@ import org.eclipse.osgi.util.NLS;
 /** The Class Messages. */
 @SuppressWarnings("squid:S3008") // tell sonar the java naming convention does not make sense for this class
 public final class Messages extends NLS {
-	private static final String BUNDLE_NAME = "org.eclipse.fordiac.ide.application.messages"; //$NON-NLS-1$
+	private static final String BUNDLE_NAME = "plugin"; //$NON-NLS-1$
 
 	public static String AbstractCommandMarkerResolution_CannotCreateCommand;
 

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editors/FBNetworkEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editors/FBNetworkEditor.java
@@ -103,6 +103,11 @@ public class FBNetworkEditor extends DiagramEditorWithFlyoutPalette implements I
 	}
 
 	@Override
+	protected String getContextId() {
+		return "org.eclipse.fordiac.ide.fbnetwork"; //$NON-NLS-1$
+	}
+
+	@Override
 	protected EditPartFactory getEditPartFactory() {
 		return new ElementEditPartFactory(this);
 	}

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.network/src/org/eclipse/fordiac/ide/fbtypeeditor/network/viewer/AbstractFbNetworkInstanceViewer.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.network/src/org/eclipse/fordiac/ide/fbtypeeditor/network/viewer/AbstractFbNetworkInstanceViewer.java
@@ -82,6 +82,11 @@ public abstract class AbstractFbNetworkInstanceViewer extends DiagramEditor {
 	}
 
 	@Override
+	protected String getContextId() {
+		return "org.eclipse.fordiac.ide.fbnetwork"; //$NON-NLS-1$
+	}
+
+	@Override
 	public <T> T getAdapter(final Class<T> adapter) {
 		if (FBNetworkElement.class == adapter) {
 			return adapter.cast(getFbNetworkElement());

--- a/plugins/org.eclipse.fordiac.ide.gef/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.gef/META-INF/MANIFEST.MF
@@ -56,4 +56,5 @@ Bundle-Activator: org.eclipse.fordiac.ide.gef.Activator
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.fordiac.ide.gef;singleton:=true
 Bundle-RequiredExecutionEnvironment: JavaSE-21
+Bundle-Localization: plugin
 Automatic-Module-Name: org.eclipse.fordiac.ide.gef

--- a/plugins/org.eclipse.fordiac.ide.gef/build.properties
+++ b/plugins/org.eclipse.fordiac.ide.gef/build.properties
@@ -2,5 +2,6 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               plugin.xml
+               plugin.xml,\
+               plugin.properties
 

--- a/plugins/org.eclipse.fordiac.ide.gef/plugin.properties
+++ b/plugins/org.eclipse.fordiac.ide.gef/plugin.properties
@@ -1,19 +1,20 @@
- ###############################################################################
- # Copyright (c) 2008, 2009, 2011, 2014 - 2016 Profactor GbmH, fortiss GmbH
- #				 2020 Andrea Zoitl
- # 
- # This program and the accompanying materials are made available under the
- # terms of the Eclipse Public License 2.0 which is available at
- # http://www.eclipse.org/legal/epl-2.0.
- #
- # SPDX-License-Identifier: EPL-2.0
- #
- # Contributors:
- #   Gerhard Ebenhofer, Alois Zoitl
- #     - initial API and implementation and/or initial documentation
- #   Andrea Zoitl
- #	   - externalized translatable strings
- ###############################################################################
+###############################################################################
+# Copyright (c) 2008, 2024 Profactor GbmH, fortiss GmbH, Andrea Zoitl,
+#						   Primetals Technologies Austria GmbH
+# 
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Gerhard Ebenhofer, Alois Zoitl
+#     - initial API and implementation and/or initial documentation
+#   Andrea Zoitl
+#	   - externalized translatable strings
+###############################################################################
+
 AbstractAttributeSection_CreateAttribute=create attribute
 AbstractAttributeSection_DeleteSelectedAttribute=delete selected attribute
 AdjustConnectionCommand_WrongConnectionSegmentIndex=Wrong connection segment index ({0}) provided to AdjustConnectionCommand!
@@ -97,4 +98,8 @@ InterfaceElementSection_ConnectionGroup=Connections
 InterfaceElementSection_InConnections=In-Connections
 InterfaceElementSection_OutConnections=Out-Connections
 InterfaceElementSection_MessageDialog_TITLE=Change Destination or Source of Connection
+
+
+context.graphicalEditing.description=4diac IDE Graphical Editing Context
+context.graphicalEditing.name=Graphical Editing
 

--- a/plugins/org.eclipse.fordiac.ide.gef/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.gef/plugin.xml
@@ -96,7 +96,7 @@
             id="org.eclipse.fordiac.ide.gef.zoomfitpage"
             name="Zoom fit Page">
       </command>
-	</extension>  
+	</extension> 
 	<extension
     		point="org.eclipse.ui.handlers">
     	<handler class="org.eclipse.fordiac.ide.gef.handlers.ZoomInHandler"
@@ -139,30 +139,50 @@
            		</or>                  
          	</activeWhen>
 		</handler>    
+	</extension>
+	<extension
+		point="org.eclipse.ui.contexts">
+		<context
+			id="org.eclipse.fordiac.ide.gef"
+			description="%context.graphicalEditing.description"
+			name="%context.graphicalEditing.name"
+			parentId="org.eclipse.ui.contexts.window">
+		</context>
 	</extension>  
 	<extension
 			point="org.eclipse.ui.bindings">
 		<key
         	commandId="org.eclipse.fordiac.ide.gef.zoom100"
-            contextId="org.eclipse.ui.contexts.window"
+            contextId="org.eclipse.fordiac.ide.gef"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-            sequence="M1+0">
-      	</key>
+            sequence="M1+0"/>
 		<key
         	commandId="org.eclipse.fordiac.ide.gef.zoomfitpage"
-            contextId="org.eclipse.ui.contexts.window"
+            contextId="org.eclipse.fordiac.ide.gef"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-            sequence="M1+M2+0">
-      	</key>
+            sequence="M1+M2+0"/>
+        <key
+	        commandId="org.eclipse.ui.edit.text.zoomIn"
+	        contextId="org.eclipse.fordiac.ide.gef"
+			schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+	        sequence="M1+="/>    
+      	<key
+	        commandId="org.eclipse.ui.edit.text.zoomIn"
+	        contextId="org.eclipse.fordiac.ide.gef"
+			schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+	        sequence="M1++"/>
+	  	<key
+	        commandId="org.eclipse.ui.edit.text.zoomOut"
+	        contextId="org.eclipse.fordiac.ide.gef"
+			schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+	        sequence="M1+-"/>
 	</extension>
 	<extension point="org.eclipse.ui.menus">
 		<menuContribution locationURI="toolbar:org.eclipse.ui.main.toolbar?after=org.eclipse.ui.workbench.navigate">
 			<toolbar id="org.eclipse.fordiac.ide.toolbars.zoomToolbar">
 				<command
 	            		commandId="org.eclipse.ui.edit.text.zoomOut"
-	                  	id="org.eclipse.fordiac.ide.toolbars.zoomToolbar"
-	                  	tooltip="Zoom out">
-	            </command>
+	                  	id="org.eclipse.fordiac.ide.toolbars.zoomToolbar"/>
 	            <control class="org.eclipse.fordiac.ide.gef.handlers.FontComboContributionItem"
               			id="org.eclipse.fordiac.ide.toolbars.fontToolbarComboBox">
               		<visibleWhen>
@@ -185,9 +205,7 @@
         		</control>
 				<command
 	            		commandId="org.eclipse.ui.edit.text.zoomIn"
-	                  	id="org.eclipse.fordiac.ide.toolbars.zoomToolbar"
-	                  	tooltip="Zoom in">
-	            </command>
+	                  	id="org.eclipse.fordiac.ide.toolbars.zoomToolbar"/>
 				<command
 	            		commandId="org.eclipse.fordiac.ide.gef.zoom100"
 	                  	icon="fordiacimage://ICON_ZOOM_100"

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/DiagramEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/DiagramEditor.java
@@ -62,9 +62,12 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IEditorSite;
 import org.eclipse.ui.IReusableEditor;
 import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.actions.ActionFactory;
+import org.eclipse.ui.contexts.IContextService;
 import org.eclipse.ui.part.MultiPageEditorSite;
 import org.eclipse.ui.views.contentoutline.IContentOutlinePage;
 import org.eclipse.ui.views.properties.IPropertySheetPage;
@@ -95,6 +98,18 @@ public abstract class DiagramEditor extends GraphicalEditor
 
 	/** Instantiates a new diagram editor. */
 	protected DiagramEditor() {
+	}
+
+	@Override
+	public void init(final IEditorSite site, final IEditorInput input) throws PartInitException {
+		super.init(site, input);
+		final IContextService cs = site.getService(IContextService.class);
+		cs.activateContext(getContextId());
+	}
+
+	@SuppressWarnings("static-method") // allow subclasses to provide refined context ids
+	protected String getContextId() {
+		return "org.eclipse.fordiac.ide.gef"; //$NON-NLS-1$
 	}
 
 	/*

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/DiagramEditorWithFlyoutPalette.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/DiagramEditorWithFlyoutPalette.java
@@ -84,6 +84,7 @@ import org.eclipse.ui.IReusableEditor;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.actions.ActionFactory;
+import org.eclipse.ui.contexts.IContextService;
 import org.eclipse.ui.part.MultiPageEditorSite;
 import org.eclipse.ui.views.contentoutline.IContentOutlinePage;
 import org.eclipse.ui.views.properties.IPropertySheetPage;
@@ -323,6 +324,13 @@ public abstract class DiagramEditorWithFlyoutPalette extends GraphicalEditorWith
 		id = ActionFactory.DELETE.getId();
 		bars.setGlobalActionHandler(id, registry.getAction(id));
 		bars.updateActionBars();
+		final IContextService cs = site.getService(IContextService.class);
+		cs.activateContext(getContextId());
+	}
+
+	@SuppressWarnings("static-method") // allow subclasses to provide refined context ids
+	protected String getContextId() {
+		return "org.eclipse.fordiac.ide.gef"; //$NON-NLS-1$
 	}
 
 	protected void setEditorPartName(final IEditorInput input) {

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/Messages.java
@@ -21,7 +21,7 @@ import org.eclipse.osgi.util.NLS;
 /** The Class Messages. */
 @SuppressWarnings("squid:S3008") // tell sonar the java naming convention does not make sense for this class
 public final class Messages extends NLS {
-	private static final String BUNDLE_NAME = "org.eclipse.fordiac.ide.gef.messages"; //$NON-NLS-1$
+	private static final String BUNDLE_NAME = "plugin"; //$NON-NLS-1$
 
 	/** The Abstract view edit part_ erro r_create figure. */
 	public static String AbstractAttributeSection_CreateAttribute;


### PR DESCRIPTION
To avoid clashes with text editing and other eclipse based editors an own editor context for GEF based editors and especially for FBNetwork Editors was introduced.