### PR TITLE
Add autoformat and reconcile to save ant task

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.ant/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.ant/META-INF/MANIFEST.MF
@@ -10,16 +10,13 @@ Require-Bundle: org.eclipse.core.resources,
  org.eclipse.ant.core,
  org.eclipse.fordiac.ide.systemmanagement,
  org.eclipse.fordiac.ide.model,
- org.eclipse.fordiac.ide.model.eval,
- org.eclipse.fordiac.ide.export.ui,
  org.eclipse.fordiac.ide.export.forte_ng,
  org.eclipse.fordiac.ide.export,
- org.eclipse.fordiac.ide.typemanagement,
  org.eclipse.fordiac.ide.export.xmi,
  org.eclipse.fordiac.ide.library,
  org.eclipse.fordiac.ide.library.model,
  org.eclipse.fordiac.ide.hierarchymanager.model,
- org.eclipse.fordiac.ide.hierarchymanager.ui,
- org.eclipse.fordiac.ide.library
+ org.eclipse.fordiac.ide.hierarchymanager.ui
 Bundle-Vendor: Eclipse 4diac
 Bundle-ActivationPolicy: lazy
+Import-Package: org.eclipse.xtext.resource;version="[2.35.0,3.0.0)"

--- a/plugins/org.eclipse.fordiac.ide.ant/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.ant/plugin.xml
@@ -124,6 +124,14 @@
    <extension
          point="org.eclipse.ant.core.antTasks">
       <antTask
+            class="org.eclipse.fordiac.ide.ant.ant.ResaveTypelib"
+            library="ant_tasks/ant-ant.jar"
+            name="fordiac.resaveTypeLib">
+      </antTask>
+   </extension>
+   <extension
+         point="org.eclipse.ant.core.antTasks">
+      <antTask
             class="org.eclipse.fordiac.ide.ant.ant.ExportProjectLibrary"
             library="ant_tasks/ant-ant.jar"
             name="fordiac.exportProjectLibrary">

--- a/plugins/org.eclipse.fordiac.ide.ant/scripts/buildExtraJAR.xml
+++ b/plugins/org.eclipse.fordiac.ide.ant/scripts/buildExtraJAR.xml
@@ -26,18 +26,26 @@
             <dirset dir="${basedir}/..">
                <include name="org.eclipse.fordiac.ide.ant/bin"/>
                <include name="org.eclipse.fordiac.ide.model/bin"/>
+               <include name="org.eclipse.fordiac.ide.library/bin"/>
+               <include name="org.eclipse.fordiac.ide.hierarchymanager/bin"/>
+               <include name="org.eclipse.fordiac.ide.library.model/bin"/>
                <include name="org.eclipse.fordiac.ide.systemmanagement/bin"/>
+               <include name="org.eclipse.fordiac.ide.export/bin"/>
+               <include name="org.eclipse.fordiac.ide.export.forte_ng/bin"/>
+               <include name="org.eclipse.fordiac.ide.export.xmi/bin"/>
             </dirset>
             <fileset dir="${target.home}">
-				<include name="plugins/eclipse.fordiac.ide.ant*.jar"/>
-				<include name="plugins/eclipse.fordiac.ide.model*.jar"/>
-				<include name="plugins/org.eclipse.core.resources*.jar"/>
-				<include name="plugins/org.eclipse.core.runtime*.jar"/>
-				<include name="plugins/org.eclipse.equinox.common*.jar"/>
-				<include name="plugins/org.eclipse.core.jobs*.jar"/>
-				<include name="plugins/org.eclipse.osgi*.jar"/>
-				<include name="plugins/org.eclipse.ant.core*.jar"/>
-				<include name="plugins/org.apache.ant*/lib/*.jar"/>
+                <include name="plugins/org.eclipse.emf.common*.jar"/>
+                <include name="plugins/org.eclipse.emf.ecore*.jar"/>
+                <include name="plugins/org.eclipse.fordiac.ide.hierarchymanager*.jar"/>
+                <include name="plugins/org.eclipse.core.resources*.jar"/>
+                <include name="plugins/org.eclipse.core.runtime*.jar"/>
+                <include name="plugins/org.eclipse.equinox.common*.jar"/>
+                <include name="plugins/org.eclipse.core.jobs*.jar"/>
+                <include name="plugins/org.eclipse.osgi*.jar"/>
+                <include name="plugins/org.eclipse.ant.core*.jar"/>
+                <include name="plugins/org.apache.ant*/lib/*.jar"/>
+                <include name="plugins/org.eclipse.xtext*.jar"/>
             </fileset>
          </classpath>
          <src path="src_ant/"/>

--- a/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/ResaveTypelib.java
+++ b/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/ResaveTypelib.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Ernst Blecha - initial implementation and/or documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.ant.ant;
+
+import java.text.MessageFormat;
+
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Task;
+
+public class ResaveTypelib extends Task {
+
+	public void setAutoFormat(final boolean enable) {
+		this.autoformat = enable;
+	}
+
+	public void setProjectname(final String projectname) {
+		this.projectname = AbstractBlockModelTask.nullCheckString(projectname);
+	}
+
+	@Override
+	public final void execute() throws BuildException {
+		final var fordiacProject = AbstractBlockModelTask.getFordiacProject(projectname);
+		final var tl = AbstractBlockModelTask.getTypeLibrary(fordiacProject, projectname);
+
+		log(MessageFormat.format("Save {0}", projectname)); //$NON-NLS-1$
+		tl.getAllTypes().forEach(te -> SaveBlock.saveBlock(te, autoformat, this::log));
+	}
+
+	protected String projectname = AbstractBlockModelTask.EMPTY_STRING;
+
+	private boolean autoformat = false;
+
+}

--- a/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/SaveBlock.java
+++ b/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/SaveBlock.java
@@ -82,15 +82,16 @@ public class SaveBlock extends AbstractBlockModelTask {
 			.getResourceServiceProvider(SYNTHETIC_URI_GCF);
 
 	private static ResourceSet getResourceSet(final TypeEntry te) {
-		XtextResourceSet resourceSet = null;
+		XtextResourceSet resourceSet;
 
 		if (te.getFile().getFullPath().getFileExtension().equalsIgnoreCase(TypeLibraryTags.FC_TYPE_FILE_ENDING)) {
 			resourceSet = SERVICE_PROVIDER_FCT.get(XtextResourceSet.class);
-		}
-		if (te.getFile().getFullPath().getFileExtension().equalsIgnoreCase(TypeLibraryTags.GLOBAL_CONST_FILE_ENDING)) {
+		} else if (te.getFile().getFullPath().getFileExtension()
+				.equalsIgnoreCase(TypeLibraryTags.GLOBAL_CONST_FILE_ENDING)) {
 			resourceSet = SERVICE_PROVIDER_GCF.get(XtextResourceSet.class);
+		} else {
+			resourceSet = SERVICE_PROVIDER_FBT.get(XtextResourceSet.class);
 		}
-		resourceSet = SERVICE_PROVIDER_FBT.get(XtextResourceSet.class);
 
 		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
 				TypeLibraryTags.FB_TYPE_FILE_ENDING.toLowerCase(), //

--- a/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/SaveBlock.java
+++ b/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/SaveBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Primetals Technologies Austria GmbH
+ * Copyright (c) 2023 - 2025 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,25 +9,102 @@
  *
  * Contributors:
  *   Ernst Blecha - initial implementation and/or documentation
+ *   Ernst Blecha - run reconciler and autoformat during saving
  *******************************************************************************/
 package org.eclipse.fordiac.ide.ant.ant;
 
+import java.io.IOException;
 import java.text.MessageFormat;
+import java.util.function.Consumer;
 
 import org.apache.tools.ant.BuildException;
-import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
+import org.eclipse.xtext.resource.IResourceFactory;
+import org.eclipse.xtext.resource.IResourceServiceProvider;
+import org.eclipse.xtext.resource.SaveOptions;
+import org.eclipse.xtext.resource.XtextResourceSet;
 
 public class SaveBlock extends AbstractBlockModelTask {
 
+	public void setAutoFormat(final boolean enable) {
+		this.autoformat = enable;
+	}
+
 	@Override
 	protected void modifyBlock(final FBType fb) {
+		log(MessageFormat.format("Save {0}/{1}", projectname, blockname)); //$NON-NLS-1$
+		saveBlock(fb.getTypeEntry(), autoformat, this::log);
+	}
+
+	private boolean autoformat = false;
+
+	public static void saveBlock(final TypeEntry te, final boolean autoformat, final Consumer<String> logger) {
 		try {
-			fb.getTypeEntry().save(fb);
-			log(MessageFormat.format("Save {0}/{1}", projectname, blockname)); //$NON-NLS-1$
-		} catch (final CoreException e) {
+			final IFile typeFile = te.getFile();
+
+			if (typeFile.isLinked(IResource.CHECK_ANCESTORS)) {
+				// do not modify files stored outside the project that are only linked in
+				return;
+			}
+
+			logger.accept(te.getFullTypeName());
+
+			final URI sourceUri = URI.createPlatformResourceURI(typeFile.getFullPath().toString(), true);
+			final Resource resource = getResourceSet(te).getResource(sourceUri, true);
+
+			final SaveOptions.Builder optionsBuilder = SaveOptions.newBuilder();
+			if (autoformat) {
+				optionsBuilder.format();
+			}
+			resource.save(optionsBuilder.getOptions().toOptionsMap());
+		} catch (final IOException e) {
 			throw new BuildException(e);
 		}
+	}
+
+	private static final URI SYNTHETIC_URI_FBT = URI.createURI("__synthetic.stalg"); //$NON-NLS-1$
+	private static final IResourceServiceProvider SERVICE_PROVIDER_FBT = IResourceServiceProvider.Registry.INSTANCE
+			.getResourceServiceProvider(SYNTHETIC_URI_FBT);
+
+	private static final URI SYNTHETIC_URI_FCT = URI.createURI("__synthetic.stfunc"); //$NON-NLS-1$
+	private static final IResourceServiceProvider SERVICE_PROVIDER_FCT = IResourceServiceProvider.Registry.INSTANCE
+			.getResourceServiceProvider(SYNTHETIC_URI_FCT);
+
+	private static final URI SYNTHETIC_URI_GCF = URI.createURI("__synthetic.globalconsts"); //$NON-NLS-1$
+	private static final IResourceServiceProvider SERVICE_PROVIDER_GCF = IResourceServiceProvider.Registry.INSTANCE
+			.getResourceServiceProvider(SYNTHETIC_URI_GCF);
+
+	private static ResourceSet getResourceSet(final TypeEntry te) {
+		XtextResourceSet resourceSet = null;
+
+		if (te.getFile().getFullPath().getFileExtension().equalsIgnoreCase("FCT")) { //$NON-NLS-1$
+			resourceSet = SERVICE_PROVIDER_FCT.get(XtextResourceSet.class);
+		}
+		if (te.getFile().getFullPath().getFileExtension().equalsIgnoreCase("GCF")) { //$NON-NLS-1$
+			resourceSet = SERVICE_PROVIDER_GCF.get(XtextResourceSet.class);
+		}
+		resourceSet = SERVICE_PROVIDER_FBT.get(XtextResourceSet.class);
+
+		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("fbt", //$NON-NLS-1$
+				SERVICE_PROVIDER_FBT.get(IResourceFactory.class));
+		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("FBT", //$NON-NLS-1$
+				SERVICE_PROVIDER_FBT.get(IResourceFactory.class));
+		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("fct", //$NON-NLS-1$
+				SERVICE_PROVIDER_FCT.get(IResourceFactory.class));
+		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("FCT", //$NON-NLS-1$
+				SERVICE_PROVIDER_FCT.get(IResourceFactory.class));
+		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("gcf", //$NON-NLS-1$
+				SERVICE_PROVIDER_GCF.get(IResourceFactory.class));
+		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("GCF", //$NON-NLS-1$
+				SERVICE_PROVIDER_GCF.get(IResourceFactory.class));
+
+		return resourceSet;
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/SaveBlock.java
+++ b/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/SaveBlock.java
@@ -25,6 +25,7 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 import org.eclipse.xtext.resource.IResourceFactory;
 import org.eclipse.xtext.resource.IResourceServiceProvider;
 import org.eclipse.xtext.resource.SaveOptions;
@@ -83,25 +84,31 @@ public class SaveBlock extends AbstractBlockModelTask {
 	private static ResourceSet getResourceSet(final TypeEntry te) {
 		XtextResourceSet resourceSet = null;
 
-		if (te.getFile().getFullPath().getFileExtension().equalsIgnoreCase("FCT")) { //$NON-NLS-1$
+		if (te.getFile().getFullPath().getFileExtension().equalsIgnoreCase(TypeLibraryTags.FC_TYPE_FILE_ENDING)) {
 			resourceSet = SERVICE_PROVIDER_FCT.get(XtextResourceSet.class);
 		}
-		if (te.getFile().getFullPath().getFileExtension().equalsIgnoreCase("GCF")) { //$NON-NLS-1$
+		if (te.getFile().getFullPath().getFileExtension().equalsIgnoreCase(TypeLibraryTags.GLOBAL_CONST_FILE_ENDING)) {
 			resourceSet = SERVICE_PROVIDER_GCF.get(XtextResourceSet.class);
 		}
 		resourceSet = SERVICE_PROVIDER_FBT.get(XtextResourceSet.class);
 
-		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("fbt", //$NON-NLS-1$
+		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+				TypeLibraryTags.FB_TYPE_FILE_ENDING.toLowerCase(), //
 				SERVICE_PROVIDER_FBT.get(IResourceFactory.class));
-		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("FBT", //$NON-NLS-1$
+		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+				TypeLibraryTags.FB_TYPE_FILE_ENDING, //
 				SERVICE_PROVIDER_FBT.get(IResourceFactory.class));
-		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("fct", //$NON-NLS-1$
+		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+				TypeLibraryTags.FC_TYPE_FILE_ENDING.toLowerCase(), //
 				SERVICE_PROVIDER_FCT.get(IResourceFactory.class));
-		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("FCT", //$NON-NLS-1$
+		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+				TypeLibraryTags.FC_TYPE_FILE_ENDING, //
 				SERVICE_PROVIDER_FCT.get(IResourceFactory.class));
-		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("gcf", //$NON-NLS-1$
+		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+				TypeLibraryTags.GLOBAL_CONST_FILE_ENDING.toLowerCase(), //
 				SERVICE_PROVIDER_GCF.get(IResourceFactory.class));
-		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("GCF", //$NON-NLS-1$
+		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+				TypeLibraryTags.GLOBAL_CONST_FILE_ENDING, //
 				SERVICE_PROVIDER_GCF.get(IResourceFactory.class));
 
 		return resourceSet;

--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/src/org/eclipse/fordiac/ide/globalconstantseditor/ui/resource/GlobalConstantsResourceSetInitializer.java
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/src/org/eclipse/fordiac/ide/globalconstantseditor/ui/resource/GlobalConstantsResourceSetInitializer.java
@@ -16,6 +16,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.fordiac.ide.globalconstantseditor.ui.internal.GlobalconstantseditorActivator;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 import org.eclipse.fordiac.ide.systemmanagement.SystemManager;
 import org.eclipse.xtext.resource.IResourceFactory;
 import org.eclipse.xtext.ui.resource.IResourceSetInitializer;
@@ -28,8 +29,12 @@ public class GlobalConstantsResourceSetInitializer implements IResourceSetInitia
 	public void initialize(final ResourceSet resourceSet, final IProject project) {
 		if (has4diacProjectNature(project)) {
 			final IResourceFactory resourceFactory = getInjector().getInstance(IResourceFactory.class);
-			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("gcf", resourceFactory); //$NON-NLS-1$
-			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("GCF", resourceFactory); //$NON-NLS-1$
+			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+					TypeLibraryTags.GLOBAL_CONST_FILE_ENDING.toLowerCase(), //
+					resourceFactory);
+			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+					TypeLibraryTags.GLOBAL_CONST_FILE_ENDING, //
+					resourceFactory);
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor/src/org/eclipse/fordiac/ide/globalconstantseditor/util/GlobalConstantsParseUtil.java
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor/src/org/eclipse/fordiac/ide/globalconstantseditor/util/GlobalConstantsParseUtil.java
@@ -23,6 +23,7 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.globalconstantseditor.globalConstants.STGlobalConstsSource;
 import org.eclipse.fordiac.ide.globalconstantseditor.resource.GlobalConstantsResource;
 import org.eclipse.fordiac.ide.model.libraryElement.GlobalConstants;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 import org.eclipse.fordiac.ide.structuredtextcore.util.STCoreParseUtil;
 import org.eclipse.xtext.parser.IParseResult;
 import org.eclipse.xtext.resource.IResourceFactory;
@@ -60,13 +61,17 @@ public final class GlobalConstantsParseUtil {
 	private static IParseResult parseInternal(final GlobalConstants type, final List<Issue> issues) {
 		final XtextResourceSet resourceSet = (XtextResourceSet) SERVICE_PROVIDER_GCF.get(ResourceSet.class);
 		resourceSet.getLoadOptions().put(ResourceDescriptionsProvider.PERSISTED_DESCRIPTIONS, Boolean.TRUE);
-		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("gcf", //$NON-NLS-1$
+		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+				TypeLibraryTags.GLOBAL_CONST_FILE_ENDING.toLowerCase(), //
 				SERVICE_PROVIDER_GCF.get(IResourceFactory.class));
-		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("GCF", //$NON-NLS-1$
+		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+				TypeLibraryTags.GLOBAL_CONST_FILE_ENDING, //
 				SERVICE_PROVIDER_GCF.get(IResourceFactory.class));
-		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("fct", //$NON-NLS-1$
+		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+				TypeLibraryTags.FC_TYPE_FILE_ENDING.toLowerCase(), //
 				SERVICE_PROVIDER_FCT.get(IResourceFactory.class));
-		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("FCT", //$NON-NLS-1$
+		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+				TypeLibraryTags.FC_TYPE_FILE_ENDING, //
 				SERVICE_PROVIDER_FCT.get(IResourceFactory.class));
 		final GlobalConstantsResource resource = (GlobalConstantsResource) SERVICE_PROVIDER_GCF
 				.get(XtextResource.class);

--- a/plugins/org.eclipse.fordiac.ide.hierarchymanager.ui/src/org/eclipse/fordiac/ide/hierarchymanager/ui/listeners/HierachyManagerUpdateListener.java
+++ b/plugins/org.eclipse.fordiac.ide.hierarchymanager.ui/src/org/eclipse/fordiac/ide/hierarchymanager/ui/listeners/HierachyManagerUpdateListener.java
@@ -47,8 +47,12 @@ public class HierachyManagerUpdateListener extends QualNameChangeListener {
 	private static EObject loadPlantHierachy(final IProject project) {
 		final Map<String, Object> loadOptions = new HashMap<>();
 		final ResourceSet hierarchyResouceSet = new ResourceSetImpl();
-		hierarchyResouceSet.getResourceFactoryRegistry().getExtensionToFactoryMap()
-				.put(PlantHierarchyView.PLANT_HIERARCHY_FILE_NAME_EXTENSION, new HierarchyResourceFactoryImpl());
+		hierarchyResouceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+				PlantHierarchyView.PLANT_HIERARCHY_FILE_NAME_EXTENSION, //
+				new HierarchyResourceFactoryImpl());
+		hierarchyResouceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+				PlantHierarchyView.PLANT_HIERARCHY_FILE_NAME_EXTENSION.toLowerCase(), //
+				new HierarchyResourceFactoryImpl());
 		loadOptions.put(XMLResource.OPTION_EXTENDED_META_DATA, Boolean.TRUE);
 		final XMLMapImpl map = new XMLMapImpl();
 		map.setNoNamespacePackage(HierarchyPackage.eINSTANCE);

--- a/plugins/org.eclipse.fordiac.ide.hierarchymanager.ui/src/org/eclipse/fordiac/ide/hierarchymanager/ui/view/PlantHierarchyView.java
+++ b/plugins/org.eclipse.fordiac.ide.hierarchymanager.ui/src/org/eclipse/fordiac/ide/hierarchymanager/ui/view/PlantHierarchyView.java
@@ -59,8 +59,10 @@ import org.eclipse.ui.views.properties.tabbed.TabbedPropertySheetPage;
 public class PlantHierarchyView extends CommonNavigator implements ITabbedPropertySheetPageContributor {
 
 	private static final String PLANT_HIERARCHY_PROJECT = "PlantHierarchy.Project"; //$NON-NLS-1$
-	private static final String PLANT_HIERARCHY_FILE_NAME = ".plant.hier"; //$NON-NLS-1$
-	public static final String PLANT_HIERARCHY_FILE_NAME_EXTENSION = "hier"; //$NON-NLS-1$
+	public static final String PLANT_HIERARCHY_FILE_NAME_EXTENSION = "HIER"; //$NON-NLS-1$
+	public static final String PLANT_HIERARCHY_FILE_NAME_EXTENSION_WITH_DOT = "." + PLANT_HIERARCHY_FILE_NAME_EXTENSION; //$NON-NLS-1$
+	private static final String PLANT_HIERARCHY_FILE_NAME = ".plant" //$NON-NLS-1$
+			+ PLANT_HIERARCHY_FILE_NAME_EXTENSION_WITH_DOT.toLowerCase();
 
 	/** The PROPERTY_CONTRIBUTOR_ID. */
 	public static final String PROPERTY_CONTRIBUTOR_ID = "org.eclipse.fordiac.ide.hierarchymanager.ui.view"; //$NON-NLS-1$
@@ -235,8 +237,12 @@ public class PlantHierarchyView extends CommonNavigator implements ITabbedProper
 
 	private void setupEMFInfra() {
 		// add file extension to registry
-		hierarchyResouceSet.getResourceFactoryRegistry().getExtensionToFactoryMap()
-				.put(PLANT_HIERARCHY_FILE_NAME_EXTENSION, new HierarchyResourceFactoryImpl());
+		hierarchyResouceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+				PLANT_HIERARCHY_FILE_NAME_EXTENSION, //
+				new HierarchyResourceFactoryImpl());
+		hierarchyResouceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+				PLANT_HIERARCHY_FILE_NAME_EXTENSION.toLowerCase(), //
+				new HierarchyResourceFactoryImpl());
 		setupLoadOptions();
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/editor/embedded/STAlgorithmEditedResourceProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/editor/embedded/STAlgorithmEditedResourceProvider.java
@@ -19,6 +19,7 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 import org.eclipse.fordiac.ide.structuredtextalgorithm.parser.antlr.STAlgorithmParser;
 import org.eclipse.fordiac.ide.structuredtextalgorithm.resource.STAlgorithmResource;
 import org.eclipse.fordiac.ide.structuredtextcore.resource.STCoreResource;
@@ -54,11 +55,23 @@ public abstract class STAlgorithmEditedResourceProvider implements IEditedResour
 	@Override
 	public STAlgorithmResource createResource() {
 		final XtextResourceSet resourceSet = (XtextResourceSet) SERVICE_PROVIDER_FBT.get(ResourceSet.class);
-		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("fbt", //$NON-NLS-1$
+		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+				TypeLibraryTags.FB_TYPE_FILE_ENDING.toLowerCase(), //
 				SERVICE_PROVIDER_FBT.get(IResourceFactory.class));
-		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("fct", //$NON-NLS-1$
+		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+				TypeLibraryTags.FB_TYPE_FILE_ENDING, //
+				SERVICE_PROVIDER_FBT.get(IResourceFactory.class));
+		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+				TypeLibraryTags.FC_TYPE_FILE_ENDING.toLowerCase(), //
 				SERVICE_PROVIDER_FCT.get(IResourceFactory.class));
-		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("gcf", //$NON-NLS-1$
+		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+				TypeLibraryTags.FC_TYPE_FILE_ENDING, //
+				SERVICE_PROVIDER_FCT.get(IResourceFactory.class));
+		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+				TypeLibraryTags.GLOBAL_CONST_FILE_ENDING.toLowerCase(), //
+				SERVICE_PROVIDER_GCF.get(IResourceFactory.class));
+		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+				TypeLibraryTags.GLOBAL_CONST_FILE_ENDING, //
 				SERVICE_PROVIDER_GCF.get(IResourceFactory.class));
 		resourceSet.getLoadOptions().putAll(Map.of(//
 				ResourceDescriptionsProvider.LIVE_SCOPE, Boolean.TRUE // use live scope

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/resource/STAlgorithmResourceSetInitializer.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/resource/STAlgorithmResourceSetInitializer.java
@@ -15,6 +15,7 @@ package org.eclipse.fordiac.ide.structuredtextalgorithm.ui.resource;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 import org.eclipse.fordiac.ide.structuredtextalgorithm.ui.internal.StructuredtextalgorithmActivator;
 import org.eclipse.fordiac.ide.systemmanagement.SystemManager;
 import org.eclipse.xtext.resource.IResourceFactory;
@@ -28,16 +29,36 @@ public class STAlgorithmResourceSetInitializer implements IResourceSetInitialize
 	public void initialize(final ResourceSet resourceSet, final IProject project) {
 		if (has4diacProjectNature(project)) {
 			final IResourceFactory resourceFactory = getInjector().getInstance(IResourceFactory.class);
-			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("fbt", resourceFactory); //$NON-NLS-1$
-			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("FBT", resourceFactory); //$NON-NLS-1$
-			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("sys", resourceFactory); //$NON-NLS-1$
-			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("SYS", resourceFactory); //$NON-NLS-1$
-			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("sub", resourceFactory); //$NON-NLS-1$
-			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("SUB", resourceFactory); //$NON-NLS-1$
-			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("atp", resourceFactory); //$NON-NLS-1$
-			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("ATP", resourceFactory); //$NON-NLS-1$
-			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("dtp", resourceFactory); //$NON-NLS-1$
-			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("DTP", resourceFactory); //$NON-NLS-1$
+			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+					TypeLibraryTags.FB_TYPE_FILE_ENDING.toLowerCase(), //
+					resourceFactory);
+			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+					TypeLibraryTags.FB_TYPE_FILE_ENDING, //
+					resourceFactory);
+			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+					TypeLibraryTags.SYSTEM_TYPE_FILE_ENDING.toLowerCase(), //
+					resourceFactory);
+			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+					TypeLibraryTags.SYSTEM_TYPE_FILE_ENDING, //
+					resourceFactory);
+			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+					TypeLibraryTags.SUBAPP_TYPE_FILE_ENDING.toLowerCase(), //
+					resourceFactory);
+			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+					TypeLibraryTags.SUBAPP_TYPE_FILE_ENDING, //
+					resourceFactory);
+			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+					TypeLibraryTags.ADAPTER_TYPE_FILE_ENDING.toLowerCase(), //
+					resourceFactory);
+			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+					TypeLibraryTags.ADAPTER_TYPE_FILE_ENDING, //
+					resourceFactory);
+			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+					TypeLibraryTags.DATA_TYPE_FILE_ENDING.toLowerCase(), //
+					resourceFactory);
+			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+					TypeLibraryTags.DATA_TYPE_FILE_ENDING, //
+					resourceFactory);
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/resource/STAlgorithmResourceSetInitializer.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/resource/STAlgorithmResourceSetInitializer.java
@@ -59,6 +59,12 @@ public class STAlgorithmResourceSetInitializer implements IResourceSetInitialize
 			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
 					TypeLibraryTags.DATA_TYPE_FILE_ENDING, //
 					resourceFactory);
+			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+					TypeLibraryTags.ATTRIBUTE_TYPE_FILE_ENDING.toLowerCase(), //
+					resourceFactory);
+			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+					TypeLibraryTags.ATTRIBUTE_TYPE_FILE_ENDING, //
+					resourceFactory);
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/formatting2/STCoreMultilineCommentReplacer.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/formatting2/STCoreMultilineCommentReplacer.java
@@ -67,7 +67,7 @@ public class STCoreMultilineCommentReplacer extends MultilineCommentReplacer {
 			commentLineLength = maxCommentWidth.intValue() - 3; // subtract 3 for " * "
 		} else {
 			indendationString = context.getIndentationString()
-					+ " ".repeat(lengthBeforeComment - FormatterUtil.getIndendationChars(context));
+					+ " ".repeat(Math.max(0, lengthBeforeComment - FormatterUtil.getIndendationChars(context)));
 			commentLineLength = maxCommentWidth.intValue() - 6; // subtract 6 for "(* " and " *)"
 		}
 		if (commentLineLength < 1) {

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/formatting2/STCoreSinglelineCommentReplacer.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/formatting2/STCoreSinglelineCommentReplacer.java
@@ -39,11 +39,11 @@ public class STCoreSinglelineCommentReplacer extends SinglelineCommentReplacer {
 		final String lineSeparator = context.getFormatter().getPreference(FormatterPreferenceKeys.lineSeparator);
 		final Integer maxCommentWidth = context.getFormatter()
 				.getPreference(STCoreFormatterPreferenceKeys.maxCommentWidth);
-		final int consecutiveIndendationChars = getConsecutiveIndendationChars(context);
+		final int consecutiveIndendationChars = Math.max(0, getConsecutiveIndendationChars(context));
 		final String consecutiveIndendation = " ".repeat(consecutiveIndendationChars);
 		final int lengthBeforeComment = context.getLeadingCharsInLineCount() + consecutiveIndendationChars;
 		final String indendationString = context.getIndentationString()
-				+ " ".repeat(lengthBeforeComment - FormatterUtil.getIndendationChars(context));
+				+ " ".repeat(Math.max(0, lengthBeforeComment - FormatterUtil.getIndendationChars(context)));
 		final int commentLineLength = maxCommentWidth.intValue() - getPrefix().length() - 1;
 		if (commentLineLength < 1) {
 			return context;

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/ui/resource/STFunctionResourceSetInitializer.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/ui/resource/STFunctionResourceSetInitializer.java
@@ -30,10 +30,10 @@ public class STFunctionResourceSetInitializer implements IResourceSetInitializer
 		if (has4diacProjectNature(project)) {
 			final IResourceFactory resourceFactory = getInjector().getInstance(IResourceFactory.class);
 			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
-					TypeLibraryTags.GLOBAL_CONST_FILE_ENDING.toLowerCase(), //
+					TypeLibraryTags.FC_TYPE_FILE_ENDING.toLowerCase(), //
 					resourceFactory);
 			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
-					TypeLibraryTags.GLOBAL_CONST_FILE_ENDING, //
+					TypeLibraryTags.FC_TYPE_FILE_ENDING, //
 					resourceFactory);
 		}
 	}

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/ui/resource/STFunctionResourceSetInitializer.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/ui/resource/STFunctionResourceSetInitializer.java
@@ -15,6 +15,7 @@ package org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.resource;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 import org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.internal.StructuredtextfunctioneditorActivator;
 import org.eclipse.fordiac.ide.systemmanagement.SystemManager;
 import org.eclipse.xtext.resource.IResourceFactory;
@@ -28,8 +29,12 @@ public class STFunctionResourceSetInitializer implements IResourceSetInitializer
 	public void initialize(final ResourceSet resourceSet, final IProject project) {
 		if (has4diacProjectNature(project)) {
 			final IResourceFactory resourceFactory = getInjector().getInstance(IResourceFactory.class);
-			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("fct", resourceFactory); //$NON-NLS-1$
-			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("FCT", resourceFactory); //$NON-NLS-1$
+			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+					TypeLibraryTags.GLOBAL_CONST_FILE_ENDING.toLowerCase(), //
+					resourceFactory);
+			resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put( //
+					TypeLibraryTags.GLOBAL_CONST_FILE_ENDING, //
+					resourceFactory);
 		}
 	}
 


### PR DESCRIPTION
The Save-Ant-Task only fixed XML formatting issues in the files when saving.

This adds the reconciler and optionally the autoformatter to the Ant-Task to ensure consistent XML-files