### PR TITLE
fix missing xtend-gen directory warnings

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.contractspec.ide/.classpath
+++ b/plugins/org.eclipse.fordiac.ide.contractspec.ide/.classpath
@@ -2,8 +2,11 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="src-gen"/>
-	<classpathentry kind="src" path="xtend-gen"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/org.eclipse.fordiac.ide.contractspec.ide/build.properties
+++ b/plugins/org.eclipse.fordiac.ide.contractspec.ide/build.properties
@@ -1,6 +1,5 @@
 source.. = src/,\
-           src-gen/,\
-           xtend-gen/
+           src-gen/
 bin.includes = .,\
                META-INF/
 bin.excludes = **/*.xtend

--- a/plugins/org.eclipse.fordiac.ide.contractspec.ui/.classpath
+++ b/plugins/org.eclipse.fordiac.ide.contractspec.ui/.classpath
@@ -2,8 +2,11 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="src-gen"/>
-	<classpathentry kind="src" path="xtend-gen"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/org.eclipse.fordiac.ide.contractspec.ui/build.properties
+++ b/plugins/org.eclipse.fordiac.ide.contractspec.ui/build.properties
@@ -1,6 +1,5 @@
 source.. = src/,\
-           src-gen/,\
-           xtend-gen/
+           src-gen/
 bin.includes = .,\
                META-INF/,\
                plugin.xml


### PR DESCRIPTION
In #896 new plugins were introduced that still had references to xtend-gen directories. This led to build errors in a local eclipse build.