### PR TITLE
Reworked Open Type Dialog to be Less Blocking

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/providers/ResultListLabelProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/providers/ResultListLabelProvider.java
@@ -35,15 +35,8 @@ public class ResultListLabelProvider extends LabelProvider implements IStyledLab
 
 	@Override
 	public StyledString getStyledText(final Object element) {
-		StyledString styledString = null;
 		if (element instanceof final TypeEntry entry) {
-			styledString = new StyledString(entry.getTypeName());
-
-			final String packageName = entry.getPackageName();
-			if (!packageName.isEmpty()) {
-				styledString.append(" - " + packageName, StyledString.DECORATIONS_STYLER); //$NON-NLS-1$
-			}
-			styledString.append(" - " + entry.getComment(), StyledString.QUALIFIER_STYLER); //$NON-NLS-1$
+			final StyledString styledString = getTypeEntryStyledText(entry);
 
 			int lastIndex = 0;
 			for (final String searchStringElement : searchString) {
@@ -54,10 +47,22 @@ public class ResultListLabelProvider extends LabelProvider implements IStyledLab
 					lastIndex = offset + searchStringElement.length();
 				}
 			}
-
-		} else {
-			styledString = new StyledString(element.toString());
+			return styledString;
 		}
+		if (element != null) {
+			return new StyledString(element.toString());
+		}
+		return new StyledString();
+	}
+
+	public static StyledString getTypeEntryStyledText(final TypeEntry entry) {
+		final StyledString styledString = new StyledString(entry.getTypeName());
+
+		final String packageName = entry.getPackageName();
+		if (!packageName.isEmpty()) {
+			styledString.append(" - " + packageName, StyledString.DECORATIONS_STYLER); //$NON-NLS-1$
+		}
+		styledString.append(" - " + entry.getComment(), StyledString.QUALIFIER_STYLER); //$NON-NLS-1$
 		return styledString;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/plugin.properties
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/plugin.properties
@@ -120,10 +120,10 @@ RenameType_TypeExists=The type {0} is already included in the library
 ResourceTypeEditor = Resource Type Editor
 
 OpenTypeHandler_EDITOR_OPEN_ERROR_MESSAGE=Could not open according editor
-OpenTypeHandler_NO_FILES_IN_WORKSPACE=There are no files in your workspace
-OpenTypeHandler_NO_FILES_SELECTED=No file selected
 OpenTypeHandler_OPEN_TYPE_ERROR_TITLE=Open Type Error
-OpenTypeHandler_OPEN_TYPE_TITLE=Open Type
+OpenTypeHandler_OPEN_TYPE_TITLE = Open Type
+OpenTypeHandler_DialogMessage = Enter type name prefix or pattern (*, ?):
+OpenTypeHandler_SearchInAllProjects = Search in all projects
 
 SegmentTypeEditor=Segment Type Editor
 

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/Messages.java
@@ -142,10 +142,10 @@ public final class Messages extends NLS {
 	public static String RenameType_Name;
 	public static String RenameType_TypeExists;
 	public static String OpenTypeHandler_EDITOR_OPEN_ERROR_MESSAGE;
-	public static String OpenTypeHandler_NO_FILES_IN_WORKSPACE;
-	public static String OpenTypeHandler_NO_FILES_SELECTED;
 	public static String OpenTypeHandler_OPEN_TYPE_ERROR_TITLE;
 	public static String OpenTypeHandler_OPEN_TYPE_TITLE;
+	public static String OpenTypeHandler_DialogMessage;
+	public static String OpenTypeHandler_SearchInAllProjects;
 
 	public static String typeLibraryHasAlreadyBeenExtracted;
 	public static String typeManagementPreferencePageTitle;

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/handlers/OpenTypeHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/handlers/OpenTypeHandler.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2020 Johannes Kepler University Linz
+ * Copyright (c) 2020, 2204 Johannes Kepler University Linz,
+ *                          Primetals Technlogies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,35 +10,44 @@
  *
  * Contributors:
  *   Daniel Lindhuber - initial API and implementation and/or initial documentation
+ *   Alois Zoitl      - reworked to use FilteredItemsSelectionDialog so that not
+ *                      all types have to be provided on creating the dialog.
  *******************************************************************************/
 
 package org.eclipse.fordiac.ide.typemanagement.handlers;
 
-import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
+import java.util.stream.Stream;
 
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
-import org.eclipse.core.commands.ExecutionException;
-import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.fordiac.ide.model.edit.providers.ResultListLabelProvider;
+import org.eclipse.fordiac.ide.model.edit.providers.TypeImageProvider;
+import org.eclipse.fordiac.ide.model.typelibrary.SystemEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
-import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
+import org.eclipse.fordiac.ide.systemmanagement.SystemManager;
 import org.eclipse.fordiac.ide.typemanagement.Messages;
 import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
+import org.eclipse.jface.dialogs.DialogSettings;
+import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.dialogs.MessageDialog;
-import org.eclipse.jface.viewers.ComboViewer;
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.viewers.DelegatingStyledCellLabelProvider.IStyledLabelProvider;
 import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.StyledString;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
@@ -47,23 +57,16 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.dialogs.ElementListSelectionDialog;
+import org.eclipse.ui.dialogs.FilteredItemsSelectionDialog;
 import org.eclipse.ui.part.FileEditorInput;
+import org.osgi.framework.FrameworkUtil;
 
 public class OpenTypeHandler extends AbstractHandler {
 
-	ElementListSelectionDialog dialog;
-	private final Set<TypeEntry> entries = new HashSet<>();
-	private final List<IContainer> projects = new ArrayList<>();
-	private int selectedProject = 0;
-
 	@Override
-	public Object execute(final ExecutionEvent event) throws ExecutionException {
-		clear();
-		collectProjects(ResourcesPlugin.getWorkspace().getRoot());
-		processContainer(ResourcesPlugin.getWorkspace().getRoot());
-		dialog = createDialog();
-		dialog.setElements(entries.toArray());
+	public Object execute(final ExecutionEvent event) {
+		final Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+		final TypeSearchDialog dialog = new TypeSearchDialog(shell);
 		dialog.open();
 
 		final Object result = dialog.getFirstResult();
@@ -71,108 +74,6 @@ public class OpenTypeHandler extends AbstractHandler {
 			openEditor(typeEntry.getFile());
 		}
 		return null;
-	}
-
-	private void clear() {
-		dialog = null;
-		entries.clear();
-		projects.clear();
-		selectedProject = 0;
-	}
-
-	private void changeDialog() {
-		final String searchString = dialog.getFilter();
-		dialog.close();
-		entries.clear();
-		processContainer(projects.get(selectedProject));
-		dialog = createDialog();
-		dialog.setElements(entries.toArray());
-		dialog.setFilter(searchString);
-		dialog.open();
-	}
-
-	private ElementListSelectionDialog createDialog() {
-		final Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
-		final ElementListSelectionDialog selDialog = new ElementListSelectionDialog(shell,
-				new ResultListLabelProvider()) {
-
-			@Override
-			protected Control createDialogArea(final Composite parent) {
-				final Composite container = (Composite) super.createDialogArea(parent);
-				final ComboViewer viewer = new ComboViewer(container);
-				viewer.getCombo().setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, true, false));
-				viewer.setLabelProvider(new LabelProvider() {
-
-					@Override
-					public String getText(final Object element) {
-						if (element instanceof final IProject project) {
-							return project.getName();
-						}
-						return "All Projects";
-					}
-
-				});
-				viewer.getCombo().addListener(SWT.Selection, e -> {
-					selectedProject = viewer.getCombo().getSelectionIndex();
-					changeDialog();
-				});
-				viewer.add(projects.toArray());
-				viewer.getCombo().select(selectedProject);
-				return container;
-			}
-
-		};
-		setDialogSettings(selDialog);
-		return selDialog;
-	}
-
-	private static void setDialogSettings(final ElementListSelectionDialog dialog) {
-		dialog.setMatchEmptyString(false);
-		dialog.setMultipleSelection(false);
-		dialog.setEmptyListMessage(Messages.OpenTypeHandler_NO_FILES_IN_WORKSPACE);
-		dialog.setEmptySelectionMessage(Messages.OpenTypeHandler_NO_FILES_SELECTED);
-		dialog.setTitle(Messages.OpenTypeHandler_OPEN_TYPE_TITLE);
-		dialog.setStatusLineAboveButtons(true);
-	}
-
-	private void collectProjects(final IContainer container) {
-		// add "All Projects" entry to dropdown
-		projects.add(0, container);
-		IResource[] members;
-		try {
-			members = container.members();
-		} catch (final CoreException e) {
-			FordiacLogHelper.logError(e.getMessage(), e);
-			members = new IResource[0];
-		}
-		for (final IResource member : members) {
-			if (member instanceof final IProject project && !project.isOpen()) {
-				continue;
-			}
-			projects.add((IContainer) member);
-		}
-	}
-
-	private void processContainer(final IContainer container) {
-		IResource[] members;
-		try {
-			members = container.members();
-		} catch (final CoreException e) {
-			FordiacLogHelper.logError(e.getMessage(), e);
-			members = new IResource[0];
-		}
-		for (final IResource member : members) {
-			if (member instanceof final IProject project && !project.isOpen()) {
-				continue;
-			}
-			if (member instanceof final IContainer cont) {
-				processContainer(cont);
-			} else if (member instanceof final IFile file
-					&& !TypeLibraryTags.SYSTEM_TYPE_FILE_ENDING.equalsIgnoreCase(file.getFileExtension())) {
-				entries.add(TypeLibraryManager.INSTANCE.getTypeEntryForFile((IFile) member));
-			}
-		}
-
 	}
 
 	private static void openEditor(final IFile file) {
@@ -191,6 +92,198 @@ public class OpenTypeHandler extends AbstractHandler {
 					MessageDialog.openError(shell, Messages.OpenTypeHandler_OPEN_TYPE_ERROR_TITLE,
 							Messages.OpenTypeHandler_EDITOR_OPEN_ERROR_MESSAGE);
 				}
+			}
+		}
+	}
+
+	private static class TypeSearchDialog extends FilteredItemsSelectionDialog {
+
+		private final List<IProject> projects;
+		private final ResultListLabelProvider listLabelProvider = new ResultListLabelProvider();
+		private String selectedProject = null;
+
+		public TypeSearchDialog(final Shell shell) {
+			super(shell);
+			setTitle(Messages.OpenTypeHandler_OPEN_TYPE_TITLE);
+			setMessage(Messages.OpenTypeHandler_DialogMessage);
+			setSelectionHistory(getSelectionHistory());
+			setListLabelProvider(listLabelProvider);
+			setDetailsLabelProvider(new TypeSearchDetailsLabelProvider());
+			projects = Arrays.stream(ResourcesPlugin.getWorkspace().getRoot().getProjects())
+					.filter(TypeSearchDialog::isOpen4diacIDEProject).toList();
+		}
+
+		@Override
+		protected Control createDialogArea(final Composite parent) {
+			final Composite container = (Composite) super.createDialogArea(parent);
+			final Combo combo = new Combo(container, SWT.DROP_DOWN | SWT.READ_ONLY);
+			GridDataFactory.fillDefaults().grab(true, false).applyTo(combo);
+
+			combo.addListener(SWT.Selection, e -> {
+				final int selectionIndex = combo.getSelectionIndex();
+				selectedProject = (selectionIndex == 0) ? null : combo.getItem(selectionIndex);
+				applyFilter();
+			});
+			combo.setItems(getProjectComboEntries());
+			combo.select(0);
+			return container;
+		}
+
+		private String[] getProjectComboEntries() {
+			return Stream.concat( //
+					Stream.of(Messages.OpenTypeHandler_SearchInAllProjects), // add the all projects to the beginning of
+																				// the stream
+					projects.stream().map(IProject::getName).sorted(Comparator.naturalOrder())).toArray(String[]::new);
+		}
+
+		@Override
+		protected Control createExtendedContentArea(final Composite parent) {
+			return null;
+		}
+
+		@Override
+		protected IDialogSettings getDialogSettings() {
+			final IDialogSettings settings = PlatformUI
+					.getDialogSettingsProvider(FrameworkUtil.getBundle(TypeSearchDialog.class)).getDialogSettings();
+			return DialogSettings.getOrCreateSection(settings, getClass().getSimpleName());
+		}
+
+		@Override
+		protected IStatus validateItem(final Object item) {
+			return Status.OK_STATUS;
+		}
+
+		@Override
+		protected ItemsFilter createFilter() {
+			return new TypeEntryFilter(selectedProject);
+		}
+
+		@Override
+		protected Comparator getItemsComparator() {
+			return Comparator.comparing(this::getElementName);
+		}
+
+		@Override
+		protected void fillContentProvider(final AbstractContentProvider contentProvider, final ItemsFilter itemsFilter,
+				final IProgressMonitor progressMonitor) throws CoreException {
+			listLabelProvider.setSearchString(itemsFilter.getPattern());
+			if (itemsFilter.getPattern().isBlank()) {
+				// an empty filter should lead to no results, so for performance reasons we can
+				// skip here
+				return;
+			}
+
+			if (selectedProject == null) {
+				// search in all projects
+				for (final IProject proj : projects) {
+					if (progressMonitor.isCanceled()) {
+						return;
+					}
+					fillForProject(contentProvider, itemsFilter, progressMonitor, proj);
+				}
+			} else {
+				fillForProject(contentProvider, itemsFilter, progressMonitor, getSelectedProject());
+			}
+		}
+
+		private IProject getSelectedProject() {
+			return projects.stream().filter(proj -> proj.getName().equals(selectedProject)).findAny().orElse(null);
+		}
+
+		private static void fillForProject(final AbstractContentProvider contentProvider, final ItemsFilter itemsFilter,
+				final IProgressMonitor progressMonitor, final IProject proj) {
+			for (final TypeEntry entry : TypeLibraryManager.INSTANCE.getTypeLibrary(proj).getAllTypes()) {
+				if (progressMonitor.isCanceled()) {
+					return;
+				}
+				if (!(entry instanceof SystemEntry) && itemsFilter.matchItem(entry)) {
+					contentProvider.add(entry, itemsFilter);
+				}
+			}
+		}
+
+		@Override
+		public String getElementName(final Object item) {
+			if (item instanceof final TypeEntry typeEntry) {
+				return typeEntry.getFullTypeName();
+			}
+			return null;
+		}
+
+		private static boolean isOpen4diacIDEProject(final IProject proj) {
+			try {
+				return proj.isOpen() && proj.hasNature(SystemManager.FORDIAC_PROJECT_NATURE_ID);
+			} catch (final CoreException e) {
+				FordiacLogHelper.logError("Could not read project nature", e); //$NON-NLS-1$
+			}
+			return false;
+		}
+
+		private final class TypeEntryFilter extends ItemsFilter {
+
+			final String selectedProject;
+
+			public TypeEntryFilter(final String selectedProject) {
+				this.selectedProject = selectedProject;
+			}
+
+			@Override
+			public boolean matchItem(final Object item) {
+				if (item instanceof final TypeEntry typeEntry) {
+					return matches(typeEntry.getTypeName()) || matches(typeEntry.getPackageName())
+							|| matches(typeEntry.getComment());
+				}
+				return false;
+			}
+
+			@Override
+			public boolean isConsistentItem(final Object item) {
+				return true;
+			}
+
+			@Override
+			public boolean equalsFilter(final ItemsFilter filter) {
+				if (filter instanceof final TypeEntryFilter typeEntryFilter
+						&& typeEntryFilter.selectedProject != selectedProject) {
+					return false;
+				}
+				return super.equalsFilter(filter);
+			}
+
+			@Override
+			public boolean isSubFilter(final ItemsFilter filter) {
+				if (filter instanceof final TypeEntryFilter typeEntryFilter
+						&& typeEntryFilter.selectedProject != selectedProject) {
+					return false;
+				}
+				return super.isSubFilter(filter);
+			}
+		}
+
+		private static class TypeSearchDetailsLabelProvider extends LabelProvider implements IStyledLabelProvider {
+
+			@Override
+			public StyledString getStyledText(final Object element) {
+				if (element instanceof final TypeEntry entry) {
+					return ResultListLabelProvider.getTypeEntryStyledText(entry);
+				}
+				if (element != null) {
+					return new StyledString(element.toString());
+				}
+				return new StyledString();
+			}
+
+			@Override
+			public String getText(final Object element) {
+				return getStyledText(element).getString();
+			}
+
+			@Override
+			public Image getImage(final Object element) {
+				if (element instanceof final TypeEntry entry) {
+					return TypeImageProvider.getImageForTypeEntry(entry);
+				}
+				return null;
 			}
 		}
 	}


### PR DESCRIPTION
The open type dialog always did load all type entries prior to opening and searching. This was rather slow. By using a
FilteredItemsSelectionDialog the required type libraries are searched on demand.