### PR TITLE
Gloabl constants reference search

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/META-INF/MANIFEST.MF
@@ -27,7 +27,10 @@ Require-Bundle: org.eclipse.fordiac.ide.globalconstantseditor,
  org.eclipse.fordiac.ide.typemanagement,
  org.eclipse.fordiac.ide.systemmanagement,
  org.eclipse.ui,
- org.eclipse.ui.editors
+ org.eclipse.ui.editors,
+ org.eclipse.ui.navigator,
+ org.eclipse.fordiac.ide.model.search,
+ org.eclipse.search
 Import-Package: org.apache.log4j,
  org.eclipse.ui,
  org.eclipse.xtext.ui.codemining;resolution:=optional

--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/plugin.xml
@@ -206,7 +206,7 @@
 	</extension>
 	<extension point="org.eclipse.ui.handlers">
 		<handler
-			class="org.eclipse.fordiac.ide.globalconstantseditor.ui.GlobalConstantsExecutableExtensionFactory:org.eclipse.xtext.ui.editor.findrefs.FindReferencesHandler"
+			class="org.eclipse.fordiac.ide.globalconstantseditor.ui.GlobalConstantsExecutableExtensionFactory:org.eclipse.fordiac.ide.globalconstantseditor.ui.handlers.GlobalConstantsFindReferencesHandler"
 			commandId="org.eclipse.xtext.ui.editor.FindReferences">
 			<activeWhen>
 				<reference

--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/src/org/eclipse/fordiac/ide/globalconstantseditor/ui/handlers/GlobalConstantsFindReferencesHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/src/org/eclipse/fordiac/ide/globalconstantseditor/ui/handlers/GlobalConstantsFindReferencesHandler.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Daniel Lindhuber
+ *    - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.globalconstantseditor.ui.handlers;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.fordiac.ide.model.search.ModelQuerySpec;
+import org.eclipse.fordiac.ide.model.search.ModelQuerySpec.SearchScope;
+import org.eclipse.fordiac.ide.model.search.ModelSearchQuery;
+import org.eclipse.fordiac.ide.structuredtextcore.stcore.STVarDeclaration;
+import org.eclipse.search.ui.NewSearchUI;
+import org.eclipse.xtext.ui.editor.findrefs.FindReferencesHandler;
+
+@SuppressWarnings("restriction")
+public class GlobalConstantsFindReferencesHandler extends FindReferencesHandler {
+
+	@Override
+	protected void findReferences(final EObject target) {
+		if (target instanceof final STVarDeclaration varDec) {
+			// @formatter:off
+			final ModelQuerySpec searchSpec = new ModelQuerySpec(
+					varDec.getName(),
+					false,
+					false,
+					true,
+					false,
+					false,
+					true,
+					SearchScope.PROJECT,
+					getProject(varDec));
+			// @formatter:on
+
+			final ModelSearchQuery searchJob = new ModelSearchQuery(searchSpec);
+			NewSearchUI.runQueryInBackground(searchJob, NewSearchUI.getSearchResultView());
+		} else {
+			super.findReferences(target);
+		}
+	}
+
+	private static IProject getProject(final STVarDeclaration varDec) {
+		final var resource = varDec.eResource();
+		final IFile file = ResourcesPlugin.getWorkspace().getRoot()
+				.getFile(new Path(resource.getURI().toPlatformString(true)));
+		return file.getProject();
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/src/org/eclipse/fordiac/ide/globalconstantseditor/ui/handlers/GlobalConstantsFindReferencesHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/src/org/eclipse/fordiac/ide/globalconstantseditor/ui/handlers/GlobalConstantsFindReferencesHandler.java
@@ -40,6 +40,7 @@ public class GlobalConstantsFindReferencesHandler extends FindReferencesHandler 
 					false,
 					false,
 					true,
+					true, // search initial value
 					SearchScope.PROJECT,
 					getProject(varDec));
 			// @formatter:on

--- a/plugins/org.eclipse.fordiac.ide.model.search/plugin.properties
+++ b/plugins/org.eclipse.fordiac.ide.model.search/plugin.properties
@@ -17,6 +17,7 @@ ContainingText=Containing Text:
 Element=Element
 ErrorMessageSearch=The search box is empty or none of the checkboxes are ticked! Please correct that and try to search again
 ExactNameMatching=Exact Name Matching
+TypeInterfaceValueMatching=Type Interface Value Matching
 InstanceName=Instance Name
 Jokers=(* - any string, ? - any character)
 Location=Location

--- a/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/Messages.java
@@ -36,6 +36,7 @@ public final class Messages extends NLS {
 	public static String Jokers;
 	public static String CaseSensitive;
 	public static String ExactNameMatching;
+	public static String TypeInterfaceValueMatching;
 	public static String Scope;
 	public static String WorkspaceScope;
 	public static String Warning;

--- a/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/ModelQuerySpec.java
+++ b/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/ModelQuerySpec.java
@@ -23,6 +23,7 @@ public record ModelQuerySpec(
 	    boolean checkComments,
 	    boolean checkCaseSensitive,
 	    boolean checkExactMatching,
+	    boolean checkInterfaceValues,
 	    SearchScope scope,
 	    IProject project
 ) {

--- a/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/ModelSearchPage.java
+++ b/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/ModelSearchPage.java
@@ -177,6 +177,7 @@ public class ModelSearchPage extends DialogPage implements ISearchPage {
 					isCheckedComment,
 					isCaseSensitive,
 					isExactNameMatching,
+					false,
 					getScope(),
 					curProject);
 			// @formatter:on

--- a/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/ModelSearchPage.java
+++ b/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/ModelSearchPage.java
@@ -63,6 +63,7 @@ public class ModelSearchPage extends DialogPage implements ISearchPage {
 	private Text query;
 	private Button caseSensitive;
 	private Button exactNameMatching;
+	private Button interfaceValueMatching;
 	private Button projectScope;
 	private IProject curProject;
 
@@ -127,6 +128,8 @@ public class ModelSearchPage extends DialogPage implements ISearchPage {
 
 		caseSensitive = WidgetFactory.button(SWT.CHECK).text(Messages.CaseSensitive).create(composite);
 		exactNameMatching = WidgetFactory.button(SWT.CHECK).text(Messages.ExactNameMatching).create(composite);
+		interfaceValueMatching = WidgetFactory.button(SWT.CHECK).text(Messages.TypeInterfaceValueMatching)
+				.create(composite);
 
 		final Group radioButtonScope = new Group(composite, SWT.NONE);
 		radioButtonScope.setLayout(new RowLayout(SWT.VERTICAL));
@@ -160,6 +163,7 @@ public class ModelSearchPage extends DialogPage implements ISearchPage {
 		final boolean isCheckedComment = comment.getSelection();
 		final boolean isCaseSensitive = caseSensitive.getSelection();
 		final boolean isExactNameMatching = exactNameMatching.getSelection();
+		final boolean isInterfaceValueMatching = interfaceValueMatching.getSelection();
 
 		// Search string aka the name of it
 		final String searchString = query.getText();
@@ -177,7 +181,7 @@ public class ModelSearchPage extends DialogPage implements ISearchPage {
 					isCheckedComment,
 					isCaseSensitive,
 					isExactNameMatching,
-					false,
+					isInterfaceValueMatching,
 					getScope(),
 					curProject);
 			// @formatter:on

--- a/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/handlers/SearchTypeReferences.java
+++ b/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/handlers/SearchTypeReferences.java
@@ -50,6 +50,7 @@ public class SearchTypeReferences extends AbstractHandler {
 					false,
 					false,
 					true,
+					false,
 					SearchScope.PROJECT,
 					typeEntry.getFile().getProject());
 			// @formatter:on


### PR DESCRIPTION
Replaced the xtext find reference search with the 4diac model search in the global constants editor. It currently does not match on the fully qualified name (e.g. "value2" instead of "GlobalTest::value2") as otherwise it would not match the occurrences in the ST code anymore.