### PR TITLE
Reducing Locking Impact of PlantHierarchy Refactoring Participants

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.hierarchymanager.ui/src/org/eclipse/fordiac/ide/hierarchymanager/ui/listeners/HierarchyManagerUpdateListener.java
+++ b/plugins/org.eclipse.fordiac.ide.hierarchymanager.ui/src/org/eclipse/fordiac/ide/hierarchymanager/ui/listeners/HierarchyManagerUpdateListener.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import org.eclipse.core.commands.operations.AbstractOperation;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.fordiac.ide.hierarchymanager.model.hierarchy.Leaf;
 import org.eclipse.fordiac.ide.hierarchymanager.model.hierarchy.Level;
 import org.eclipse.fordiac.ide.hierarchymanager.model.hierarchy.RootLevel;
@@ -46,7 +47,6 @@ public class HierarchyManagerUpdateListener extends QualNameChangeListener {
 	@Override
 	protected List<AbstractOperation> constructExecutableOperations(final QualNameChange qualNameChange,
 			final Object rootLevel) {
-
 		return constructOperation(qualNameChange, rootLevel, false);
 	}
 
@@ -54,7 +54,6 @@ public class HierarchyManagerUpdateListener extends QualNameChangeListener {
 			final boolean isUndo) {
 
 		if (qualNameChange.state() == QualNameChangeState.DELETE_UNDO) {
-
 			return undoDeleteOperations.remove(qualNameChange.oldQualName());
 		}
 
@@ -73,9 +72,7 @@ public class HierarchyManagerUpdateListener extends QualNameChangeListener {
 		for (final Leaf leaf : leafs) {
 			if (qualNameChange.state() == QualNameChangeState.DELETE
 					|| qualNameChange.state() == QualNameChangeState.DELETE_REDO) {
-
 				result.add(new DeleteNodeOperation(leaf));
-
 				storeUndoDeleteOperations(qualNameChange.oldQualName(), leaf);
 			} else {
 				result.add(new UpdateLeafRefOperation(leaf, newRef, identifier));
@@ -87,7 +84,12 @@ public class HierarchyManagerUpdateListener extends QualNameChangeListener {
 
 	@Override
 	protected Object getReceiver(final TypeEntry key) {
-		return HierarchyManagerRefactoringUtil.getPlantHierarchy(key.getFile().getProject());
+		final IProject project = key.getFile().getProject();
+		if (!HierarchyManagerRefactoringUtil.plantHierachyExists(project)) {
+			return null;
+		}
+
+		return HierarchyManagerRefactoringUtil.getPlantHierarchy(project);
 	}
 
 	@Override
@@ -102,7 +104,6 @@ public class HierarchyManagerUpdateListener extends QualNameChangeListener {
 
 	protected void storeUndoDeleteOperations(final String qualName, final Leaf leaf) {
 		final AddLeafOperation op = new AddLeafOperation((Level) leaf.eContainer(), leaf);
-
 		undoDeleteOperations.computeIfAbsent(qualName, k -> new ArrayList<>()).add(op);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.hierarchymanager.ui/src/org/eclipse/fordiac/ide/hierarchymanager/ui/refactoring/DeleteLibraryElementParticipant.java
+++ b/plugins/org.eclipse.fordiac.ide.hierarchymanager.ui/src/org/eclipse/fordiac/ide/hierarchymanager/ui/refactoring/DeleteLibraryElementParticipant.java
@@ -37,18 +37,18 @@ public class DeleteLibraryElementParticipant extends DeleteParticipant {
 
 	@Override
 	protected boolean initialize(final Object element) {
-
 		if (element instanceof final IResource resource) {
-
-			plantHierarchy = HierarchyManagerRefactoringUtil.getPlantHierarchy(resource.getProject());
-
-			try {
-				this.files = HierarchyManagerRefactoringUtil.getFilesFromResource(resource);
-			} catch (final CoreException e) {
-				return false;
+			if (!HierarchyManagerRefactoringUtil.plantHierachyExists(resource.getProject())) {
+				plantHierarchy = null;
+			} else {
+				plantHierarchy = HierarchyManagerRefactoringUtil.getPlantHierarchy(resource.getProject());
+				try {
+					this.files = HierarchyManagerRefactoringUtil.getFilesFromResource(resource);
+				} catch (final CoreException e) {
+					return false;
+				}
 			}
 		}
-
 		return plantHierarchy != null;
 	}
 
@@ -60,7 +60,6 @@ public class DeleteLibraryElementParticipant extends DeleteParticipant {
 	@Override
 	public RefactoringStatus checkConditions(final IProgressMonitor pm, final CheckConditionsContext context)
 			throws OperationCanceledException {
-
 		return new RefactoringStatus();
 	}
 
@@ -74,7 +73,6 @@ public class DeleteLibraryElementParticipant extends DeleteParticipant {
 			for (final IFile file : files) {
 				final List<Leaf> matches = HierarchyManagerUtil.searchLeaf(plantHierarchy,
 						leaf -> leaf.getContainerFileName().contains(file.getName()));
-
 				leaves.addAll(matches);
 			}
 

--- a/plugins/org.eclipse.fordiac.ide.hierarchymanager.ui/src/org/eclipse/fordiac/ide/hierarchymanager/ui/refactoring/MoveFileParticipant.java
+++ b/plugins/org.eclipse.fordiac.ide.hierarchymanager.ui/src/org/eclipse/fordiac/ide/hierarchymanager/ui/refactoring/MoveFileParticipant.java
@@ -40,20 +40,21 @@ public class MoveFileParticipant extends MoveParticipant {
 
 	@Override
 	protected boolean initialize(final Object element) {
-
 		if (element instanceof final IResource resource) {
-
 			this.element = resource;
 
-			plantHierarchy = HierarchyManagerRefactoringUtil.getPlantHierarchy(resource.getProject());
+			if (!HierarchyManagerRefactoringUtil.plantHierachyExists(resource.getProject())) {
+				plantHierarchy = null;
+			} else {
+				plantHierarchy = HierarchyManagerRefactoringUtil.getPlantHierarchy(resource.getProject());
 
-			try {
-				this.files = HierarchyManagerRefactoringUtil.getFilesFromResource(resource);
-			} catch (final CoreException e) {
-				return false;
+				try {
+					this.files = HierarchyManagerRefactoringUtil.getFilesFromResource(resource);
+				} catch (final CoreException e) {
+					return false;
+				}
 			}
 		}
-
 		return !(plantHierarchy == null || files.isEmpty());
 	}
 
@@ -65,7 +66,6 @@ public class MoveFileParticipant extends MoveParticipant {
 	@Override
 	public RefactoringStatus checkConditions(final IProgressMonitor pm, final CheckConditionsContext context)
 			throws OperationCanceledException {
-
 		return new RefactoringStatus();
 	}
 
@@ -79,7 +79,6 @@ public class MoveFileParticipant extends MoveParticipant {
 			for (final IFile file : files) {
 				final List<Leaf> matches = HierarchyManagerUtil.searchLeaf(plantHierarchy,
 						leaf -> leaf.getContainerFileName().contains(file.getName()));
-
 				leaves.addAll(matches);
 			}
 

--- a/plugins/org.eclipse.fordiac.ide.hierarchymanager.ui/src/org/eclipse/fordiac/ide/hierarchymanager/ui/refactoring/RenameFileParticipant.java
+++ b/plugins/org.eclipse.fordiac.ide.hierarchymanager.ui/src/org/eclipse/fordiac/ide/hierarchymanager/ui/refactoring/RenameFileParticipant.java
@@ -39,20 +39,21 @@ public class RenameFileParticipant extends RenameParticipant {
 
 	@Override
 	protected boolean initialize(final Object element) {
-
 		if (element instanceof final IResource resource) {
-
 			this.element = resource;
 
-			plantHierarchy = HierarchyManagerRefactoringUtil.getPlantHierarchy(resource.getProject());
+			if (!HierarchyManagerRefactoringUtil.plantHierachyExists(resource.getProject())) {
+				plantHierarchy = null;
+			} else {
+				plantHierarchy = HierarchyManagerRefactoringUtil.getPlantHierarchy(resource.getProject());
 
-			try {
-				this.files = HierarchyManagerRefactoringUtil.getFilesFromResource(resource);
-			} catch (final CoreException e) {
-				return false;
+				try {
+					this.files = HierarchyManagerRefactoringUtil.getFilesFromResource(resource);
+				} catch (final CoreException e) {
+					return false;
+				}
 			}
 		}
-
 		return !(plantHierarchy == null || files.isEmpty());
 	}
 
@@ -64,13 +65,11 @@ public class RenameFileParticipant extends RenameParticipant {
 	@Override
 	public RefactoringStatus checkConditions(final IProgressMonitor pm, final CheckConditionsContext context)
 			throws OperationCanceledException {
-
 		return new RefactoringStatus();
 	}
 
 	@Override
 	public Change createChange(final IProgressMonitor pm) throws CoreException, OperationCanceledException {
-
 		try {
 			pm.beginTask("Creating change...", 1); //$NON-NLS-1$
 
@@ -79,7 +78,6 @@ public class RenameFileParticipant extends RenameParticipant {
 			for (final IFile file : files) {
 				final List<Leaf> matches = HierarchyManagerUtil.searchLeaf(plantHierarchy,
 						leaf -> leaf.getContainerFileName().contains(file.getName()));
-
 				leaves.addAll(matches);
 			}
 

--- a/plugins/org.eclipse.fordiac.ide.hierarchymanager.ui/src/org/eclipse/fordiac/ide/hierarchymanager/ui/view/PlantHierarchyView.java
+++ b/plugins/org.eclipse.fordiac.ide.hierarchymanager.ui/src/org/eclipse/fordiac/ide/hierarchymanager/ui/view/PlantHierarchyView.java
@@ -61,7 +61,7 @@ public class PlantHierarchyView extends CommonNavigator implements ITabbedProper
 	private static final String PLANT_HIERARCHY_PROJECT = "PlantHierarchy.Project"; //$NON-NLS-1$
 	public static final String PLANT_HIERARCHY_FILE_NAME_EXTENSION = "HIER"; //$NON-NLS-1$
 	public static final String PLANT_HIERARCHY_FILE_NAME_EXTENSION_WITH_DOT = "." + PLANT_HIERARCHY_FILE_NAME_EXTENSION; //$NON-NLS-1$
-	private static final String PLANT_HIERARCHY_FILE_NAME = ".plant" //$NON-NLS-1$
+	public static final String PLANT_HIERARCHY_FILE_NAME = ".plant" //$NON-NLS-1$
 			+ PLANT_HIERARCHY_FILE_NAME_EXTENSION_WITH_DOT.toLowerCase();
 
 	/** The PROPERTY_CONTRIBUTOR_ID. */
@@ -197,7 +197,7 @@ public class PlantHierarchyView extends CommonNavigator implements ITabbedProper
 		return null;
 	}
 
-	public static EObject createNewHierarchyFile(final IFile file, final URI uri,
+	private static EObject createNewHierarchyFile(final IFile file, final URI uri,
 			final ResourceSet hierarchyResouceSet) {
 		Resource resource = hierarchyResouceSet.getResource(uri, false);
 		if (resource == null) {


### PR DESCRIPTION
For acquiring the plant hierarchy model the plant hierarchy refactoring participants where locking the display not only for getting the plant hierarchy view but also for loading it. In case of non existing plant hierarchies this led to deadlocks. This fix reduces the lock time and also only enables refactoring when an plant hierarchy file exists.