### PR TITLE
Export 4diac FORTE Core Includes with Full Source Directory

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteNgExportTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteNgExportTemplate.xtend
@@ -37,11 +37,11 @@ abstract class ForteNgExportTemplate extends ExportTemplate {
 		«FOR include : types.map[generateDefiningInclude].toSet.sort»
 			«include.generateDependencyInclude»
 		«ENDFOR»
-		«generateDependencyInclude("iec61131_functions.h")»
-		«generateDependencyInclude("forte_array_common.h")»
-		«generateDependencyInclude("forte_array.h")»
-		«generateDependencyInclude("forte_array_fixed.h")»
-		«generateDependencyInclude("forte_array_variable.h")»
+		«generateDependencyInclude("core/iec61131_functions.h")»
+		«generateDependencyInclude("core/datatypes/forte_array_common.h")»
+		«generateDependencyInclude("core/datatypes/forte_array.h")»
+		«generateDependencyInclude("core/datatypes/forte_array_fixed.h")»
+		«generateDependencyInclude("core/datatypes/forte_array_variable.h")»
 	'''
 
 	def protected generateDependencyInclude(String path) {

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/adapter/AdapterFBHeaderTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/adapter/AdapterFBHeaderTemplate.xtend
@@ -70,8 +70,8 @@ class AdapterFBHeaderTemplate extends ForteFBTemplate<AdapterType> {
 	'''
 
 	override protected generateHeaderIncludes() '''
-		«generateDependencyInclude("adapter.h")»
-		«generateDependencyInclude("typelib.h")»
+		«generateDependencyInclude("core/adapter.h")»
+		«generateDependencyInclude("core/typelib.h")»
 		«super.generateHeaderIncludes»
 	'''
 

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/basic/BasicFBHeaderTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/basic/BasicFBHeaderTemplate.xtend
@@ -37,7 +37,7 @@ class BasicFBHeaderTemplate extends BaseFBHeaderTemplate<BasicFBType> {
 		«generateStates»
 	'''
 	
-	override generateClassInclude() '''«generateDependencyInclude("basicfb.h")»'''
+	override generateClassInclude() '''«generateDependencyInclude("core/basicfb.h")»'''
 
 	def protected generateStates() '''
 		«FOR state : type.ECC.ECState AFTER '\n'»

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/composite/CompositeFBHeaderTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/composite/CompositeFBHeaderTemplate.xtend
@@ -79,8 +79,8 @@ class CompositeFBHeaderTemplate extends ForteFBTemplate<CompositeFBType> {
 	'''
 
 	override protected CharSequence generateHeaderIncludes() '''
-		«generateDependencyInclude("cfb.h")»
-		«generateDependencyInclude("typelib.h")»
+		«generateDependencyInclude("core/cfb.h")»
+		«generateDependencyInclude("core/typelib.h")»
 		«super.generateHeaderIncludes»
 	'''
 

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/function/FunctionFBHeaderTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/function/FunctionFBHeaderTemplate.xtend
@@ -58,7 +58,7 @@ class FunctionFBHeaderTemplate extends FunctionFBTemplate {
 	'''
 
 	override protected generateHeaderIncludes() '''
-		«generateDependencyInclude("funcbloc.h")»
+		«generateDependencyInclude("core/funcbloc.h")»
 		«super.generateHeaderIncludes»
 	'''
 

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/language/LanguageImplTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/language/LanguageImplTemplate.xtend
@@ -52,7 +52,7 @@ class LanguageImplTemplate extends ForteNgExportTemplate {
 		#include "«fileBasename»_gen.cpp"
 		#endif
 
-		«generateDependencyInclude("iec61131_functions.h")»
+		«generateDependencyInclude("core/iec61131_functions.h")»
 		«IF languageSupport !== null»«languageSupport.getDependencies(emptyMap).generateDependencyIncludes»«ENDIF»
 	'''
 

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/service/ServiceInterfaceFBHeaderTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/service/ServiceInterfaceFBHeaderTemplate.xtend
@@ -58,7 +58,7 @@ class ServiceInterfaceFBHeaderTemplate extends ForteFBTemplate<ServiceInterfaceF
 	'''
 
 	override protected generateHeaderIncludes() '''
-		«generateDependencyInclude("funcbloc.h")»
+		«generateDependencyInclude("core/funcbloc.h")»
 		«super.generateHeaderIncludes»
 	'''
 }

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/simple/SimpleFBHeaderTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/simple/SimpleFBHeaderTemplate.xtend
@@ -29,7 +29,7 @@ class SimpleFBHeaderTemplate extends BaseFBHeaderTemplate<SimpleFBType> {
 		super(type, name, prefix, "CSimpleFB", options)
 	}
 
-	override generateClassInclude() '''«generateDependencyInclude("simplefb.h")»'''
+	override generateClassInclude() '''«generateDependencyInclude("core/simplefb.h")»'''
 
 	override generateAdditionalDeclarations() '''
 		«generateStates»

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/struct/StructuredTypeHeaderTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/struct/StructuredTypeHeaderTemplate.xtend
@@ -71,7 +71,7 @@ class StructuredTypeHeaderTemplate extends StructBaseTemplate {
 	'''
 
 	def protected generateHeaderIncludes() '''
-		«generateDependencyInclude("forte_struct.h")»
+		«generateDependencyInclude("core/datatypes/forte_struct.h")»
 		
 		«getDependencies(#{ForteNgExportFilter.OPTION_HEADER -> Boolean.TRUE}).generateDependencyIncludes»
 		

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/util/ForteNgExportUtil.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/util/ForteNgExportUtil.xtend
@@ -17,6 +17,7 @@ import org.eclipse.emf.common.util.EList
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.resource.Resource
 import org.eclipse.fordiac.ide.model.data.AnyDerivedType
+import org.eclipse.fordiac.ide.model.data.AnyType
 import org.eclipse.fordiac.ide.model.data.ArrayType
 import org.eclipse.fordiac.ide.model.data.DataType
 import org.eclipse.fordiac.ide.model.data.DateAndTimeType
@@ -120,7 +121,7 @@ final class ForteNgExportUtil {
 	def static String generateDefiningInclude(Resource resource) {
 		resource.contents.filter(LibraryElement)?.head?.generateTypeIncludePath ?:
 			'''«resource.URI.trimFileExtension.lastSegment».h'''
-	}
+	}	
 
 	def static String generateTypeIncludePath(INamedElement type) {
 		switch (path : type.generateTypePath) {
@@ -189,6 +190,8 @@ final class ForteNgExportUtil {
 
 	def static String generateTypePath(INamedElement type) {
 		switch (type) {
+			AnyType case type.typeEntry === null: 
+				"core/datatypes"
 			LibraryElement:
 				type.compilerInfo?.packageName?.replace("::", "/") ?: ""
 			default:

--- a/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/forte_ng/ForteNgBasicFBTest.xtend
+++ b/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/forte_ng/ForteNgBasicFBTest.xtend
@@ -55,12 +55,12 @@ class ForteNgBasicFBTest extends ExporterTestBasicFBTypeBase {
 						
 						#pragma once
 						
-						#include "basicfb.h"
-						#include "iec61131_functions.h"
-						#include "forte_array_common.h"
-						#include "forte_array.h"
-						#include "forte_array_fixed.h"
-						#include "forte_array_variable.h"
+						#include "core/basicfb.h"
+						#include "core/iec61131_functions.h"
+						#include "core/datatypes/forte_array_common.h"
+						#include "core/datatypes/forte_array.h"
+						#include "core/datatypes/forte_array_fixed.h"
+						#include "core/datatypes/forte_array_variable.h"
 						
 						class «EXPORTED_FUNCTIONBLOCK_NAME» final : public CBasicFB {
 						  DECLARE_FIRMWARE_FB(«EXPORTED_FUNCTIONBLOCK_NAME»)
@@ -116,13 +116,13 @@ class ForteNgBasicFBTest extends ExporterTestBasicFBTypeBase {
 						#include "«ExporterTestBase.BASICFUNCTIONBLOCK_NAME»_fbt_gen.cpp"
 						#endif
 						
-						#include "forte_dword.h"
-						#include "forte_sint.h"
-						#include "iec61131_functions.h"
-						#include "forte_array_common.h"
-						#include "forte_array.h"
-						#include "forte_array_fixed.h"
-						#include "forte_array_variable.h"
+						#include "core/datatypes/forte_dword.h"
+						#include "core/datatypes/forte_sint.h"
+						#include "core/iec61131_functions.h"
+						#include "core/datatypes/forte_array_common.h"
+						#include "core/datatypes/forte_array.h"
+						#include "core/datatypes/forte_array_fixed.h"
+						#include "core/datatypes/forte_array_variable.h"
 						
 						DEFINE_FIRMWARE_FB(«EXPORTED_FUNCTIONBLOCK_NAME», g_nStringId«ExporterTestBase.BASICFUNCTIONBLOCK_NAME»)
 						

--- a/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/forte_ng/ForteNgTest.xtend
+++ b/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/forte_ng/ForteNgTest.xtend
@@ -240,12 +240,12 @@ class ForteNgTest extends ExporterTestBasicFBTypeBase {
 						
 						#pragma once
 						
-						#include "basicfb.h"
-						#include "iec61131_functions.h"
-						#include "forte_array_common.h"
-						#include "forte_array.h"
-						#include "forte_array_fixed.h"
-						#include "forte_array_variable.h"
+						#include "core/basicfb.h"
+						#include "core/iec61131_functions.h"
+						#include "core/datatypes/forte_array_common.h"
+						#include "core/datatypes/forte_array.h"
+						#include "core/datatypes/forte_array_fixed.h"
+						#include "core/datatypes/forte_array_variable.h"
 						
 						class «EXPORTED_FUNCTIONBLOCK_NAME» final : public CBasicFB {
 						  DECLARE_FIRMWARE_FB(«EXPORTED_FUNCTIONBLOCK_NAME»)
@@ -301,11 +301,11 @@ class ForteNgTest extends ExporterTestBasicFBTypeBase {
 						#include "«ExporterTestBase.BASICFUNCTIONBLOCK_NAME»_fbt_gen.cpp"
 						#endif
 						
-						#include "iec61131_functions.h"
-						#include "forte_array_common.h"
-						#include "forte_array.h"
-						#include "forte_array_fixed.h"
-						#include "forte_array_variable.h"
+						#include "core/iec61131_functions.h"
+						#include "core/datatypes/forte_array_common.h"
+						#include "core/datatypes/forte_array.h"
+						#include "core/datatypes/forte_array_fixed.h"
+						#include "core/datatypes/forte_array_variable.h"
 						
 						DEFINE_FIRMWARE_FB(«EXPORTED_FUNCTIONBLOCK_NAME», g_nStringIdfunctionblock)
 						


### PR DESCRIPTION
In order to allow the number of inlcude directory options core includes are now exported with their full 4diac FORTE source directory.