### PR TITLE
GraphicalViewer may be null for EditPart

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/annotation/FordiacAnnotationUtil.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/annotation/FordiacAnnotationUtil.java
@@ -69,7 +69,8 @@ public final class FordiacAnnotationUtil {
 	}
 
 	public static GraphicalAnnotationModel getAnnotationModel(final EditPart editPart) {
-		if (editPart.getViewer().getEditPartFactory() instanceof final Abstract4diacEditPartFactory factory
+		if (editPart.getViewer() != null
+				&& editPart.getViewer().getEditPartFactory() instanceof final Abstract4diacEditPartFactory factory
 				&& factory.getEditor() != null) {
 			return factory.getEditor().getAdapter(GraphicalAnnotationModel.class);
 		}


### PR DESCRIPTION
This is not checked in the annotation utils which may lead to NPEs when the RepairElementPropertyTester is searching for markers.