### PR TITLE
Fix conversion of prefixed values in structs and arrays

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/Messages.java
@@ -20,6 +20,8 @@ import org.eclipse.osgi.util.NLS;
 public final class Messages extends NLS {
 	private static final String BUNDLE_NAME = "org.eclipse.fordiac.ide.model.messages"; //$NON-NLS-1$
 
+	public static String ArrayValueConverter_IllegalElementValue;
+
 	public static String ArrayValueConverter_InvalidRepeatSyntax;
 
 	public static String CommonElementImporter_ERROR_DeclarationNotSet;
@@ -104,7 +106,11 @@ public final class Messages extends NLS {
 	public static String LinkConstraints_STATUSMessage_IN_IN_OUT_OUT_notAllowed;
 	public static String LinkConstraints_STATUSMessage_NotCompatible;
 	public static String NameRepository_NameAlreadyExists;
+	public static String StructValueConverter_IllegalMemberValue;
+
 	public static String StructValueConverter_InvalidStructLiteral;
+
+	public static String StructValueConverter_NoValueConverter;
 	public static String TypedElementAnnotations_TypeNotFound;
 	public static String TypedElementAnnotations_TypeNotSet;
 	public static String TypeLibrary_TypeExists;

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/messages.properties
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/messages.properties
@@ -11,6 +11,7 @@
  #  Gerhard Ebenhofer, Alois Zoitl
  #    - initial API and implementation and/or initial documentation
  ################################################################################
+ArrayValueConverter_IllegalElementValue=Illegal value for element at index {0}
 ArrayValueConverter_InvalidRepeatSyntax=Invalid array repeat syntax
 CommonElementImporter_ERROR_DeclarationNotSet=Declaration not set
 CommonElementImporter_ERROR_MissingAuthorInfo=Author missing
@@ -87,7 +88,9 @@ LinkConstraints_STATUSMessage_hasAlreadyOutputConnection={0} has already an outp
 LinkConstraints_STATUSMessage_IN_IN_OUT_OUT_notAllowed=Input - Input or Output - Output connections are not allowed\!
 LinkConstraints_STATUSMessage_NotCompatible={0} not compatible with {1}
 NameRepository_NameAlreadyExists=Element with Name: {0} already exists\!
+StructValueConverter_IllegalMemberValue=Illegal value for member ''{0}''
 StructValueConverter_InvalidStructLiteral=Invalid struct literal
+StructValueConverter_NoValueConverter=No value converter for member ''{0}''
 TypedElementAnnotations_TypeNotFound=Type ''{0}'' not found
 TypedElementAnnotations_TypeNotSet=Type is not set
 TypeLibrary_TypeExists=A type with name ''{0}'' already exists

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/BoolValueConverter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/BoolValueConverter.java
@@ -42,7 +42,7 @@ public final class BoolValueConverter implements ValueConverter<Boolean> {
 
 	@Override
 	public Boolean toValue(final Scanner scanner) throws IllegalArgumentException {
-		return toValue(scanner.findWithinHorizon(SCANNER_PATTERN, 0));
+		return toValue(scanner, SCANNER_PATTERN);
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/DateAndTimeValueConverter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/DateAndTimeValueConverter.java
@@ -59,7 +59,7 @@ public final class DateAndTimeValueConverter implements ValueConverter<LocalDate
 	@Override
 	public LocalDateTime toValue(final Scanner scanner)
 			throws IllegalArgumentException, NoSuchElementException, IllegalStateException {
-		return toValue(scanner.findWithinHorizon(SCANNER_PATTERN, 0));
+		return toValue(scanner, SCANNER_PATTERN);
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/DateValueConverter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/DateValueConverter.java
@@ -42,7 +42,7 @@ public final class DateValueConverter implements ValueConverter<LocalDate> {
 
 	@Override
 	public LocalDate toValue(final Scanner scanner) throws IllegalArgumentException {
-		return toValue(scanner.findWithinHorizon(SCANNER_PATTERN, 0));
+		return toValue(scanner, SCANNER_PATTERN);
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/NumericValueConverter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/NumericValueConverter.java
@@ -78,7 +78,7 @@ public final class NumericValueConverter implements ValueConverter<Object> {
 
 	@Override
 	public Object toValue(final Scanner scanner) throws IllegalArgumentException {
-		return toValue(scanner.findWithinHorizon(SCANNER_PATTERN, 0));
+		return toValue(scanner, SCANNER_PATTERN);
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/StructValueConverter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/StructValueConverter.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.fordiac.ide.model.value;
 
+import java.text.MessageFormat;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
@@ -52,7 +53,16 @@ public class StructValueConverter implements ValueConverter<Map<String, Object>>
 			}
 			final String name = scanner.match().group(1);
 			final ValueConverter<?> converter = memberValueConverter.apply(name);
-			result.put(name, converter.toValue(scanner));
+			if (converter == null) {
+				throw new IllegalArgumentException(
+						MessageFormat.format(Messages.StructValueConverter_NoValueConverter, name));
+			}
+			try {
+				result.put(name, converter.toValue(scanner));
+			} catch (final IllegalArgumentException e) {
+				throw new IllegalArgumentException(
+						MessageFormat.format(Messages.StructValueConverter_IllegalMemberValue, name), e);
+			}
 		} while (scanner.findWithinHorizon(STRUCT_SEPARATOR_PATTERN, 0) != null);
 		if (scanner.findWithinHorizon(STRUCT_END_PATTERN, 0) == null) {
 			throw new IllegalArgumentException(Messages.StructValueConverter_InvalidStructLiteral);

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/TimeOfDayValueConverter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/TimeOfDayValueConverter.java
@@ -64,7 +64,7 @@ public final class TimeOfDayValueConverter implements ValueConverter<LocalTime> 
 	@Override
 	public LocalTime toValue(final Scanner scanner)
 			throws IllegalArgumentException, NoSuchElementException, IllegalStateException {
-		return toValue(scanner.findWithinHorizon(SCANNER_PATTERN, 0));
+		return toValue(scanner, SCANNER_PATTERN);
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/TimeValueConverter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/TimeValueConverter.java
@@ -110,7 +110,7 @@ public final class TimeValueConverter implements ValueConverter<Duration> {
 	@Override
 	public Duration toValue(final Scanner scanner)
 			throws IllegalArgumentException, NoSuchElementException, IllegalStateException {
-		return toValue(scanner.findWithinHorizon(SCANNER_PATTERN, 0));
+		return toValue(scanner, SCANNER_PATTERN);
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/ValueConverter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/ValueConverter.java
@@ -12,10 +12,14 @@
  */
 package org.eclipse.fordiac.ide.model.value;
 
+import java.text.MessageFormat;
 import java.util.Objects;
 import java.util.Scanner;
+import java.util.regex.Pattern;
 
 public interface ValueConverter<T> {
+	Pattern ANY_PATTERN = Pattern.compile(".*", Pattern.DOTALL); //$NON-NLS-1$
+
 	default String toString(final T value) {
 		return Objects.toString(value).toUpperCase();
 	}
@@ -23,4 +27,13 @@ public interface ValueConverter<T> {
 	T toValue(String string) throws IllegalArgumentException;
 
 	T toValue(Scanner scanner) throws IllegalArgumentException;
+
+	default T toValue(final Scanner scanner, final Pattern pattern) throws IllegalArgumentException {
+		final String string = scanner.findWithinHorizon(pattern, 0);
+		if (string == null) {
+			throw new IllegalArgumentException(
+					MessageFormat.format("Invalid value: {0}", scanner.findWithinHorizon(ANY_PATTERN, 0))); //$NON-NLS-1$
+		}
+		return toValue(string);
+	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/ValueConverterFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/ValueConverterFactory.java
@@ -35,6 +35,7 @@ import org.eclipse.fordiac.ide.model.data.WordType;
 import org.eclipse.fordiac.ide.model.data.WstringType;
 import org.eclipse.fordiac.ide.model.datatype.helper.TypeDeclarationParser;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.typelibrary.DataTypeLibrary;
 
 public final class ValueConverterFactory {
 	public static ValueConverter<?> createValueConverter(final DataType type) {
@@ -56,9 +57,11 @@ public final class ValueConverterFactory {
 		case final LtodType unused -> TimeOfDayValueConverter.INSTANCE;
 		case final DateAndTimeType unused -> DateAndTimeValueConverter.INSTANCE;
 		case final LdtType unused -> DateAndTimeValueConverter.INSTANCE;
-		case final ArrayType arrayType -> new ArrayValueConverter<>(createValueConverter(getElementType(arrayType)));
+		case final ArrayType arrayType -> new ArrayValueConverter<>(
+				new TypedValueConverter(getElementType(arrayType), getDataTypeLibrary(arrayType)));
 		case final StructuredType structuredType ->
-			new StructValueConverter(name -> createValueConverter(getMemberType(structuredType, name)));
+			new StructValueConverter(name -> new TypedValueConverter(getMemberType(structuredType, name),
+					getDataTypeLibrary(structuredType)));
 		case null, default -> null;
 		};
 	}
@@ -79,6 +82,10 @@ public final class ValueConverterFactory {
 			return TypeDeclarationParser.parseTypeDeclaration(member.getType(), member.getArraySize().getValue());
 		}
 		return member.getType();
+	}
+
+	private static DataTypeLibrary getDataTypeLibrary(final DataType type) {
+		return type.getTypeLibrary() != null ? type.getTypeLibrary().getDataTypeLibrary() : null;
 	}
 
 	private ValueConverterFactory() {

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/value/TypedValueConverterTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/value/TypedValueConverterTest.java
@@ -132,8 +132,35 @@ class TypedValueConverterTest {
 		assertEquals(Map.of("a", BigInteger.valueOf(17), "b", "test"),
 				new TypedValueConverter(structType).toValue("(a:=17,b:='test')"));
 		assertEquals(Map.of("a", BigInteger.valueOf(17), "b", "test"),
+				new TypedValueConverter(structType).toValue("(a:=DINT#17,b:=STRING#'test')"));
+		assertEquals(Map.of("a", BigInteger.valueOf(17), "b", "test"),
 				new TypedValueConverter(GenericTypes.ANY, typeLibrary.getDataTypeLibrary())
 						.toValue("TestStruct#(a:=17,b:='test')"));
+	}
+
+	@Test
+	void toValueTimeStructTest() {
+		final StructuredType structType = DataFactory.eINSTANCE.createStructuredType();
+		structType.setName("TimeTestStruct");
+		structType.getMemberVariables().add(createVarDeclaration("a", ElementaryTypes.TIME));
+		structType.getMemberVariables().add(createVarDeclaration("b", ElementaryTypes.DATE));
+		structType.getMemberVariables().add(createVarDeclaration("c", ElementaryTypes.TIME_OF_DAY));
+		structType.getMemberVariables().add(createVarDeclaration("d", ElementaryTypes.DATE_AND_TIME));
+		typeLibrary.addTypeEntry(new DataTypeEntryMock(structType, typeLibrary, null));
+		assertEquals(Map.of(//
+				"a", Duration.ofDays(17).plusMinutes(4).plusSeconds(21), //
+				"b", LocalDate.of(2017, 04, 21), //
+				"c", LocalTime.of(21, 04, 17), //
+				"d", LocalDateTime.of(2017, 04, 21, 21, 04, 17)//
+		), new TypedValueConverter(structType)
+				.toValue("(a:=T#17d4m21s,b:=D#2017-04-21,c:=TOD#21:04:17,d:=DT#2017-04-21-21:04:17)"));
+		assertEquals(Map.of(//
+				"a", Duration.ofDays(17).plusMinutes(4).plusSeconds(21), //
+				"b", LocalDate.of(2017, 04, 21), //
+				"c", LocalTime.of(21, 04, 17), //
+				"d", LocalDateTime.of(2017, 04, 21, 21, 04, 17)//
+		), new TypedValueConverter(GenericTypes.ANY, typeLibrary.getDataTypeLibrary())
+				.toValue("TimeTestStruct#(a:=T#17d4m21s,b:=D#2017-04-21,c:=TOD#21:04:17,d:=DT#2017-04-21-21:04:17)"));
 	}
 
 	public static VarDeclaration createVarDeclaration(final String name, final DataType type) {

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/value/ValueConverterTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/value/ValueConverterTest.java
@@ -142,7 +142,11 @@ class ValueConverterTest {
 										unused -> new ArrayValueConverter<>(StringValueConverter.INSTANCE))),
 						named("{a=[abc, ab,xy, ab,',xy], b=[test, value]}",
 								Map.of("a", List.of("abc", "ab,xy", "ab,',xy"), "b", List.of("test", "value"))),
-						"(a:=['abc','ab,xy','ab,$',xy'],b:=['test','value'])")//
+						"(a:=['abc','ab,xy','ab,$',xy'],b:=['test','value'])"), //
+				arguments(
+						named("StructValueConverter [NumericValueConverter]",
+								new StructValueConverter(unused -> NumericValueConverter.INSTANCE)),
+						IllegalArgumentException.class, "(a:=invalid,b:=4)") //
 		);
 	}
 

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/value/ValueConverterTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/value/ValueConverterTest.java
@@ -25,15 +25,18 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
 import java.util.stream.Stream;
 
+import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes.ElementaryTypes;
 import org.eclipse.fordiac.ide.model.value.ArrayValueConverter;
 import org.eclipse.fordiac.ide.model.value.NumericValueConverter;
 import org.eclipse.fordiac.ide.model.value.StringValueConverter;
 import org.eclipse.fordiac.ide.model.value.StructValueConverter;
+import org.eclipse.fordiac.ide.model.value.TypedValueConverter;
 import org.eclipse.fordiac.ide.model.value.ValueConverter;
 import org.eclipse.fordiac.ide.model.value.WStringValueConverter;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -104,6 +107,9 @@ class ValueConverterTest {
 						"[2(1,2,3)]"), //
 				arguments(new ArrayValueConverter<>(StringValueConverter.INSTANCE), List.of("abc", "ab,xy", "ab,',xy"),
 						"['abc','ab,xy','ab,$',xy']"), //
+				arguments(new ArrayValueConverter<>(new TypedValueConverter(ElementaryTypes.TIME)),
+						List.of(Duration.ZERO, Duration.ofDays(17).plusMinutes(4).plusSeconds(21)),
+						"[T#0ns, T#17d4m21s]"), //
 				arguments(new ArrayValueConverter<>(NumericValueConverter.INSTANCE), IllegalArgumentException.class,
 						""), //
 				arguments(new ArrayValueConverter<>(NumericValueConverter.INSTANCE), IllegalArgumentException.class,
@@ -124,6 +130,12 @@ class ValueConverterTest {
 								new StructValueConverter(unused -> StringValueConverter.INSTANCE)),
 						named("{a=ab,xy, b=ab,',xy}", Map.of("a", "ab,xy", "b", "ab,',xy")),
 						"(a:='ab,xy',b:='ab,$',xy')"), //
+				arguments(
+						named("StructValueConverter [TimeValueConverter]",
+								new StructValueConverter(unused -> new TypedValueConverter(ElementaryTypes.TIME))),
+						named("{a=T#0ns, b=T#17d4m21.42s}",
+								Map.of("a", Duration.ZERO, "b", Duration.ofDays(17).plusMinutes(4).plusSeconds(21))),
+						"(a:=T#0ns, b:=T#17d4m21s)"), //
 				arguments(
 						named("StructValueConverter [ArrayValueConverter [StringValueConverter]]",
 								new StructValueConverter(
@@ -185,6 +197,9 @@ class ValueConverterTest {
 				arguments(new ArrayValueConverter<>(NumericValueConverter.INSTANCE), "[TRUE, 4, 21, 3.14159]",
 						List.of(Boolean.TRUE, BigInteger.valueOf(4), BigInteger.valueOf(21),
 								BigDecimal.valueOf(3.14159))), //
+				arguments(new ArrayValueConverter<>(new TypedValueConverter(ElementaryTypes.TIME)),
+						"[T#0s, T#17d4m21s]",
+						List.of(Duration.ZERO, Duration.ofDays(17).plusMinutes(4).plusSeconds(21))), //
 				arguments(
 						named("StructValueConverter [NumericValueConverter]",
 								new StructValueConverter(unused -> NumericValueConverter.INSTANCE)),
@@ -195,6 +210,12 @@ class ValueConverterTest {
 								new StructValueConverter(unused -> StringValueConverter.INSTANCE)),
 						"(a := 'ab,xy', b := 'ab,$',xy')",
 						named("{a=ab,xy, b=ab,',xy}", Map.of("a", "ab,xy", "b", "ab,',xy"))), //
+				arguments(
+						named("StructValueConverter [TimeValueConverter]",
+								new StructValueConverter(unused -> new TypedValueConverter(ElementaryTypes.TIME))),
+						"(a := T#0s, b := T#17d4m21s)",
+						named("{a=T#0ns, b=T#17d4m21s}",
+								Map.of("a", Duration.ZERO, "b", Duration.ofDays(17).plusMinutes(4).plusSeconds(21)))), //
 				arguments(
 						named("StructValueConverter [ArrayValueConverter [StringValueConverter]]",
 								new StructValueConverter(


### PR DESCRIPTION
The conversion of values in structs and arrays did not properly handle the required type prefix (e.g., `T#` or `DATE#`) or any optional type prefix (e.g., `BOOL#TRUE`). This uses the typed value converter with created array and struct value converters to handle both required and optional type prefixes.

Also fix error handling in value converters to avoid NPE if a value cannot be found with the scanner for the specific pattern and also improve error messages during array and struct parsing.