### PR TITLE
REmove Memory Boundary Settings

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.product/org.eclipse.fordiac.ide.product
+++ b/plugins/org.eclipse.fordiac.ide.product/org.eclipse.fordiac.ide.product
@@ -26,10 +26,7 @@
 -Dswt.autoScale=exact
 -XX:+UseG1GC
 -XX:+UseStringDeduplication
--Dosgi.dataAreaRequiresExplicitInit=true
 -Xmn512m
--Xms1024m
--Xmx5120m
       </vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
@@ -53,7 +50,6 @@
 
    <vm>
    </vm>
-
 
    <plugins>
    </plugins>


### PR DESCRIPTION
As discussed in EPP and Eclipse Platform with modern JVMs these settings do not make sense anymore and removing them can help to address a wider range of users.

https://github.com/eclipse-packaging/packages/issues/37