### PR TITLE
Improving Graphical Editor Appearance on Fractional Native Scaling

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.product/org.eclipse.fordiac.ide.product
+++ b/plugins/org.eclipse.fordiac.ide.product/org.eclipse.fordiac.ide.product
@@ -23,6 +23,7 @@
 -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true
 -Declipse.e4.inject.javax.warning=false
 -Dorg.slf4j.simpleLogger.defaultLogLevel=off
+-Dswt.autoScale=exact
 -XX:+UseG1GC
 -XX:+UseStringDeduplication
 -Dosgi.dataAreaRequiresExplicitInit=true


### PR DESCRIPTION
The default setting of the Eclipse Platform for swt.autoScaling is only only using full integer scale values. For fractional native scaling settings (e.g., 125%, 175%) this lead to problems as the graphical elements where not scaled but the text was always scaled with native scaling.

This commit is now adding the exact as swt.autoScaling parameter as this greatly improves drawing aspect ratios on screen settings with fractional scaling settings.