### PR TITLE
Add GenericClassName attribute to event types

### DIFF
--- a/data/typelibrary/events-1.0.0/typelib/E_MUX_2.fbt
+++ b/data/typelibrary/events-1.0.0/typelib/E_MUX_2.fbt
@@ -22,4 +22,5 @@
 			<VarDeclaration Name="K" Type="UINT" Comment="Event index"/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_E_MUX'"/>
 </FBType>

--- a/data/typelibrary/events-1.0.0/typelib/E_MUX_4.fbt
+++ b/data/typelibrary/events-1.0.0/typelib/E_MUX_4.fbt
@@ -26,4 +26,5 @@
 			<VarDeclaration Name="K" Type="UINT" Comment="Event index"/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_E_MUX'"/>
 </FBType>

--- a/data/typelibrary/events-1.0.0/typelib/E_MUX_8.fbt
+++ b/data/typelibrary/events-1.0.0/typelib/E_MUX_8.fbt
@@ -34,4 +34,5 @@
 			<VarDeclaration Name="K" Type="UINT" Comment="Event index"/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_E_MUX'"/>
 </FBType>


### PR DESCRIPTION
- Introduced a new attribute `GenericClassName` with value `'GEN_E_MUX'` in multiple event type definitions.
- Updated the structure for consistency across different event types.
