### PR TITLE
Internal Attributes should not be shown in trees

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/AdapterDeclarationItemProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/AdapterDeclarationItemProvider.java
@@ -345,4 +345,8 @@ public class AdapterDeclarationItemProvider extends ItemProviderAdapter implemen
 		return FordiacEditPlugin.INSTANCE;
 	}
 
+	@Override
+	public Collection<?> getChildren(Object object) {
+		return AttributeItemProviderAnnotation.filterInternalAttributes(super.getChildren(object));
+	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/ApplicationItemProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/ApplicationItemProvider.java
@@ -255,4 +255,8 @@ public class ApplicationItemProvider
 		return FordiacEditPlugin.INSTANCE;
 	}
 
+	@Override
+	public Collection<?> getChildren(Object object) {
+		return AttributeItemProviderAnnotation.filterInternalAttributes(super.getChildren(object));
+	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/AttributeDeclarationItemProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/AttributeDeclarationItemProvider.java
@@ -266,4 +266,8 @@ public class AttributeDeclarationItemProvider extends ItemProviderAdapter implem
 		return FordiacEditPlugin.INSTANCE;
 	}
 
+	@Override
+	public Collection<?> getChildren(Object object) {
+		return AttributeItemProviderAnnotation.filterInternalAttributes(super.getChildren(object));
+	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/ConfigurableObjectItemProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/ConfigurableObjectItemProvider.java
@@ -176,4 +176,8 @@ public class ConfigurableObjectItemProvider
 		return FordiacEditPlugin.INSTANCE;
 	}
 
+	@Override
+	public Collection<?> getChildren(Object object) {
+		return AttributeItemProviderAnnotation.filterInternalAttributes(super.getChildren(object));
+	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/ErrorMarkerInterfaceItemProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/ErrorMarkerInterfaceItemProvider.java
@@ -333,4 +333,8 @@ public class ErrorMarkerInterfaceItemProvider
 		return FordiacEditPlugin.INSTANCE;
 	}
 
+	@Override
+	public Collection<?> getChildren(Object object) {
+		return AttributeItemProviderAnnotation.filterInternalAttributes(super.getChildren(object));
+	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/EventItemProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/EventItemProvider.java
@@ -332,4 +332,8 @@ public class EventItemProvider
 		return FordiacEditPlugin.INSTANCE;
 	}
 
+	@Override
+	public Collection<?> getChildren(Object object) {
+		return AttributeItemProviderAnnotation.filterInternalAttributes(super.getChildren(object));
+	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/LibraryElementItemProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/LibraryElementItemProvider.java
@@ -258,4 +258,8 @@ public class LibraryElementItemProvider
 		return FordiacEditPlugin.INSTANCE;
 	}
 
+	@Override
+	public Collection<?> getChildren(Object object) {
+		return AttributeItemProviderAnnotation.filterInternalAttributes(super.getChildren(object));
+	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/LinkItemProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/LinkItemProvider.java
@@ -277,4 +277,8 @@ public class LinkItemProvider
 		return FordiacEditPlugin.INSTANCE;
 	}
 
+	@Override
+	public Collection<?> getChildren(Object object) {
+		return AttributeItemProviderAnnotation.filterInternalAttributes(super.getChildren(object));
+	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/ServiceSequenceItemProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/ServiceSequenceItemProvider.java
@@ -1053,4 +1053,8 @@ public class ServiceSequenceItemProvider
 		return FordiacEditPlugin.INSTANCE;
 	}
 
+	@Override
+	public Collection<?> getChildren(Object object) {
+		return AttributeItemProviderAnnotation.filterInternalAttributes(super.getChildren(object));
+	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/TypedConfigureableObjectItemProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/TypedConfigureableObjectItemProvider.java
@@ -36,9 +36,10 @@ import org.eclipse.emf.edit.provider.ITreeItemContentProvider;
 import org.eclipse.emf.edit.provider.ItemPropertyDescriptor;
 import org.eclipse.emf.edit.provider.ItemProviderAdapter;
 import org.eclipse.emf.edit.provider.ViewerNotification;
-
+import org.eclipse.fordiac.ide.model.data.InternalDataType;
 import org.eclipse.fordiac.ide.model.data.provider.FordiacEditPlugin;
-
+import org.eclipse.fordiac.ide.model.datatype.helper.InternalAttributeDeclarations;
+import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.libraryElement.TypedConfigureableObject;
 
@@ -255,4 +256,9 @@ public class TypedConfigureableObjectItemProvider
 		return FordiacEditPlugin.INSTANCE;
 	}
 
+	@Override
+	public Collection<?> getChildren(Object object) {
+		return AttributeItemProviderAnnotation.filterInternalAttributes(super.getChildren(object));
+	}
+	
 }

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/VarDeclarationItemProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/VarDeclarationItemProvider.java
@@ -387,4 +387,8 @@ public class VarDeclarationItemProvider
 		return FordiacEditPlugin.INSTANCE;
 	}
 
+	@Override
+	public Collection<?> getChildren(Object object) {
+		return AttributeItemProviderAnnotation.filterInternalAttributes(super.getChildren(object));
+	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/libraryElement/provider/AttributeItemProviderAnnotation.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/libraryElement/provider/AttributeItemProviderAnnotation.java
@@ -12,6 +12,10 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.model.libraryElement.provider;
 
+import java.util.Collection;
+
+import org.eclipse.fordiac.ide.model.data.InternalDataType;
+import org.eclipse.fordiac.ide.model.datatype.helper.InternalAttributeDeclarations;
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
 
 final class AttributeItemProviderAnnotation {
@@ -23,7 +27,7 @@ final class AttributeItemProviderAnnotation {
 			return provider.getString("_UI_Attribute_type"); //$NON-NLS-1$
 		}
 
-		if (attribute.getAttributeDeclaration() != null
+		if (attribute.getAttributeDeclaration() != null && attribute.getAttributeDeclaration().getTypeEntry() != null
 				&& attribute.getAttributeDeclaration().getTypeEntry().getPackageName() != null
 				&& !attribute.getAttributeDeclaration().getTypeEntry().getPackageName().isBlank()) {
 			label += " [" + attribute.getAttributeDeclaration().getTypeEntry().getPackageName() + "]"; //$NON-NLS-1$ //$NON-NLS-2$
@@ -38,6 +42,18 @@ final class AttributeItemProviderAnnotation {
 		}
 
 		return label;
+	}
+
+	public static Collection<?> filterInternalAttributes(final Collection<?> children) {
+		return children.stream().filter(obj -> !isInternalAttribute(obj)).toList();
+	}
+
+	private static boolean isInternalAttribute(final Object obj) {
+		if (!(obj instanceof final Attribute att)) {
+			return false;
+		}
+		return (att.getType() instanceof InternalDataType)
+				|| InternalAttributeDeclarations.isInternalAttribue(att.getAttributeDeclaration());
 	}
 
 	private AttributeItemProviderAnnotation() {


### PR DESCRIPTION
Any UI Element showing a list of attributes from our model that is using the EMF generated ItemProviders shouldn't show any internal attributes to the user. Unfortunately this can only be done by filtering the children in the getChildren method.