### PR TITLE
Fix stale or ambiguous method parameter references in ST editor

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm/src/org/eclipse/fordiac/ide/structuredtextalgorithm/resource/STAlgorithmResourceDescriptionStrategy.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm/src/org/eclipse/fordiac/ide/structuredtextalgorithm/resource/STAlgorithmResourceDescriptionStrategy.java
@@ -15,6 +15,8 @@ package org.eclipse.fordiac.ide.structuredtextalgorithm.resource;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
+import org.eclipse.fordiac.ide.model.libraryElement.STAlgorithm;
+import org.eclipse.fordiac.ide.model.libraryElement.STMethod;
 import org.eclipse.fordiac.ide.structuredtextalgorithm.stalgorithm.STAlgorithmBody;
 import org.eclipse.fordiac.ide.structuredtextalgorithm.stalgorithm.STMethodBody;
 import org.eclipse.fordiac.ide.structuredtextcore.resource.STCoreResourceDescriptionStrategy;
@@ -28,8 +30,9 @@ public class STAlgorithmResourceDescriptionStrategy extends STCoreResourceDescri
 		if (eObject instanceof LibraryElement && eObject.eResource().getURI().hasQuery()) {
 			return false; // do not export library element from resource with query
 		}
-		if (eObject instanceof STAlgorithmBody || eObject instanceof STMethodBody || eObject instanceof FBNetwork) {
-			return false; // do not export anything inside of an algorithm or FB network
+		if (eObject instanceof STAlgorithm || eObject instanceof STMethod || eObject instanceof STAlgorithmBody
+				|| eObject instanceof STMethodBody || eObject instanceof FBNetwork) {
+			return false; // do not export anything inside of an algorithm, method, or FB network
 		}
 		return super.createEObjectDescriptions(eObject, acceptor);
 	}

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm/src/org/eclipse/fordiac/ide/structuredtextalgorithm/scoping/STAlgorithmImportedNamespaceAwareLocalScopeProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm/src/org/eclipse/fordiac/ide/structuredtextalgorithm/scoping/STAlgorithmImportedNamespaceAwareLocalScopeProvider.java
@@ -13,16 +13,35 @@
 package org.eclipse.fordiac.ide.structuredtextalgorithm.scoping;
 
 import java.util.List;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Consumer;
 
+import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.model.libraryElement.CompilerInfo;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
+import org.eclipse.fordiac.ide.model.libraryElement.STAlgorithm;
+import org.eclipse.fordiac.ide.model.libraryElement.STMethod;
 import org.eclipse.fordiac.ide.structuredtextcore.resource.LibraryElementXtextResource;
+import org.eclipse.xtext.naming.IQualifiedNameProvider;
 import org.eclipse.xtext.naming.QualifiedName;
+import org.eclipse.xtext.resource.IEObjectDescription;
+import org.eclipse.xtext.resource.ISelectable;
+import org.eclipse.xtext.scoping.Scopes;
 import org.eclipse.xtext.scoping.impl.ImportNormalizer;
 import org.eclipse.xtext.scoping.impl.ImportedNamespaceAwareLocalScopeProvider;
+import org.eclipse.xtext.scoping.impl.MultimapBasedSelectable;
+
+import com.google.inject.Inject;
 
 public class STAlgorithmImportedNamespaceAwareLocalScopeProvider extends ImportedNamespaceAwareLocalScopeProvider {
+
+	@Inject
+	private IQualifiedNameProvider qualifiedNameProvider;
 
 	@Override
 	public List<ImportNormalizer> internalGetImportedNamespaceResolvers(final EObject context,
@@ -59,7 +78,59 @@ public class STAlgorithmImportedNamespaceAwareLocalScopeProvider extends Importe
 	}
 
 	@Override
+	protected ISelectable internalGetAllDescriptions(final Resource resource) {
+		final Iterable<EObject> allContents = () -> Spliterators
+				.iterator(new STAlgorithmResourceContentsSpliterator(resource));
+		final Iterable<IEObjectDescription> allDescriptions = Scopes.scopedElementsFor(allContents,
+				qualifiedNameProvider);
+		return new MultimapBasedSelectable(allDescriptions);
+	}
+
+	@Override
 	public boolean isRelativeImport() {
 		return false;
+	}
+
+	protected static class STAlgorithmResourceContentsSpliterator implements Spliterator<EObject> {
+
+		private final TreeIterator<EObject> delegate;
+
+		public STAlgorithmResourceContentsSpliterator(final Resource resource) {
+			this.delegate = EcoreUtil.getAllContents(resource, false);
+		}
+
+		@Override
+		public boolean tryAdvance(final Consumer<? super EObject> action) {
+			while (delegate.hasNext()) {
+				final EObject eObject = delegate.next();
+				if (filter(eObject)) {
+					action.accept(eObject);
+					return true;
+				}
+				delegate.prune();
+			}
+			return false;
+		}
+
+		@SuppressWarnings("static-method") // subclasses may override
+		protected boolean filter(final EObject eObject) {
+			// do not export anything inside of an algorithm, method, or FB network
+			return !(eObject instanceof STAlgorithm || eObject instanceof STMethod || eObject instanceof FBNetwork);
+		}
+
+		@Override
+		public Spliterator<EObject> trySplit() {
+			return null;
+		}
+
+		@Override
+		public long estimateSize() {
+			return Long.MAX_VALUE;
+		}
+
+		@Override
+		public int characteristics() {
+			return Spliterator.DISTINCT | Spliterator.IMMUTABLE | Spliterator.NONNULL | Spliterator.ORDERED;
+		}
 	}
 }


### PR DESCRIPTION
The current resource in the ST editor also contains the ST algorithms and methods of the copied internal FB type and their parameters. These were subsequently included in the object descriptions of the resource, which caused stale or ambiguous references compared to the actual ST algorithms and methods in the ST source. This filters the ST algorithms and methods of the internal FB type, including their children, when computing the descriptions to avoid the problem.