### PR TITLE
Update E_SPLIT function block description and comments.

### DIFF
--- a/data/typelibrary/events-1.0.0/typelib/E_SPLIT.fbt
+++ b/data/typelibrary/events-1.0.0/typelib/E_SPLIT.fbt
@@ -1,28 +1,31 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE FBType SYSTEM "http://www.holobloc.com/xml/LibraryElement.dtd">
-<FBType Comment="Template for an empty basic function block" Name="E_SPLIT">
-  <Identification Classification="event function block" Description="Copyright (c) 2017 fortiss GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Function="Split one event into two events" Standard="61499-1 Annex A"/>
-  <VersionInfo Author="Alois Zoitl" Date="2017" Organization="fortiss GmbH" Remarks="initial API and implementation and/or initial documentation" Version="1.0"/>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Input event" Name="EI" Type="Event"/>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="First output event" Name="EO1" Type="Event"/>
-      <Event Comment="Second output event" Name="EO2" Type="Event"/>
-    </EventOutputs>
-    <InputVars/>
-    <OutputVars/>
-  </InterfaceList>
-  <BasicFB>
-    <ECC>
-      <ECState Comment="Initial State" Name="START" x="550.0" y="425.0"/>
-      <ECState Comment="Output events" Name="State" x="1755.0" y="280.0">
-        <ECAction Output="EO1"/>
-        <ECAction Output="EO2"/>
-      </ECState>
-      <ECTransition Comment="" Condition="EI" Destination="State" Source="START" x="1270.0" y="395.0"/>
-      <ECTransition Comment="" Condition="1" Destination="START" Source="State" x="1265.0" y="605.0"/>
-    </ECC>
-  </BasicFB>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="E_SPLIT" Comment="Template for an empty basic function block" >
+	<Identification Standard="61499-1 Annex A" Classification="event function block" Function="Split one event into two events" Description="Copyright (c) 2017 fortiss GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+	</Identification>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="EI" Type="Event" Comment="Input event" >
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="EO1" Type="Event" Comment="First output event" >
+			</Event>
+			<Event Name="EO2" Type="Event" Comment="Second output event" >
+			</Event>
+		</EventOutputs>
+	</InterfaceList>
+	<BasicFB>
+		<ECC>
+			<ECState Name="START" Comment="Initial State"  x="550" y="425">
+			</ECState>
+			<ECState Name="State" Comment="Output events"  x="1755" y="280">
+				<ECAction Output="EO1"/>
+				<ECAction Output="EO2"/>
+			</ECState>
+			<ECTransition Source="START" Destination="State" Condition="EI" Comment="" x="1270" y="395"/>
+			<ECTransition Source="State" Destination="START" Condition="1" Comment="" x="1265" y="605"/>
+		</ECC>
+	</BasicFB>
 </FBType>

--- a/data/typelibrary/events-1.0.0/typelib/E_SPLIT.fbt
+++ b/data/typelibrary/events-1.0.0/typelib/E_SPLIT.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="E_SPLIT" Comment="Template for an empty basic function block" >
-	<Identification Standard="61499-1 Annex A" Classification="event function block" Function="Split one event into two events" Description="Copyright (c) 2017 fortiss GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+<FBType Name="E_SPLIT" Comment="Split one event into two events" >
+	<Identification Standard="61499-1 Annex A" Classification="event function block" Function="When EI is Triggered, A Event EO1 followed by a Event EO2 is issued." Description="Copyright (c) 2017 fortiss GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
 	</Identification>
 	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>


### PR DESCRIPTION
to remove the "Template for a empty basic function block" 