### PR TITLE
Update E_TABLE and E_TABLE_CTRL with event name changes and version info.

### DIFF
--- a/data/typelibrary/events-1.0.0/typelib/E_TABLE.fbt
+++ b/data/typelibrary/events-1.0.0/typelib/E_TABLE.fbt
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="E_TABLE" Comment="Composite Function Block Type">
-	<Identification Standard="61499-1 Annex A" Description="Copyright (c) 2017 fortiss GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
+<FBType Name="E_TABLE" Comment="Generation of a finite train of events, table driven">
+	<Identification Standard="61499-1 Annex A" Description="Copyright (c) 2017, 2025 fortiss GmbH, HR Agrartechnik GmbH&#10;  &#10;This program and the accompanying materials are made &#10;available under the terms of the Eclipse Public License 2.0 &#10;which is available at https://www.eclipse.org/legal/epl-2.0/ &#10; &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-09-22" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<VersionInfo Organization="Rename INIT to START" Version="1.1" Author="Franz Höpfinger" Date="2025-02-17" Remarks="Rename INIT to START">
 	</VersionInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -27,22 +29,22 @@
 		</OutputVars>
 	</InterfaceList>
 	<FBNetwork>
-		<FB Name="E_TABLE_CTRL" Type="E_TABLE_CTRL" Comment="" x="-780.0" y="633.3333333333334">
+		<FB Name="E_TABLE_CTRL" Type="E_TABLE_CTRL" x="-780" y="633.33">
 		</FB>
-		<FB Name="E_DELAY" Type="E_DELAY" Comment="" x="606.6666666666667" y="633.3333333333334">
+		<FB Name="E_DELAY" Type="E_DELAY" x="606.67" y="633.33">
 		</FB>
 		<EventConnections>
-			<Connection Source="E_TABLE_CTRL.CLKO" Destination="E_DELAY.START" Comment=""/>
-			<Connection Source="E_DELAY.EO" Destination="EO" Comment="" dx1="1380.0"/>
-			<Connection Source="START" Destination="E_TABLE_CTRL.INIT" Comment="" dx1="473.33333333333337"/>
-			<Connection Source="E_DELAY.EO" Destination="E_TABLE_CTRL.CLK" Comment="" dx1="73.33333333333334" dx2="133.33333333333334" dy="-240.0"/>
-			<Connection Source="STOP" Destination="E_DELAY.STOP" Comment="" dx1="1460.0"/>
+			<Connection Source="E_TABLE_CTRL.CLKO" Destination="E_DELAY.START"/>
+			<Connection Source="E_DELAY.EO" Destination="EO" dx1="1380"/>
+			<Connection Source="START" Destination="E_TABLE_CTRL.START" dx1="473.33"/>
+			<Connection Source="E_DELAY.EO" Destination="E_TABLE_CTRL.CLK" dx1="73.33" dx2="73.33" dy="-240"/>
+			<Connection Source="STOP" Destination="E_DELAY.STOP" dx1="1460"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="E_TABLE_CTRL.DTO" Destination="E_DELAY.DT" Comment="" dx1="73.33333333333334"/>
-			<Connection Source="E_TABLE_CTRL.CV" Destination="CV" Comment="" dx1="1960.0"/>
-			<Connection Source="DT" Destination="E_TABLE_CTRL.DT" Comment="" dx1="280.0"/>
-			<Connection Source="N" Destination="E_TABLE_CTRL.N" Comment="" dx1="280.0"/>
+			<Connection Source="E_TABLE_CTRL.DTO" Destination="E_DELAY.DT" dx1="73.33"/>
+			<Connection Source="E_TABLE_CTRL.CV" Destination="CV" dx1="1960"/>
+			<Connection Source="DT" Destination="E_TABLE_CTRL.DT" dx1="280"/>
+			<Connection Source="N" Destination="E_TABLE_CTRL.N" dx1="280"/>
 		</DataConnections>
 	</FBNetwork>
 </FBType>

--- a/data/typelibrary/events-1.0.0/typelib/E_TABLE_CTRL.fbt
+++ b/data/typelibrary/events-1.0.0/typelib/E_TABLE_CTRL.fbt
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="E_TABLE_CTRL" Comment="Support function block for E_TABLE" >
-	<Identification Standard="61499-1 Annex A" Description="Copyright (c) 2017 fortiss GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10;" >
+<FBType Name="E_TABLE_CTRL" Comment="Support function block for E_TABLE">
+	<Identification Standard="61499-1 Annex A" Description="Copyright (c) 2017, 2025 fortiss GmbH, HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10;">
 	</Identification>
 	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-09-22" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
+	<VersionInfo Organization="Rename INIT to START" Version="1.1" Author="Franz Höpfinger" Date="2025-02-17" Remarks="Rename INIT to START">
+	</VersionInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="EInit">
+			<Event Name="START" Type="Event">
 				<With Var="DT"/>
 				<With Var="N"/>
 			</Event>
@@ -21,16 +23,16 @@
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="DT" Type="TIME" ArraySize="4"/>
-			<VarDeclaration Name="N" Type="UINT" Comment="Actual number of time steps" />
+			<VarDeclaration Name="N" Type="UINT" Comment="Actual number of time steps"/>
 		</InputVars>
 		<OutputVars>
-			<VarDeclaration Name="DTO" Type="TIME" Comment="Current delay interval" />
-			<VarDeclaration Name="CV" Type="UINT" Comment="Current event index, 0..N-1" />
+			<VarDeclaration Name="DTO" Type="TIME" Comment="Current delay interval"/>
+			<VarDeclaration Name="CV" Type="UINT" Comment="Current event index, 0..N-1"/>
 		</OutputVars>
 	</InterfaceList>
 	<BasicFB>
 		<ECC>
-			<ECState Name="START" Comment="Initial State"  x="400" y="700">
+			<ECState Name="START" Comment="Initial State" x="400" y="700">
 			</ECState>
 			<ECState Name="INIT" x="736.84" y="84.21">
 				<ECAction Algorithm="INIT"/>
@@ -41,7 +43,7 @@
 			<ECState Name="NEXT_STEP" x="1000" y="1273.68">
 				<ECAction Algorithm="NEXT_STEP" Output="CLKO"/>
 			</ECState>
-			<ECTransition Source="START" Destination="INIT" Condition="INIT" Comment="" x="684.21" y="431.58"/>
+			<ECTransition Source="START" Destination="INIT" Condition="START" Comment="" x="684.21" y="431.58"/>
 			<ECTransition Source="INIT" Destination="START" Condition="[N = 0]" Comment="" x="400" y="342.11"/>
 			<ECTransition Source="INIT" Destination="INIT1" Condition="[N &gt; 0]" Comment="" x="1078.95" y="310.53"/>
 			<ECTransition Source="INIT1" Destination="START" Condition="1" Comment="" x="952.63" y="647.37"/>


### PR DESCRIPTION
- Renamed INIT to START in FBType E_TABLE and E_TABLE_CTRL
- Updated version info for both FBTypes
