### PR TITLE
Update imports for non-Xtext resources with Xtext language

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/STCoreRelatedXtextResourceUpdater.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/STCoreRelatedXtextResourceUpdater.java
@@ -13,6 +13,8 @@
 package org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring;
 
 import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
+import org.eclipse.fordiac.ide.model.resource.FordiacTypeResource;
 import org.eclipse.fordiac.ide.structuredtextcore.resource.LibraryElementXtextResource;
 import org.eclipse.xtext.ide.serializer.IEmfResourceChange;
 import org.eclipse.xtext.ide.serializer.impl.EObjectDescriptionDeltaProvider.Deltas;
@@ -34,6 +36,9 @@ public class STCoreRelatedXtextResourceUpdater extends RelatedXtextResourceUpdat
 		final Resource resource = getResourceSet().getResource(getResource().getUri(), true);
 		if (resource instanceof final LibraryElementXtextResource libResource) {
 			importUpdater.updateImports(deltas, libResource.getInternalLibraryElement(),
+					(imp, value) -> changeAcceptor.accept(new ImportedNamespaceChange(imp, value)));
+		} else if (resource instanceof final FordiacTypeResource typeResource) {
+			importUpdater.updateImports(deltas, (LibraryElement) typeResource.getContents().getFirst(),
 					(imp, value) -> changeAcceptor.accept(new ImportedNamespaceChange(imp, value)));
 		}
 		if (resource instanceof final XtextResource xtextResource && hasContents(xtextResource)) {


### PR DESCRIPTION
There are non-Xtext resources with an associated Xtext language that were still not updated correctly. This adds the missing updates for those resources.