### PR TITLE
Fix 2nd premature apply when selecting proposal in initial value editor

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editors/XtextEmbeddedFieldEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editors/XtextEmbeddedFieldEditor.java
@@ -81,11 +81,13 @@ public abstract class XtextEmbeddedFieldEditor {
 
 			@Override
 			public void focusLost(final FocusEvent e) {
-				commit();
+				if (!isProposalPopupOpen()) {
+					commit();
+				}
 			}
 		});
 		control.addVerifyKeyListener(event -> {
-			if (!isProposalPopupOpen()) {
+			if (event.doit && !isProposalPopupOpen()) {
 				if ((event.keyCode == SWT.CR || event.keyCode == SWT.KEYPAD_CR) && event.stateMask != SWT.MOD3) {
 					parent.forceFocus();
 					event.doit = false;

--- a/plugins/org.eclipse.fordiac.ide.ui/src/org/eclipse/fordiac/ide/ui/widget/StyledTextCellEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.ui/src/org/eclipse/fordiac/ide/ui/widget/StyledTextCellEditor.java
@@ -140,7 +140,7 @@ public class StyledTextCellEditor extends CellEditor {
 		text.addVerifyKeyListener(event -> {
 			// if the proposal popup is open we do not handle keystrokes
 			// ourself to ensure proposal handling is working correctly
-			if (!isProposalPopupOpen()) {
+			if (event.doit && !isProposalPopupOpen()) {
 				if (event.keyCode == SWT.CR || event.keyCode == SWT.KEYPAD_CR) {
 
 					boolean commit = event.stateMask != SWT.MOD3;


### PR DESCRIPTION
Fix second premature apply when selecting proposal in initial value editor due to loss of focus while proposal popup is open.