### PR TITLE
Updated exporter to new StringId handling

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteFBTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteFBTemplate.xtend
@@ -30,6 +30,7 @@ import java.util.Map
 import java.util.Set
 import org.eclipse.emf.common.util.EList
 import org.eclipse.fordiac.ide.model.LibraryElementTags
+import org.eclipse.fordiac.ide.model.data.ArrayType
 import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes.GenericTypes
 import org.eclipse.fordiac.ide.model.datatype.helper.RetainHelper.RetainTag
 import org.eclipse.fordiac.ide.model.libraryElement.AdapterDeclaration
@@ -37,7 +38,9 @@ import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType
 import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableFB
 import org.eclipse.fordiac.ide.model.libraryElement.Event
 import org.eclipse.fordiac.ide.model.libraryElement.FB
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement
 import org.eclipse.fordiac.ide.model.libraryElement.FBType
+import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration
 import org.eclipse.fordiac.ide.model.libraryElement.With
@@ -71,15 +74,6 @@ abstract class ForteFBTemplate<T extends FBType> extends ForteLibraryElementTemp
 		«type.compilerInfo?.header»
 	'''
 
-	def protected generateImplIncludes() '''
-		#include "«fileBasename».h"
-		#ifdef FORTE_ENABLE_GENERATED_SOURCE_CPP
-		#include "«type.generateTypeGenIncludePath»"
-		#endif
-		
-		«getDependencies(emptyMap).generateDependencyIncludes»
-		«type.compilerInfo?.header»
-	'''
 
 	def protected generateFBDeclaration() '''
 		DECLARE_FIRMWARE_FB(«FBClassName»)
@@ -610,5 +604,24 @@ abstract class ForteFBTemplate<T extends FBType> extends ForteLibraryElementTemp
 	override Set<INamedElement> getDependencies(Map<?, ?> options) {
 		(super.getDependencies(options) + (type.interfaceList.sockets + type.interfaceList.plugs).map[getType]
 			).toSet
+	}
+	
+	override Set<String> getUsedStrings(Map<?, ?> options) {
+		val strings = super.getUsedStrings(options)
+		type.interfaceList.allInterfaceElements.forEach[getUsedIEStrings(it, strings)]
+		return strings	
+	}
+	
+	def protected void getUsedIEStrings(IInterfaceElement ie, Set<String> strings){
+		strings.add(ie.name)
+		strings.add(ie.type.generateTypeNamePlain)
+		if(ie.type instanceof ArrayType) {
+			strings.add((ie.type as ArrayType).baseType.generateTypeNamePlain)
+		}
+	}
+	
+	def protected void getUsedFBStrings(FBNetworkElement fb, Set<String> strings){
+		strings.add(fb.name)
+		strings.add(fb.type.generateTypeNamePlain)
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteLibraryElementTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteLibraryElementTemplate.xtend
@@ -70,6 +70,13 @@ abstract class ForteLibraryElementTemplate<T extends LibraryElement> extends For
 
 	def protected generateIncludeGuardEnd() '''
 	'''
+	
+	def protected generateImplIncludes() '''
+		#include "«fileBasename».h"
+		
+		«getDependencies(emptyMap).generateDependencyIncludes»
+		«type.compilerInfo?.header»
+	'''
 
 	def protected generateVariableDeclarations(List<VarDeclaration> variables, boolean const) '''
 		«FOR variable : variables AFTER '\n'»
@@ -146,6 +153,14 @@ abstract class ForteLibraryElementTemplate<T extends LibraryElement> extends For
 	def CharSequence generateVariableTypeSpec(VarDeclaration decl) {
 		variableLanguageSupport.get(decl)?.generate(#{ForteNgExportFilter.OPTION_TYPE_SPEC -> Boolean.TRUE})
 	}
+	
+	def protected generateUseStringId() '''
+		«getUsedStrings(emptyMap).generateUseStringIdDecls»
+	'''
+	
+	def generateUseStringIdDecls(Set<String> strings) '''
+		«FOR str : strings.sort»USE_STRING_ID(«str»);«ENDFOR»
+	'''
 
 	def protected getFORTENameList(List<? extends INamedElement> elements) {
 		elements.map[name.FORTEStringId].join(", ")
@@ -173,5 +188,9 @@ abstract class ForteLibraryElementTemplate<T extends LibraryElement> extends For
 
 	def Set<INamedElement> getDependencies(Map<?, ?> options) {
 		variableLanguageSupport.values.filterNull.flatMap[getDependencies(options)].toSet
+	}
+	
+	def protected Set<String> getUsedStrings(Map<?, ?> options) {
+		newHashSet(type.generateTypeNamePlain)
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/adapter/AdapterFBImplTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/adapter/AdapterFBImplTemplate.xtend
@@ -38,6 +38,8 @@ class AdapterFBImplTemplate extends ForteFBTemplate<AdapterType> {
 		
 		«generateImplIncludes»
 		
+		«generateUseStringId»
+		
 		«generateFBDefinition»
 		
 		«generateFBInterfaceDefinition»

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/base/BaseFBImplTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/base/BaseFBImplTemplate.xtend
@@ -46,6 +46,8 @@ abstract class BaseFBImplTemplate<T extends BaseFBType> extends ForteFBTemplate<
 		
 		«generateImplIncludes»
 		
+		«generateUseStringId»
+		
 		«generateFBDefinition»
 		«generateFBInterfaceDefinition»
 		«generateFBInterfaceSpecDefinition»
@@ -139,5 +141,12 @@ abstract class BaseFBImplTemplate<T extends BaseFBType> extends ForteFBTemplate<
 				getDependencies(options)
 			]
 		).toSet
+	}
+	
+	override Set<String> getUsedStrings(Map<?, ?> options) {
+		val strings = super.getUsedStrings(options)
+		type.internalVars.forEach[getUsedIEStrings(it, strings)]
+		type.internalFbs.forEach[getUsedFBStrings(it, strings)]		
+		return strings	
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/composite/CompositeFBImplTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/composite/CompositeFBImplTemplate.xtend
@@ -38,6 +38,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration
 
 import static extension org.eclipse.fordiac.ide.export.forte_ng.util.ForteNgExportUtil.*
+import java.util.Set
 
 class CompositeFBImplTemplate extends ForteFBTemplate<CompositeFBType> {
 
@@ -61,6 +62,8 @@ class CompositeFBImplTemplate extends ForteFBTemplate<CompositeFBType> {
 		«generateHeader»
 		
 		«generateImplIncludes»
+		
+		«generateUseStringId»
 		
 		«generateFBDefinition»
 		«generateFBInterfaceDefinition»
@@ -314,4 +317,29 @@ class CompositeFBImplTemplate extends ForteFBTemplate<CompositeFBType> {
 			getDependencies(options)
 		]).toSet
 	}
+	
+	override Set<String> getUsedStrings(Map<?, ?> options) {
+		val strings = super.getUsedStrings(options)
+		type.FBNetwork.networkElements.forEach[{ getUsedFBStrings(it, strings) getUsedInitialFBVarStrings(it, strings)}]		
+		type.FBNetwork.eventConnections.forEach[getUsedConStrings(it, strings)]		
+		type.FBNetwork.dataConnections.forEach[getUsedConStrings(it, strings)]		
+		type.FBNetwork.adapterConnections.forEach[getUsedConStrings(it, strings)]		
+		return strings	
+	}
+	
+	def protected void getUsedConStrings(Connection con, Set<String> strings){
+		//fb instances names are already added when the network elements are added so we can ignore them here
+		strings.add(con.source.name)
+		strings.add(con.destination.name)
+	}
+	
+	
+	def protected void getUsedInitialFBVarStrings(FBNetworkElement fbe, Set<String> strings){
+		if(fbe.type.genericType){
+		  	for (variable : fbe.interface.inputVars.filter[!value?.value.nullOrEmpty]) {
+		  		strings.add(variable.name)
+	  		}
+  		}
+	}
+	
 }

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/function/FunctionFBImplTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/function/FunctionFBImplTemplate.xtend
@@ -30,6 +30,8 @@ class FunctionFBImplTemplate extends FunctionFBTemplate {
 		
 		«generateImplIncludes»
 		
+		«generateUseStringId»
+		
 		«generateFBDefinition»
 		«generateFBInterfaceDefinition»
 		«generateFBInterfaceSpecDefinition»

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/language/LanguageImplTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/language/LanguageImplTemplate.xtend
@@ -48,9 +48,6 @@ class LanguageImplTemplate extends ForteNgExportTemplate {
 
 	def protected generateImplIncludes() '''
 		#include "«fileBasename».h"
-		#ifdef FORTE_ENABLE_GENERATED_SOURCE_CPP
-		#include "«fileBasename»_gen.cpp"
-		#endif
 
 		«generateDependencyInclude("core/iec61131_functions.h")»
 		«IF languageSupport !== null»«languageSupport.getDependencies(emptyMap).generateDependencyIncludes»«ENDIF»

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/service/ServiceInterfaceFBImplTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/service/ServiceInterfaceFBImplTemplate.xtend
@@ -30,6 +30,8 @@ class ServiceInterfaceFBImplTemplate extends ForteFBTemplate<ServiceInterfaceFBT
 		
 		«generateImplIncludes»
 		
+		«generateUseStringId»
+		
 		«generateFBDefinition»
 		«generateFBInterfaceDefinition»
 		«generateFBInterfaceSpecDefinition»

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/struct/StructuredTypeImplTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/struct/StructuredTypeImplTemplate.xtend
@@ -17,6 +17,7 @@ package org.eclipse.fordiac.ide.export.forte_ng.struct
 
 import java.nio.file.Path
 import java.util.Map
+import java.util.Set
 import org.eclipse.fordiac.ide.model.data.StructuredType
 
 import static extension org.eclipse.fordiac.ide.export.forte_ng.util.ForteNgExportUtil.*
@@ -31,6 +32,8 @@ class StructuredTypeImplTemplate extends StructBaseTemplate {
 		«generateHeader»
 		
 		«generateImplIncludes»
+		
+		«generateUseStringId»
 		
 		DEFINE_FIRMWARE_DATATYPE(«type.generateTypeNamePlain», «type.generateTypeSpec»);
 		
@@ -56,14 +59,6 @@ class StructuredTypeImplTemplate extends StructBaseTemplate {
 		«type.memberVariables.generateAccessorDefinition("getMember", true)»
 	'''
 
-	def protected generateImplIncludes() '''
-		#include "«fileBasename».h"
-		#ifdef FORTE_ENABLE_GENERATED_SOURCE_CPP
-		#include "«fileBasename»_gen.cpp"
-		#endif
-		
-		«getDependencies(emptyMap).generateDependencyIncludes»
-	'''
 	
 	def protected generateSetValue() '''
 		void «className»::setValue(const CIEC_ANY &paValue) {
@@ -75,5 +70,9 @@ class StructuredTypeImplTemplate extends StructBaseTemplate {
 		  }
 		}
 	'''
+	
+	override Set<String> getUsedStrings(Map<?, ?> options) {
+		(super.getUsedStrings(options) + type.memberVariables.map[name]).toSet
+	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/util/ForteNgExportUtil.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/util/ForteNgExportUtil.xtend
@@ -234,7 +234,7 @@ final class ForteNgExportUtil {
 		}
 	}
 
-	def static CharSequence getFORTEStringId(String s) '''g_nStringId«s»'''
+	def static CharSequence getFORTEStringId(String s) '''STRID(«s»)'''
 
 	def static int getInterfaceElementIndex(IInterfaceElement element) {
 		if (element.eContainer !== null && element.eContainingFeature.many) {

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/exporter/CppBoostTestConstants.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/exporter/CppBoostTestConstants.java
@@ -30,8 +30,8 @@ public final class CppBoostTestConstants {
 
 	public static final String TEST_FIXTURE_STRUCT = "struct {0}_TestFixture : public CFBTestFixtureBase '{'";
 
-	public static final String TEST_FICTURE_BASE = "{0}_TestFixture() : " + NEW_LINE
-			+ "CFBTestFixtureBase(g_nStringIdservSeq__{0}) '{'";
+	public static final String TEST_FIXTURE_BASE = "{0}_TestFixture() : " + NEW_LINE
+			+ "CFBTestFixtureBase(STRID(servSeq__{0})) '{'";
 
 	public static final String TEST_FICTURE_SETUP = "CFBTestFixtureBase::setup();" + NEW_LINE + "}";
 

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/exporter/ExportServiceSequenceToCppTest.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/exporter/ExportServiceSequenceToCppTest.java
@@ -157,7 +157,7 @@ public class ExportServiceSequenceToCppTest {
 
 		writer.append(MessageFormat.format(CppBoostTestConstants.TEST_FIXTURE_STRUCT, fb.getName()));
 		writer.newLine();
-		writer.append(MessageFormat.format(CppBoostTestConstants.TEST_FICTURE_BASE, fb.getName()));
+		writer.append(MessageFormat.format(CppBoostTestConstants.TEST_FIXTURE_BASE, fb.getName()));
 		writer.newLine();
 		writer.append(CppBoostTestConstants.SET_INPUT_DATA_START);
 		if (!inputData.isEmpty()) {

--- a/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/forte_ng/ForteNgBasicFBTest.xtend
+++ b/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/forte_ng/ForteNgBasicFBTest.xtend
@@ -112,9 +112,6 @@ class ForteNgBasicFBTest extends ExporterTestBasicFBTypeBase {
 						 *************************************************************************/
 						
 						#include "«ExporterTestBase.BASICFUNCTIONBLOCK_NAME»_fbt.h"
-						#ifdef FORTE_ENABLE_GENERATED_SOURCE_CPP
-						#include "«ExporterTestBase.BASICFUNCTIONBLOCK_NAME»_fbt_gen.cpp"
-						#endif
 						
 						#include "core/datatypes/forte_dword.h"
 						#include "core/datatypes/forte_sint.h"
@@ -124,7 +121,9 @@ class ForteNgBasicFBTest extends ExporterTestBasicFBTypeBase {
 						#include "core/datatypes/forte_array_fixed.h"
 						#include "core/datatypes/forte_array_variable.h"
 						
-						DEFINE_FIRMWARE_FB(«EXPORTED_FUNCTIONBLOCK_NAME», g_nStringId«ExporterTestBase.BASICFUNCTIONBLOCK_NAME»)
+						USE_STRING_ID(«ExporterTestBase.BASICFUNCTIONBLOCK_NAME»);
+						
+						DEFINE_FIRMWARE_FB(«EXPORTED_FUNCTIONBLOCK_NAME», STRID(«ExporterTestBase.BASICFUNCTIONBLOCK_NAME»))
 						
 						const SFBInterfaceSpec «EXPORTED_FUNCTIONBLOCK_NAME»::scmFBInterfaceSpec = {
 						  0, nullptr, nullptr, nullptr, nullptr,

--- a/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/forte_ng/ForteNgTest.xtend
+++ b/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/forte_ng/ForteNgTest.xtend
@@ -297,9 +297,6 @@ class ForteNgTest extends ExporterTestBasicFBTypeBase {
 						 *************************************************************************/
 						
 						#include "«ExporterTestBase.BASICFUNCTIONBLOCK_NAME»_fbt.h"
-						#ifdef FORTE_ENABLE_GENERATED_SOURCE_CPP
-						#include "«ExporterTestBase.BASICFUNCTIONBLOCK_NAME»_fbt_gen.cpp"
-						#endif
 						
 						#include "core/iec61131_functions.h"
 						#include "core/datatypes/forte_array_common.h"
@@ -307,7 +304,9 @@ class ForteNgTest extends ExporterTestBasicFBTypeBase {
 						#include "core/datatypes/forte_array_fixed.h"
 						#include "core/datatypes/forte_array_variable.h"
 						
-						DEFINE_FIRMWARE_FB(«EXPORTED_FUNCTIONBLOCK_NAME», g_nStringIdfunctionblock)
+						USE_STRING_ID(functionblock);
+						
+						DEFINE_FIRMWARE_FB(«EXPORTED_FUNCTIONBLOCK_NAME», STRID(functionblock))
 						
 						const SFBInterfaceSpec «EXPORTED_FUNCTIONBLOCK_NAME»::scmFBInterfaceSpec = {
 						  0, nullptr, nullptr, nullptr, nullptr,


### PR DESCRIPTION
The FORTE exporter is creating the new USE_STRING_ID and STRID() for all string ids.

@mx990 as string ids are only used for external accessibility I miss the imagination why and how languages can provide string ids and have left that out. 

I hope I have not missed any ids.