### PR TITLE
Unnecessary space after comment

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/CommonElementExporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/CommonElementExporter.java
@@ -413,7 +413,7 @@ public class CommonElementExporter {
 			osWriter.write(attributeName);
 			osWriter.write("=\""); //$NON-NLS-1$
 			osWriter.write(fullyEscapeValue(attributeValue));
-			osWriter.write("\" "); //$NON-NLS-1$
+			osWriter.write("\""); //$NON-NLS-1$
 		} catch (final IOException e) {
 			throw new XMLStreamException("Could not write raw attribute", e); //$NON-NLS-1$
 		}


### PR DESCRIPTION
For some reason the comment-XML attribute had a stray whitespace after the attribute. Based on the examples I had available removing this whitespace should pose no problems.