### PR TITLE
Reduce warnings from contract plugins

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.contractspec.ide/.classpath
+++ b/plugins/org.eclipse.fordiac.ide.contractspec.ide/.classpath
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="src-gen"/>
+	<classpathentry kind="src" path="src-gen">
+		<attributes>
+			<attribute name="ignore_optional_problems" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
 		<attributes>
 			<attribute name="module" value="true"/>

--- a/plugins/org.eclipse.fordiac.ide.contractspec.ui.tests/src-gen/org/eclipse/fordiac/ide/ui/tests/ContractSpecUiInjectorProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.contractspec.ui.tests/src-gen/org/eclipse/fordiac/ide/ui/tests/ContractSpecUiInjectorProvider.java
@@ -13,15 +13,16 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.ui.tests;
 
-import com.google.inject.Injector;
 import org.eclipse.fordiac.ide.contractspec.ui.internal.ContractspecActivator;
 import org.eclipse.xtext.testing.IInjectorProvider;
+
+import com.google.inject.Injector;
 
 public class ContractSpecUiInjectorProvider implements IInjectorProvider {
 
 	@Override
 	public Injector getInjector() {
-		return ContractspecActivator.getInstance().getInjector("org.eclipse.fordiac.ide.ContractSpec");
+		return ContractspecActivator.getInstance().getInjector("org.eclipse.fordiac.ide.ContractSpec"); //$NON-NLS-1$
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.contractspec.ui/.classpath
+++ b/plugins/org.eclipse.fordiac.ide.contractspec.ui/.classpath
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="src-gen"/>
+	<classpathentry kind="src" path="src-gen">
+		<attributes>
+			<attribute name="ignore_optional_problems" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
 		<attributes>
 			<attribute name="module" value="true"/>

--- a/plugins/org.eclipse.fordiac.ide.contractspec/.classpath
+++ b/plugins/org.eclipse.fordiac.ide.contractspec/.classpath
@@ -1,9 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="src-gen"/>
+	<classpathentry kind="src" path="src-gen">
+		<attributes>
+			<attribute name="ignore_optional_problems" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="src" path="xtend-gen"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
The Xtext plugins contain src-gen directories with automatically generated files that produced a lot of warnings and infos.
Fixing those within the files is not helpful, since those changes might get overwritten when regenerating the Xtext artifacts.
Therefore, I have set those directories to ignore optional warning which gets rid of ~30 warnings and ~350 infos.