### PR TITLE
LibraryManager didn't Correctly Handle Closing Projects

### DIFF
--- a/tests/org.eclipse.fordiac.ide.test.library/src/org/eclipse/fordiac/ide/test/library/LibraryImportTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.library/src/org/eclipse/fordiac/ide/test/library/LibraryImportTest.java
@@ -169,7 +169,7 @@ class LibraryImportTest {
 		ManifestHelper.addDependency(manifest, ManifestHelper.createRequired(TEST01, "[1.0.0-2.0.0)")); //$NON-NLS-1$
 		ManifestHelper.saveManifest(manifest);
 
-		LibraryManager.INSTANCE.checkManifestFile(project, TypeLibraryManager.INSTANCE.getTypeLibrary(project));
+		LibraryManager.INSTANCE.checkManifestFile(project);
 		Job.getJobManager().join(LibraryManager.FAMILY_FORDIAC_LIBRARY, null);
 
 		manifest = ManifestHelper.getContainerManifest(project);


### PR DESCRIPTION
When closing project the library manager tried to resolve the dependencies of the closed project which resulted in a broken typelibrary instance. On project reopening this led to broken types.

Furthermore as part of this work we could remove a workspace job from the resouce change listener making it cleaner and hopefully more stable.