### PR TITLE
Add ESC to cancel contract editing

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/ContractCellEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/ContractCellEditor.java
@@ -35,6 +35,7 @@ public class ContractCellEditor extends CellEditor {
 	private EmbeddedEditor editor;
 	private EmbeddedEditorModelAccess modelAccess;
 	private boolean popupOpen = false;
+	private boolean closing = false;
 
 	public ContractCellEditor(final Composite composite, final InstanceContract contract) {
 		this.contract = contract;
@@ -57,7 +58,7 @@ public class ContractCellEditor extends CellEditor {
 		editor.getViewer().getTextWidget().addFocusListener(new FocusAdapter() {
 			@Override
 			public void focusLost(final FocusEvent e) {
-				if (popupOpen) {
+				if (popupOpen || closing) {
 					return;
 				}
 				// if a quickfix is applied, we also loose focus but regain it right after
@@ -71,6 +72,13 @@ public class ContractCellEditor extends CellEditor {
 						ContractCellEditor.this.focusLost();
 					}
 				});
+			}
+		});
+
+		editor.getViewer().getTextWidget().addTraverseListener(e -> {
+			if (!popupOpen && e.keyCode == SWT.ESC) { // close when pressing ESC key
+				closing = true;
+				ContractCellEditor.this.focusLost();
 			}
 		});
 

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/InstanceContractFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/InstanceContractFigure.java
@@ -24,7 +24,10 @@ import org.eclipse.fordiac.ide.gef.figures.BorderedRoundedRectangle;
 import org.eclipse.fordiac.ide.gef.figures.RoundedRectangleShadowBorder;
 import org.eclipse.fordiac.ide.gef.preferences.GefPreferenceConstants;
 import org.eclipse.fordiac.ide.model.CoordinateConverter;
+import org.eclipse.fordiac.ide.ui.preferences.UIPreferenceConstants;
 import org.eclipse.fordiac.ide.ui.utils.ContractScanner;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.swt.graphics.Font;
 
 public class InstanceContractFigure extends Figure {
 
@@ -65,6 +68,7 @@ public class InstanceContractFigure extends Figure {
 		}
 		currentText = text;
 
+		final Font boldFont = JFaceResources.getFontRegistry().getBold(UIPreferenceConstants.DIAGRAM_FONT);
 		flowPage.removeAll();
 		if (text != null) {
 			final ContractScanner scan = new ContractScanner(text);
@@ -77,7 +81,8 @@ public class InstanceContractFigure extends Figure {
 					tf.setForegroundColor(ContractScanner.COMMENT);
 					break;
 				case KEYWORD:
-					tf.setForegroundColor(ContractScanner.HIGHLIGHT);
+					tf.setForegroundColor(ContractScanner.KEYWORD);
+					tf.setFont(boldFont);
 					break;
 				default:
 					tf.setForegroundColor(ContractScanner.NORMAL);

--- a/plugins/org.eclipse.fordiac.ide.contracts/src/org/eclipse/fordiac/ide/contracts/DefineContractDecisionDialog.java
+++ b/plugins/org.eclipse.fordiac.ide.contracts/src/org/eclipse/fordiac/ide/contracts/DefineContractDecisionDialog.java
@@ -84,7 +84,7 @@ public class DefineContractDecisionDialog extends MessageDialog {
 				idx += len;
 				range.foreground = switch (t.type()) {
 				case COMMENT -> ContractScanner.COMMENT;
-				case KEYWORD -> ContractScanner.HIGHLIGHT;
+				case KEYWORD -> ContractScanner.KEYWORD;
 				default -> ContractScanner.NORMAL;
 				};
 				if (t.type() == ContractScanner.TokenType.KEYWORD) {

--- a/plugins/org.eclipse.fordiac.ide.contractspec.ui/src/org/eclipse/fordiac/ide/ui/utils/ContractScanner.java
+++ b/plugins/org.eclipse.fordiac.ide.contractspec.ui/src/org/eclipse/fordiac/ide/ui/utils/ContractScanner.java
@@ -25,7 +25,7 @@ public class ContractScanner implements Iterable<ContractScanner.Token> {
 	}
 
 	public static final Color NORMAL = new Color(0, 0, 0);
-	public static final Color HIGHLIGHT = new Color(127, 0, 85);
+	public static final Color KEYWORD = new Color(127, 0, 85);
 	public static final Color COMMENT = new Color(63, 127, 95);
 
 	public enum TokenType {


### PR DESCRIPTION
Pressing ESC in the contract cell editor now cancels editing, similar to how it works for comments.
Also made appearance of contracts in diagram more similar to the cell editor by making keywords bold.