### PR TITLE
Fix remote function calls in evaluator

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.debug/src/org/eclipse/fordiac/ide/debug/EvaluatorProcess.java
+++ b/plugins/org.eclipse.fordiac.ide.debug/src/org/eclipse/fordiac/ide/debug/EvaluatorProcess.java
@@ -33,6 +33,7 @@ import org.eclipse.fordiac.ide.model.eval.EvaluatorCache;
 import org.eclipse.fordiac.ide.model.eval.EvaluatorMonitor;
 import org.eclipse.fordiac.ide.model.eval.EvaluatorThreadPoolExecutor;
 import org.eclipse.fordiac.ide.model.eval.value.Value;
+import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 
 public class EvaluatorProcess extends AbstractLaunchProcess implements Callable<IStatus> {
 
@@ -74,6 +75,7 @@ public class EvaluatorProcess extends AbstractLaunchProcess implements Callable<
 			return Status.error("Terminated"); //$NON-NLS-1$
 		} catch (final Exception t) {
 			streamsProxy.getErrorStreamMonitor().error("Exception occurred", t); //$NON-NLS-1$
+			FordiacLogHelper.logWarning("Exception occurred while evaluating " + name, t); //$NON-NLS-1$
 			return Status.error("Exception occurred", t); //$NON-NLS-1$
 		} finally {
 			executor.shutdown();

--- a/plugins/org.eclipse.fordiac.ide.deployment.eval/src/org/eclipse/fordiac/ide/deployment/eval/fb/DeploymentFBEvaluator.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.eval/src/org/eclipse/fordiac/ide/deployment/eval/fb/DeploymentFBEvaluator.java
@@ -106,13 +106,13 @@ public class DeploymentFBEvaluator<T extends FBType> extends FBEvaluator<T> {
 
 	@Override
 	public void evaluate(final Event event) throws EvaluatorException, InterruptedException {
+		prepare();
 		final Event instanceEvent = deploymentData.getFb().getInterface().getEvent(event.getName());
 		if (instanceEvent == null) {
 			throw new EvaluatorException(
 					MessageFormat.format(Messages.DeploymentFBEvaluator_NoSuchInstanceEvent, event.getQualifiedName()),
 					this);
 		}
-		prepare();
 		try {
 			writeVariables(getType().getInterfaceList().getInputVars());
 			writeVariables(getType().getInterfaceList().getInOutVars());

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/EvaluatorThreadPoolExecutor.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/EvaluatorThreadPoolExecutor.java
@@ -13,7 +13,6 @@
 package org.eclipse.fordiac.ide.model.eval;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.time.Clock;
 import java.util.Map;
 import java.util.Set;
@@ -175,7 +174,7 @@ public class EvaluatorThreadPoolExecutor extends ThreadPoolExecutor {
 		sharedResources.forEach((key, value) -> {
 			try {
 				value.close();
-			} catch (final IOException e) {
+			} catch (final Exception e) {
 				monitorSet.forEach(monitor -> monitor.error("Exception closing shared resource " + key, e)); //$NON-NLS-1$
 			}
 		});


### PR DESCRIPTION
Fix NPE in deployment FB evaluator when not already prepared, which can happen for certain remote function calls (i.e., executing functions on FORTE). Also catch all exceptions when closing shared resources in evaluator to ensure proper termination regardless of exceptions in any of the shared resources. Also log exceptions in evaluator process to aid in debugging problems related to evaluator execution.
