### PR TITLE
Avoid duplicate imports from content assist or quickfixes

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AttributeSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AttributeSection.java
@@ -35,6 +35,7 @@ import org.eclipse.fordiac.ide.model.commands.create.CreateAttributeCommand;
 import org.eclipse.fordiac.ide.model.commands.delete.DeleteAttributeCommand;
 import org.eclipse.fordiac.ide.model.data.InternalDataType;
 import org.eclipse.fordiac.ide.model.datatype.helper.InternalAttributeDeclarations;
+import org.eclipse.fordiac.ide.model.helpers.ImportHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
 import org.eclipse.fordiac.ide.model.libraryElement.AttributeDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableObject;
@@ -244,7 +245,8 @@ public class AttributeSection extends AbstractSection implements I4diacNatTableU
 
 		protected void proposalAccepted(final IContentProposal proposal) {
 			if (proposal instanceof final ImportContentProposal importProposal
-					&& EcoreUtil.getRootContainer(getType()) instanceof final LibraryElement libraryElement) {
+					&& EcoreUtil.getRootContainer(getType()) instanceof final LibraryElement libraryElement
+					&& !ImportHelper.matchesImports(importProposal.getImportedNamespace(), libraryElement)) {
 				executeCommand(new AddNewImportCommand(libraryElement, importProposal.getImportedNamespace()));
 			}
 		}

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/VariableOperations.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/VariableOperations.java
@@ -33,6 +33,7 @@ import org.eclipse.fordiac.ide.model.data.DataType;
 import org.eclipse.fordiac.ide.model.data.DirectlyDerivedType;
 import org.eclipse.fordiac.ide.model.data.StructuredType;
 import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes.GenericTypes;
+import org.eclipse.fordiac.ide.model.datatype.helper.InternalAttributeDeclarations;
 import org.eclipse.fordiac.ide.model.datatype.helper.TypeDeclarationParser;
 import org.eclipse.fordiac.ide.model.eval.Evaluator;
 import org.eclipse.fordiac.ide.model.eval.EvaluatorCache;
@@ -357,8 +358,8 @@ public final class VariableOperations {
 	}
 
 	public static Set<String> getDependencies(final VarDeclaration varDeclaration) {
-		if (varDeclaration.isArray()
-				&& !TypeDeclarationParser.isSimpleTypeDeclaration(varDeclaration.getArraySize().getValue())) {
+		if (!isSimpleInitialValue(varDeclaration) || (varDeclaration.isArray()
+				&& !TypeDeclarationParser.isSimpleTypeDeclaration(varDeclaration.getArraySize().getValue()))) {
 			final Evaluator evaluator = EvaluatorFactory.createEvaluator(varDeclaration, VarDeclaration.class, null,
 					Collections.emptySet(), null);
 			if (evaluator instanceof final VariableEvaluator variableEvaluator) {
@@ -370,7 +371,10 @@ public final class VariableOperations {
 	}
 
 	public static Set<String> getDependencies(final Attribute attribute) {
-		if (hasValue(attribute)) {
+		if (InternalAttributeDeclarations.isInternalAttribute(attribute)) {
+			return Set.of();
+		}
+		if (!isSimpleAttributeValue(attribute)) {
 			final Evaluator evaluator = EvaluatorFactory.createEvaluator(attribute, VarDeclaration.class, null,
 					Collections.emptySet(), null);
 			if (evaluator instanceof final VariableEvaluator variableEvaluator) {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/ImportHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/ImportHelper.java
@@ -178,15 +178,19 @@ public final class ImportHelper {
 		return null; // skip colliding names
 	}
 
+	public static boolean matchesImports(final String name, final LibraryElement libraryElement) {
+		return getImports(libraryElement).stream().anyMatch(imp -> matchesImport(name, imp));
+	}
+
 	public static boolean matchesImports(final String name, final List<Import> imports) {
 		return imports.stream().anyMatch(imp -> matchesImport(name, imp));
 	}
 
 	private static boolean matchesImport(final String name, final Import imp) {
 		final String importedNamespace = imp.getImportedNamespace();
-		return importedNamespace.equals(name)
-				|| (importedNamespace.endsWith(WILDCARD_IMPORT_SUFFIX) && PackageNameHelper
-						.extractPackageName(importedNamespace).equals(PackageNameHelper.extractPackageName(name)));
+		return importedNamespace.equalsIgnoreCase(name) || (importedNamespace.endsWith(WILDCARD_IMPORT_SUFFIX)
+				&& PackageNameHelper.extractPackageName(importedNamespace)
+						.equalsIgnoreCase(PackageNameHelper.extractPackageName(name)));
 	}
 
 	public static boolean isImplicitImport(final String imported, final String packageName) {

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/contentassist/STAlgorithmImportReplacementTextApplier.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/contentassist/STAlgorithmImportReplacementTextApplier.java
@@ -13,6 +13,7 @@
 package org.eclipse.fordiac.ide.structuredtextalgorithm.ui.contentassist;
 
 import org.eclipse.fordiac.ide.model.commands.create.AddNewImportCommand;
+import org.eclipse.fordiac.ide.model.helpers.ImportHelper;
 import org.eclipse.fordiac.ide.structuredtextalgorithm.ui.editor.STAlgorithmEditorUtils;
 import org.eclipse.fordiac.ide.structuredtextcore.resource.LibraryElementXtextResource;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.contentassist.STCoreImportReplacementTextApplier;
@@ -32,7 +33,8 @@ public class STAlgorithmImportReplacementTextApplier extends STCoreImportReplace
 	@Override
 	protected void applyImport(final IDocument document, final ConfigurableCompletionProposal proposal)
 			throws BadLocationException {
-		if (getResource() instanceof final LibraryElementXtextResource libraryElementResource) {
+		if (getResource() instanceof final LibraryElementXtextResource libraryElementResource
+				&& !ImportHelper.matchesImports(getImportedNamespace(), libraryElementResource.getLibraryElement())) {
 			STAlgorithmEditorUtils.executeCommand(getResource().getURI(),
 					new AddNewImportCommand(libraryElementResource.getLibraryElement(), getImportedNamespace()));
 		}

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/quickfix/STAlgorithmQuickfixProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/quickfix/STAlgorithmQuickfixProvider.java
@@ -27,6 +27,7 @@ import org.eclipse.fordiac.ide.model.commands.create.CreateInterfaceElementComma
 import org.eclipse.fordiac.ide.model.commands.create.CreateInternalVariableCommand;
 import org.eclipse.fordiac.ide.model.commands.create.CreateVarInOutCommand;
 import org.eclipse.fordiac.ide.model.data.DataType;
+import org.eclipse.fordiac.ide.model.helpers.ImportHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.ICallable;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
@@ -151,7 +152,8 @@ public class STAlgorithmQuickfixProvider extends STCoreQuickfixProvider {
 	protected void createImportProposal(final Issue issue, final String label, final String importedNamespace,
 			final IssueResolutionAcceptor acceptor) {
 		acceptor.accept(issue, label, label, null, (element, context) -> {
-			if (element.eResource() instanceof final STAlgorithmResource resource) {
+			if (element.eResource() instanceof final STAlgorithmResource resource
+					&& !ImportHelper.matchesImports(importedNamespace, resource.getLibraryElement())) {
 				STAlgorithmEditorUtils.executeCommand(resource.getURI(),
 						new AddNewImportCommand(resource.getLibraryElement(), importedNamespace));
 			}

--- a/tests/org.eclipse.fordiac.ide.test.model.eval/src/org/eclipse/fordiac/ide/test/model/eval/variable/VariableOperationTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model.eval/src/org/eclipse/fordiac/ide/test/model/eval/variable/VariableOperationTest.java
@@ -476,8 +476,7 @@ class VariableOperationTest extends AbstractEvaluatorTest {
 	@Test
 	void testGetDependenciesForAttribute() {
 		assertEquals(Set.of("TestStructAttribute"), VariableOperations.getDependencies(attribute1));
-		assertEquals(Set.of("TestStructAttribute", "TestStructAttribute::TestStructAttribute"),
-				VariableOperations.getDependencies(attribute2));
+		assertEquals(Set.of("TestStructAttribute"), VariableOperations.getDependencies(attribute2));
 		assertEquals(Set.of("TestDerivedAttribute"), VariableOperations.getDependencies(attribute3));
 		assertEquals(Set.of("TestDerivedAttribute"), VariableOperations.getDependencies(attribute4));
 	}


### PR DESCRIPTION
Avoid duplicate imports from content assist or quickfixes. Also fix unnecessary dependencies and unnecessary parsing for internal attributes and missing dependencies for initial values.