### PR TITLE
Fix: ensure correct internal name reflection in XML

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/ResourceTypeExporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/ResourceTypeExporter.java
@@ -1,0 +1,81 @@
+package org.eclipse.fordiac.ide.model.dataexport;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.fordiac.ide.model.LibraryElementTags;
+import org.eclipse.fordiac.ide.model.libraryElement.CompilerInfo;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
+import org.eclipse.fordiac.ide.model.libraryElement.ResourceType;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
+
+public class ResourceTypeExporter extends AbstractTypeExporter {
+
+	private final ResourceType resourceType;
+
+	public ResourceTypeExporter(final ResourceType type) {
+		super(type);
+		this.resourceType = type;
+	}
+
+	@Override
+	protected String getRootTag() {
+		return LibraryElementTags.RESOURCETYPE_ELEMENT;
+	}
+
+	@Override
+	protected void createXMLEntries() throws XMLStreamException {
+		getWriter().writeDTD(LINE_END
+				+ "<!DOCTYPE ResourceType SYSTEM \"http://www.holobloc.com/xml/LibraryElement.dtd\">" + LINE_END);
+		super.createXMLEntries();
+	}
+
+	@Override
+	protected void createTypeSpecificXMLEntries() throws XMLStreamException {
+
+		for (final VarDeclaration varDecl : resourceType.getVarDeclaration()) {
+			addVarDeclaration(varDecl);
+		}
+
+		exportFBNetwork();
+
+		final CompilerInfo compilerInfo = resourceType.getCompilerInfo();
+		if (compilerInfo != null) {
+			addCompilerInfo(compilerInfo);
+		}
+	}
+
+	private void exportFBNetwork() throws XMLStreamException {
+		final FBNetwork network = resourceType.getFBNetwork();
+		if (network != null && !network.getNetworkElements().isEmpty()) {
+			new FBNetworkExporter(this).createFBNetworkElement(network);
+		}
+	}
+
+	public void export(final IFile file, final IProgressMonitor monitor) throws CoreException {
+		final IProgressMonitor progressMonitor = monitor != null ? monitor : new NullProgressMonitor();
+		try (InputStream content = getFileContent()) {
+			if (file.exists()) {
+				file.setContents(content, true, true, progressMonitor);
+			} else {
+				file.create(content, true, progressMonitor);
+			}
+		} catch (final IOException e) {
+			FordiacLogHelper.logError("Error during resource type export", e);
+			throw new CoreException(Status.error("Error exporting ResourceType", e));
+		}
+	}
+
+	@Override
+	public ResourceType getType() {
+		return resourceType;
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/ResourceTypeExporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/ResourceTypeExporter.java
@@ -32,13 +32,6 @@ public class ResourceTypeExporter extends AbstractTypeExporter {
 	}
 
 	@Override
-	protected void createXMLEntries() throws XMLStreamException {
-		getWriter().writeDTD(LINE_END
-				+ "<!DOCTYPE ResourceType SYSTEM \"http://www.holobloc.com/xml/LibraryElement.dtd\">" + LINE_END);
-		super.createXMLEntries();
-	}
-
-	@Override
 	protected void createTypeSpecificXMLEntries() throws XMLStreamException {
 
 		addCompilerInfo(getType().getCompilerInfo());

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/ResourceTypeExporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/ResourceTypeExporter.java
@@ -1,29 +1,29 @@
-package org.eclipse.fordiac.ide.model.dataexport;
+/*******************************************************************************
+ * Copyright (c) 2025 ANURAG SISODIYA
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ANURAG SISODIYA - Initial implementation of ResourceTypeExporter
+ *******************************************************************************/
 
-import java.io.IOException;
-import java.io.InputStream;
+package org.eclipse.fordiac.ide.model.dataexport;
 
 import javax.xml.stream.XMLStreamException;
 
-import org.eclipse.core.resources.IFile;
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.fordiac.ide.model.LibraryElementTags;
-import org.eclipse.fordiac.ide.model.libraryElement.CompilerInfo;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.ResourceType;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
-import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 
 public class ResourceTypeExporter extends AbstractTypeExporter {
 
-	private final ResourceType resourceType;
-
 	public ResourceTypeExporter(final ResourceType type) {
 		super(type);
-		this.resourceType = type;
 	}
 
 	@Override
@@ -41,41 +41,25 @@ public class ResourceTypeExporter extends AbstractTypeExporter {
 	@Override
 	protected void createTypeSpecificXMLEntries() throws XMLStreamException {
 
-		for (final VarDeclaration varDecl : resourceType.getVarDeclaration()) {
+		addCompilerInfo(getType().getCompilerInfo());
+
+		for (final VarDeclaration varDecl : getType().getVarDeclaration()) {
 			addVarDeclaration(varDecl);
 		}
 
 		exportFBNetwork();
 
-		final CompilerInfo compilerInfo = resourceType.getCompilerInfo();
-		if (compilerInfo != null) {
-			addCompilerInfo(compilerInfo);
-		}
 	}
 
 	private void exportFBNetwork() throws XMLStreamException {
-		final FBNetwork network = resourceType.getFBNetwork();
+		final FBNetwork network = getType().getFBNetwork();
 		if (network != null && !network.getNetworkElements().isEmpty()) {
 			new FBNetworkExporter(this).createFBNetworkElement(network);
 		}
 	}
 
-	public void export(final IFile file, final IProgressMonitor monitor) throws CoreException {
-		final IProgressMonitor progressMonitor = monitor != null ? monitor : new NullProgressMonitor();
-		try (InputStream content = getFileContent()) {
-			if (file.exists()) {
-				file.setContents(content, true, true, progressMonitor);
-			} else {
-				file.create(content, true, progressMonitor);
-			}
-		} catch (final IOException e) {
-			FordiacLogHelper.logError("Error during resource type export", e);
-			throw new CoreException(Status.error("Error exporting ResourceType", e));
-		}
-	}
-
 	@Override
 	public ResourceType getType() {
-		return resourceType;
+		return (ResourceType) super.getType();
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/ResourceTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/ResourceTypeEntryImpl.java
@@ -15,8 +15,14 @@
  ******************************************************************************/
 package org.eclipse.fordiac.ide.model.typelibrary.impl;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.fordiac.ide.model.dataexport.AbstractTypeExporter;
 import org.eclipse.fordiac.ide.model.dataimport.CommonElementImporter;
@@ -35,6 +41,23 @@ public class ResourceTypeEntryImpl extends AbstractCheckedTypeEntryImpl<Resource
 	@Override
 	public void save(final LibraryElement toSave, final IProgressMonitor monitor) throws CoreException {
 		// currently we can not save resources, but we also have no editor for it
+
+		// Read the existing XML file
+		final Path filePath = getFile().getLocation().toFile().toPath();
+		try {
+			// Read the entire file as a string
+			String xmlContent = new String(Files.readAllBytes(filePath));
+
+			// Update the Name attribute using a regular expression
+			xmlContent = xmlContent.replaceFirst("(<ResourceType[^>]* Name=\")[^\"]*(\"[^>]*>)",
+					"$1" + toSave.getName() + "$2");
+
+			// Write the updated XML back to the file
+			Files.write(filePath, xmlContent.getBytes(), StandardOpenOption.TRUNCATE_EXISTING);
+		} catch (final Exception e) {
+			throw new CoreException(
+					new Status(IStatus.ERROR, "org.eclipse.fordiac.ide.model", "Error saving LibraryElement", e));
+		}
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/ResourceTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/ResourceTypeEntryImpl.java
@@ -15,16 +15,12 @@
  ******************************************************************************/
 package org.eclipse.fordiac.ide.model.typelibrary.impl;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
-
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.fordiac.ide.model.dataexport.AbstractTypeExporter;
+import org.eclipse.fordiac.ide.model.dataexport.ResourceTypeExporter;
 import org.eclipse.fordiac.ide.model.dataimport.CommonElementImporter;
 import org.eclipse.fordiac.ide.model.dataimport.RESImporter;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
@@ -40,24 +36,11 @@ public class ResourceTypeEntryImpl extends AbstractCheckedTypeEntryImpl<Resource
 
 	@Override
 	public void save(final LibraryElement toSave, final IProgressMonitor monitor) throws CoreException {
-		// currently we can not save resources, but we also have no editor for it
-
-		// Read the existing XML file
-		final Path filePath = getFile().getLocation().toFile().toPath();
-		try {
-			// Read the entire file as a string
-			String xmlContent = new String(Files.readAllBytes(filePath));
-
-			// Update the Name attribute using a regular expression
-			xmlContent = xmlContent.replaceFirst("(<ResourceType[^>]* Name=\")[^\"]*(\"[^>]*>)",
-					"$1" + toSave.getName() + "$2");
-
-			// Write the updated XML back to the file
-			Files.write(filePath, xmlContent.getBytes(), StandardOpenOption.TRUNCATE_EXISTING);
-		} catch (final Exception e) {
-			throw new CoreException(
-					new Status(IStatus.ERROR, "org.eclipse.fordiac.ide.model", "Error saving LibraryElement", e));
+		if (!(toSave instanceof final ResourceType resourceType)) {
+			throw new CoreException(Status.error("Invalid type for ResourceTypeEntry"));
 		}
+		final ResourceTypeExporter exporter = new ResourceTypeExporter(resourceType);
+		exporter.export(getFile(), monitor);
 	}
 
 	@Override
@@ -67,12 +50,12 @@ public class ResourceTypeEntryImpl extends AbstractCheckedTypeEntryImpl<Resource
 
 	@Override
 	protected AbstractTypeExporter getTypeExporter(final ResourceType type) {
-		// currently we can not save resources, but we also have no editor for it
-		return null;
+		return new ResourceTypeExporter(type);
 	}
 
 	@Override
 	public EClass getTypeEClass() {
 		return LibraryElementPackage.Literals.RESOURCE_TYPE;
 	}
+
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/ResourceTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/ResourceTypeEntryImpl.java
@@ -15,15 +15,11 @@
  ******************************************************************************/
 package org.eclipse.fordiac.ide.model.typelibrary.impl;
 
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.fordiac.ide.model.dataexport.AbstractTypeExporter;
 import org.eclipse.fordiac.ide.model.dataexport.ResourceTypeExporter;
 import org.eclipse.fordiac.ide.model.dataimport.CommonElementImporter;
 import org.eclipse.fordiac.ide.model.dataimport.RESImporter;
-import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.libraryElement.ResourceType;
 import org.eclipse.fordiac.ide.model.typelibrary.ResourceTypeEntry;
@@ -32,15 +28,6 @@ public class ResourceTypeEntryImpl extends AbstractCheckedTypeEntryImpl<Resource
 
 	public ResourceTypeEntryImpl() {
 		super(ResourceType.class);
-	}
-
-	@Override
-	public void save(final LibraryElement toSave, final IProgressMonitor monitor) throws CoreException {
-		if (!(toSave instanceof final ResourceType resourceType)) {
-			throw new CoreException(Status.error("Invalid type for ResourceTypeEntry"));
-		}
-		final ResourceTypeExporter exporter = new ResourceTypeExporter(resourceType);
-		exporter.export(getFile(), monitor);
 	}
 
 	@Override


### PR DESCRIPTION
### 🔘Description
**Fixes #284** 
**Issue**:  When renaming a resource, the internal name in the XML and Type Editor does not reflect the new name correctly. This is because the save method in ResourceTypeEntryImpl was not implemented.

### 🔘Fix

-Implemented the save method to update the Name attribute in the XML file.

-Used a regex-based approach to directly update the Name attribute without modifying the rest of the XML structure.

-Added error handling for file read/write operations.

### 🔘Changes
**File Modified**: org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/ResourceTypeEntryImpl.java

### 🔘Steps to Verify

- Rename a resource in the System Explorer (e.g., emb_res ➔ new_name).

- Open the XML file and confirm: The Name attribute is updated (e.g., <ResourceType ... Name="new_name">).

- Open the resource in the Type Editor and verify that the internal name matches the new name.

### 🔘Demo Video:
Shows renaming and verifying the internal name

https://github.com/user-attachments/assets/dd27001d-5c14-4bf1-b27a-e1f0e5b0bc8c



