### PR TITLE
Fix infinite recursion for subapp through connections in monitoring

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/DeploymentDebugWatchUtils.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/DeploymentDebugWatchUtils.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.deployment.debug.watch;
 
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.eclipse.fordiac.ide.model.libraryElement.AdapterDeclaration;
@@ -73,9 +74,11 @@ public final class DeploymentDebugWatchUtils {
 			subapp.loadSubAppNetwork(); // ensure network is loaded
 			if (element.isIsInput()) {
 				yield (Stream<T>) element.getOutputConnections().stream().map(Connection::getDestination)
+						.filter(IInterfaceElement::isIsInput) // skip inner connections to output
 						.flatMap(DeploymentDebugWatchUtils::resolveSubappInterfaceConnections);
 			}
 			yield (Stream<T>) element.getInputConnections().stream().map(Connection::getSource)
+					.filter(Predicate.not(IInterfaceElement::isIsInput)) // skip inner connections to input
 					.flatMap(DeploymentDebugWatchUtils::resolveSubappInterfaceConnections);
 		}
 		case final AdapterFB adapterFB -> (Stream<T>) resolveSubappInterfaceConnections(adapterFB.getAdapterDecl())


### PR DESCRIPTION
Fix infinite recursion for subapp through connections in monitoring by only considering connections from input to input and output to output when recursively resolving subapp interface connections.