### PR TITLE
Fix unavailable attributes of removed marker annotations

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/annotation/GraphicalMarkerAnnotation.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/annotation/GraphicalMarkerAnnotation.java
@@ -22,29 +22,29 @@ import org.eclipse.core.runtime.CoreException;
 public class GraphicalMarkerAnnotation extends GraphicalAnnotation {
 
 	private final IMarker marker;
+	private String text;
+	private String location;
+	private Map<String, Object> attributes;
 
 	protected GraphicalMarkerAnnotation(final IMarker marker, final String type, final Object target) {
 		super(type, target);
 		this.marker = marker;
+		refresh();
 	}
 
 	@Override
 	public String getText() {
-		return marker.getAttribute(IMarker.MESSAGE, null);
+		return text;
 	}
 
 	@Override
 	public String getLocation() {
-		return marker.getAttribute(IMarker.LOCATION, null);
+		return location;
 	}
 
 	@Override
 	public Object getAttribute(final String attributeName) {
-		try {
-			return marker.getAttribute(attributeName);
-		} catch (final CoreException e) {
-			return null;
-		}
+		return attributes.get(attributeName);
 	}
 
 	@Override
@@ -53,6 +53,16 @@ public class GraphicalMarkerAnnotation extends GraphicalAnnotation {
 			return Objects.requireNonNullElse(marker.getAttributes(), Collections.emptyMap());
 		} catch (final CoreException e) {
 			return Collections.emptyMap();
+		}
+	}
+
+	public void refresh() {
+		text = marker.getAttribute(IMarker.MESSAGE, null);
+		location = marker.getAttribute(IMarker.LOCATION, null);
+		try {
+			attributes = marker.getAttributes();
+		} catch (final CoreException e) {
+			attributes = Map.of();
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/annotation/ResourceMarkerGraphicalAnnotationModel.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/annotation/ResourceMarkerGraphicalAnnotationModel.java
@@ -112,6 +112,7 @@ public abstract class ResourceMarkerGraphicalAnnotationModel extends AbstractGra
 					added.add(annotation);
 				}
 			} else {
+				annotation.refresh();
 				changed.add(annotation);
 			}
 			return annotation;


### PR DESCRIPTION
The attributes of removed marker annotations are no longer available after the corresponding marker has been removed. This caches the attributes inside the marker annotation to avoid the problem.