### PR TITLE
Harmonize release and develop maven github workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,12 +7,21 @@ on:
     branches: [ "release", "develop", "freeze", "3.0.x"]
 
 jobs:
+  event_file:
+    name: "Upload Event File"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Upload
+      uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+      with:
+        name: event_file
+        path: ${{ github.event_path }}
   build:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        java: [17]
+        os: [ubuntu-latest]
+        java: [21]
     runs-on: ${{ matrix.os }} 
     name: OS ${{ matrix.os }} Java ${{ matrix.java }} compile
     steps:
@@ -26,7 +35,7 @@ jobs:
     - name: Set up Maven
       uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
       with:
-        maven-version: 3.9.3
+        maven-version: 3.9.6
     - name: Build with Maven
       uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
       with:


### PR DESCRIPTION
As dependabot only checks the default branch the same settings between the branches are important. This commit moves the develop settings to release so that in the future it easier to merge from release to develop.