### PR TITLE
Relax validation to allow comparable types for CASE labels

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/Messages.java
@@ -69,6 +69,7 @@ public final class Messages extends NLS {
 	public static String STCoreValidator_IndexRangeExpressionInvalid;
 	public static String STCoreValidator_IndexRangeTypeInvalid;
 	public static String STCoreValidator_NonAnyStringNotMaxLengthSettingNotAllowed;
+	public static String STCoreValidator_NonComparableTypes;
 	public static String STCoreValidator_NonConstantExpressionInVariableDeclaration;
 	public static String STCoreValidator_MaxLengthTypeInvalid;
 	public static String STCoreValidator_TooManyIndicesGiven;

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/messages.properties
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/messages.properties
@@ -62,6 +62,7 @@ STCoreValidator_DuplicateAttribute=Duplicate attribute {0} in pragma
 STCoreValidator_IndexRangeExpressionInvalid=Invalid expression for defining ranges, must be of the form ANY_INT..ANY_INT
 STCoreValidator_IndexRangeTypeInvalid=Type {0} is not valid for defining ranges. Ranges must be of type ANY_INT
 STCoreValidator_NonAnyStringNotMaxLengthSettingNotAllowed=For types not of ANY_STRING no maximum length may be defined
+STCoreValidator_NonComparableTypes=Cannot compare {0} with {1}
 STCoreValidator_NonConstantExpressionInVariableDeclaration=Non-constant expression in variable declaration
 STCoreValidator_MaxLengthTypeInvalid=Type {0} is not valid to specify an ANY_STRING max length. Max length must be of type ANY_INT
 STCoreValidator_TooManyIndicesGiven=Too many indices in subscript access: {0} indices given, but only {1} allowed for {2}

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/validation/STCoreValidator.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/validation/STCoreValidator.java
@@ -137,6 +137,7 @@ public class STCoreValidator extends AbstractSTCoreValidator {
 			+ "identiferEndsInUnderscoreError"; //$NON-NLS-1$
 	public static final String VALUE_NOT_ASSIGNABLE = ISSUE_CODE_PREFIX + "valueNotAssignable"; //$NON-NLS-1$
 	public static final String NON_COMPATIBLE_TYPES = ISSUE_CODE_PREFIX + "nonCompatibleTypes"; //$NON-NLS-1$
+	public static final String NON_COMPARABLE_TYPES = ISSUE_CODE_PREFIX + "nonComparableTypes"; //$NON-NLS-1$
 	public static final String WRONG_NAME_CASE = ISSUE_CODE_PREFIX + "wrongNameCase"; //$NON-NLS-1$
 	public static final String RESERVED_IDENTIFIER_ERROR = ISSUE_CODE_PREFIX + "reservedIdentifierError"; //$NON-NLS-1$
 	public static final String UNQUALIFIED_FB_CALL_ON_FB_WITH_INPUT_EVENT_SIZE_NOT_ONE = ISSUE_CODE_PREFIX
@@ -665,8 +666,15 @@ public class STCoreValidator extends AbstractSTCoreValidator {
 	@Check
 	public void checkCaseConditionType(final STCaseCases stmt) {
 		final var type = stmt.getStatement().getSelector().getResultType();
-		stmt.getConditions().forEach(condition -> checkTypeCompatibility(type, condition.getResultType(),
-				STCorePackage.Literals.ST_CASE_CASES__CONDITIONS, stmt.getConditions().indexOf(condition)));
+		IntStream.range(0, stmt.getConditions().size()).forEachOrdered(index -> {
+			final STExpression condition = stmt.getConditions().get(index);
+			final INamedElement resultType = condition.getResultType();
+			if (!STCoreUtil.hasCommonSupertype(type, resultType)) {
+				error(MessageFormat.format(Messages.STCoreValidator_NonComparableTypes, resultType.getName(),
+						type.getName()), STCorePackage.Literals.ST_CASE_CASES__CONDITIONS, index, NON_COMPARABLE_TYPES,
+						resultType.getName(), type.getName());
+			}
+		});
 	}
 
 	@Check

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.tests/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/tests/STFunctionValidatorTest.xtend
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.tests/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/tests/STFunctionValidatorTest.xtend
@@ -701,7 +701,7 @@ class STFunctionValidatorTest {
 	}
 
 	@Test
-	def void testInvalidCaseConditionType() {
+	def void testValidCaseConditionType() {
 		'''
 			FUNCTION hubert
 			VAR
@@ -713,7 +713,24 @@ class STFunctionValidatorTest {
 				LINT#2: int1 := 17;
 			END_CASE;
 			END_FUNCTION
-		'''.parse.assertError(STCorePackage.eINSTANCE.STCaseCases, STCoreValidator.NON_COMPATIBLE_TYPES)
+		'''.parse.assertNoErrors
+	}
+
+	@Test
+	def void testInvalidCaseConditionType() {
+		'''
+			FUNCTION hubert
+			VAR
+				int1 : INT;
+			END_VAR
+			
+			CASE int1 OF
+				1: int1 := 17;
+				'abc': int1 := 17;
+			END_CASE;
+			END_FUNCTION
+		'''.parse.assertError(STCorePackage.eINSTANCE.STCaseCases, STCoreValidator.NON_COMPARABLE_TYPES,
+			"Cannot compare STRING with INT")
 	}
 
 	@Test
@@ -1705,7 +1722,6 @@ class STFunctionValidatorTest {
 		'''.parse.assertWarning(STCorePackage.eINSTANCE.STFeatureExpression,
 			STCoreValidator.UNNECESSARY_LITERAL_CONVERSION, "Unnecessary conversion of literal to CHAR")
 	}
-
 
 	@Test
 	def void testTruncatingLiteralConversions() {


### PR DESCRIPTION
Relax the validation of CASE statements to allow comparable types for CASE labels, instead of requiring that the type of the label is assignable to the type of the selector expression.