### PR TITLE
Fix Follow Connection Handler for var inout only blocks

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/FollowLeftConnectionHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/FollowLeftConnectionHandler.java
@@ -128,7 +128,8 @@ public class FollowLeftConnectionHandler extends FollowConnectionHandler {
 			return false;
 		}
 		final InterfaceList il = (InterfaceList) pin.getModel().eContainer();
-		return !(il.getEventInputs().isEmpty() && il.getInputVars().isEmpty() && il.getSockets().isEmpty());
+		return !(il.getEventInputs().isEmpty() && il.getInputVars().isEmpty() && il.getSockets().isEmpty()
+				&& il.getOutMappedInOutVars().isEmpty());
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/FollowRightConnectionHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/FollowRightConnectionHandler.java
@@ -128,7 +128,8 @@ public class FollowRightConnectionHandler extends FollowConnectionHandler {
 			return false;
 		}
 		final InterfaceList il = (InterfaceList) pin.getModel().eContainer();
-		return !(il.getEventOutputs().isEmpty() && il.getOutputVars().isEmpty() && il.getPlugs().isEmpty());
+		return !(il.getEventOutputs().isEmpty() && il.getOutputVars().isEmpty() && il.getPlugs().isEmpty()
+				&& il.getInOutVars().isEmpty());
 	}
 
 	@Override


### PR DESCRIPTION
The follow left and right connection handler didn't correctly handle blocks with only inout pins.