### PR TITLE
[Fix] For EditPartViewers the Editor of their EP Factory may be Null

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/annotation/FordiacAnnotationUtil.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/annotation/FordiacAnnotationUtil.java
@@ -69,7 +69,8 @@ public final class FordiacAnnotationUtil {
 	}
 
 	public static GraphicalAnnotationModel getAnnotationModel(final EditPart editPart) {
-		if (editPart.getViewer().getEditPartFactory() instanceof final Abstract4diacEditPartFactory factory) {
+		if (editPart.getViewer().getEditPartFactory() instanceof final Abstract4diacEditPartFactory factory
+				&& factory.getEditor() != null) {
 			return factory.getEditor().getAdapter(GraphicalAnnotationModel.class);
 		}
 		return null;


### PR DESCRIPTION
Different viewers using the same EditParts (e.g., FB Debug View) the editor entry of the EditPartFactory may be null. This fix adds a null check to protect against NPEs.