### PR TITLE
Refactor result and expected types in ST editor

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/ExpressionAnnotations.xtend
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/ExpressionAnnotations.xtend
@@ -94,19 +94,14 @@ final package class ExpressionAnnotations {
 							ElementaryTypes.TIME
 						else if (left instanceof AnyDateType && right instanceof AnyDateType)
 							ElementaryTypes.LTIME
-						else if (left.isAssignableFrom(right))
-							left
-						else if (right.isAssignableFrom(left))
-							right
+						else if (left instanceof AnyDurationType && right instanceof AnyDurationType)
+							left.commonSupertype(right)
 						else
-							null
-					} else if (expr.op.logical || expr.op.range) {
-						if (left.isAssignableFrom(right))
-							left
-						else if (right.isAssignableFrom(left))
-							right
-						else
-							null
+							left.commonSupertype(right).equivalentAnyNumType
+					} else if (expr.op.logical) {
+						left.commonSupertype(right).equivalentAnyBitType
+					} else if (expr.op.range) {
+						left.commonSupertype(right)
 					} else
 						null
 				} else if (declared)
@@ -471,5 +466,18 @@ final package class ExpressionAnnotations {
 					second
 			}
 		}
+	}
+
+	def package static DataType commonSupertype(DataType first, DataType second) {
+		if (first === null)
+			second
+		else if (second === null)
+			first
+		else if (first.isAssignableFrom(second))
+			first
+		else if (second.isAssignableFrom(first))
+			second
+		else
+			null
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/ExpressionAnnotations.xtend
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/ExpressionAnnotations.xtend
@@ -206,7 +206,7 @@ final package class ExpressionAnnotations {
 	}
 
 	def package static INamedElement getResultType(STNumericLiteral expr) {
-		getDeclaredResultType(expr) ?: switch (result : expr.expectedType) {
+		expr.type ?: switch (result : expr.expectedType) {
 			DataType case result.isNumericValueValid(expr.value):
 				result
 			AnyUnsignedType:
@@ -227,7 +227,13 @@ final package class ExpressionAnnotations {
 				}
 			default:
 				null
-		} ?: switch (it : expr.value) {
+		} ?: getValueType(expr)
+	}
+
+	def package static INamedElement getDeclaredResultType(STNumericLiteral expr) { expr.type ?: getValueType(expr) }
+
+	def package static INamedElement getValueType(STNumericLiteral expr) {
+		switch (it : expr.value) {
 			Boolean: ElementaryTypes.BOOL
 			BigDecimal: ElementaryTypes.LREAL
 			BigInteger case checkRange(Byte.MIN_VALUE, Byte.MAX_VALUE): ElementaryTypes.SINT
@@ -238,8 +244,6 @@ final package class ExpressionAnnotations {
 			default: null
 		}
 	}
-
-	def package static INamedElement getDeclaredResultType(STNumericLiteral expr) { expr.type }
 
 	def package static INamedElement getResultType(STDateLiteral expr) { getDeclaredResultType(expr) }
 
@@ -258,17 +262,21 @@ final package class ExpressionAnnotations {
 	def package static INamedElement getDeclaredResultType(STDateAndTimeLiteral expr) { expr.type }
 
 	def package static INamedElement getResultType(STStringLiteral expr) {
-		getDeclaredResultType(expr) ?: switch (result : expr.expectedType) {
+		expr.type ?: switch (result : expr.expectedType) {
 			DataType case result.isStringValueValid(expr.value): result
 			default: null
-		} ?: if (expr.value.length == 1) {
+		} ?: getValueType(expr)
+	}
+
+	def package static INamedElement getDeclaredResultType(STStringLiteral expr) { expr.type ?: getValueType(expr) }
+
+	def package static INamedElement getValueType(STStringLiteral expr) {
+		if (expr.value.length == 1) {
 			if(expr.value.wide) ElementaryTypes.WCHAR else ElementaryTypes.CHAR
 		} else {
 			if(expr.value.wide) ElementaryTypes.WSTRING else ElementaryTypes.STRING
 		}
 	}
-
-	def package static INamedElement getDeclaredResultType(STStringLiteral expr) { expr.type }
 
 	def package static INamedElement getResultType(STCallUnnamedArgument arg) { arg.argument?.resultType }
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/util/STCoreUtil.xtend
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/util/STCoreUtil.xtend
@@ -87,7 +87,6 @@ import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCallNamedOutputArgume
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCallUnnamedArgument
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCaseCases
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCoreFactory
-import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpression
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpressionSource
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STFeatureExpression
@@ -404,7 +403,7 @@ final class STCoreUtil {
 	def private static INamedElement computeExpectedType(STCallArgument argument) {
 		val featureExpression = argument.eContainer
 		if (featureExpression instanceof STFeatureExpression) {
-			val feature = featureExpression.featureNoresolve
+			val feature = featureExpression.feature
 			if (feature instanceof STStandardFunction) {
 				val expectedReturnType = switch (type: featureExpression.expectedType) { DataType: type }
 				val index = featureExpression.parameters.indexOf(argument)
@@ -414,29 +413,25 @@ final class STCoreUtil {
 						index)
 				}
 			} else {
-				argument.parameterNoresolve.featureType
+				argument.parameter.featureType
 			}
 		}
 	}
 
-	def package static dispatch getParameterNoresolve(STCallNamedInputArgument argument) {
-		switch (target : argument.eGet(STCorePackage.eINSTANCE.STCallNamedInputArgument_Parameter, false)) {
-			INamedElement case !target.eIsProxy: target
-		}
+	def package static dispatch getParameter(STCallNamedInputArgument argument) {
+		argument.parameter
 	}
 
-	def package static dispatch getParameterNoresolve(STCallNamedOutputArgument argument) {
-		switch (target : argument.eGet(STCorePackage.eINSTANCE.STCallNamedOutputArgument_Parameter, false)) {
-			INamedElement case !target.eIsProxy: target
-		}
+	def package static dispatch getParameter(STCallNamedOutputArgument argument) {
+		argument.parameter
 	}
 
-	def package static dispatch getParameterNoresolve(STCallUnnamedArgument argument) {
+	def package static dispatch getParameter(STCallUnnamedArgument argument) {
 		val featureExpression = argument.eContainer
 		if (featureExpression instanceof STFeatureExpression) {
 			val index = featureExpression.parameters.indexOf(argument)
 			if (index >= 0) {
-				val feature = featureExpression.featureNoresolve
+				val feature = featureExpression.feature
 				if (feature instanceof ICallable) {
 					val inputParameters = feature.inputParameters
 					val outputParameters = feature.outputParameters
@@ -451,12 +446,6 @@ final class STCoreUtil {
 						outputParameters.get(index - inputParameters.size - inOutParameters.size)
 				}
 			}
-		}
-	}
-
-	def package static getFeatureNoresolve(STFeatureExpression expr) {
-		switch (feature : expr.eGet(STCorePackage.eINSTANCE.STFeatureExpression_Feature, false)) {
-			INamedElement case !feature.eIsProxy: feature
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/codemining/STCoreCodeMiningProvider.xtend
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/codemining/STCoreCodeMiningProvider.xtend
@@ -65,7 +65,7 @@ class STCoreCodeMiningProvider extends AbstractXtextCodeMiningProvider {
 
 	def dispatch void createCodeMinings(STNumericLiteral literal, IDocument document,
 		IAcceptor<? super ICodeMining> acceptor) throws BadLocationException {
-		if (isEnableLiteralTypeCodeMinings && literal.declaredResultType === null &&
+		if (isEnableLiteralTypeCodeMinings && literal.type === null &&
 			literal.showLiteralTypeCodeMining) {
 			val inferredType = literal.resultType
 			if (inferredType !== null) {
@@ -82,7 +82,7 @@ class STCoreCodeMiningProvider extends AbstractXtextCodeMiningProvider {
 
 	def dispatch void createCodeMinings(STStringLiteral literal, IDocument document,
 		IAcceptor<? super ICodeMining> acceptor) throws BadLocationException {
-		if (isEnableLiteralTypeCodeMinings && literal.declaredResultType === null &&
+		if (isEnableLiteralTypeCodeMinings && literal.type === null &&
 			literal.showLiteralTypeCodeMining) {
 			val inferredType = literal.resultType
 			if (inferredType !== null) {

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/scoping/STCoreLinkingDiagnosticMessageProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/scoping/STCoreLinkingDiagnosticMessageProvider.java
@@ -42,7 +42,7 @@ public class STCoreLinkingDiagnosticMessageProvider extends LinkingDiagnosticMes
 			final var receiverType = getReceiverType(context);
 			if (context.getContext() instanceof final STFeatureExpression expression && expression.isCall()) {
 				final List<INamedElement> argumentTypes = expression.getParameters().stream()
-						.map(STCallArgument::getResultType).toList();
+						.map(STCallArgument::getDeclaredResultType).toList();
 				return createCallableDiagnosticMessage(context, argumentTypes, receiverType);
 			}
 			return createVariableDiagnosticMessage(context, receiverType);
@@ -77,32 +77,38 @@ public class STCoreLinkingDiagnosticMessageProvider extends LinkingDiagnosticMes
 	}
 
 	protected static DiagnosticMessage createDataTypeDiagnosticMessage(final ILinkingDiagnosticContext context) {
-		return new DiagnosticMessage(MessageFormat.format(Messages.STCoreLinkingDiagnosticMessageProvider_UndefinedDataType, context.getLinkText()),
+		return new DiagnosticMessage(MessageFormat
+				.format(Messages.STCoreLinkingDiagnosticMessageProvider_UndefinedDataType, context.getLinkText()),
 				Severity.ERROR, Diagnostic.LINKING_DIAGNOSTIC);
 	}
 
 	protected static DiagnosticMessage createVariableDiagnosticMessage(final ILinkingDiagnosticContext context,
 			final INamedElement type) {
 		if (type != null && !type.eIsProxy()) {
-			return new DiagnosticMessage(MessageFormat.format(Messages.STCoreLinkingDiagnosticMessageProvider_UndefinedVariableForType,
-					context.getLinkText(), type.getQualifiedName()), Severity.ERROR, Diagnostic.LINKING_DIAGNOSTIC);
+			return new DiagnosticMessage(
+					MessageFormat.format(Messages.STCoreLinkingDiagnosticMessageProvider_UndefinedVariableForType,
+							context.getLinkText(), type.getQualifiedName()),
+					Severity.ERROR, Diagnostic.LINKING_DIAGNOSTIC);
 		}
-		return new DiagnosticMessage(MessageFormat.format(Messages.STCoreLinkingDiagnosticMessageProvider_UndefinedVariable, context.getLinkText()),
+		return new DiagnosticMessage(MessageFormat
+				.format(Messages.STCoreLinkingDiagnosticMessageProvider_UndefinedVariable, context.getLinkText()),
 				Severity.ERROR, Diagnostic.LINKING_DIAGNOSTIC);
 	}
 
 	protected static DiagnosticMessage createCallableDiagnosticMessage(final ILinkingDiagnosticContext context,
 			final List<INamedElement> argumentTypes, final INamedElement type) {
-		final String argumentTypesString = argumentTypes.stream().map(t -> t != null ? t.getName() : Messages.STCoreLinkingDiagnosticMessageProvider_UnknownType)
+		final String argumentTypesString = argumentTypes.stream()
+				.map(t -> t != null ? t.getName() : Messages.STCoreLinkingDiagnosticMessageProvider_UnknownType)
 				.collect(Collectors.joining(", ")); //$NON-NLS-1$
 		if (type != null && !type.eIsProxy()) {
-			return new DiagnosticMessage(MessageFormat.format(Messages.STCoreLinkingDiagnosticMessageProvider_UndefinedCallableForType,
-					context.getLinkText(),
-					argumentTypesString, type.getQualifiedName()),
+			return new DiagnosticMessage(
+					MessageFormat.format(Messages.STCoreLinkingDiagnosticMessageProvider_UndefinedCallableForType,
+							context.getLinkText(), argumentTypesString, type.getQualifiedName()),
 					Severity.ERROR, Diagnostic.LINKING_DIAGNOSTIC);
 		}
 		return new DiagnosticMessage(
-				MessageFormat.format(Messages.STCoreLinkingDiagnosticMessageProvider_UndefinedCallable, context.getLinkText(), argumentTypesString),
+				MessageFormat.format(Messages.STCoreLinkingDiagnosticMessageProvider_UndefinedCallable,
+						context.getLinkText(), argumentTypesString),
 				Severity.ERROR, Diagnostic.LINKING_DIAGNOSTIC);
 	}
 
@@ -110,11 +116,12 @@ public class STCoreLinkingDiagnosticMessageProvider extends LinkingDiagnosticMes
 			final INamedElement feature) {
 		if (feature instanceof final ICallable callable && !callable.eIsProxy()) {
 			return new DiagnosticMessage(
-					MessageFormat.format(Messages.STCoreLinkingDiagnosticMessageProvider_UndefinedParameterForCallable, context.getLinkText(),
-							callable.getQualifiedName()),
+					MessageFormat.format(Messages.STCoreLinkingDiagnosticMessageProvider_UndefinedParameterForCallable,
+							context.getLinkText(), callable.getQualifiedName()),
 					Severity.ERROR, Diagnostic.LINKING_DIAGNOSTIC);
 		}
-		return new DiagnosticMessage(MessageFormat.format(Messages.STCoreLinkingDiagnosticMessageProvider_UndefinedParameter, context.getLinkText()),
+		return new DiagnosticMessage(MessageFormat
+				.format(Messages.STCoreLinkingDiagnosticMessageProvider_UndefinedParameter, context.getLinkText()),
 				Severity.ERROR, Diagnostic.LINKING_DIAGNOSTIC);
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/scoping/STCoreScopeProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/scoping/STCoreScopeProvider.java
@@ -129,7 +129,7 @@ public class STCoreScopeProvider extends AbstractSTCoreScopeProvider {
 			}
 			if (context instanceof final STFeatureExpression expression && expression.isCall()) {
 				final List<DataType> argumentTypes = expression.getParameters().stream()
-						.map(STCallArgument::getResultType).map(DataType.class::cast)
+						.map(STCallArgument::getDeclaredResultType).map(DataType.class::cast)
 						.map(type -> Objects.requireNonNullElse(type, GenericTypes.ANY)).toList();
 				return new STStandardFunctionScope(
 						filterScope(super.getScope(context, reference), this::isApplicableForFeatureReference),

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.tests/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/tests/STFunctionParsingTest.xtend=UTF-8
 encoding/<project>=UTF-8

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.tests/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/tests/TypeInferenceTest.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.tests/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/tests/TypeInferenceTest.java
@@ -1,0 +1,316 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Martin Erich Jobst
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Martin Jobst - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.structuredtextfunctioneditor.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.Collection;
+import java.util.stream.Stream;
+
+import org.eclipse.fordiac.ide.model.data.DataType;
+import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes.ElementaryTypes;
+import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes.GenericTypes;
+import org.eclipse.fordiac.ide.structuredtextcore.stcore.STAssignment;
+import org.eclipse.fordiac.ide.structuredtextcore.stcore.STBinaryExpression;
+import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCallArgument;
+import org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpression;
+import org.eclipse.fordiac.ide.structuredtextcore.stcore.STFeatureExpression;
+import org.eclipse.fordiac.ide.structuredtextcore.stcore.STStatement;
+import org.eclipse.fordiac.ide.structuredtextfunctioneditor.stfunction.STFunctionSource;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.extensions.InjectionExtension;
+import org.eclipse.xtext.testing.util.ParseHelper;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.google.inject.Inject;
+
+@SuppressWarnings("nls")
+@ExtendWith(InjectionExtension.class)
+@InjectWith(STFunctionInjectorProvider.class)
+class TypeInferenceTest {
+	@Inject
+	private ParseHelper<STFunctionSource> parseHelper;
+
+	static Stream<Arguments> testSimpleAssignment() {
+		return Stream.of(//
+				arguments("INT", "17", "INT", "SINT"), // promote to expected
+				arguments("INT", "128", "INT", "INT"), // matches expected
+				arguments("INT", "32768", "DINT", "DINT"), // larger than expected
+				// unsigned
+				arguments("UINT", "17", "UINT", "SINT"), // promote and convert to unsigned
+				arguments("UINT", "128", "UINT", "INT"), // convert to unsigned
+				arguments("UINT", "32768", "UINT", "DINT"), // would be larger than expected
+				arguments("UINT", "65536", "UDINT", "DINT"), // larger than expected
+				// bit
+				arguments("WORD", "17", "WORD", "SINT"), // promote and convert to bit
+				arguments("WORD", "128", "WORD", "INT"), // convert to bit
+				arguments("WORD", "32768", "WORD", "DINT"), // would be larger than expected
+				arguments("WORD", "65536", "DWORD", "DINT") // larger than expected
+		);
+	}
+
+	@ParameterizedTest(name = "{0} := {1};")
+	@MethodSource
+	void testSimpleAssignment(final String typeName, final String value, final String resultTypeName,
+			final String declaredResultTypeName) throws Exception {
+		final var result = parseHelper.parse("""
+					FUNCTION test
+					VAR_TEMP
+						X : %s;
+					END_VAR
+					X := %s;
+					END_FUNCTION
+				""".formatted(typeName, value));
+		final STAssignment assignment = (STAssignment) getFirstStatement(result);
+		assertEquals(getTypeByName(resultTypeName), assignment.getRight().getResultType(), "result type");
+		assertEquals(getTypeByName(declaredResultTypeName), assignment.getRight().getDeclaredResultType(),
+				"declared result type");
+	}
+
+	static Stream<Arguments> testBinaryExpression() {
+		return Stream.of(//
+				arguments("INT", "+", "17", "4", "INT", "SINT", "INT", "SINT"), // promote to expected
+				arguments("INT", "+", "128", "4", "INT", "INT", "INT", "INT"), // matches expected
+				arguments("INT", "+", "32768", "4", "DINT", "DINT", "DINT", "DINT"), // larger than expected
+				arguments("INT", "+", "17", "128", "INT", "INT", "INT", "SINT"), // 2nd matches expected
+				arguments("INT", "+", "17", "32768", "DINT", "DINT", "INT", "SINT"), // 2nd larger than expected
+				// unsigned
+				arguments("UINT", "+", "17", "4", "UINT", "SINT", "UINT", "SINT"), // promote and convert to unsigned
+				arguments("UINT", "+", "128", "4", "UINT", "INT", "UINT", "INT"), // convert to unsigned
+				arguments("UINT", "+", "32768", "4", "UINT", "DINT", "UINT", "DINT"), // would be larger than expected
+				arguments("UINT", "+", "65536", "4", "UDINT", "DINT", "UDINT", "DINT"), // larger than expected
+				arguments("UINT", "+", "17", "128", "UINT", "INT", "UINT", "SINT"), // 2nd convert to unsigned
+				arguments("UINT", "+", "17", "32768", "UINT", "DINT", "UINT", "SINT"), // 2nd would be larger
+				arguments("UINT", "+", "17", "65536", "UDINT", "DINT", "UINT", "SINT"), // 2nd larger than expected
+				// bit
+				arguments("WORD", "AND", "17", "4", "WORD", "BYTE", "WORD", "SINT"), // promote and convert to bit
+				arguments("WORD", "AND", "128", "4", "WORD", "WORD", "WORD", "INT"), // convert to bit
+				arguments("WORD", "AND", "32768", "4", "WORD", "DWORD", "WORD", "DINT"), // would be larger
+				arguments("WORD", "AND", "65536", "4", "DWORD", "DWORD", "DWORD", "DINT"), // larger than expected
+				arguments("WORD", "AND", "17", "128", "WORD", "WORD", "WORD", "SINT"), // 2nd convert to bit
+				arguments("WORD", "AND", "17", "32768", "WORD", "DWORD", "WORD", "SINT"), // 2nd would be larger
+				arguments("WORD", "AND", "17", "65536", "DWORD", "DWORD", "WORD", "SINT") // 2nd larger than expected
+		);
+	}
+
+	@ParameterizedTest(name = "{0} := {2} {1} {3};")
+	@MethodSource
+	void testBinaryExpression(final String typeName, final String operator, final String value1, final String value2,
+			final String exprResultTypeName, final String exprDeclaredResultTypeName, final String leftResultTypeName,
+			final String leftDeclaredResultTypeName) throws Exception {
+		final var result = parseHelper.parse("""
+					FUNCTION test
+					VAR_TEMP
+						X : %s;
+					END_VAR
+					X := %s %s %s;
+					END_FUNCTION
+				""".formatted(typeName, value1, operator, value2));
+		final STAssignment assignment = (STAssignment) getFirstStatement(result);
+		final STBinaryExpression expression = (STBinaryExpression) assignment.getRight();
+		assertEquals(getTypeByName(exprResultTypeName), expression.getResultType(), "expr result type");
+		assertEquals(getTypeByName(exprDeclaredResultTypeName), expression.getDeclaredResultType(),
+				"expr declared result type");
+
+		final STExpression left = expression.getLeft();
+		assertEquals(getTypeByName(leftResultTypeName), left.getResultType(), "left result type");
+		assertEquals(getTypeByName(leftDeclaredResultTypeName), left.getDeclaredResultType(),
+				"left declared result type");
+	}
+
+	static Stream<Arguments> testStandardFunctionCall() {
+		return Stream.of(//
+				arguments("INT", "ADD", "17", "4", "INT", "SINT", "INT", "SINT"), // promote to expected
+				arguments("INT", "ADD", "128", "4", "INT", "INT", "INT", "INT"), // matches expected
+				arguments("INT", "ADD", "32768", "4", "DINT", "DINT", "DINT", "DINT"), // larger than expected
+				arguments("INT", "ADD", "17", "128", "INT", "INT", "INT", "SINT"), // 2nd matches expected
+				arguments("INT", "ADD", "17", "32768", "DINT", "DINT", "INT", "SINT"), // 2nd larger than expected
+				// unsigned
+				arguments("UINT", "ADD", "17", "4", "UINT", "SINT", "UINT", "SINT"), // promote and convert to unsigned
+				arguments("UINT", "ADD", "128", "4", "UINT", "INT", "UINT", "INT"), // convert to unsigned
+				arguments("UINT", "ADD", "32768", "4", "UINT", "DINT", "UINT", "DINT"), // would be larger than expected
+				arguments("UINT", "ADD", "65536", "4", "UDINT", "DINT", "UDINT", "DINT"), // larger than expected
+				arguments("UINT", "ADD", "17", "128", "UINT", "INT", "UINT", "SINT"), // 2nd convert to unsigned
+				arguments("UINT", "ADD", "17", "32768", "UINT", "DINT", "UINT", "SINT"), // 2nd would be larger
+				arguments("UINT", "ADD", "17", "65536", "UDINT", "DINT", "UINT", "SINT"), // 2nd larger than expected
+				// bit
+				arguments("WORD", "AND", "17", "4", "WORD", "ANY_BIT", "WORD", "SINT"), // promote and convert to bit
+				arguments("WORD", "AND", "128", "4", "WORD", "ANY_BIT", "WORD", "INT"), // convert to bit
+				arguments("WORD", "AND", "32768", "4", "WORD", "ANY_BIT", "WORD", "DINT"), // would be larger
+				arguments("WORD", "AND", "65536", "4", "DWORD", "ANY_BIT", "DWORD", "DINT"), // larger than expected
+				arguments("WORD", "AND", "17", "128", "WORD", "ANY_BIT", "WORD", "SINT"), // 2nd convert to bit
+				arguments("WORD", "AND", "17", "32768", "WORD", "ANY_BIT", "WORD", "SINT"), // 2nd would be larger
+				arguments("WORD", "AND", "17", "65536", "DWORD", "ANY_BIT", "WORD", "SINT") // 2nd larger than expected
+		);
+	}
+
+	@ParameterizedTest(name = "{0} := {1}({2}, {3});")
+	@MethodSource
+	void testStandardFunctionCall(final String typeName, final String function, final String value1,
+			final String value2, final String callResultTypeName, final String callDeclaredResultTypeName,
+			final String argumentResultTypeName, final String argumentDeclaredResultTypeName) throws Exception {
+		final var result = parseHelper.parse("""
+					FUNCTION test
+					VAR_TEMP
+						X : %s;
+					END_VAR
+					X := %s(%s, %s);
+					END_FUNCTION
+				""".formatted(typeName, function, value1, value2));
+		final STAssignment assignment = (STAssignment) getFirstStatement(result);
+		final STFeatureExpression call = (STFeatureExpression) assignment.getRight();
+		assertEquals(getTypeByName(callResultTypeName), call.getResultType(), "call result type");
+		assertEquals(getTypeByName(callDeclaredResultTypeName), call.getDeclaredResultType(),
+				"call declared result type");
+
+		final STCallArgument argument = call.getParameters().getFirst();
+		assertEquals(getTypeByName(argumentResultTypeName), argument.getResultType(), "arg result type");
+		assertEquals(getTypeByName(argumentDeclaredResultTypeName), argument.getDeclaredResultType(),
+				"arg declared result type");
+	}
+
+	static Stream<Arguments> testStandardFunctionCallWithBinaryExpression() {
+		return Stream.of(//
+				// promote to expected
+				arguments("INT", "ADD", "+", "17", "4", "21", //
+						"INT", "SINT", "INT", "SINT", //
+						"INT", "SINT", "INT", "SINT"),
+				// matches expected
+				arguments("INT", "ADD", "+", "128", "4", "21", //
+						"INT", "INT", "INT", "INT", //
+						"INT", "INT", "INT", "INT"),
+				// larger than expected
+				arguments("INT", "ADD", "+", "32768", "4", "21", //
+						"DINT", "DINT", "DINT", "DINT", //
+						"DINT", "DINT", "DINT", "DINT"),
+				// 2nd matches expected
+				arguments("INT", "ADD", "+", "17", "128", "21", //
+						"INT", "INT", "INT", "INT", //
+						"INT", "INT", "INT", "SINT"),
+				// 2nd larger than expected
+				arguments("INT", "ADD", "+", "17", "32768", "21", //
+						"DINT", "DINT", "DINT", "DINT", //
+						"DINT", "DINT", "INT", "SINT"),
+
+				// unsigned
+				// promote and convert to unsigned
+				arguments("UINT", "ADD", "+", "17", "4", "21", //
+						"UINT", "SINT", "UINT", "SINT", //
+						"UINT", "SINT", "UINT", "SINT"),
+				// convert to unsigned
+				arguments("UINT", "ADD", "+", "128", "4", "21", //
+						"UINT", "INT", "UINT", "INT", //
+						"UINT", "INT", "UINT", "INT"),
+				// would be larger than expected
+				arguments("UINT", "ADD", "+", "32768", "4", "21", //
+						"UINT", "DINT", "UINT", "DINT", //
+						"UINT", "DINT", "UINT", "DINT"),
+				// larger than expected
+				arguments("UINT", "ADD", "+", "65536", "4", "21", //
+						"UDINT", "DINT", "UDINT", "DINT", //
+						"UDINT", "DINT", "UDINT", "DINT"),
+				// 2nd convert to unsigned
+				arguments("UINT", "ADD", "+", "17", "128", "21", //
+						"UINT", "INT", "UINT", "INT", //
+						"UINT", "INT", "UINT", "SINT"),
+				// 2nd would be larger
+				arguments("UINT", "ADD", "+", "17", "32768", "21", //
+						"UINT", "DINT", "UINT", "DINT", //
+						"UINT", "DINT", "UINT", "SINT"),
+				// 2nd larger than expected
+				arguments("UINT", "ADD", "+", "17", "65536", "21", //
+						"UDINT", "DINT", "UDINT", "DINT", //
+						"UDINT", "DINT", "UINT", "SINT"),
+
+				// bit
+				// promote and convert to bit
+				arguments("WORD", "AND", "AND", "17", "4", "21", //
+						"WORD", "ANY_BIT", "WORD", "BYTE", //
+						"WORD", "BYTE", "WORD", "SINT"),
+				// convert to bit
+				arguments("WORD", "AND", "AND", "128", "4", "21", //
+						"WORD", "ANY_BIT", "WORD", "WORD", //
+						"WORD", "WORD", "WORD", "INT"),
+				// would be larger
+				arguments("WORD", "AND", "AND", "32768", "4", "21", //
+						"WORD", "ANY_BIT", "WORD", "DWORD", //
+						"WORD", "DWORD", "WORD", "DINT"),
+				// larger than expected
+				arguments("WORD", "AND", "AND", "65536", "4", "21", //
+						"DWORD", "ANY_BIT", "DWORD", "DWORD", //
+						"DWORD", "DWORD", "DWORD", "DINT"),
+				// 2nd convert to bit
+				arguments("WORD", "AND", "AND", "17", "128", "21", //
+						"WORD", "ANY_BIT", "WORD", "WORD", //
+						"WORD", "WORD", "WORD", "SINT"),
+				// 2nd would be larger
+				arguments("WORD", "AND", "AND", "17", "32768", "21", //
+						"WORD", "ANY_BIT", "WORD", "DWORD", //
+						"WORD", "DWORD", "WORD", "SINT"),
+				// 2nd larger than expected
+				arguments("WORD", "AND", "AND", "17", "65536", "21", //
+						"DWORD", "ANY_BIT", "DWORD", "DWORD", //
+						"DWORD", "DWORD", "WORD", "SINT"));
+	}
+
+	@ParameterizedTest(name = "{0} := {1}({3} {2} {4}, {5});")
+	@MethodSource
+	void testStandardFunctionCallWithBinaryExpression(final String typeName, final String function,
+			final String operator, final String value1, final String value2, final String value3,
+			final String callResultTypeName, final String callDeclaredResultTypeName,
+			final String argumentResultTypeName, final String argumentDeclaredResultTypeName,
+			final String exprResultTypeName, final String exprDeclaredResultTypeName, final String leftResultTypeName,
+			final String leftDeclaredResultTypeName) throws Exception {
+		final var result = parseHelper.parse("""
+					FUNCTION test
+					VAR_TEMP
+						X : %s;
+					END_VAR
+					X := %s(%s %s %s, %s);
+					END_FUNCTION
+				""".formatted(typeName, function, value1, operator, value2, value3));
+		final STAssignment assignment = (STAssignment) getFirstStatement(result);
+		final STFeatureExpression call = (STFeatureExpression) assignment.getRight();
+		assertEquals(getTypeByName(callResultTypeName), call.getResultType(), "call result type");
+		assertEquals(getTypeByName(callDeclaredResultTypeName), call.getDeclaredResultType(),
+				"call declared result type");
+
+		final STCallArgument argument = call.getParameters().getFirst();
+		assertEquals(getTypeByName(argumentResultTypeName), argument.getResultType(), "arg result type");
+		assertEquals(getTypeByName(argumentDeclaredResultTypeName), argument.getDeclaredResultType(),
+				"arg declared result type");
+
+		final STBinaryExpression expression = (STBinaryExpression) argument.getArgument();
+		assertEquals(getTypeByName(exprResultTypeName), expression.getResultType(), "expr result type");
+		assertEquals(getTypeByName(exprDeclaredResultTypeName), expression.getDeclaredResultType(),
+				"expr declared result type");
+
+		final STExpression left = expression.getLeft();
+		assertEquals(getTypeByName(leftResultTypeName), left.getResultType(), "left result type");
+		assertEquals(getTypeByName(leftDeclaredResultTypeName), left.getDeclaredResultType(),
+				"left declared result type");
+	}
+
+	private static STStatement getFirstStatement(final STFunctionSource source) {
+		return source.getFunctions().getFirst().getCode().getFirst();
+	}
+
+	private static DataType getTypeByName(final String typeName) {
+		return Stream.of(ElementaryTypes.getAllElementaryType(), GenericTypes.getAllGenericTypes())
+				.flatMap(Collection::stream).filter(type -> typeName.equals(type.getName())).findFirst().orElseThrow();
+	}
+}


### PR DESCRIPTION
There was a problem when cached expected types were based on unresolved features or parameters. It was necessary to explicitly avoid resolving call parameters or risk an infinite recursion with the scope provider. The overload resolution of standard functions would rely on the result type of arguments which may depend on the expected type again.

This PR refactors the result and expected type handling to address the problem:
- Use the type derived from the value as fallback for the declared type of numeric and string literals. This enables the use of the declared result type, which does not rely on complex type inference, in more cases.
- Use the declared result type to perform overload resolution of call arguments, which avoids a potential infinite recursion when the (full) result type would depend on resolving the parameters first.
- Resolve parameters when computing the expected type of call arguments, which can now no longer cause an infinite recursion.
- Fix computing the expected type of binary expressions, which prefers the expected type of the container, as long as it is compatible with the type of the other operand. This is necessary to ensure that operands remain compatible, even when the type of the container is not.
- Use an equivalent numeric or bit type as the result type for arithmetic or logical binary expressions to ensure that the result type is always of the correct kind.
- Also add tests for the type inference in the ST parser.