### PR TITLE
Disallow VarConfig for CFB networks

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/InterfaceElementSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/InterfaceElementSection.java
@@ -24,6 +24,7 @@ package org.eclipse.fordiac.ide.application.properties;
 import java.text.MessageFormat;
 
 import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.fordiac.ide.application.Messages;
 import org.eclipse.fordiac.ide.gef.editors.InitialValueEditor;
 import org.eclipse.fordiac.ide.gef.preferences.DiagramPreferencePage;
@@ -38,6 +39,8 @@ import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes;
 import org.eclipse.fordiac.ide.model.edit.helper.CommentHelper;
 import org.eclipse.fordiac.ide.model.edit.helper.InitialValueRefreshJob;
 import org.eclipse.fordiac.ide.model.libraryElement.AdapterType;
+import org.eclipse.fordiac.ide.model.libraryElement.CFBInstance;
+import org.eclipse.fordiac.ide.model.libraryElement.CompositeFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.ErrorMarkerInterface;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
@@ -190,8 +193,26 @@ public class InterfaceElementSection extends AbstractDoubleColumnSection {
 		}
 
 		if (fb != null) {
-			setEditable(!fb.isContainedInTypedInstance());
+			setEditable(!fb.isContainedInTypedInstance() && !containsCFB(getType().eContainer()));
 		}
+	}
+
+	static boolean containsCFB(EObject container) {
+		if (container == null) {
+			return false;
+		}
+		if (container instanceof CFBInstance) {
+			return true;
+		}
+
+		while (container != null) {
+			if (container instanceof CFBInstance || container instanceof CompositeFBType) {
+				return true;
+			}
+			container = container.eContainer();
+		}
+
+		return false;
 	}
 
 	private void configureOpenEditorButton() {

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/VarDeclarationColumnAccessor.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/VarDeclarationColumnAccessor.java
@@ -30,6 +30,8 @@ import org.eclipse.fordiac.ide.model.datatype.helper.RetainHelper;
 import org.eclipse.fordiac.ide.model.edit.helper.CommentHelper;
 import org.eclipse.fordiac.ide.model.edit.helper.InitialValueHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
+import org.eclipse.fordiac.ide.model.libraryElement.CFBInstance;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.MemberVarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
@@ -56,13 +58,22 @@ public class VarDeclarationColumnAccessor extends AbstractColumnAccessor<VarDecl
 		case TYPE -> rowObject.getFullTypeName();
 		case COMMENT -> CommentHelper.getInstanceComment(rowObject);
 		case INITIAL_VALUE -> getInitialValue(rowObject);
-		case VAR_CONFIG -> Boolean.valueOf(rowObject.isVarConfig());
+		case VAR_CONFIG -> getVarConfString(rowObject);
 		case VISIBLE -> Boolean.valueOf(rowObject.isVisible());
 		case RETAIN -> getAttributeValueAsString(rowObject);
 		case VISIBLEIN, VISIBLEOUT -> Boolean.valueOf(handleInOutCheck(rowObject, column));
 
 		default -> throw new IllegalArgumentException("Unexpected value: " + column); //$NON-NLS-1$
 		};
+	}
+
+	private static boolean getVarConfString(final VarDeclaration rowObject) {
+		return isCompositeFBType(rowObject) ? null : Boolean.valueOf(rowObject.isVarConfig());
+	}
+
+	private static boolean isCompositeFBType(final VarDeclaration rowObject) {
+		final FBNetworkElement fbElement = rowObject.getFBNetworkElement();
+		return fbElement instanceof CFBInstance;
 	}
 
 	private static boolean handleInOutCheck(final VarDeclaration rowObject, final VarDeclarationTableColumn column) {

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/widgets/PinInfoDataWidget.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/widgets/PinInfoDataWidget.java
@@ -20,6 +20,7 @@ import java.util.function.Consumer;
 
 import org.eclipse.fordiac.ide.gef.editors.InitialValueEditor;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeVarConfigurationCommand;
+import org.eclipse.fordiac.ide.model.libraryElement.CompositeFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.ui.FordiacMessages;
@@ -96,6 +97,6 @@ public class PinInfoDataWidget extends PinInfoBasicWidget {
 	protected void checkFieldEnablements() {
 		super.checkFieldEnablements();
 		initialValueEditor.setEditable(isTypeChangeable());
-		varConfigCheckBox.setEnabled(isEditable());
+		varConfigCheckBox.setEnabled(isEditable() && !(getType().eContainer().eContainer() instanceof CompositeFBType));
 	}
 }


### PR DESCRIPTION
This makes it impossible to VarConfig-check pins in a composite fb network.