### PR TITLE
Correctly handle the right interfacebar in collision detection

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/Messages.java
@@ -68,6 +68,7 @@ public final class Messages extends NLS {
 
 	public static String ErrorMarkerInterfaceAnnotations_MissingVariableForValue;
 	public static String FBNetworkAnnotations_CollisionMessage;
+	public static String FBNetworkAnnotations_InterfaceBarCollisionMessage;
 
 	public static String FBTImporter_ADAPTER_DECLARATION_TYPE_EXCEPTION;
 	public static String FBTImporter_ECTRANASITION_CONDITION_EXCEPTION;

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/FBShapeHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/FBShapeHelper.java
@@ -33,6 +33,10 @@ public final class FBShapeHelper {
 			"MaxPinLabelSize", 60, null); //$NON-NLS-1$
 	private static int maxTypeLabelSize = Platform.getPreferencesService().getInt(DIAGRAM_PREFERENCE_QUALIFIER,
 			"MaxTypeLabelSize", 120, null); //$NON-NLS-1$
+	private static final int MAX_INTERFACE_BAR_SIZE = Platform.getPreferencesService()
+			.getInt(DIAGRAM_PREFERENCE_QUALIFIER, "MaxInterfaceBarSize", 0, null); //$NON-NLS-1$
+
+	private static int maxInterfaceBarWidth = -1;
 
 	/*
 	 * Constants for width and height adjustments to account for borders, padding,
@@ -89,6 +93,14 @@ public final class FBShapeHelper {
 		final int lines = fbLines + Math.max(inputLines, outputLines);
 		final int heightAdjust = getHeightAdjust(element);
 		return (int) (lines * lineHeight) + heightAdjust;
+	}
+
+	public static int getMaxInterfaceBarWidth() {
+		if (maxInterfaceBarWidth == -1) {
+			maxInterfaceBarWidth = (int) (CoordinateConverter.INSTANCE.getAverageCharacterWidth()
+					* MAX_INTERFACE_BAR_SIZE + 2) + WIDTH_ADJUST_INTERFACE;
+		}
+		return maxInterfaceBarWidth;
 	}
 
 	private static int getInterfaceLines(final FBNetworkElement element, final Predicate<IInterfaceElement> filter) {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/messages.properties
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/messages.properties
@@ -51,6 +51,7 @@ Error_SelfInsertion={0} cannot be inserted into itself!
 ErrorMarkerInterfaceAnnotations_MissingVariableForAttribute=Missing variable for attribute: {0}
 ErrorMarkerInterfaceAnnotations_MissingVariableForValue=Missing variable for value: {0}
 FBNetworkAnnotations_CollisionMessage=Collision between {0} and {1}
+FBNetworkAnnotations_InterfaceBarCollisionMessage=Collision of {0} with Maximum Size of Interface Bar of {1}
 FBTImporter_ADAPTER_DECLARATION_TYPE_EXCEPTION=AdapterDeclaration: type has to be set\!
 FBTImporter_ECTRANASITION_CONDITION_EXCEPTION=ECTransition Condition has to be set\!
 FBTImporter_ECTRANSITION_DEST_EXCEPTION=ECTransition Destination has to be set\!


### PR DESCRIPTION
To correctly handle collisions of children of expanded subapps the width of the subapp has to be reduced.