### PR TITLE
Disable QuickDiff for embedded Xtext editor tabs

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editors/FBTypeXtextEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editors/FBTypeXtextEditor.java
@@ -216,6 +216,11 @@ public abstract class FBTypeXtextEditor extends XtextEditor implements IFBTEdito
 	}
 
 	@Override
+	protected boolean isPrefQuickDiffAlwaysOn() {
+		return false;
+	}
+
+	@Override
 	public Object getSelectableObject() {
 		return null;
 	}


### PR DESCRIPTION
This disables QuickDiff for embedded Xtext editor tabs, since it currently shows bogus results, without having to disable it globally for the entire workspace.