### PR TITLE
Fix premature apply when selecting proposal in initial value editor

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.ui/src/org/eclipse/fordiac/ide/ui/widget/StyledTextCellEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.ui/src/org/eclipse/fordiac/ide/ui/widget/StyledTextCellEditor.java
@@ -198,6 +198,13 @@ public class StyledTextCellEditor extends CellEditor {
 		return text;
 	}
 
+	@Override
+	protected void focusLost() {
+		if (!isProposalPopupOpen()) {
+			super.focusLost();
+		}
+	}
+
 	/**
 	 * Create the text control
 	 *


### PR DESCRIPTION
Fix premature apply when selecting proposal in initial value editor due to loss of focus while proposal popup is open.