### PR TITLE
Add plugin.xml and Extension Point Schema to Model Commands build.prop

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.commands/build.properties
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/build.properties
@@ -1,4 +1,6 @@
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
-               .
+               .,\
+               plugin.xml,\
+               schema/QualNameChangeListener.exsd


### PR DESCRIPTION
The model commands plugin didn't add the new plugin.xml and Full Qualified Name Change Listener extension point schema to the bin.includes section of build.properties. Therefore the extension point was not available in deployed 4diac IDE instances.