### PR TITLE
Fix type usage with semi-qualified names in ST parser

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm/src/org/eclipse/fordiac/ide/structuredtextalgorithm/util/StructuredTextParseUtil.xtend
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm/src/org/eclipse/fordiac/ide/structuredtextalgorithm/util/StructuredTextParseUtil.xtend
@@ -103,8 +103,8 @@ class StructuredTextParseUtil {
 			rootASTElement as STAlgorithmSource
 	}
 
-	def static STInitializerExpressionSource validate(String expression, URI uri, INamedElement expectedType, LibraryElement type,
-		Collection<? extends EObject> additionalContent, List<Issue> issues) {
+	def static STInitializerExpressionSource validate(String expression, URI uri, INamedElement expectedType,
+		LibraryElement type, Collection<? extends EObject> additionalContent, List<Issue> issues) {
 		val parser = SERVICE_PROVIDER_FBT.get(IParser) as STAlgorithmParser
 		expression.parse(parser.grammarAccess.STInitializerExpressionSourceRule, uri, expectedType, type,
 			additionalContent, issues).rootASTElement as STInitializerExpressionSource
@@ -144,10 +144,11 @@ class StructuredTextParseUtil {
 		val parser = SERVICE_PROVIDER_FBT.get(IParser) as STAlgorithmParser
 		// use context from FB type since the type declaration is in the context of the FB type (and not an instance)
 		val typeVariable = decl.FBNetworkElement?.type?.interfaceList?.getVariable(decl.name) ?: decl
-		decl.fullTypeName.parse(parser.grammarAccess.STTypeDeclarationRule, typeVariable?.eResource?.URI, null, decl.name,
-			typeVariable.getContainerOfType(LibraryElement), null, errors, warnings, infos)?.rootASTElement as STTypeDeclaration
+		decl.fullTypeName.parse(parser.grammarAccess.STTypeDeclarationRule, typeVariable?.eResource?.URI, null,
+			decl.name, typeVariable.getContainerOfType(LibraryElement), null, errors, warnings, infos)?.
+			rootASTElement as STTypeDeclaration
 	}
-	
+
 	def private static IParseResult parse(String text, ParserRule entryPoint, String name, LibraryElement type,
 		List<String> errors, List<String> warnings, List<String> infos) {
 		text.parse(entryPoint, type?.eResource?.URI, null, name, type, null, errors, warnings, infos)
@@ -185,9 +186,11 @@ class StructuredTextParseUtil {
 				STResource.OPTION_EXPECTED_TYPE -> expectedType
 			})
 	}
-	
+
 	def static Set<String> collectUsedTypes(EObject object) {
 		val qualifiedNameConverter = SERVICE_PROVIDER_FBT.get(IQualifiedNameConverter)
-		SERVICE_PROVIDER_FBT.get(STCoreTypeUsageCollector).collectUsedTypes(object).map[qualifiedNameConverter.toString(it)].toSet
+		SERVICE_PROVIDER_FBT.get(STCoreTypeUsageCollector).includeFullyQualifiedReferences.collectUsedTypes(object).map [
+			qualifiedNameConverter.toString(it)
+		].toSet
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/validation/STCoreTypeUsageCollector.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/validation/STCoreTypeUsageCollector.java
@@ -13,63 +13,156 @@
 package org.eclipse.fordiac.ide.structuredtextcore.validation;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
-import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.emf.ecore.EReference;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
-import org.eclipse.xtext.EcoreUtil2;
+import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
+import org.eclipse.xtext.linking.impl.LinkingHelper;
+import org.eclipse.xtext.naming.IQualifiedNameConverter;
 import org.eclipse.xtext.naming.IQualifiedNameProvider;
 import org.eclipse.xtext.naming.QualifiedName;
+import org.eclipse.xtext.nodemodel.INode;
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
+import org.eclipse.xtext.resource.IEObjectDescription;
+import org.eclipse.xtext.scoping.IScope;
+import org.eclipse.xtext.scoping.IScopeProvider;
 
 import com.google.inject.Inject;
 
 public class STCoreTypeUsageCollector {
 
+	// ignore references which do not individually contribute to the used types,
+	// since they get their scope from somewhere else (e.g., members from the
+	// receiver or parameters from the called feature)
+	private static final Set<EReference> IGNORED_REFERENCES = Set.of(
+			STCorePackage.Literals.ST_MEMBER_ACCESS_EXPRESSION__MEMBER, //
+			STCorePackage.Literals.ST_CALL_NAMED_INPUT_ARGUMENT__PARAMETER, //
+			STCorePackage.Literals.ST_CALL_NAMED_OUTPUT_ARGUMENT__PARAMETER, //
+			STCorePackage.Literals.ST_FOR_STATEMENT__VARIABLE, //
+			STCorePackage.Literals.ST_STRUCT_INIT_ELEMENT__VARIABLE //
+	);
+
 	@Inject
 	private IQualifiedNameProvider nameProvider;
 
+	@Inject
+	private IQualifiedNameConverter nameConverter;
+
+	@Inject
+	private LinkingHelper linkingHelper;
+
+	@Inject
+	private IScopeProvider scopeProvider;
+
 	private final Set<QualifiedName> usedTypes = new HashSet<>();
+	private boolean includeFullyQualifiedReferences;
 
 	public Set<QualifiedName> collectUsedTypes(final EObject object) {
-		collectUsedTypesFrom(object);
-		final TreeIterator<EObject> iter = EcoreUtil.getAllProperContents(object, true);
-		while (iter.hasNext()) {
-			collectUsedTypesFrom(iter.next());
+		for (final EReference reference : object.eClass().getEAllReferences()) {
+			if (object.eIsSet(reference) && !IGNORED_REFERENCES.contains(reference)) {
+				if (reference.isContainment()) {
+					handleContainment(object, reference);
+				} else if (!reference.isContainer()) {
+					handleCrossReference(object, reference);
+				}
+			}
 		}
 		return usedTypes;
 	}
 
-	protected void collectUsedTypesFrom(final EObject object) {
-		object.eCrossReferences().stream().filter(target -> isExternalReference(object, target))
-				.forEachOrdered(this::addUsedType);
+	protected void handleContainment(final EObject object, final EReference reference) {
+		if (reference.isMany()) {
+			@SuppressWarnings("unchecked")
+			final List<EObject> children = (List<EObject>) object.eGet(reference);
+			for (final EObject child : children) {
+				collectUsedTypes(child);
+			}
+		} else {
+			final EObject child = (EObject) object.eGet(reference);
+			if (child != null) {
+				collectUsedTypes(child);
+			}
+		}
+	}
+
+	protected void handleCrossReference(final EObject object, final EReference reference) {
+		if (reference.isMany()) {
+			@SuppressWarnings("unchecked")
+			final List<EObject> targets = (List<EObject>) object.eGet(reference);
+			for (int index = 0; index < targets.size(); index++) {
+				handleCrossReference(object, reference, index, targets.get(index));
+			}
+		} else {
+			final EObject target = (EObject) object.eGet(reference);
+			if (target != null) {
+				handleCrossReference(object, reference, 0, target);
+			}
+		}
+	}
+
+	protected void handleCrossReference(final EObject source, final EReference reference, final int index,
+			final EObject target) {
+		if (isExternalReference(source, target) && !target.eIsProxy()) {
+			final QualifiedName name = getCrossReferenceName(source, reference, index);
+			handleExternalReference(source, reference, name, target);
+		}
+	}
+
+	protected void handleExternalReference(final EObject source, final EReference reference, final QualifiedName name,
+			final EObject target) {
+		final IScope scope = scopeProvider.getScope(source, reference);
+		if (name != null) {
+			final IEObjectDescription description = scope.getSingleElement(name);
+			if (description != null) {
+				addUsedType(description);
+			}
+		} else {
+			final IEObjectDescription description = scope.getSingleElement(target);
+			if (description != null) {
+				addUsedType(description);
+			}
+		}
+	}
+
+	protected QualifiedName getCrossReferenceName(final EObject source, final EReference reference, final int index) {
+		final List<INode> nodes = NodeModelUtils.findNodesForFeature(source, reference);
+		if (index >= nodes.size()) {
+			return null;
+		}
+		final String crossRefString = linkingHelper.getCrossRefNodeAsString(nodes.get(index), true);
+		if (crossRefString == null || crossRefString.isBlank()) {
+			return null;
+		}
+		return nameConverter.toQualifiedName(crossRefString);
+	}
+
+	public void addUsedType(final LibraryElement libraryElement) {
+		final QualifiedName qualifiedName = nameProvider.apply(libraryElement);
+		if (includeFullyQualifiedReferences || qualifiedName.getSegmentCount() > 1) {
+			usedTypes.add(qualifiedName);
+		}
+	}
+
+	protected void addUsedType(final IEObjectDescription description) {
+		final QualifiedName relativeName = description.getName();
+		final QualifiedName qualifiedName = description.getQualifiedName();
+		if (relativeName.getSegmentCount() < qualifiedName.getSegmentCount()) {
+			usedTypes.add(qualifiedName.skipLast(relativeName.getSegmentCount() - 1));
+		} else if (includeFullyQualifiedReferences) {
+			usedTypes.add(qualifiedName);
+		}
 	}
 
 	protected static boolean isExternalReference(final EObject source, final EObject target) {
 		return source.eResource() != target.eResource();
 	}
 
-	public void addUsedType(final EObject object) {
-		final INamedElement importedType = resolveImportedType(object);
-		if (importedType != null) {
-			usedTypes.add(nameProvider.apply(importedType));
-		}
-	}
-
-	protected static INamedElement resolveImportedType(final EObject object) {
-		if (object.eIsProxy()) {
-			return null;
-		}
-		final LibraryElement libraryElement = EcoreUtil2.getContainerOfType(object, LibraryElement.class);
-		if (libraryElement != null) {
-			return libraryElement;
-		}
-		if (object instanceof final INamedElement element) {
-			return element;
-		}
-		return null;
+	public STCoreTypeUsageCollector includeFullyQualifiedReferences() {
+		includeFullyQualifiedReferences = true;
+		return this;
 	}
 
 	public Set<QualifiedName> getUsedTypes() {

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/util/STFunctionParseUtil.xtend
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/util/STFunctionParseUtil.xtend
@@ -103,9 +103,11 @@ final class STFunctionParseUtil {
 			STCoreResource.OPTION_PLAIN_ST -> Boolean.TRUE
 		})
 	}
-	
+
 	def static Set<String> collectUsedTypes(EObject object) {
 		val qualifiedNameConverter = SERVICE_PROVIDER_FCT.get(IQualifiedNameConverter)
-		SERVICE_PROVIDER_FCT.get(STCoreTypeUsageCollector).collectUsedTypes(object).map[qualifiedNameConverter.toString(it)].toSet
+		SERVICE_PROVIDER_FCT.get(STCoreTypeUsageCollector).includeFullyQualifiedReferences.collectUsedTypes(object).map [
+			qualifiedNameConverter.toString(it)
+		].toSet
 	}
 }


### PR DESCRIPTION
When using a semi-qualified name, the imported type should be the enclosing type and not the full-qualified name. Also avoid adding imports for fully-qualified references, unless requested.

A declaration of a global constant `util::Math::PI`, for example, requires the following imports:
- `util::Math::PI` when used as `PI`,
- `util::Math` when used as `Math::PI`,
- none when used as `util::Math::PI`.