### PR TITLE
Fix missing output in process console for deployment

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/DeploymentProcess.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/DeploymentProcess.java
@@ -36,6 +36,7 @@ public class DeploymentProcess extends AbstractLaunchProcess {
 	private final DeploymentStreamsProxy streamsProxy = new DeploymentStreamsProxy();
 	private final DownloadRunnable downloadRunnable;
 	private final Job job;
+	private boolean terminated;
 
 	public DeploymentProcess(final AutomationSystem system, final Set<INamedElement> selection, final ILaunch launch)
 			throws DeploymentException {
@@ -68,6 +69,7 @@ public class DeploymentProcess extends AbstractLaunchProcess {
 	}
 
 	protected void terminated(final IJobChangeEvent event) {
+		terminated = true;
 		fireTerminateEvent();
 	}
 
@@ -82,7 +84,7 @@ public class DeploymentProcess extends AbstractLaunchProcess {
 
 	@Override
 	public boolean isTerminated() {
-		return job.getState() == Job.NONE;
+		return terminated;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.fortelauncher/src/org/eclipse/fordiac/ide/fortelauncher/StopForteLaunchDelegate.java
+++ b/plugins/org.eclipse.fordiac.ide.fortelauncher/src/org/eclipse/fordiac/ide/fortelauncher/StopForteLaunchDelegate.java
@@ -64,6 +64,7 @@ public class StopForteLaunchDelegate extends LaunchConfigurationDelegate {
 
 		private final Job job;
 		private final List<ILaunch> launchesToTerminate;
+		private boolean terminated;
 
 		public StopForteProcess(final String name, final List<ILaunch> launchesToTerminate, final ILaunch launch) {
 			super(name, launch);
@@ -101,6 +102,7 @@ public class StopForteLaunchDelegate extends LaunchConfigurationDelegate {
 		}
 
 		private void terminated(final IJobChangeEvent event) {
+			terminated = true;
 			fireTerminateEvent();
 		}
 
@@ -111,7 +113,7 @@ public class StopForteLaunchDelegate extends LaunchConfigurationDelegate {
 
 		@Override
 		public boolean isTerminated() {
-			return job.getState() == Job.NONE;
+			return terminated;
 		}
 
 		@Override


### PR DESCRIPTION
The deployment process was using the job state to determine whether it was terminated. This also meant that it considered itself terminated for a short time before the job was scheduled during launch. If the corresponding process console was initialized during that time, it then prematurely closed its streams, leading to no output in the console.

This uses a separate flag to determine the terminated state, which is set only after the job is done.