### PR TITLE
Update event type in E_TABLE_CTRL.fbt

### DIFF
--- a/data/typelibrary/events-1.0.0/typelib/E_TABLE_CTRL.fbt
+++ b/data/typelibrary/events-1.0.0/typelib/E_TABLE_CTRL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="EInit">
+			<Event Name="INIT" Type="Event">
 				<With Var="DT"/>
 				<With Var="N"/>
 			</Event>


### PR DESCRIPTION
Changed event type from "EInit" to "Event" for the INIT event.
