### PR TITLE
Fix duplicate type errors in builder and live validation

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/validation/VariableDiagnostician.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/validation/VariableDiagnostician.java
@@ -43,7 +43,7 @@ public class VariableDiagnostician extends CancelableDiagnostician {
 	protected boolean doValidate(final EValidator eValidator, final EClass eClass, final EObject eObject,
 			final DiagnosticChain diagnostics, final Map<Object, Object> context) {
 		boolean result = super.doValidate(eValidator, eClass, eObject, diagnostics, context);
-		if (eObject instanceof final VarDeclaration varDeclaration) {
+		if (eObject instanceof final VarDeclaration varDeclaration && varDeclaration.getType() instanceof AnyType) {
 			result &= validate(varDeclaration, VariableOperations::validateType, diagnostics,
 					varDeclaration.getArraySize());
 			result &= validate(varDeclaration, VariableOperations::validateValue, diagnostics,

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/builder/STAlgorithmInitialValueBuilderParticipant.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/builder/STAlgorithmInitialValueBuilderParticipant.java
@@ -148,11 +148,13 @@ public class STAlgorithmInitialValueBuilderParticipant implements IXtextBuilderP
 			return;
 		}
 		final List<Issue> issues = new ArrayList<>();
-		if (varDeclaration.isArray()) {
-			validate(varDeclaration.getArraySize(), delta, typeUsageCollector, issues, context);
-			issues.replaceAll(issue -> ValidationUtil.convertToModelIssue(issue, varDeclaration.getArraySize()));
-		} else {
-			typeUsageCollector.addUsedType(varDeclaration.getType());
+		if (varDeclaration.getType() instanceof AnyType) {
+			if (varDeclaration.isArray()) {
+				validate(varDeclaration.getArraySize(), delta, typeUsageCollector, issues, context);
+				issues.replaceAll(issue -> ValidationUtil.convertToModelIssue(issue, varDeclaration.getArraySize()));
+			} else {
+				typeUsageCollector.addUsedType(varDeclaration.getType());
+			}
 		}
 		if (monitor.isCanceled()) {
 			throw new OperationCanceledException();
@@ -170,7 +172,8 @@ public class STAlgorithmInitialValueBuilderParticipant implements IXtextBuilderP
 			final IBuildContext context, final IProgressMonitor monitor) throws CoreException {
 		final String value = getValue(varDeclaration);
 		final List<Issue> issues = new ArrayList<>();
-		if (!value.isBlank()) { // do not parse value if blank
+		// do not parse value if blank or variable has invalid type
+		if (!value.isBlank() && varDeclaration.getType() instanceof AnyType) {
 			final INamedElement featureType = STCoreUtil.getFeatureType(varDeclaration);
 			try {
 				new TypedValueConverter((DataType) featureType, true).toValue(value);


### PR DESCRIPTION
Fix duplicate type errors in type declarations and initial values because of a missing or invalid type in builder and live validation.