### PR TITLE
Remove potential trailing slash on library extraction URL

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/LibraryManager.java
+++ b/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/LibraryManager.java
@@ -299,6 +299,11 @@ public enum LibraryManager {
 		}
 		checkLibChanges();
 
+		// strip potential trailing slash
+		if (folderName.endsWith("/")) { //$NON-NLS-1$
+			folderName = folderName.substring(0, folderName.length() - 1);
+		}
+
 		final java.net.URI importURI = URIUtil.append(workspaceLibraryURI, folderName);
 
 		if (autoImport && project != null) {


### PR DESCRIPTION
trailing slash stopped preferred version from being linked