### PR TITLE
Introducing error markers with QuickFix support for attributes

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/marker/resolution/BestFitAttributeMarkerResolution.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/marker/resolution/BestFitAttributeMarkerResolution.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Johannes Kepler University Linz
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Paul Stemmer - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.application.marker.resolution;
+
+import java.text.MessageFormat;
+import java.util.stream.Stream;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.fordiac.ide.model.commands.change.ChangeAttributeDeclarationCommand;
+import org.eclipse.fordiac.ide.model.errormarker.FordiacErrorMarker;
+import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
+import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
+import org.eclipse.fordiac.ide.model.typelibrary.AttributeTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
+import org.eclipse.fordiac.ide.ui.FordiacMessages;
+import org.eclipse.gef.commands.Command;
+import org.eclipse.swt.graphics.Image;
+
+public class BestFitAttributeMarkerResolution extends AbstractCommandMarkerResolution<Attribute> {
+
+	private final AttributeTypeEntry selectedAttribute;
+
+	protected BestFitAttributeMarkerResolution(final IMarker marker, final AttributeTypeEntry selectedAttribute) {
+		super(marker, Attribute.class);
+		this.selectedAttribute = selectedAttribute;
+	}
+
+	@Override
+	protected boolean prepare(final IMarker[] markers, final IProgressMonitor monitor) throws CoreException {
+		return true;
+	}
+
+	@Override
+	protected Command createCommand(final Attribute element, final IProgressMonitor monitor) throws CoreException {
+		return ChangeAttributeDeclarationCommand.forName(element, selectedAttribute.getFullTypeName());
+
+	}
+
+	public static Stream<BestFitAttributeMarkerResolution> createResolutions(final IMarker marker) {
+		String attrName = null;
+		if (FordiacErrorMarker.getTarget(marker) instanceof final Attribute attr) {
+			attrName = PackageNameHelper.extractPlainTypeName(attr.getName());
+		}
+		if (null == attrName) {
+			return Stream.empty();
+		}
+		final String name = attrName;
+		final TypeLibrary typeLibrary = TypeLibraryManager.INSTANCE.getTypeLibrary(marker.getResource().getProject());
+		return typeLibrary.getAttributeTypes().stream().filter(type -> type.getTypeName().equals(name))
+				.map(typeEntry -> new BestFitAttributeMarkerResolution(marker, typeEntry));
+	}
+
+	@Override
+	public String getDescription() {
+		return MessageFormat.format(FordiacMessages.Repair_Dialog_BestFitAttrType, selectedAttribute.getFullTypeName());
+	}
+
+	@Override
+	public Image getImage() {
+		return null;
+	}
+
+	@Override
+	public String getLabel() {
+		return MessageFormat.format(FordiacMessages.Repair_Dialog_BestFitAttrType, selectedAttribute.getFullTypeName());
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/marker/resolution/ChangeAttributeMarkerResolution.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/marker/resolution/ChangeAttributeMarkerResolution.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Johannes Kepler University Linz
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Paul Stemmer - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.application.marker.resolution;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.fordiac.ide.model.commands.change.ChangeAttributeDeclarationCommand;
+import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
+import org.eclipse.fordiac.ide.model.typelibrary.AttributeTypeEntry;
+import org.eclipse.fordiac.ide.model.ui.editors.DataTypeTreeSelectionDialog;
+import org.eclipse.fordiac.ide.model.ui.nat.AttributeSelectionTreeContentProvider;
+import org.eclipse.fordiac.ide.model.ui.nat.TypeNode;
+import org.eclipse.fordiac.ide.ui.FordiacMessages;
+import org.eclipse.gef.commands.Command;
+import org.eclipse.jface.window.Window;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.ui.PlatformUI;
+
+public class ChangeAttributeMarkerResolution extends AbstractCommandMarkerResolution<Attribute> {
+
+	private AttributeTypeEntry attribute;
+
+	protected ChangeAttributeMarkerResolution(final IMarker marker) {
+		super(marker, Attribute.class);
+	}
+
+	@Override
+	protected boolean prepare(final IMarker[] markers, final IProgressMonitor monitor) throws CoreException {
+		final DataTypeTreeSelectionDialog dialog = new DataTypeTreeSelectionDialog(
+				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(),
+				AttributeSelectionTreeContentProvider.INSTANCE);
+		dialog.setInput(getTypeLibrary());
+		if ((dialog.open() == Window.OK && dialog.getFirstResult() instanceof final TypeNode node
+				&& !node.isDirectory())) {
+			attribute = (AttributeTypeEntry) node.getTypeEntry();
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	protected Command createCommand(final Attribute element, final IProgressMonitor monitor) throws CoreException {
+		return ChangeAttributeDeclarationCommand.forName(element, attribute.getFullTypeName());
+	}
+
+	@Override
+	public String getDescription() {
+		return FordiacMessages.Repair_Dialog_ChangeAttribute;
+	}
+
+	@Override
+	public Image getImage() {
+		return null;
+	}
+
+	@Override
+	public String getLabel() {
+		return FordiacMessages.Repair_Dialog_ChangeAttribute;
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/marker/resolution/CreateAttributMarkerResolution.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/marker/resolution/CreateAttributMarkerResolution.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Johannes Kepler University Linz
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Paul Stemmer - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.application.marker.resolution;
+
+import java.io.File;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.fordiac.ide.model.commands.change.ChangeAttributeDeclarationCommand;
+import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
+import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
+import org.eclipse.fordiac.ide.model.typelibrary.AttributeTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
+import org.eclipse.fordiac.ide.typemanagement.util.TypeFromTemplateCreator;
+import org.eclipse.fordiac.ide.typemanagement.wizards.NewTypeWizard;
+import org.eclipse.fordiac.ide.ui.FordiacMessages;
+import org.eclipse.gef.commands.Command;
+import org.eclipse.swt.graphics.Image;
+
+public class CreateAttributMarkerResolution extends AbstractCommandMarkerResolution<Attribute> {
+	private static final String TEMPLATE_PATH = Platform.getInstallLocation().getURL().getFile() + File.separatorChar
+			+ "template" + File.separatorChar + "AttributeDeclaration.atp"; //$NON-NLS-1$ //$NON-NLS-2$
+
+	private AttributeTypeEntry newEntry;
+
+	protected CreateAttributMarkerResolution(final IMarker marker) {
+		super(marker, Attribute.class);
+	}
+
+	@Override
+	protected boolean prepare(final IMarker[] markers, final IProgressMonitor monitor) throws CoreException {
+		final File template = new File(TEMPLATE_PATH);
+
+		final String typeName = getMarker().getAttributes().get("location").toString(); //$NON-NLS-1$
+		final IFile targetFile = getTargetFile(typeName, markers[0].getResource().getProject());
+		final TypeFromTemplateCreator creator = new TypeFromTemplateCreator(targetFile, template,
+				PackageNameHelper.extractPackageName(typeName));
+		creator.createTypeFromTemplate(new NullProgressMonitor());
+		NewTypeWizard.openTypeEditor(targetFile);
+
+		newEntry = (AttributeTypeEntry) creator.getTypeEntry();
+		return null != newEntry;
+	}
+
+	private static IFile getTargetFile(final String typeName, final IProject project) {
+		return project.getFile(Path.fromOSString(TypeLibraryTags.TYPE_LIB_FOLDER_NAME)
+				.append(typeName.replace(PackageNameHelper.PACKAGE_NAME_DELIMITER, String.valueOf(IPath.SEPARATOR)))
+				.addFileExtension(TypeLibraryTags.ATTRIBUTE_TYPE_FILE_ENDING.toLowerCase()));
+	}
+
+	@Override
+	protected Command createCommand(final Attribute element, final IProgressMonitor monitor) throws CoreException {
+		return switch (element) {
+		case final Attribute attr -> ChangeAttributeDeclarationCommand.forName(attr, newEntry.getFullTypeName());
+		};
+	}
+
+	@Override
+	public String getDescription() {
+		return FordiacMessages.Repair_Dialog_New_Attribute;
+	}
+
+	@Override
+	public Image getImage() {
+		return null;
+	}
+
+	@Override
+	public String getLabel() {
+		return FordiacMessages.Repair_Dialog_New_Attribute;
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/marker/resolution/CreateAttributeMarkerResolution.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/marker/resolution/CreateAttributeMarkerResolution.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Johannes Kepler University Linz
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Paul Stemmer - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.application.marker.resolution;
+
+import java.io.File;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.fordiac.ide.model.commands.change.ChangeAttributeDeclarationCommand;
+import org.eclipse.fordiac.ide.model.errormarker.FordiacErrorMarker;
+import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
+import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
+import org.eclipse.fordiac.ide.model.typelibrary.AttributeTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
+import org.eclipse.fordiac.ide.typemanagement.util.TypeFromTemplateCreator;
+import org.eclipse.fordiac.ide.typemanagement.wizards.NewTypeWizard;
+import org.eclipse.fordiac.ide.ui.FordiacMessages;
+import org.eclipse.gef.commands.Command;
+import org.eclipse.swt.graphics.Image;
+
+public class CreateAttributeMarkerResolution extends AbstractCommandMarkerResolution<Attribute> {
+	private static final String TEMPLATE_PATH = Platform.getInstallLocation().getURL().getFile() + File.separatorChar
+			+ "template" + File.separatorChar + "AttributeDeclaration.atp"; //$NON-NLS-1$ //$NON-NLS-2$
+
+	private AttributeTypeEntry newEntry;
+
+	protected CreateAttributeMarkerResolution(final IMarker marker) {
+		super(marker, Attribute.class);
+	}
+
+	@Override
+	protected boolean prepare(final IMarker[] markers, final IProgressMonitor monitor) throws CoreException {
+		final File template = new File(TEMPLATE_PATH);
+		final String typeName = FordiacErrorMarker.getData(markers[0])[0];
+		final IFile targetFile = getTargetFile(typeName, markers[0].getResource().getProject());
+		final TypeFromTemplateCreator creator = new TypeFromTemplateCreator(targetFile, template,
+				PackageNameHelper.extractPackageName(typeName));
+		creator.createTypeFromTemplate(new NullProgressMonitor());
+		NewTypeWizard.openTypeEditor(targetFile);
+
+		newEntry = (AttributeTypeEntry) creator.getTypeEntry();
+		return null != newEntry;
+	}
+
+	private static IFile getTargetFile(final String typeName, final IProject project) {
+		return project.getFile(Path.fromOSString(TypeLibraryTags.TYPE_LIB_FOLDER_NAME)
+				.append(typeName.replace(PackageNameHelper.PACKAGE_NAME_DELIMITER, String.valueOf(IPath.SEPARATOR)))
+				.addFileExtension(TypeLibraryTags.ATTRIBUTE_TYPE_FILE_ENDING.toLowerCase()));
+	}
+
+	@Override
+	protected Command createCommand(final Attribute element, final IProgressMonitor monitor) throws CoreException {
+		return ChangeAttributeDeclarationCommand.forName(element, newEntry.getFullTypeName());
+	}
+
+	@Override
+	public String getDescription() {
+		return FordiacMessages.Repair_Dialog_New_Attribute;
+	}
+
+	@Override
+	public Image getImage() {
+		return null;
+	}
+
+	@Override
+	public String getLabel() {
+		return FordiacMessages.Repair_Dialog_New_Attribute;
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/marker/resolution/FordiacMarkerResolutionGenerator.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/marker/resolution/FordiacMarkerResolutionGenerator.java
@@ -13,6 +13,8 @@
  *    - initial API and implementation and/or initial documentation
  *   Martin Erich Jobst
  *    - add resolutions for configurable FBs
+ *   Paul Stemmer
+ *    - add resolutions for Attributes
  *******************************************************************************/
 package org.eclipse.fordiac.ide.application.marker.resolution;
 
@@ -29,6 +31,9 @@ public class FordiacMarkerResolutionGenerator implements IMarkerResolutionGenera
 	@Override
 	public IMarkerResolution[] getResolutions(final IMarker marker) {
 		return switch (FordiacErrorMarker.getCode(marker)) {
+		case LibraryElementValidator.ATTRIBUTE__VALIDATE_ATTRIBUTE_DECLARATION -> Stream.concat(
+				Stream.of(new CreateAttributeMarkerResolution(marker), new ChangeAttributeMarkerResolution(marker)),
+				BestFitAttributeMarkerResolution.createResolutions(marker)).toArray(IMarkerResolution[]::new);
 		case LibraryElementValidator.ITYPED_ELEMENT__VALIDATE_TYPE,
 				LibraryElementValidator.CONFIGURABLE_FB__VALIDATE_DATA_TYPE ->
 			Stream.concat(
@@ -47,6 +52,7 @@ public class FordiacMarkerResolutionGenerator implements IMarkerResolutionGenera
 		return LibraryElementValidator.DIAGNOSTIC_SOURCE.equals(FordiacErrorMarker.getSource(marker))
 				&& (LibraryElementValidator.ITYPED_ELEMENT__VALIDATE_TYPE == code
 						|| LibraryElementValidator.TYPED_CONFIGUREABLE_OBJECT__VALIDATE_TYPE == code
-						|| LibraryElementValidator.CONFIGURABLE_FB__VALIDATE_DATA_TYPE == code);
+						|| LibraryElementValidator.CONFIGURABLE_FB__VALIDATE_DATA_TYPE == code
+						|| LibraryElementValidator.ATTRIBUTE__VALIDATE_ATTRIBUTE_DECLARATION == code);
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/Messages.java
@@ -24,6 +24,7 @@ public final class Messages extends NLS {
 	public static String DataTypeDropdown_Type_Selection;
 	public static String DataTypeDropdown_Select_Type;
 	public static String DataTypeDropdown_Elementary_Types;
+	public static String AttributeTypeDropdown_Attribute_Types;
 	public static String DataTypeDropdown_STRUCT_Types;
 	public static String OpenEditorAction_text;
 	public static String OpenEditorAction_viewertext;

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/messages.properties
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/messages.properties
@@ -16,6 +16,7 @@ AutoReloadError_PathNotFound=Automatic reload of editor not possible due to data
 DataTypeDropdown_Type_Selection=Type Selection
 DataTypeDropdown_Select_Type=Select a Type:
 DataTypeDropdown_Elementary_Types=Elementary Types
+AttributeTypeDropdown_Attribute_Types=Attribute Types
 DataTypeDropdown_STRUCT_Types=Structured Types
 DataTypeDropdown_Adapter_Types=Adapter Types
 DataTypeDropdown_FB_Types=FB Types

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/nat/AttributeSelectionTreeContentProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/nat/AttributeSelectionTreeContentProvider.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Johannes Kepler University Linz
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Paul Stemmer - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.model.ui.nat;
+
+import java.util.List;
+
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
+import org.eclipse.fordiac.ide.model.ui.Messages;
+
+public class AttributeSelectionTreeContentProvider extends TypeSelectionTreeContentProvider {
+
+	public static final AttributeSelectionTreeContentProvider INSTANCE = new AttributeSelectionTreeContentProvider();
+
+	@Override
+	protected List<TypeNode> createTree(final TypeLibrary typeLibrary) {
+		final TypeNode attributeTypes = new TypeNode(Messages.AttributeTypeDropdown_Attribute_Types);
+		addPathSubtree(attributeTypes, typeLibrary.getAttributeTypes());
+		attributeTypes.sortChildren();
+
+		return List.of(attributeTypes);
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.model/model/fordiac.genmodel
+++ b/plugins/org.eclipse.fordiac.ide.model/model/fordiac.genmodel
@@ -79,6 +79,11 @@
         <genParameters ecoreParameter="lib.ecore#//Attribute/validateName/diagnostics"/>
         <genParameters ecoreParameter="lib.ecore#//Attribute/validateName/context"/>
       </genOperations>
+      <genOperations ecoreOperation="lib.ecore#//Attribute/validateAttributeDeclaration"
+          body="return org.eclipse.fordiac.ide.model.libraryElement.impl.AttributeAnnotations.validateAttributeDeclaration(this, diagnostics, context);">
+        <genParameters ecoreParameter="lib.ecore#//Attribute/validateAttributeDeclaration/diagnostics"/>
+        <genParameters ecoreParameter="lib.ecore#//Attribute/validateAttributeDeclaration/context"/>
+      </genOperations>
     </genClasses>
     <genClasses ecoreClass="lib.ecore#//AttributeDeclaration">
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference lib.ecore#//AttributeDeclaration/type"/>

--- a/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
+++ b/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
@@ -124,6 +124,21 @@
         </eGenericType>
       </eParameters>
     </eOperations>
+    <eOperations name="validateAttributeDeclaration" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore">
+        <details key="invariant" value="true"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="body" value="return org.eclipse.fordiac.ide.model.libraryElement.impl.AttributeAnnotations.validateAttributeDeclaration(this, diagnostics, context);"/>
+      </eAnnotations>
+      <eParameters name="diagnostics" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDiagnosticChain"/>
+      <eParameters name="context">
+        <eGenericType eClassifier="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EMap">
+          <eTypeArguments eClassifier="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EJavaObject"/>
+          <eTypeArguments eClassifier="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EJavaObject"/>
+        </eGenericType>
+      </eParameters>
+    </eOperations>
     <eStructuralFeatures xsi:type="ecore:EReference" name="attributeDeclaration" eType="#//AttributeDeclaration"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="type" eType="ecore:EClass data.ecore#//DataType"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/Attribute.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/Attribute.java
@@ -123,4 +123,12 @@ public interface Attribute extends ITypedElement {
 	 */
 	boolean validateName(DiagnosticChain diagnostics, Map<Object, Object> context);
 
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @model annotation="http://www.eclipse.org/emf/2002/Ecore invariant='true'"
+	 * @generated
+	 */
+	boolean validateAttributeDeclaration(DiagnosticChain diagnostics, Map<Object, Object> context);
+
 } // Attribute

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/AttributeImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/AttributeImpl.java
@@ -221,6 +221,16 @@ public class AttributeImpl extends EObjectImpl implements Attribute {
 	 * @generated
 	 */
 	@Override
+	public boolean validateAttributeDeclaration(final DiagnosticChain diagnostics, final Map<Object, Object> context) {
+		return org.eclipse.fordiac.ide.model.libraryElement.impl.AttributeAnnotations.validateAttributeDeclaration(this, diagnostics, context);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public DataType getType() {
 		if (type != null && type.eIsProxy()) {
 			InternalEObject oldType = (InternalEObject)type;

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
@@ -4441,6 +4441,15 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 		g1.getETypeArguments().add(g2);
 		addEParameter(op, g1, "context", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
+		op = addEOperation(attributeEClass, ecorePackage.getEBoolean(), "validateAttributeDeclaration", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEParameter(op, ecorePackage.getEDiagnosticChain(), "diagnostics", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		g1 = createEGenericType(ecorePackage.getEMap());
+		g2 = createEGenericType(ecorePackage.getEJavaObject());
+		g1.getETypeArguments().add(g2);
+		g2 = createEGenericType(ecorePackage.getEJavaObject());
+		g1.getETypeArguments().add(g2);
+		addEParameter(op, g1, "context", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+
 		initEClass(attributeDeclarationEClass, AttributeDeclaration.class, "AttributeDeclaration", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getAttributeDeclaration_Type(), theDataPackage.getAnyDerivedType(), null, "type", null, 0, 1, AttributeDeclaration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
@@ -6149,6 +6158,12 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 		String source = "http://www.eclipse.org/emf/2002/Ecore"; //$NON-NLS-1$
 		addAnnotation
 		  (attributeEClass.getEOperations().get(1),
+		   source,
+		   new String[] {
+			   "invariant", "true" //$NON-NLS-1$ //$NON-NLS-2$
+		   });
+		addAnnotation
+		  (attributeEClass.getEOperations().get(2),
 		   source,
 		   new String[] {
 			   "invariant", "true" //$NON-NLS-1$ //$NON-NLS-2$

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/util/LibraryElementValidator.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/util/LibraryElementValidator.java
@@ -179,12 +179,20 @@ public class LibraryElementValidator extends EObjectValidator {
 	public static final int ATTRIBUTE__VALIDATE_NAME = 1;
 
 	/**
+	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Attribute Declaration' of 'Attribute'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public static final int ATTRIBUTE__VALIDATE_ATTRIBUTE_DECLARATION = 2;
+
+	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Package Name' of 'Compiler Info'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int COMPILER_INFO__VALIDATE_PACKAGE_NAME = 2;
+	public static final int COMPILER_INFO__VALIDATE_PACKAGE_NAME = 3;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Data Type' of 'Configurable FB'.
@@ -192,7 +200,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONFIGURABLE_FB__VALIDATE_DATA_TYPE = 3;
+	public static final int CONFIGURABLE_FB__VALIDATE_DATA_TYPE = 4;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Missing Source' of 'Connection'.
@@ -200,7 +208,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONNECTION__VALIDATE_MISSING_SOURCE = 4;
+	public static final int CONNECTION__VALIDATE_MISSING_SOURCE = 5;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Missing Source Endpoint' of 'Connection'.
@@ -208,7 +216,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONNECTION__VALIDATE_MISSING_SOURCE_ENDPOINT = 5;
+	public static final int CONNECTION__VALIDATE_MISSING_SOURCE_ENDPOINT = 6;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Missing Destination' of 'Connection'.
@@ -216,7 +224,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONNECTION__VALIDATE_MISSING_DESTINATION = 6;
+	public static final int CONNECTION__VALIDATE_MISSING_DESTINATION = 7;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Missing Destination Endpoint' of 'Connection'.
@@ -224,7 +232,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONNECTION__VALIDATE_MISSING_DESTINATION_ENDPOINT = 7;
+	public static final int CONNECTION__VALIDATE_MISSING_DESTINATION_ENDPOINT = 8;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Duplicate' of 'Connection'.
@@ -232,7 +240,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONNECTION__VALIDATE_DUPLICATE = 8;
+	public static final int CONNECTION__VALIDATE_DUPLICATE = 9;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Type Mismatch' of 'Connection'.
@@ -240,7 +248,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONNECTION__VALIDATE_TYPE_MISMATCH = 9;
+	public static final int CONNECTION__VALIDATE_TYPE_MISMATCH = 10;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Mapped Var In Outs Do Not Cross Resource Boundaries' of 'Connection'.
@@ -248,7 +256,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONNECTION__VALIDATE_MAPPED_VAR_IN_OUTS_DO_NOT_CROSS_RESOURCE_BOUNDARIES = 10;
+	public static final int CONNECTION__VALIDATE_MAPPED_VAR_IN_OUTS_DO_NOT_CROSS_RESOURCE_BOUNDARIES = 11;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Var In Out Array Sizes Are Compatible' of 'Connection'.
@@ -256,7 +264,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONNECTION__VALIDATE_VAR_IN_OUT_ARRAY_SIZES_ARE_COMPATIBLE = 11;
+	public static final int CONNECTION__VALIDATE_VAR_IN_OUT_ARRAY_SIZES_ARE_COMPATIBLE = 12;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Var In Out String Lengths Match' of 'Connection'.
@@ -264,7 +272,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONNECTION__VALIDATE_VAR_IN_OUT_STRING_LENGTHS_MATCH = 12;
+	public static final int CONNECTION__VALIDATE_VAR_IN_OUT_STRING_LENGTHS_MATCH = 13;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Var In Outs Are Not Connected To Outs' of 'Connection'.
@@ -272,7 +280,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONNECTION__VALIDATE_VAR_IN_OUTS_ARE_NOT_CONNECTED_TO_OUTS = 13;
+	public static final int CONNECTION__VALIDATE_VAR_IN_OUTS_ARE_NOT_CONNECTED_TO_OUTS = 14;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Var In Out Connections Forms No Loop' of 'Connection'.
@@ -280,7 +288,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONNECTION__VALIDATE_VAR_IN_OUT_CONNECTIONS_FORMS_NO_LOOP = 14;
+	public static final int CONNECTION__VALIDATE_VAR_IN_OUT_CONNECTIONS_FORMS_NO_LOOP = 15;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Value' of 'Error Marker Interface'.
@@ -288,7 +296,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int ERROR_MARKER_INTERFACE__VALIDATE_VALUE = 15;
+	public static final int ERROR_MARKER_INTERFACE__VALIDATE_VALUE = 16;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Attributes' of 'Error Marker Interface'.
@@ -296,7 +304,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int ERROR_MARKER_INTERFACE__VALIDATE_ATTRIBUTES = 16;
+	public static final int ERROR_MARKER_INTERFACE__VALIDATE_ATTRIBUTES = 17;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Collisions' of 'FB Network'.
@@ -304,7 +312,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int FB_NETWORK__VALIDATE_COLLISIONS = 17;
+	public static final int FB_NETWORK__VALIDATE_COLLISIONS = 18;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Name' of 'FB Network Element'.
@@ -312,7 +320,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int FB_NETWORK_ELEMENT__VALIDATE_NAME = 18;
+	public static final int FB_NETWORK_ELEMENT__VALIDATE_NAME = 19;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Collisions' of 'Group'.
@@ -320,7 +328,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int GROUP__VALIDATE_COLLISIONS = 19;
+	public static final int GROUP__VALIDATE_COLLISIONS = 20;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Name' of 'IInterface Element'.
@@ -328,7 +336,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int IINTERFACE_ELEMENT__VALIDATE_NAME = 20;
+	public static final int IINTERFACE_ELEMENT__VALIDATE_NAME = 21;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Name' of 'INamed Element'.
@@ -336,7 +344,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int INAMED_ELEMENT__VALIDATE_NAME = 21;
+	public static final int INAMED_ELEMENT__VALIDATE_NAME = 22;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Type' of 'ITyped Element'.
@@ -344,7 +352,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int ITYPED_ELEMENT__VALIDATE_TYPE = 22;
+	public static final int ITYPED_ELEMENT__VALIDATE_TYPE = 23;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Type' of 'Typed Configureable Object'.
@@ -352,7 +360,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int TYPED_CONFIGUREABLE_OBJECT__VALIDATE_TYPE = 23;
+	public static final int TYPED_CONFIGUREABLE_OBJECT__VALIDATE_TYPE = 24;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Multiple Input Connections' of 'Var Declaration'.
@@ -360,7 +368,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_MULTIPLE_INPUT_CONNECTIONS = 24;
+	public static final int VAR_DECLARATION__VALIDATE_MULTIPLE_INPUT_CONNECTIONS = 25;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate No Value For Generic Type Variable' of 'Var Declaration'.
@@ -368,7 +376,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_NO_VALUE_FOR_GENERIC_TYPE_VARIABLE = 25;
+	public static final int VAR_DECLARATION__VALIDATE_NO_VALUE_FOR_GENERIC_TYPE_VARIABLE = 26;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate No Value For Variable Length Array Variable' of 'Var Declaration'.
@@ -376,7 +384,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_NO_VALUE_FOR_VARIABLE_LENGTH_ARRAY_VARIABLE = 26;
+	public static final int VAR_DECLARATION__VALIDATE_NO_VALUE_FOR_VARIABLE_LENGTH_ARRAY_VARIABLE = 27;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Value For Generic Instance Variable' of 'Var Declaration'.
@@ -384,7 +392,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_VALUE_FOR_GENERIC_INSTANCE_VARIABLE = 27;
+	public static final int VAR_DECLARATION__VALIDATE_VALUE_FOR_GENERIC_INSTANCE_VARIABLE = 28;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Var In Out Source Type Is Well Defined' of 'Var Declaration'.
@@ -392,7 +400,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_VAR_IN_OUT_SOURCE_TYPE_IS_WELL_DEFINED = 28;
+	public static final int VAR_DECLARATION__VALIDATE_VAR_IN_OUT_SOURCE_TYPE_IS_WELL_DEFINED = 29;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Var In Out Is Withed' of 'Var Declaration'.
@@ -400,7 +408,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_VAR_IN_OUT_IS_WITHED = 29;
+	public static final int VAR_DECLARATION__VALIDATE_VAR_IN_OUT_IS_WITHED = 30;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Var In Out Subapp Interface' of 'Var Declaration'.
@@ -408,7 +416,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_VAR_IN_OUT_SUBAPP_INTERFACE = 30;
+	public static final int VAR_DECLARATION__VALIDATE_VAR_IN_OUT_SUBAPP_INTERFACE = 31;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Var In Out Subapp Network' of 'Var Declaration'.
@@ -416,7 +424,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_VAR_IN_OUT_SUBAPP_NETWORK = 31;
+	public static final int VAR_DECLARATION__VALIDATE_VAR_IN_OUT_SUBAPP_NETWORK = 32;
 
 	/**
 	 * A constant with a fixed name that can be used as the base value for additional hand written constants.
@@ -424,7 +432,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	private static final int GENERATED_DIAGNOSTIC_CODE_COUNT = 31;
+	private static final int GENERATED_DIAGNOSTIC_CODE_COUNT = 32;
 
 	/**
 	 * A constant with a fixed name that can be used as the base value for additional hand written constants in a derived class.
@@ -856,6 +864,7 @@ public class LibraryElementValidator extends EObjectValidator {
 		if (result || diagnostics != null) result &= validate_EveryMapEntryUnique(attribute, diagnostics, context);
 		if (result || diagnostics != null) result &= validateAttribute_validateName(attribute, diagnostics, context);
 		if (result || diagnostics != null) result &= validateITypedElement_validateType(attribute, diagnostics, context);
+		if (result || diagnostics != null) result &= validateAttribute_validateAttributeDeclaration(attribute, diagnostics, context);
 		return result;
 	}
 
@@ -867,6 +876,16 @@ public class LibraryElementValidator extends EObjectValidator {
 	 */
 	public boolean validateAttribute_validateName(Attribute attribute, DiagnosticChain diagnostics, Map<Object, Object> context) {
 		return attribute.validateName(diagnostics, context);
+	}
+
+	/**
+	 * Validates the validateAttributeDeclaration constraint of '<em>Attribute</em>'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public boolean validateAttribute_validateAttributeDeclaration(Attribute attribute, DiagnosticChain diagnostics, Map<Object, Object> context) {
+		return attribute.validateAttributeDeclaration(diagnostics, context);
 	}
 
 	/**

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/Messages.java
@@ -65,6 +65,7 @@ public final class Messages extends NLS {
 	public static String Error_RecursiveType;
 	public static String Error_SelfInsertion;
 	public static String ErrorMarkerInterfaceAnnotations_MissingVariableForAttribute;
+	public static String AttributeAnnotations_MissingAttributeDeclaration;
 
 	public static String ErrorMarkerInterfaceAnnotations_MissingVariableForValue;
 	public static String FBNetworkAnnotations_CollisionMessage;

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/CommonElementImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/CommonElementImporter.java
@@ -49,6 +49,7 @@ import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes.ElementaryTypes;
 import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes.HelperTypes;
 import org.eclipse.fordiac.ide.model.datatype.helper.InternalAttributeDeclarations;
 import org.eclipse.fordiac.ide.model.errormarker.FordiacErrorMarkerInterfaceHelper;
+import org.eclipse.fordiac.ide.model.errormarker.FordiacMarkerHelper;
 import org.eclipse.fordiac.ide.model.helpers.FBNetworkHelper;
 import org.eclipse.fordiac.ide.model.helpers.ImportHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
@@ -444,6 +445,8 @@ public abstract class CommonElementImporter {
 				if (attributeTypeEntry != null && attributeTypeEntry.getType() != null) {
 					attribute.setAttributeDeclaration(attributeTypeEntry.getType());
 					attribute.setType(attributeTypeEntry.getType().getType());
+				} else {
+					FordiacMarkerHelper.createAttributeErrorMarker(attribute, typeLibrary);
 				}
 			}
 		}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/errormarker/FordiacMarkerHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/errormarker/FordiacMarkerHelper.java
@@ -38,10 +38,13 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
+import org.eclipse.fordiac.ide.model.libraryElement.AttributeDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.ErrorMarkerFBNElement;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.libraryElement.Position;
 import org.eclipse.fordiac.ide.model.libraryElement.util.LibraryElementValidator;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
@@ -320,6 +323,15 @@ public final class FordiacMarkerHelper {
 		position.setY(0);
 		createErrorMarkerFBNElement.setPosition(position);
 		return createErrorMarkerFBNElement;
+	}
+
+	public static void createAttributeErrorMarker(final Attribute attribute, final TypeLibrary typeLib) {
+		final TypeEntry typeEntry = typeLib.createErrorTypeEntry(attribute.getName(),
+				LibraryElementPackage.eINSTANCE.getAttributeDeclaration());
+		final AttributeDeclaration aDecl = (AttributeDeclaration) typeEntry.getType();
+
+		attribute.setAttributeDeclaration(aDecl);
+		attribute.setType(aDecl.getType());
 	}
 
 	private static boolean errorMarkersNeedsUpdate(final IResource resource, final String type,

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/AttributeAnnotations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/AttributeAnnotations.java
@@ -12,12 +12,20 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.model.libraryElement.impl;
 
+import java.text.MessageFormat;
 import java.util.Map;
 
+import org.eclipse.emf.common.util.BasicDiagnostic;
+import org.eclipse.emf.common.util.Diagnostic;
 import org.eclipse.emf.common.util.DiagnosticChain;
+import org.eclipse.fordiac.ide.model.Messages;
 import org.eclipse.fordiac.ide.model.datatype.helper.InternalAttributeDeclarations;
+import org.eclipse.fordiac.ide.model.errormarker.FordiacMarkerHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
 import org.eclipse.fordiac.ide.model.libraryElement.Connection;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
+import org.eclipse.fordiac.ide.model.libraryElement.util.LibraryElementValidator;
+import org.eclipse.fordiac.ide.model.typelibrary.ErrorTypeEntry;
 
 public final class AttributeAnnotations {
 	private static final String NAMED_ELEMENTS_KEY = AttributeAnnotations.class.getName() + ".NAMED_ELEMENTS"; //$NON-NLS-1$
@@ -28,6 +36,26 @@ public final class AttributeAnnotations {
 					+ NamedElementAnnotations.QUALIFIED_NAME_DELIMITER + attribute.getName();
 		}
 		return NamedElementAnnotations.getQualifiedName(attribute);
+	}
+
+	public static boolean validateAttributeDeclaration(final Attribute attribute, final DiagnosticChain diagnostics,
+			final Map<Object, Object> context) {
+		if (null != attribute.getAttributeDeclaration()
+				&& attribute.getAttributeDeclaration().getTypeEntry() instanceof ErrorTypeEntry) {
+			if (diagnostics != null) {
+				diagnostics.add(createAttributeValidationDiagnostic(MessageFormat.format(
+						Messages.AttributeAnnotations_MissingAttributeDeclaration, attribute.getName()), attribute));
+			}
+			return false;
+		}
+		return true;
+	}
+
+	private static Diagnostic createAttributeValidationDiagnostic(final String message, final Attribute attribute) {
+		return new BasicDiagnostic(Diagnostic.ERROR, LibraryElementValidator.DIAGNOSTIC_SOURCE,
+				LibraryElementValidator.ATTRIBUTE__VALIDATE_ATTRIBUTE_DECLARATION, message,
+				FordiacMarkerHelper.getDiagnosticData(attribute,
+						LibraryElementPackage.Literals.ATTRIBUTE__ATTRIBUTE_DECLARATION, attribute.getName()));
 	}
 
 	public static boolean validateName(final Attribute attribute, final DiagnosticChain diagnostics,

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/messages.properties
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/messages.properties
@@ -50,6 +50,7 @@ Error_RecursiveType={0} cannot be inserted as {1} would be recursively contained
 Error_SelfInsertion={0} cannot be inserted into itself!
 ErrorMarkerInterfaceAnnotations_MissingVariableForAttribute=Missing variable for attribute: {0}
 ErrorMarkerInterfaceAnnotations_MissingVariableForValue=Missing variable for value: {0}
+AttributeAnnotations_MissingAttributeDeclaration=Attribute Declaration ''{0}'' not found 
 FBNetworkAnnotations_CollisionMessage=Collision between {0} and {1}
 FBNetworkAnnotations_InterfaceBarCollisionMessage=Collision of {0} with Maximum Size of Interface Bar of {1}
 FBTImporter_ADAPTER_DECLARATION_TYPE_EXCEPTION=AdapterDeclaration: type has to be set\!

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/ErrorAttributeTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/ErrorAttributeTypeEntryImpl.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Johannes Kepler University Linz
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Paul Stemmer - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.model.typelibrary.impl;
+
+import org.eclipse.fordiac.ide.model.typelibrary.ErrorTypeEntry;
+
+public class ErrorAttributeTypeEntryImpl extends AttributeTypeEntryImpl implements ErrorTypeEntry {
+	// marker class
+}

--- a/plugins/org.eclipse.fordiac.ide.ui/src/org/eclipse/fordiac/ide/ui/FordiacMessages.java
+++ b/plugins/org.eclipse.fordiac.ide.ui/src/org/eclipse/fordiac/ide/ui/FordiacMessages.java
@@ -134,13 +134,16 @@ public final class FordiacMessages extends NLS {
 
 	public static String Repair_Dialog_Delete_Elements; // NOSONAR
 	public static String Repair_Dialog_New_DataType;// NOSONAR
+	public static String Repair_Dialog_New_Attribute;// NOSONAR
 	public static String Repair_Dialog_Pin_Add;// NOSONAR
 	public static String Repair_Dialog_Pin_Remove;// NOSONAR
 	public static String Repair_Dialog_FB_Title;// NOSONAR
 	public static String Repair_Dialog_New_FB;// NOSONAR
 	public static String Repair_Dialog_ChangeDataType;// NOSONAR
+	public static String Repair_Dialog_ChangeAttribute;// NOSONAR
 	public static String Repair_Dialog_ChangeFBType;// NOSONAR
 	public static String Repair_Dialog_BestFitDataType;// NOSONAR
+	public static String Repair_Dialog_BestFitAttrType;// NOSONAR
 	public static String Repair_Dialog_BestFitFBType;// NOSONAR
 
 	public static String Subapp_Size_DisableAutoResize; // NOSONAR

--- a/plugins/org.eclipse.fordiac.ide.ui/src/org/eclipse/fordiac/ide/ui/messages.properties
+++ b/plugins/org.eclipse.fordiac.ide.ui/src/org/eclipse/fordiac/ide/ui/messages.properties
@@ -129,11 +129,14 @@ Dialog_Repair_Remove=Remove pin from instances
 
 Repair_Dialog_Delete_Elements=Delete elements that contain missing data type
 Repair_Dialog_New_DataType=Create Missing Data Type
+Repair_Dialog_New_Attribute=Create Missing Attribute Declaration
 Repair_Dialog_Pin_Add=Add pin to definition
 Repair_Dialog_Pin_Remove=Remove pin from instances
 Repair_Dialog_FB_Title=Repair broken FB
 Repair_Dialog_New_FB=Create new FB
 Repair_Dialog_ChangeDataType=Change Data Type
+Repair_Dialog_ChangeAttribute=Change Attribute Declaration
 Repair_Dialog_ChangeFBType=Change FB Type
 Repair_Dialog_BestFitDataType=Change to: {0}
+Repair_Dialog_BestFitAttrType=Change to: {0}
 Repair_Dialog_BestFitFBType=Change to: {0}


### PR DESCRIPTION
When an attribute is deleted from the type library, a new error marker will be created. This error marker now includes QuickFix support. The following Quickfixes are supported:
      Change atp
      Create atp
      Suggestion of best fitting atp