### PR TITLE
Removed Draw2d & GEF Examples from Target Platform

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.product/org.eclipse.fordiac.ide.product.target
+++ b/plugins/org.eclipse.fordiac.ide.product/org.eclipse.fordiac.ide.product.target
@@ -17,13 +17,9 @@
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/tools/gef/classic/nightly/latest/"/>
-			<unit id="org.eclipse.draw2d.examples" version="0.0.0"/>
-			<unit id="org.eclipse.draw2d.examples.source" version="0.0.0"/>
 			<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.draw2d.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.draw2d.source.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.gef.examples.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.gef.examples.source.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.gef.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.gef.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.gef.source.feature.group" version="0.0.0"/>


### PR DESCRIPTION
The examples are no dependency we should use. Furthermore with latest changes in the examples they are more demanding and not fitting to our current target platform.