### PR TITLE
Added a refresh to see the manifest in the system explorer

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/SystemManager.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/SystemManager.java
@@ -127,7 +127,7 @@ public enum SystemManager {
 		ManifestHelper.createProjectManifest(project, includedLibraries.keySet());
 
 		TypeLibraryManager.INSTANCE.getTypeLibrary(project); // insert the project into the project list
-
+		project.refreshLocal(IResource.DEPTH_ONE, monitor);
 		return project;
 	}
 


### PR DESCRIPTION
The project manifest was not visible after a new project has been created. 
A manual refresh was necessary for that.