### PR TITLE
GoToChild/Parent Context menu not shown in root editors

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.application/plugin.xml
@@ -1426,14 +1426,20 @@
       <command commandId="org.eclipse.fordiac.ide.application.commands.gotoparent">
         <visibleWhen checkEnabled="true">
           <with variable="activeEditor">
-            <adapt type="org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement" />
+          	<or>
+            	<adapt type="org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement" />
+            	<adapt type="org.eclipse.fordiac.ide.model.libraryElement.FBNetwork" />
+            </or>	
           </with>
         </visibleWhen>
       </command>
       <command commandId="org.eclipse.fordiac.ide.application.commands.gotochild">
         <visibleWhen checkEnabled="true">
           <with variable="activeEditor">
-            <adapt type="org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement" />
+          	<or>
+            	<adapt type="org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement" />
+            	<adapt type="org.eclipse.fordiac.ide.model.libraryElement.FBNetwork" />
+            </or>	
           </with>
         </visibleWhen>
       </command>


### PR DESCRIPTION
GoToChild/Parent was not shown in the root editors (e.g., application editor and root editor in a type subapp/CFB Type.