### PR TITLE
fbrt launcher working dir broken for eclipse vars

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbrtlauncher/src/org/eclipse/fordiac/ide/fbrtlauncher/FBRTLaunchTab.java
+++ b/plugins/org.eclipse.fordiac.ide.fbrtlauncher/src/org/eclipse/fordiac/ide/fbrtlauncher/FBRTLaunchTab.java
@@ -186,7 +186,7 @@ public class FBRTLaunchTab extends RuntimeLaunchTab {
 			configuration.setAttribute(ATTR_TOOL_ARGUMENTS, arguments);
 			final File parentFile = runtimeFile.getParentFile();
 			if (parentFile != null) {
-				configuration.setAttribute(ATTR_WORKING_DIRECTORY, parentFile.getAbsolutePath());
+				configuration.setAttribute(ATTR_WORKING_DIRECTORY, parentFile.getPath());
 			}
 
 		} catch (final CoreException e) {


### PR DESCRIPTION
When Eclipse variables where used FBRt launching was not correctly working.