### PR TITLE
Fix SubApp expanded view sizing issues

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/SubAppForFBNetworkEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/SubAppForFBNetworkEditPart.java
@@ -384,8 +384,12 @@ public class SubAppForFBNetworkEditPart extends AbstractFBNElementEditPart imple
 
 	private Dimension getSubappSize() {
 		if (getModel().isUnfolded()) {
-			return new Dimension(CoordinateConverter.INSTANCE.iec61499ToScreen(getModel().getWidth()),
+			final int minWidth = 100;
+			final int minHeight = 60;
+			final int width = Math.max(minWidth, CoordinateConverter.INSTANCE.iec61499ToScreen(getModel().getWidth()));
+			final int height = Math.max(minHeight,
 					CoordinateConverter.INSTANCE.iec61499ToScreen(getModel().getHeight()));
+			return new Dimension(width, height);
 		}
 		return new Dimension(-1, -1);
 	}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/SubAppForFbNetworkFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/SubAppForFbNetworkFigure.java
@@ -185,8 +185,8 @@ public class SubAppForFbNetworkFigure extends FBNetworkElementFigure {
 		expandedMainFigure = new BorderedRoundedRectangle();
 		expandedMainFigure.setOutline(false);
 		expandedMainFigure.setOpaque(false);
-		expandedMainFigure
-				.setCornerDimensions(new Dimension(GefPreferenceConstants.CORNER_DIM, GefPreferenceConstants.CORNER_DIM));
+		expandedMainFigure.setCornerDimensions(
+				new Dimension(GefPreferenceConstants.CORNER_DIM, GefPreferenceConstants.CORNER_DIM));
 		expandedMainFigure.setBorder(new RoundedRectangleShadowBorder());
 		expandedMainFigure.setLayoutManager(createExpandedMainFigureLayout());
 		final GridData gridData = new GridData(GridData.HORIZONTAL_ALIGN_FILL | GridData.GRAB_HORIZONTAL
@@ -308,7 +308,7 @@ public class SubAppForFbNetworkFigure extends FBNetworkElementFigure {
 	private static int getMinExpandedInterfaceBarWidth() {
 		if (minExpSubappBarWidhtPixels == -1) {
 			minExpSubappBarWidhtPixels = EditorWithInterfaceEditPart.getMinInterfaceBarWidth()
-					+ ConnectorBorder.LR_MARGIN; // we have connectors on both sides
+					+ ConnectorBorder.LR_MARGIN - 50; // we have connectors on both sides
 		}
 		return minExpSubappBarWidhtPixels;
 	}


### PR DESCRIPTION
Fixes #402 

### Problem:

- Expanded SubApps had overly wide sidebars by default.

- Empty SubApps collapsed into a thin line due to incorrect size calculation.

### Solution:

- Reduced the minimum width of input/output sidebars in SubAppForFbNetworkFigure.

- Enforced minimum dimensions for empty SubApps in SubAppForFBNetworkEditPart.

### Testing:

- Create a new SubApp → Expand it. Verify sidebars are narrower.

- Resize an empty SubApp → Ensure it retains a usable size (min 100x60).


https://github.com/user-attachments/assets/ce240467-72cf-4dae-ad55-f0177ca4ddd3



