### PR TITLE
Children of Typed subapps where not correctly opened in type editor

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/GotoChildHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/GotoChildHandler.java
@@ -19,6 +19,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.fordiac.ide.model.libraryElement.CFBInstance;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
+import org.eclipse.fordiac.ide.model.ui.actions.OpenListener;
 import org.eclipse.fordiac.ide.model.ui.editors.AbstractBreadCrumbEditor;
 import org.eclipse.fordiac.ide.model.ui.widgets.GoIntoSubappSelectionEvent;
 import org.eclipse.gef.EditPart;
@@ -41,9 +42,11 @@ public class GotoChildHandler extends AbstractHandler {
 		if (editPart != null) {
 			if (editPart.getModel() instanceof final SubApp subapp && subapp.isUnfolded()) {
 				// with go to child we now want to open the subapp
-				if (HandlerUtil.getActiveEditor(event) instanceof final AbstractBreadCrumbEditor breadcrumbEditor) {
-					breadcrumbEditor.getBreadcrumb().setInput(editPart.getModel(),
-							new GoIntoSubappSelectionEvent(breadcrumbEditor.getBreadcrumb(), subapp));
+				final IEditorPart activeEditor = HandlerUtil.getActiveEditor(event);
+				final AbstractBreadCrumbEditor breadCrumbEditor = OpenListener.getBreadCrumbEditor(activeEditor);
+				if (breadCrumbEditor != null) {
+					breadCrumbEditor.getBreadcrumb().setInput(editPart.getModel(),
+							new GoIntoSubappSelectionEvent(breadCrumbEditor.getBreadcrumb(), subapp));
 				}
 			} else {
 				editPart.performRequest(new Request(RequestConstants.REQ_OPEN));

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/actions/OpenListener.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/actions/OpenListener.java
@@ -32,8 +32,9 @@ import org.eclipse.jface.action.IAction;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPart;
-import org.eclipse.ui.forms.editor.FormEditor;
 import org.eclipse.ui.part.FileEditorInput;
+import org.eclipse.ui.part.MultiPageEditorPart;
+import org.eclipse.ui.part.MultiPageEditorSite;
 
 /**
  * Helper class for reducing the effort to implement open listeners
@@ -90,23 +91,15 @@ public abstract class OpenListener implements IOpenListener {
 	}
 
 	public static AbstractBreadCrumbEditor getBreadCrumbEditor(final IEditorPart openedEditor) {
-		AbstractBreadCrumbEditor breadCrumbEditor = openedEditor.getAdapter(AbstractBreadCrumbEditor.class);
-		if ((breadCrumbEditor == null) && (openedEditor instanceof final FormEditor formEditor)) {
-			breadCrumbEditor = getBreadCrumbFromMultiPageEditor(formEditor);
-		}
-		return breadCrumbEditor;
-	}
-
-	private static AbstractBreadCrumbEditor getBreadCrumbFromMultiPageEditor(final FormEditor openedEditor) {
-		final IEditorInput input = openedEditor.getActiveEditor().getEditorInput();
-
-		for (final IEditorPart subEditor : openedEditor.findEditors(input)) {
-			if (subEditor instanceof final AbstractBreadCrumbEditor bcEditor) {
-				openedEditor.setActiveEditor(subEditor);
-				return bcEditor;
+		final AbstractBreadCrumbEditor breadCrumbEditor = openedEditor.getAdapter(AbstractBreadCrumbEditor.class);
+		if ((breadCrumbEditor != null)
+				&& (breadCrumbEditor.getEditorSite() instanceof final MultiPageEditorSite multiPageEditorSite)) {
+			final MultiPageEditorPart multiPageEditor = multiPageEditorSite.getMultiPageEditor();
+			if (multiPageEditor.getSelectedPage() != breadCrumbEditor) {
+				multiPageEditor.setActiveEditor(breadCrumbEditor);
 			}
 		}
-		return null;
+		return breadCrumbEditor;
 	}
 
 	private static boolean sameLevelAsParent(final Object element) {


### PR DESCRIPTION
When duble clicking in the system epxlorer or using go into of expanded subapps for elements contained in typed subapp the element where not opend neither it was switched to the right editor tab.