### PR TITLE
Fix crash when deleting input primitive

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/commands/DeleteInputPrimitiveCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/commands/DeleteInputPrimitiveCommand.java
@@ -18,35 +18,27 @@ import org.eclipse.fordiac.ide.model.libraryElement.ServiceTransaction;
 import org.eclipse.gef.commands.Command;
 
 /**
- * DeleteInputPrimitiveCommand removes an InputPrimitive from its parent. If the
- * primitive is the last one of the parent, then also the parent
- * (ServiceTransaction) is removed.
+ * DeleteInputPrimitiveCommand removes the parent ServiceTransaction, because a
+ * ServiceTransaction is assumed to always have an InputPrimitive.
  */
 public class DeleteInputPrimitiveCommand extends Command {
 
-	private final InputPrimitive primitive;
 	private final ServiceTransaction parent;
 	private DeleteTransactionCommand deleteTransactionCmd = null;
 
 	public DeleteInputPrimitiveCommand(final InputPrimitive primitive) {
-		this.primitive = primitive;
 		this.parent = primitive.getServiceTransaction();
 	}
 
 	@Override
 	public boolean canExecute() {
-		return (null != primitive) && (null != parent);
+		return null != parent;
 	}
 
 	@Override
 	public void execute() {
-		if (null != parent) {
-			parent.setInputPrimitive(null);
-			if (parent.getOutputPrimitive().isEmpty()) {
-				deleteTransactionCmd = new DeleteTransactionCommand(parent);
-				deleteTransactionCmd.execute();
-			}
-		}
+		deleteTransactionCmd = new DeleteTransactionCommand(parent);
+		deleteTransactionCmd.execute();
 	}
 
 	@Override
@@ -54,12 +46,10 @@ public class DeleteInputPrimitiveCommand extends Command {
 		if (deleteTransactionCmd != null) {
 			deleteTransactionCmd.undo();
 		}
-		parent.setInputPrimitive(primitive);
 	}
 
 	@Override
 	public void redo() {
-		parent.setInputPrimitive(null);
 		if (deleteTransactionCmd != null) {
 			deleteTransactionCmd.redo();
 		}


### PR DESCRIPTION
Some code parts assume that a service transaction always has an input primitive. However, the user could individually delete the input primitive.
Now, deleting the input primitive will delete the entire service transaction to avoid this issue.