### PR TITLE
Do not update package name for simple renames in ST refactoring

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/LibraryElementResourceRelocationStrategy.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/LibraryElementResourceRelocationStrategy.java
@@ -20,6 +20,7 @@ import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.xtext.ide.refactoring.IResourceRelocationStrategy;
 import org.eclipse.xtext.ide.refactoring.ResourceRelocationChange;
 import org.eclipse.xtext.ide.refactoring.ResourceRelocationContext;
+import org.eclipse.xtext.ide.refactoring.ResourceRelocationContext.ChangeType;
 import org.eclipse.xtext.resource.FileExtensionProvider;
 
 import com.google.inject.Inject;
@@ -39,14 +40,17 @@ public class LibraryElementResourceRelocationStrategy implements IResourceReloca
 	}
 
 	protected void applyChange(final ResourceRelocationContext context, final ResourceRelocationChange change) {
-		context.addModification(change, resource -> modifyResource(resource, change));
+		context.addModification(change, resource -> modifyResource(resource, change, context.getChangeType()));
 	}
 
-	protected void modifyResource(final Resource resource, final ResourceRelocationChange change) {
+	protected void modifyResource(final Resource resource, final ResourceRelocationChange change,
+			final ChangeType changeType) {
 		if (resource instanceof final FordiacTypeResource typeResource && !typeResource.getContents().isEmpty()
 				&& typeResource.getContents().getFirst() instanceof final LibraryElement libraryElement) {
 			updateTypeName(libraryElement, change);
-			updatePackageName(libraryElement, change);
+			if (changeType != ChangeType.RENAME) {
+				updatePackageName(libraryElement, change);
+			}
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/STCoreResourceRelocationStrategy.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/STCoreResourceRelocationStrategy.java
@@ -21,6 +21,7 @@ import org.eclipse.fordiac.ide.structuredtextcore.stcore.STSource;
 import org.eclipse.xtext.ide.refactoring.IResourceRelocationStrategy;
 import org.eclipse.xtext.ide.refactoring.ResourceRelocationChange;
 import org.eclipse.xtext.ide.refactoring.ResourceRelocationContext;
+import org.eclipse.xtext.ide.refactoring.ResourceRelocationContext.ChangeType;
 import org.eclipse.xtext.resource.FileExtensionProvider;
 import org.eclipse.xtext.util.SimpleAttributeResolver;
 
@@ -41,13 +42,16 @@ public class STCoreResourceRelocationStrategy implements IResourceRelocationStra
 	}
 
 	protected void applyChange(final ResourceRelocationContext context, final ResourceRelocationChange change) {
-		context.addModification(change, resource -> modifyResource(resource, change));
+		context.addModification(change, resource -> modifyResource(resource, change, context.getChangeType()));
 	}
 
-	protected void modifyResource(final Resource resource, final ResourceRelocationChange change) {
+	protected void modifyResource(final Resource resource, final ResourceRelocationChange change,
+			final ChangeType changeType) {
 		if (resource instanceof final STCoreResource coreResource && coreResource.getInternalLibraryElement() != null) {
 			updateTypeName(coreResource, change);
-			updatePackageName(coreResource, change);
+			if (changeType != ChangeType.RENAME) {
+				updatePackageName(coreResource, change);
+			}
 		}
 	}
 


### PR DESCRIPTION
The package name was also updated for simple renames in the ST refactoring participant. This could cause a mismatch between the package name seen by Xtext and the actual package name, in cases where the package name did not conform to the folder structure. This fixes the problem by not updating the package name for simple renames.