### PR TITLE
Changed Storage of Struct_Demux configuration to use % Separator

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/DemultiplexerSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/DemultiplexerSection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Johannes Kepler University Linz
+ * Copyright (c) 2020, 2025 Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/InterfaceElementSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/InterfaceElementSection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2024 fortiss GmbH, Johannes Kepler University Linz,
+ * Copyright (c) 2016, 2025 fortiss GmbH, Johannes Kepler University Linz,
  * 							Primetals Technologies Austria GmbH,
  *                          Martin Erich Jobst
  *
@@ -41,6 +41,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.AdapterType;
 import org.eclipse.fordiac.ide.model.libraryElement.ErrorMarkerInterface;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
+import org.eclipse.fordiac.ide.model.libraryElement.MemberVarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.ui.widgets.OpenStructMenu;
 import org.eclipse.fordiac.ide.ui.FordiacMessages;
@@ -249,8 +250,10 @@ public class InterfaceElementSection extends AbstractDoubleColumnSection {
 		return null;
 	}
 
-	private Object getPinName() {
-		return getType().getName() != null ? getType().getName() : ""; //$NON-NLS-1$
+	private String getPinName() {
+		final String pinName = (getType() instanceof final MemberVarDeclaration memVar) ? memVar.getDisplayName()
+				: getType().getName();
+		return pinName != null ? pinName : ""; //$NON-NLS-1$
 	}
 
 	private void refreshParameterVisibility() {

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/InterfaceEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/InterfaceEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 Profactor GbmH, TU Wien ACIN, fortiss GmbH,
+ * Copyright (c) 2008, 2025 Profactor GbmH, TU Wien ACIN, fortiss GmbH,
  *                          Johannes Kepler University Linz,
  *                          Primetals Technologies Austria GmbH
  *
@@ -192,7 +192,7 @@ public abstract class InterfaceEditPart extends AbstractConnectableEditPart
 
 	private static String getPinName(final IInterfaceElement pin) {
 		if (pin instanceof final MemberVarDeclaration memberVarDecl) {
-			return memberVarDecl.getName();
+			return memberVarDecl.getDisplayName();
 		}
 		return pin.getName();
 	}

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/figures/ToolTipFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/figures/ToolTipFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 - 2011, 2014, 2017 Profactor GbmH, TU Wien ACIN, fortiss GmbH
+ * Copyright (c) 2008, 2025 Profactor GbmH, TU Wien ACIN, fortiss GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -24,6 +24,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.Device;
 import org.eclipse.fordiac.ide.model.libraryElement.Event;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.MemberVarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.With;
 import org.eclipse.fordiac.ide.ui.FordiacMessages;
@@ -47,7 +48,7 @@ public class ToolTipFigure extends Figure {
 		setLayoutManager(mainLayout);
 		mainLayout.setStretchMinorAxis(true);
 
-		String nameLine = element.getName();
+		String nameLine = getName(element);
 
 		if (element instanceof final ITypedElement typedElement && typedElement.getFullTypeName() != null) {
 			nameLine += " - " + typedElement.getFullTypeName(); //$NON-NLS-1$
@@ -72,6 +73,13 @@ public class ToolTipFigure extends Figure {
 			annotationModel.getAnnotations(element).stream().forEach(annotation -> line
 					.add(new Label(annotation.getText(), GraphicalAnnotationStyles.getAnnotationImage(annotation))));
 		}
+	}
+
+	private static String getName(final INamedElement element) {
+		if (element instanceof final MemberVarDeclaration memberVarDecl) {
+			return memberVarDecl.getDisplayName();
+		}
+		return element.getName();
 	}
 
 	public final VerticalLineCompartmentFigure getLine() {

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/VarDeclarationColumnAccessor.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/VarDeclarationColumnAccessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Primetals Technologies Austria GmbH
+ * Copyright (c) 2022, 2025 Primetals Technologies Austria GmbH
  *                          Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
@@ -31,6 +31,7 @@ import org.eclipse.fordiac.ide.model.edit.helper.CommentHelper;
 import org.eclipse.fordiac.ide.model.edit.helper.InitialValueHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
+import org.eclipse.fordiac.ide.model.libraryElement.MemberVarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.ui.FordiacMessages;
 import org.eclipse.fordiac.ide.ui.widget.CommandExecutor;
@@ -50,7 +51,8 @@ public class VarDeclarationColumnAccessor extends AbstractColumnAccessor<VarDecl
 	@Override
 	public Object getDataValue(final VarDeclaration rowObject, final VarDeclarationTableColumn column) {
 		return switch (column) {
-		case NAME -> rowObject.getName();
+		case NAME ->
+			(rowObject instanceof final MemberVarDeclaration memVar) ? memVar.getDisplayName() : rowObject.getName();
 		case TYPE -> rowObject.getFullTypeName();
 		case COMMENT -> CommentHelper.getInstanceComment(rowObject);
 		case INITIAL_VALUE -> getInitialValue(rowObject);

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/MemberVarDeclarationItemProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src-gen/org/eclipse/fordiac/ide/model/libraryElement/provider/MemberVarDeclarationItemProvider.java
@@ -100,11 +100,11 @@ public class MemberVarDeclarationItemProvider
 	 * This returns the label text for the adapted class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
+	 * @generated NOT
 	 */
 	@Override
 	public String getText(Object object) {
-		String label = ((MemberVarDeclaration)object).getName();
+		String label = ((MemberVarDeclaration)object).getDisplayName();
 		return label == null || label.length() == 0 ?
 			getString("_UI_MemberVarDeclaration_type") : //$NON-NLS-1$
 			getString("_UI_MemberVarDeclaration_type") + " " + label; //$NON-NLS-1$ //$NON-NLS-2$

--- a/plugins/org.eclipse.fordiac.ide.model/model/fordiac.genmodel
+++ b/plugins/org.eclipse.fordiac.ide.model/model/fordiac.genmodel
@@ -661,9 +661,14 @@
     <genClasses ecoreClass="lib.ecore#//MappingTarget"/>
     <genClasses ecoreClass="lib.ecore#//MemberVarDeclaration">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute lib.ecore#//MemberVarDeclaration/parentNames"/>
-      <genOperations ecoreOperation="lib.ecore#//MemberVarDeclaration/getName" body="return ConfigurableFBManagement.getMemberVarName(this);"/>
+      <genOperations ecoreOperation="lib.ecore#//MemberVarDeclaration/getName" body="return ConfigurableFBManagement.getMemberVarName(this, ConfigurableFBManagement.MEMBER_VAR_SEPARATOR);"/>
+      <genOperations ecoreOperation="lib.ecore#//MemberVarDeclaration/getDisplayName"
+          body="return ConfigurableFBManagement.getMemberVarName(this, &quot;.&quot;);   //$NON-NLS-1$"/>
       <genOperations ecoreOperation="lib.ecore#//MemberVarDeclaration/getVarName"
           body="return super.getName();"/>
+      <genOperations ecoreOperation="lib.ecore#//MemberVarDeclaration/setName" body="// ensure that we are always only setting the last segment as name&#xA;final String[] subNames = ConfigurableFBManagement.splitMemberVarName(name);&#xA;super.setName(subNames[subNames.length - 1]);">
+        <genParameters ecoreParameter="lib.ecore#//MemberVarDeclaration/setName/name"/>
+      </genOperations>
     </genClasses>
     <genClasses ecoreClass="lib.ecore#//Method"/>
     <genClasses ecoreClass="lib.ecore#//Multiplexer">

--- a/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
+++ b/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
@@ -1773,13 +1773,24 @@
   <eClassifiers xsi:type="ecore:EClass" name="MemberVarDeclaration" eSuperTypes="#//VarDeclaration">
     <eOperations name="getName" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
-        <details key="body" value="return ConfigurableFBManagement.getMemberVarName(this);"/>
+        <details key="body" value="return ConfigurableFBManagement.getMemberVarName(this, ConfigurableFBManagement.MEMBER_VAR_SEPARATOR);"/>
+      </eAnnotations>
+    </eOperations>
+    <eOperations name="getDisplayName" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="body" value="return ConfigurableFBManagement.getMemberVarName(this, &quot;.&quot;);   //$NON-NLS-1$"/>
       </eAnnotations>
     </eOperations>
     <eOperations name="getVarName" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return super.getName();"/>
       </eAnnotations>
+    </eOperations>
+    <eOperations name="setName">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="body" value="// ensure that we are always only setting the last segment as name&#xA;final String[] subNames = ConfigurableFBManagement.splitMemberVarName(name);&#xA;super.setName(subNames[subNames.length - 1]);"/>
+      </eAnnotations>
+      <eParameters name="name" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     </eOperations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="parentNames" upperBound="-1"
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/MemberVarDeclaration.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/MemberVarDeclaration.java
@@ -61,6 +61,22 @@ public interface MemberVarDeclaration extends VarDeclaration {
 	 * @model kind="operation"
 	 * @generated
 	 */
+	String getDisplayName();
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @model kind="operation"
+	 * @generated
+	 */
 	String getVarName();
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @model nameRequired="true"
+	 * @generated
+	 */
+	void setName(String name);
 
 } // MemberVarDeclaration

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
@@ -5181,7 +5181,12 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 
 		addEOperation(memberVarDeclarationEClass, ecorePackage.getEString(), "getName", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
+		addEOperation(memberVarDeclarationEClass, ecorePackage.getEString(), "getDisplayName", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+
 		addEOperation(memberVarDeclarationEClass, ecorePackage.getEString(), "getVarName", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+
+		op = addEOperation(memberVarDeclarationEClass, null, "setName", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEParameter(op, ecorePackage.getEString(), "name", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(methodEClass, Method.class, "Method", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/MemberVarDeclarationImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/MemberVarDeclarationImpl.java
@@ -90,7 +90,17 @@ public class MemberVarDeclarationImpl extends VarDeclarationImpl implements Memb
 	 */
 	@Override
 	public String getName() {
-		return ConfigurableFBManagement.getMemberVarName(this);
+		return ConfigurableFBManagement.getMemberVarName(this, ConfigurableFBManagement.MEMBER_VAR_SEPARATOR);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String getDisplayName() {
+		return ConfigurableFBManagement.getMemberVarName(this, ".");   //$NON-NLS-1$
 	}
 
 	/**
@@ -101,6 +111,18 @@ public class MemberVarDeclarationImpl extends VarDeclarationImpl implements Memb
 	@Override
 	public String getVarName() {
 		return super.getName();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void setName(final String name) {
+		// ensure that we are always only setting the last segment as name
+		final String[] subNames = ConfigurableFBManagement.splitMemberVarName(name);
+		super.setName(subNames[subNames.length - 1]);
 	}
 
 	/**

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/AbstractStructTree.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/AbstractStructTree.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Primetals Technologies Austria GmbH
+ * Copyright (c) 2021, 2025 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -33,7 +33,7 @@ public abstract class AbstractStructTree<T extends AbstractStructTreeNode> {
 		initTree(manipulator, struct);
 	}
 
-	public void initTree(final StructManipulator manipulator, final StructuredType struct) {
+	private final void initTree(final StructManipulator manipulator, final StructuredType struct) {
 		root = createRoot();
 		buildTree(manipulator, struct, root);
 	}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/AbstractStructTreeNode.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/AbstractStructTreeNode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Primetals Technologies Austria GmbH
+ * Copyright (c) 2021, 2025 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,7 +16,6 @@ package org.eclipse.fordiac.ide.model;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.emf.ecore.EObject;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 
 public abstract class AbstractStructTreeNode {
@@ -97,9 +96,16 @@ public abstract class AbstractStructTreeNode {
 		if ((null == parent) || (null == parent.pinName)) {
 			return getVariableName(variable);
 		}
-		return (parent.pinName + "." + getVariableName(variable)); //$NON-NLS-1$
+		return (parent.pinName + getChildSeparator() + getVariableName(variable));
 	}
 
-	public abstract AbstractStructTreeNode addChild(final EObject obj);
+	public AbstractStructTreeNode addChild(final VarDeclaration memberVariable) {
+		final AbstractStructTreeNode treeNode = createChild(memberVariable);
+		getChildren().add(treeNode);
+		return treeNode;
+	}
 
+	protected abstract AbstractStructTreeNode createChild(VarDeclaration vardeclaration);
+
+	protected abstract String getChildSeparator();
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/CheckableStructTreeNode.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/CheckableStructTreeNode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Primetals Technologies Austria GmbH
+ * Copyright (c) 2021, 2025 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,9 +16,9 @@ package org.eclipse.fordiac.ide.model;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.libraryElement.impl.ConfigurableFBManagement;
 import org.eclipse.jface.viewers.CheckboxTreeViewer;
 
 public class CheckableStructTreeNode extends AbstractStructTreeNode {
@@ -42,13 +42,8 @@ public class CheckableStructTreeNode extends AbstractStructTreeNode {
 	}
 
 	@Override
-	public CheckableStructTreeNode addChild(final EObject memberVariable) {
-		if (memberVariable instanceof final VarDeclaration vardeclaration) {
-			final CheckableStructTreeNode treeNode = new CheckableStructTreeNode(vardeclaration, this, getTree());
-			getChildren().add(treeNode);
-			return treeNode;
-		}
-		return null;
+	public CheckableStructTreeNode addChild(final VarDeclaration memberVariable) {
+		return (CheckableStructTreeNode) super.addChild(memberVariable);
 	}
 
 	public void updateNode(final boolean check) {
@@ -236,6 +231,16 @@ public class CheckableStructTreeNode extends AbstractStructTreeNode {
 		}
 
 		return super.equals(obj);
+	}
+
+	@Override
+	protected AbstractStructTreeNode createChild(final VarDeclaration vardeclaration) {
+		return new CheckableStructTreeNode(vardeclaration, this, getTree());
+	}
+
+	@Override
+	protected String getChildSeparator() {
+		return ConfigurableFBManagement.MEMBER_VAR_SEPARATOR;
 	}
 
 }

--- a/tests/org.eclipse.fordiac.ide.test.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/AddDeleteDemuxPortCommandTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/AddDeleteDemuxPortCommandTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Primetals Technologies Germany GmbH
+ * Copyright (c) 2020, 2025 Primetals Technologies Germany GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -55,7 +55,7 @@ public class AddDeleteDemuxPortCommandTest extends CommandTestBase<State> {
 	private static final String VARIABLE6 = "VAR6"; //$NON-NLS-1$
 	private static final String INNER_STRUCT_OBJECT1 = "innerstruct1"; //$NON-NLS-1$
 	private static final String INNER_STRUCT_OBJECT2 = "innerstruct2"; //$NON-NLS-1$
-	private static final String SEP = "."; //$NON-NLS-1$
+	private static final String SEP = "%"; //$NON-NLS-1$
 
 	protected static class State extends CommandTestBase.StateBase {
 


### PR DESCRIPTION
In order to treat a struct child pin of a struct demuxer as single entity the internal string and configuration string uses now the % separator. In the ui still the . is shown.