### PR TITLE
The BreadCrumb in Typed Subapps Didn't Show the Hierarchy Correctly

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.emf.compare/src/org/eclipse/fordiac/ide/emf/compare/provider/CFBInstanceItemProviderEmfCompare.java
+++ b/plugins/org.eclipse.fordiac.ide.emf.compare/src/org/eclipse/fordiac/ide/emf/compare/provider/CFBInstanceItemProviderEmfCompare.java
@@ -15,9 +15,9 @@ package org.eclipse.fordiac.ide.emf.compare.provider;
 
 import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.fordiac.ide.model.edit.providers.CFBInstanceItemProviderForSystem;
 import org.eclipse.fordiac.ide.model.libraryElement.CFBInstance;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
-import org.eclipse.fordiac.ide.systemmanagement.ui.providers.CFBInstanceItemProviderForSystem;
 
 public class CFBInstanceItemProviderEmfCompare extends CFBInstanceItemProviderForSystem {
 

--- a/plugins/org.eclipse.fordiac.ide.emf.compare/src/org/eclipse/fordiac/ide/emf/compare/provider/FBNetworkItemProviderEmfCompare.java
+++ b/plugins/org.eclipse.fordiac.ide.emf.compare/src/org/eclipse/fordiac/ide/emf/compare/provider/FBNetworkItemProviderEmfCompare.java
@@ -16,8 +16,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import org.eclipse.emf.common.notify.AdapterFactory;
+import org.eclipse.fordiac.ide.model.edit.providers.FBNetworkItemProviderForSystem;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
-import org.eclipse.fordiac.ide.systemmanagement.ui.providers.FBNetworkItemProviderForSystem;
 
 public class FBNetworkItemProviderEmfCompare extends FBNetworkItemProviderForSystem {
 

--- a/plugins/org.eclipse.fordiac.ide.emf.compare/src/org/eclipse/fordiac/ide/emf/compare/provider/UntypedSubAppItemProviderEmfCompare.java
+++ b/plugins/org.eclipse.fordiac.ide.emf.compare/src/org/eclipse/fordiac/ide/emf/compare/provider/UntypedSubAppItemProviderEmfCompare.java
@@ -18,9 +18,9 @@ import java.util.Collection;
 
 import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.fordiac.ide.model.edit.providers.UntypedSubAppItemProviderForSystem;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
-import org.eclipse.fordiac.ide.systemmanagement.ui.providers.UntypedSubAppItemProviderForSystem;
 
 public class UntypedSubAppItemProviderEmfCompare extends UntypedSubAppItemProviderForSystem {
 

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/providers/CFBInstanceItemProviderForSystem.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/providers/CFBInstanceItemProviderForSystem.java
@@ -11,7 +11,7 @@
  *   Alois Zoitl - initial API and implementation and/or initial documentation
  *                 (Based on SubAppItmeProviderForSystem
  *******************************************************************************/
-package org.eclipse.fordiac.ide.systemmanagement.ui.providers;
+package org.eclipse.fordiac.ide.model.edit.providers;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -24,10 +24,13 @@ import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.provider.CFBInstanceItemProvider;
 import org.eclipse.fordiac.ide.model.libraryElement.provider.FBNetworkItemProvider;
 
-/** a dedicated item provider that will ensure that in the system tree the CFB instances will have the content of the
- * fbnetwork without the intermediate FBnetwork node shown.
+/**
+ * a dedicated item provider that will ensure that in the system tree the CFB
+ * instances will have the content of the fbnetwork without the intermediate
+ * FBnetwork node shown.
  *
- * @author alil */
+ * @author alil
+ */
 public class CFBInstanceItemProviderForSystem extends CFBInstanceItemProvider {
 
 	private FBNetworkItemProvider networkItemProvider = null;
@@ -59,7 +62,7 @@ public class CFBInstanceItemProviderForSystem extends CFBInstanceItemProvider {
 	public Object getParent(final Object object) {
 		final EObject cont = ((EObject) object).eContainer();
 		if (cont instanceof FBNetwork) {
-			return ((FBNetwork) cont).eContainer();
+			return cont.eContainer();
 		}
 		return super.getParent(object);
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/providers/FBNetworkItemProviderForSystem.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/providers/FBNetworkItemProviderForSystem.java
@@ -10,7 +10,7 @@
  * Contributors:
  *   Alois Zoitl - initial API and implementation and/or initial documentation
  *******************************************************************************/
-package org.eclipse.fordiac.ide.systemmanagement.ui.providers;
+package org.eclipse.fordiac.ide.model.edit.providers;
 
 import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
@@ -19,7 +19,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.provider.FBNetworkItemProvider;
 
 public class FBNetworkItemProviderForSystem extends FBNetworkItemProvider {
-	protected FBNetworkItemProviderForSystem(final AdapterFactory adapterFactory) {
+	public FBNetworkItemProviderForSystem(final AdapterFactory adapterFactory) {
 		super(adapterFactory);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/providers/UntypedSubAppItemProviderForSystem.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/providers/UntypedSubAppItemProviderForSystem.java
@@ -12,7 +12,7 @@
  *   Alois Zoitl - initial API and implementation and/or initial documentation
  *               - added defensive checks when the fbnetwork is null
  *******************************************************************************/
-package org.eclipse.fordiac.ide.systemmanagement.ui.providers;
+package org.eclipse.fordiac.ide.model.edit.providers;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -73,7 +73,7 @@ public class UntypedSubAppItemProviderForSystem extends UntypedSubAppItemProvide
 	public Object getParent(final Object object) {
 		final EObject cont = ((SubApp) object).eContainer();
 		if (cont instanceof FBNetwork) {
-			return ((FBNetwork) cont).eContainer();
+			return cont.eContainer();
 		}
 		return super.getParent(object);
 	}

--- a/plugins/org.eclipse.fordiac.ide.subapptypeeditor/src/org/eclipse/fordiac/ide/subapptypeeditor/providers/TypedSubappProviderAdapterFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.subapptypeeditor/src/org/eclipse/fordiac/ide/subapptypeeditor/providers/TypedSubappProviderAdapterFactory.java
@@ -13,6 +13,8 @@
 package org.eclipse.fordiac.ide.subapptypeeditor.providers;
 
 import org.eclipse.emf.common.notify.Adapter;
+import org.eclipse.fordiac.ide.model.edit.providers.CFBInstanceItemProviderForSystem;
+import org.eclipse.fordiac.ide.model.edit.providers.UntypedSubAppItemProviderForSystem;
 import org.eclipse.fordiac.ide.model.libraryElement.provider.LibraryElementItemProviderAdapterFactory;
 
 public class TypedSubappProviderAdapterFactory extends LibraryElementItemProviderAdapterFactory {
@@ -31,6 +33,22 @@ public class TypedSubappProviderAdapterFactory extends LibraryElementItemProvide
 			typedSubAppItemProvider = new SubAppItemProviderForTypedSubapps(this);
 		}
 		return typedSubAppItemProvider;
+	}
+
+	@Override
+	public Adapter createUntypedSubAppAdapter() {
+		if (untypedSubAppItemProvider == null) {
+			untypedSubAppItemProvider = new UntypedSubAppItemProviderForSystem(this);
+		}
+		return untypedSubAppItemProvider;
+	}
+
+	@Override
+	public Adapter createCFBInstanceAdapter() {
+		if (cfbInstanceItemProvider == null) {
+			cfbInstanceItemProvider = new CFBInstanceItemProviderForSystem(this);
+		}
+		return cfbInstanceItemProvider;
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/providers/ApplicationItemProviderForSystem.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/providers/ApplicationItemProviderForSystem.java
@@ -18,6 +18,7 @@ import java.util.Collection;
 import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.edit.provider.INotifyChangedListener;
+import org.eclipse.fordiac.ide.model.edit.providers.FBNetworkItemProviderForSystem;
 import org.eclipse.fordiac.ide.model.libraryElement.Application;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.provider.ApplicationItemProvider;

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/providers/AutomationSystemProviderAdapterFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/providers/AutomationSystemProviderAdapterFactory.java
@@ -14,6 +14,8 @@
 package org.eclipse.fordiac.ide.systemmanagement.ui.providers;
 
 import org.eclipse.emf.common.notify.Adapter;
+import org.eclipse.fordiac.ide.model.edit.providers.CFBInstanceItemProviderForSystem;
+import org.eclipse.fordiac.ide.model.edit.providers.UntypedSubAppItemProviderForSystem;
 import org.eclipse.fordiac.ide.model.libraryElement.provider.AutomationSystemItemProvider;
 import org.eclipse.fordiac.ide.model.libraryElement.provider.LibraryElementItemProviderAdapterFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.provider.SystemConfigurationItemProvider;

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/providers/SystemElementItemProviderAdapterFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/providers/SystemElementItemProviderAdapterFactory.java
@@ -15,6 +15,8 @@ package org.eclipse.fordiac.ide.systemmanagement.ui.providers;
 
 import org.eclipse.emf.common.notify.Adapter;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.fordiac.ide.model.edit.providers.CFBInstanceItemProviderForSystem;
+import org.eclipse.fordiac.ide.model.edit.providers.UntypedSubAppItemProviderForSystem;
 import org.eclipse.fordiac.ide.model.libraryElement.FB;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.provider.FBItemProvider;

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/providers/TypedSubAppItemProviderForSystem.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/providers/TypedSubAppItemProviderForSystem.java
@@ -22,6 +22,7 @@ import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.edit.provider.ViewerNotification;
+import org.eclipse.fordiac.ide.model.edit.providers.FBNetworkItemProviderForSystem;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;


### PR DESCRIPTION
The content providers for typed subapps and applications where different. Typed subapps only correctly show the first level of hierarchy. With this fix both use the same hierarchy to fix this.