### PR TITLE
Read-only FBs cannot be refactored in the FBN editor anymore.

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/RefactorElementPropertyTester.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/RefactorElementPropertyTester.java
@@ -30,7 +30,10 @@ public class RefactorElementPropertyTester extends PropertyTester {
 		if (element instanceof final EditPart editPart) {
 			return isSupported(editPart.getModel());
 		}
-		return (element instanceof IInterfaceElement && !(element instanceof ErrorMarkerInterface))
-				|| (element instanceof final FB fb && fb.eContainer() instanceof BaseFBType);
+
+		return ((element instanceof final IInterfaceElement ie && !(element instanceof ErrorMarkerInterface))
+				&& (ie.getFBNetworkElement() instanceof final FB fb
+						&& !fb.getType().getTypeEntry().getFile().isReadOnly()))
+				|| (element instanceof final FB fbb && fbb.eContainer() instanceof BaseFBType);
 	}
 }


### PR DESCRIPTION
If the "Read-only" checkbox is checked, read-only FBs cannot be refactored.