### PR TITLE
Moved Connection Parsing and Checking to Connection Helper

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/CommonElementImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/CommonElementImporter.java
@@ -757,8 +757,7 @@ public abstract class CommonElementImporter {
 		processChildren(LibraryElementTags.RESOURCE_ELEMENT, name -> {
 			switch (name) {
 			case LibraryElementTags.FBNETWORK_ELEMENT:
-				new ResDevFBNetworkImporter(this, fbNetwork, resource.getVarDeclarations(), fbNetworkElementMap)
-						.parseFBNetwork(LibraryElementTags.FBNETWORK_ELEMENT);
+				parseResourceNetwork(fbNetworkElementMap, resource, fbNetwork);
 				break;
 			case LibraryElementTags.ATTRIBUTE_ELEMENT:
 				parseGenericAttributeNode(resource);
@@ -782,6 +781,12 @@ public abstract class CommonElementImporter {
 			return true;
 		});
 		return resource;
+	}
+
+	protected void parseResourceNetwork(final Map<String, FBNetworkElement> fbNetworkElementMap,
+			final Resource resource, final FBNetwork fbNetwork) throws TypeImportException, XMLStreamException {
+		new ResDevFBNetworkImporter(this, fbNetwork, resource.getVarDeclarations(), fbNetworkElementMap)
+				.parseFBNetwork(LibraryElementTags.FBNETWORK_ELEMENT);
 	}
 
 	private void parseResourceType(final Resource resource) {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/CommonElementImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/CommonElementImporter.java
@@ -126,7 +126,7 @@ public abstract class CommonElementImporter {
 		return file;
 	}
 
-	protected TypeLibrary getTypeLibrary() {
+	TypeLibrary getTypeLibrary() {
 		return typeLibrary;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/ConnectionHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/ConnectionHelper.java
@@ -119,6 +119,22 @@ public final class ConnectionHelper {
 			}
 		}
 
+		public void repair() {
+			if (isMissingConnectionSource()) {
+				connection.setSource(getConnectionEndPoint(sourceString, false));
+			}
+			if (isMissingConnectionDestination()) {
+				connection.setDestination(getConnectionEndPoint(destinationString, true));
+			}
+			connectionState.clear();
+			connectionState.add(ConnectionState.VALID);
+			validate();
+			handleErrorCases();
+			if (getConnection() != null) {
+				importer.getFbNetwork().addConnection(connection);
+			}
+		}
+
 		public void handleErrorCases() {
 			if (isMissingConnectionDestination()) {
 				handleMissingConnectionDestination();
@@ -377,6 +393,10 @@ public final class ConnectionHelper {
 			FBNetworkElement element = importer.findFBNetworkElement(elementName);
 			while (element == null && separatorPos != -1) {
 				separatorPos = path.indexOf('.', separatorPos + 1);
+				if (separatorPos == -1) {
+					// we have no element with the name
+					return null;
+				}
 				elementName = path.substring(0, separatorPos);
 				element = importer.findFBNetworkElement(elementName);
 			}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/ConnectionHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/ConnectionHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021-2022 Primetals Technologies Austria GmbH
+ * Copyright (c) 2021, 2024 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -10,6 +10,7 @@
  * Contributors:
  *   Michael Oberlehner - initial API and implementation and/or initial documentation
  *                      - added data type check for connection
+ *   Alois Zoitl        - moved connection checking and building here
  *******************************************************************************/
 package org.eclipse.fordiac.ide.model.dataimport;
 
@@ -17,40 +18,71 @@ import java.text.MessageFormat;
 import java.util.EnumSet;
 import java.util.Set;
 
+import javax.xml.stream.XMLStreamException;
+
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.fordiac.ide.model.LibraryElementTags;
 import org.eclipse.fordiac.ide.model.Messages;
+import org.eclipse.fordiac.ide.model.NameRepository;
+import org.eclipse.fordiac.ide.model.data.DataType;
+import org.eclipse.fordiac.ide.model.dataimport.exceptions.TypeImportException;
+import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes;
+import org.eclipse.fordiac.ide.model.errormarker.FordiacErrorMarkerInterfaceHelper;
+import org.eclipse.fordiac.ide.model.errormarker.FordiacMarkerHelper;
+import org.eclipse.fordiac.ide.model.libraryElement.AdapterConnection;
+import org.eclipse.fordiac.ide.model.libraryElement.Connection;
+import org.eclipse.fordiac.ide.model.libraryElement.ConnectionRoutingData;
+import org.eclipse.fordiac.ide.model.libraryElement.DataConnection;
+import org.eclipse.fordiac.ide.model.libraryElement.ErrorMarkerInterface;
+import org.eclipse.fordiac.ide.model.libraryElement.Event;
+import org.eclipse.fordiac.ide.model.libraryElement.EventConnection;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
+import org.eclipse.fordiac.ide.model.resource.TypeImportDiagnostic;
+import org.eclipse.fordiac.ide.model.typelibrary.AdapterTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.EventTypeLibrary;
 import org.eclipse.fordiac.ide.model.validation.LinkConstraints;
 
 public final class ConnectionHelper {
 
-	public static class ConnectionBuilder {
+	public static class ConnectionBuilder<T extends Connection> {
 
-		private Set<ConnectionState> connectionState;
+		private final Set<ConnectionState> connectionState;
 
-		private String destination;
+		final T connection;
+		final FBNetworkImporter importer;
+
+		private final String destinationString;
 		private InterfaceList destInterfaceList;
-		private IInterfaceElement destinationEndpoint;
 
-		private String source;
+		private final String sourceString;
 		private InterfaceList srcInterfaceList;
-		private IInterfaceElement sourceEndpoint;
 
-		public ConnectionBuilder(final String source, final String destination) {
+		public ConnectionBuilder(final String sourceString, final String destinationString, final T connection,
+				final FBNetworkImporter importer) {
 			this.connectionState = EnumSet.of(ConnectionState.VALID);
-			this.source = source;
-			this.destination = destination;
+			this.sourceString = sourceString;
+			this.destinationString = destinationString;
+			this.connection = connection;
+			this.importer = importer;
+
+			connection.setSource(getConnectionEndPoint(sourceString, false));
+			connection.setDestination(getConnectionEndPoint(destinationString, true));
 		}
 
 		public void validate() {
+			final IInterfaceElement sourcePin = connection.getSource();
+			final IInterfaceElement destPin = connection.getDestination();
 
-			if (sourceEndpoint != null && destinationEndpoint != null) {
-				if (!LinkConstraints.typeCheck(sourceEndpoint, destinationEndpoint)) {
+			if (sourcePin != null && destPin != null) {
+				if (!LinkConstraints.typeCheck(sourcePin, destPin)) {
 					connectionState.add(ConnectionState.DATATYPE_MISSMATCH);
 					connectionState.remove(ConnectionState.VALID);
 				}
 
-				if (LinkConstraints.duplicateConnection(sourceEndpoint, destinationEndpoint)) {
+				if (LinkConstraints.duplicateConnection(sourcePin, destPin)) {
 					connectionState.add(ConnectionState.DUPLICATE);
 					connectionState.remove(ConnectionState.VALID);
 				}
@@ -58,7 +90,7 @@ public final class ConnectionHelper {
 				return;
 			}
 
-			if (sourceEndpoint != null) {
+			if (sourcePin != null) {
 				connectionState.add(ConnectionState.SOURCE_ENDPOINT_EXISTS);
 			} else {
 				connectionState.add(ConnectionState.SOURCE_ENDPOINT_MISSING);
@@ -72,28 +104,58 @@ public final class ConnectionHelper {
 				connectionState.remove(ConnectionState.VALID);
 			}
 
-			if (destinationEndpoint != null) {
+			if (destPin != null) {
 				connectionState.add(ConnectionState.DEST_ENPOINT_EXITS);
 			} else {
 				connectionState.add(ConnectionState.DEST_ENDPOINT_MISSING);
 				connectionState.remove(ConnectionState.VALID);
 			}
 
-			if (destination != null && destInterfaceList != null) {
+			if (destInterfaceList != null) {
 				connectionState.add(ConnectionState.DEST_EXISTS);
 			} else {
 				connectionState.add(ConnectionState.DEST_MISSING);
 				connectionState.remove(ConnectionState.VALID);
 			}
+		}
 
+		public void handleErrorCases() {
+			if (isMissingConnectionDestination()) {
+				handleMissingConnectionDestination();
+			}
+
+			if (isMissingConnectionDestinationEndpoint()) {
+				createErrorMarkerInterface(true);
+			}
+
+			if (isMissingConnectionSource()) {
+				handleMissingConnectionSource();
+			}
+
+			if (isMissingConnectionSourceEndpoint()) {
+				createErrorMarkerInterface(false);
+			}
+
+			if (isMissingSourceAndDestEndpoint()) {
+				handleMissingSrcAndDestEnpoint();
+			}
+
+			if (isEmptyConnection()) {
+				// if 4diac should be capable of seeing the error marker in the FBNetworkEditor
+				// then error marker blocks need to be created at this location
+				importer.getErrors()
+						.add(new TypeImportDiagnostic("Connection missing both source and destination element", //$NON-NLS-1$
+								MessageFormat.format("{0} -> {1}", sourceString, destinationString), //$NON-NLS-1$
+								importer.getLineNumber()));
+			}
 		}
 
 		public String getSourceFbName() {
-			if (source == null) {
+			if (sourceString == null) {
 				return Messages.ConnectionHelper_ErrorMarker_Source_Missing;
 			}
 
-			final String[] qualNames = source.split("\\."); //$NON-NLS-1$
+			final String[] qualNames = sourceString.split("\\."); //$NON-NLS-1$
 			if (qualNames.length == 0) {
 				return Messages.ConnectionHelper_ErrorMarker_Source_Missing;
 			}
@@ -102,11 +164,11 @@ public final class ConnectionHelper {
 
 		public String getDestFbName() {
 
-			if (destination == null) {
+			if (destinationString == null) {
 				return Messages.ConnectionHelper_ErrorMarker_Dest_Missing;
 			}
 
-			final String[] qualNames = destination.split("\\."); //$NON-NLS-1$
+			final String[] qualNames = destinationString.split("\\."); //$NON-NLS-1$
 
 			if (qualNames.length == 0) {
 				return Messages.ConnectionHelper_ErrorMarker_Dest_Missing;
@@ -118,20 +180,16 @@ public final class ConnectionHelper {
 			return connectionState;
 		}
 
-		public String getDestination() {
-			return destination;
-		}
-
 		public IInterfaceElement getDestinationEndpoint() {
-			return destinationEndpoint;
-		}
-
-		public String getSource() {
-			return source;
+			return connection.getDestination();
 		}
 
 		public IInterfaceElement getSourceEndpoint() {
-			return sourceEndpoint;
+			return connection.getSource();
+		}
+
+		public T getConnection() {
+			return isEmptyConnection() ? null : connection;
 		}
 
 		public boolean isMissingConnectionDestination() {
@@ -179,25 +237,28 @@ public final class ConnectionHelper {
 		}
 
 		public boolean dataInputHasMultipleConnections() {
-			return (!(sourceEndpoint.getType().getName().equalsIgnoreCase("Event")) && sourceEndpoint.isIsInput()
+			final IInterfaceElement sourceEndpoint = connection.getSource();
+			final IInterfaceElement destinationEndpoint = connection.getDestination();
+
+			return (!(sourceEndpoint instanceof Event) && sourceEndpoint.isIsInput()
 					&& sourceEndpoint.getInputConnections().size() > 1)
-					|| (!(destinationEndpoint.getType().getName().equalsIgnoreCase("Event"))
-							&& destinationEndpoint.isIsInput() && destinationEndpoint.getInputConnections().size() > 1);
+					|| (!(destinationEndpoint instanceof Event) && destinationEndpoint.isIsInput()
+							&& destinationEndpoint.getInputConnections().size() > 1);
 		}
 
 		public String getSourcePinName() {
 
-			if (source == null) {
+			if (sourceString == null) {
 				return MessageFormat.format(Messages.ConnectionHelper_pin_not_found, "«null»"); //$NON-NLS-1$
 			}
 
-			if (sourceEndpoint != null) {
-				return sourceEndpoint.getName();
+			if (connection.getSource() != null) {
+				return connection.getSource().getName();
 			}
 
-			final String[] qualNames = source.split("\\."); //$NON-NLS-1$
+			final String[] qualNames = sourceString.split("\\."); //$NON-NLS-1$
 			if (qualNames.length < 2) {
-				return MessageFormat.format(Messages.ConnectionHelper_pin_not_found, source);
+				return MessageFormat.format(Messages.ConnectionHelper_pin_not_found, sourceString);
 			}
 
 			return qualNames[1];
@@ -205,56 +266,175 @@ public final class ConnectionHelper {
 
 		public String getDestinationPinName() {
 
-			if (destination == null) {
+			if (destinationString == null) {
 				return MessageFormat.format(Messages.ConnectionHelper_pin_not_found, "«null»"); //$NON-NLS-1$
 			}
 
-			if (destinationEndpoint != null) {
-				return destinationEndpoint.getName();
+			if (connection.getDestination() != null) {
+				return connection.getDestination().getName();
 			}
 
-			final String[] qualNames = destination.split("\\."); //$NON-NLS-1$
+			final String[] qualNames = destinationString.split("\\."); //$NON-NLS-1$
 			if (qualNames.length < 2) {
-				return MessageFormat.format(Messages.ConnectionHelper_pin_not_found, destination);
+				return MessageFormat.format(Messages.ConnectionHelper_pin_not_found, destinationString);
 			}
 
 			return qualNames[1];
 		}
 
-		public InterfaceList getDestInterfaceList() {
-			return destInterfaceList;
+		private void handleMissingConnectionSource() {
+			final FBNetworkElement sourceFB = FordiacMarkerHelper.createErrorMarkerFB(getSourceFbName());
+			srcInterfaceList = sourceFB.getInterface();
+			importer.getFbNetwork().getNetworkElements().add(sourceFB);
+			sourceFB.setName(NameRepository.createUniqueName(sourceFB, sourceFB.getName()));
+			createErrorMarkerInterface(false);
 		}
 
-		public void setDestInterfaceList(final InterfaceList destInterfaceList) {
-			this.destInterfaceList = destInterfaceList;
+		private void handleMissingConnectionDestination() {
+			// check if there is already one
+			final FBNetworkElement destinationFb = FordiacMarkerHelper.createErrorMarkerFB(getDestFbName());
+			destInterfaceList = destinationFb.getInterface();
+			importer.getFbNetwork().getNetworkElements().add(destinationFb);
+			destinationFb.setName(NameRepository.createUniqueName(destinationFb, destinationFb.getName()));
+			createErrorMarkerInterface(true);
 		}
 
-		public InterfaceList getSrcInterfaceList() {
-			return srcInterfaceList;
+		private void handleMissingSrcAndDestEnpoint() {
+			final DataType pinType = determineConnectionType();
+
+			final ErrorMarkerInterface srcEndpoint = FordiacErrorMarkerInterfaceHelper
+					.createErrorMarkerInterface(pinType, getSourcePinName(), false, srcInterfaceList);
+			final ErrorMarkerInterface destEndpoint = FordiacErrorMarkerInterfaceHelper
+					.createErrorMarkerInterface(pinType, getDestinationPinName(), true, destInterfaceList);
+			connection.setSource(srcEndpoint);
+			connection.setDestination(destEndpoint);
 		}
 
-		public void setSrcInterfaceList(final InterfaceList srcInterfaceList) {
-			this.srcInterfaceList = srcInterfaceList;
+		private DataType determineConnectionType() {
+			if (connection instanceof EventConnection) {
+				return EventTypeLibrary.getInstance().getType(null);
+			}
+			if (connection instanceof AdapterConnection) {
+				final AdapterTypeEntry entry = importer.getTypeLibrary().getAdapterTypeEntry("ANY_ADAPTER"); //$NON-NLS-1$
+				if (null != entry) {
+					return entry.getType();
+				}
+				// we don't have an any_adapter return generic adapter, may not be reparable
+				return LibraryElementFactory.eINSTANCE.createAdapterType();
+			}
+			if (connection instanceof DataConnection) {
+				return IecTypes.GenericTypes.ANY;
+			}
+			return null;
 		}
 
-		public void setConnectionState(final Set<ConnectionState> connectionState) {
-			this.connectionState = connectionState;
+		private ErrorMarkerInterface createErrorMarkerInterface(final boolean isInput) {
+			final IInterfaceElement oppositeEndpoint = isInput ? getSourceEndpoint() : getDestinationEndpoint();
+
+			// we need a special treatment for FB's that lost their type
+			if (oppositeEndpoint == null) {
+				getConnectionState().add(ConnectionState.MISSING_TYPE);
+				return null;
+			}
+
+			DataType type = oppositeEndpoint.getType();
+			if (type == null) {
+				type = determineConnectionType();
+			}
+
+			final InterfaceList ieList = isInput ? destInterfaceList : srcInterfaceList;
+			final String pinName = isInput ? getDestinationPinName() : getSourcePinName();
+			final ErrorMarkerInterface errorMarkerInterface = FordiacErrorMarkerInterfaceHelper
+					.createErrorMarkerInterface(type, pinName, isInput, ieList);
+
+			if (isInput) {
+				connection.setSource(oppositeEndpoint);
+				connection.setDestination(errorMarkerInterface);
+			} else {
+				connection.setSource(errorMarkerInterface);
+				connection.setDestination(oppositeEndpoint);
+			}
+			return errorMarkerInterface;
 		}
 
-		public void setDestination(final String destination) {
-			this.destination = destination;
-		}
+		private IInterfaceElement getConnectionEndPoint(final String path, final boolean isInput) {
+			if (path == null) {
+				return null;
+			}
+			int separatorPos = path.indexOf('.');
 
-		public void setDestinationEndpoint(final IInterfaceElement destinationEndpoint) {
-			this.destinationEndpoint = destinationEndpoint;
-		}
+			if (separatorPos == -1) {
+				// we have a connection to the containing interface
+				if (isInput) {
+					destInterfaceList = importer.getInterfaceList();
+				} else {
+					srcInterfaceList = importer.getInterfaceList();
+				}
+				return importer.getContainingInterfaceElement(path, connection.eClass(), isInput);
+			}
 
-		public void setSource(final String source) {
-			this.source = source;
-		}
+			String elementName = path.substring(0, separatorPos);
+			FBNetworkElement element = importer.findFBNetworkElement(elementName);
+			while (element == null && separatorPos != -1) {
+				separatorPos = path.indexOf('.', separatorPos + 1);
+				elementName = path.substring(0, separatorPos);
+				element = importer.findFBNetworkElement(elementName);
+			}
 
-		public void setSourceEndpoint(final IInterfaceElement sourceEndpoint) {
-			this.sourceEndpoint = sourceEndpoint;
+			if (null != element) {
+				final InterfaceList ieList = element.getInterface();
+				if (isInput) {
+					destInterfaceList = ieList;
+				} else {
+					srcInterfaceList = ieList;
+				}
+				final String pinName = path.substring(separatorPos + 1);
+				return FBNetworkImporter.getInterfaceElement(ieList, pinName, connection.eClass(), isInput);
+			}
+			return null;
+		}
+	}
+
+	public static <T extends Connection> ConnectionBuilder<T> createConnectionBuilder(final EClass conType,
+			final FBNetworkImporter importer) throws XMLStreamException, TypeImportException {
+		@SuppressWarnings("unchecked")
+		final T connection = (T) LibraryElementFactory.eINSTANCE.create(conType);
+
+		final String sourceElement = importer.getAttributeValue(LibraryElementTags.SOURCE_ATTRIBUTE);
+		final String destinationElement = importer.getAttributeValue(LibraryElementTags.DESTINATION_ATTRIBUTE);
+
+		final String commentElement = importer.getAttributeValue(LibraryElementTags.COMMENT_ATTRIBUTE);
+		if (null != commentElement) {
+			connection.setComment(commentElement);
+		}
+		parseConnectionRouting(connection, importer);
+		importer.parseAttributes(connection);
+
+		return new ConnectionBuilder<>(sourceElement, destinationElement, connection, importer);
+	}
+
+	private static void parseConnectionRouting(final Connection connection, final CommonElementImporter importer) {
+		final ConnectionRoutingData routingData = LibraryElementFactory.eINSTANCE.createConnectionRoutingData();
+		final String dx1Element = importer.getAttributeValue(LibraryElementTags.DX1_ATTRIBUTE);
+		if (null != dx1Element) {
+			routingData.setDx1(parseConnectionValue(dx1Element));
+		}
+		final String dx2Element = importer.getAttributeValue(LibraryElementTags.DX2_ATTRIBUTE);
+		if (null != dx2Element) {
+			routingData.setDx2(parseConnectionValue(dx2Element));
+		}
+		final String dyElement = importer.getAttributeValue(LibraryElementTags.DY_ATTRIBUTE);
+		if (null != dyElement) {
+			routingData.setDy(parseConnectionValue(dyElement));
+		}
+		connection.setRoutingData(routingData);
+	}
+
+	private static double parseConnectionValue(final String value) {
+		try {
+			return Double.parseDouble(value);
+		} catch (final NumberFormatException ex) {
+			return 0;
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/FBNetworkImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/FBNetworkImporter.java
@@ -243,7 +243,7 @@ class FBNetworkImporter extends CommonElementImporter {
 		});
 	}
 
-	private <T extends Connection> T parseConnection(final EClass conType)
+	protected <T extends Connection> T parseConnection(final EClass conType)
 			throws XMLStreamException, TypeImportException {
 		final ConnectionBuilder<T> builder = ConnectionHelper.createConnectionBuilder(conType, this);
 		builder.validate();

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/ResDevFBNetworkImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/ResDevFBNetworkImporter.java
@@ -15,10 +15,17 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.model.dataimport;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+
+import javax.xml.stream.XMLStreamException;
 
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.fordiac.ide.model.dataimport.ConnectionHelper.ConnectionBuilder;
+import org.eclipse.fordiac.ide.model.dataimport.exceptions.TypeImportException;
+import org.eclipse.fordiac.ide.model.libraryElement.Connection;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
@@ -27,6 +34,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 class ResDevFBNetworkImporter extends SubAppNetworkImporter {
 
 	private final EList<VarDeclaration> varInputs;
+	private final List<ConnectionBuilder<Connection>> brokenConnections = new ArrayList<>();
 
 	ResDevFBNetworkImporter(final CommonElementImporter importer, final EList<VarDeclaration> varInputs) {
 		super(importer);
@@ -37,6 +45,10 @@ class ResDevFBNetworkImporter extends SubAppNetworkImporter {
 			final EList<VarDeclaration> varInputs, final Map<String, FBNetworkElement> fbNetworkElementMap) {
 		super(importer, fbNetwork, fbNetworkElementMap);
 		this.varInputs = varInputs;
+	}
+
+	public List<ConnectionBuilder<Connection>> getBrokenConnections() {
+		return brokenConnections;
 	}
 
 	@Override
@@ -61,6 +73,24 @@ class ResDevFBNetworkImporter extends SubAppNetworkImporter {
 		super.addFBNetworkElement(element);
 		// update name to the correct short one
 		element.setName(name);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	protected <T extends Connection> T parseConnection(final EClass conType)
+			throws XMLStreamException, TypeImportException {
+		final ConnectionBuilder<T> builder = ConnectionHelper.createConnectionBuilder(conType, this);
+		builder.validate();
+
+		if (builder.isMissingConnectionDestination() || builder.isMissingConnectionSource()) {
+			// potential connection to a mapped fb, store for retry after mapping
+			// information is created
+			brokenConnections.add((ConnectionBuilder<Connection>) builder);
+			return null;
+		}
+
+		builder.handleErrorCases();
+		return builder.getConnection();
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/ResDevFBNetworkImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/ResDevFBNetworkImporter.java
@@ -40,7 +40,7 @@ class ResDevFBNetworkImporter extends SubAppNetworkImporter {
 	}
 
 	@Override
-	protected IInterfaceElement getContainingInterfaceElement(final String interfaceElement, final EClass conType,
+	IInterfaceElement getContainingInterfaceElement(final String interfaceElement, final EClass conType,
 			final boolean isInput) {
 		for (final VarDeclaration inVar : varInputs) {
 			if (inVar.getName().equals(interfaceElement)) {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/SystemImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/SystemImporter.java
@@ -521,7 +521,7 @@ public class SystemImporter extends CommonElementImporter {
 		final Connection resCon = EcoreUtil.copy(con);
 		resCon.setSource(srcResFB.getOutput(con.getSource().getName()));
 		resCon.setDestination(dstResFB.getInput(con.getDestination().getName()));
-		return con;
+		return resCon;
 	}
 
 }


### PR DESCRIPTION
In order to make the ConnectionBuilder better maintainable and allow it to be used for creating mapped to unmapped FB connections all connection parsing, creation, and checking code is moved to the ConnectionBuilder.