### PR TITLE
Fix type inference for nested binary expressions

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/ExpressionAnnotations.xtend
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/ExpressionAnnotations.xtend
@@ -97,9 +97,9 @@ final package class ExpressionAnnotations {
 						else if (left instanceof AnyDurationType && right instanceof AnyDurationType)
 							left.commonSupertype(right)
 						else
-							left.commonSupertype(right).equivalentAnyNumType
+							commonSupertype(left.equivalentAnyNumType, right.equivalentAnyNumType)
 					} else if (expr.op.logical) {
-						left.commonSupertype(right).equivalentAnyBitType
+						commonSupertype(left.equivalentAnyBitType, right.equivalentAnyBitType)
 					} else if (expr.op.range) {
 						left.commonSupertype(right)
 					} else

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/util/STCoreUtil.xtend
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/util/STCoreUtil.xtend
@@ -584,6 +584,10 @@ final class STCoreUtil {
 			(type.isAssignableFrom(other.equivalentAnyUnsignedType) ||
 				other.equivalentAnyUnsignedType.isAssignableFrom(type)))
 			type
+		else if (type instanceof AnyBitType &&
+			(type.isAssignableFrom(other.equivalentAnyBitType) ||
+				other.equivalentAnyBitType.isAssignableFrom(type)))
+			type
 		else // fallback to other _only_ if type is not compatible
 			other
 	}
@@ -602,7 +606,7 @@ final class STCoreUtil {
 	def static AnyUnsignedType getEquivalentAnyUnsignedType(INamedElement type) {
 		switch (type) {
 			SintType: ElementaryTypes.USINT
-			IntType: ElementaryTypes.ULINT
+			IntType: ElementaryTypes.UINT
 			DintType: ElementaryTypes.UDINT
 			LintType: ElementaryTypes.ULINT
 			AnyUnsignedType: type


### PR DESCRIPTION
There was a problem where operand types were not converted to the required unsigned or bit types before determining the common result type. Also fix equivalent unsigned type for INT.