### PR TITLE
LibraryElement Hash Generation

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
+++ b/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
@@ -735,6 +735,9 @@
         defaultValueLiteral=""/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ConnectionRoutingData">
+    <eAnnotations source="http:///org/eclipse/fordiac/ide/model/HashMetaData">
+      <details key="ignored" value="true"/>
+    </eAnnotations>
     <eOperations name="is1SegementData" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return ConnectionRoutingDataAnnotations.connectionRoutingDataValueIsNull(getDx1());"/>
@@ -937,6 +940,9 @@
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
         <details key="kind" value="attribute"/>
         <details key="name" value="Condition"/>
+      </eAnnotations>
+      <eAnnotations source="http:///org/eclipse/fordiac/ide/model/HashMetaData">
+        <details key="transformer" value="org.eclipse.fordiac.ide.model.util.StringTransformer"/>
       </eAnnotations>
     </eStructuralFeatures>
     <eStructuralFeatures xsi:type="ecore:EReference" name="source" lowerBound="1"
@@ -1551,7 +1557,11 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String"
         defaultValueLiteral=""/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="comment" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String"
-        defaultValueLiteral=""/>
+        defaultValueLiteral="">
+      <eAnnotations source="http:///org/eclipse/fordiac/ide/model/HashMetaData">
+        <details key="ignored" value="true"/>
+      </eAnnotations>
+    </eStructuralFeatures>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="InputPrimitive" eSuperTypes="#//Primitive"/>
   <eClassifiers xsi:type="ecore:EClass" name="InterfaceList">
@@ -1842,6 +1852,9 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="OutputPrimitive" eSuperTypes="#//Primitive"/>
   <eClassifiers xsi:type="ecore:EClass" name="Position">
+    <eAnnotations source="http:///org/eclipse/fordiac/ide/model/HashMetaData">
+      <details key="ignored" value="true"/>
+    </eAnnotations>
     <eOperations name="toScreenPoint" lowerBound="1" eType="#//Point">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return PositionAnnotation.toScreenPoint(this);"/>
@@ -2008,7 +2021,11 @@
       </eAnnotations>
     </eStructuralFeatures>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="comment" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String"
-        defaultValueLiteral=""/>
+        defaultValueLiteral="">
+      <eAnnotations source="http:///org/eclipse/fordiac/ide/model/HashMetaData">
+        <details key="ignored" value="true"/>
+      </eAnnotations>
+    </eStructuralFeatures>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ServiceSequence" eSuperTypes="#//INamedElement #//ConfigurableObject">
     <eOperations name="getService" lowerBound="1" eType="#//Service">
@@ -2180,7 +2197,11 @@
     </eStructuralFeatures>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="TextAlgorithm" abstract="true" eSuperTypes="#//Algorithm">
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="text" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="text" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString">
+      <eAnnotations source="http:///org/eclipse/fordiac/ide/model/HashMetaData">
+        <details key="transformer" value="org.eclipse.fordiac.ide.model.util.StringTransformer"/>
+      </eAnnotations>
+    </eStructuralFeatures>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="TextFunction" abstract="true" eSuperTypes="#//Function">
     <eStructuralFeatures xsi:type="ecore:EReference" name="inputParameters" upperBound="-1"
@@ -2191,10 +2212,18 @@
         eType="#//ITypedElement" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="returnType" eType="ecore:EClass data.ecore#//DataType"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="varargs" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="text" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="text" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString">
+      <eAnnotations source="http:///org/eclipse/fordiac/ide/model/HashMetaData">
+        <details key="transformer" value="org.eclipse.fordiac.ide.model.util.StringTransformer"/>
+      </eAnnotations>
+    </eStructuralFeatures>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="TextFunctionBody" abstract="true" eSuperTypes="#//FunctionBody">
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="text" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="text" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString">
+      <eAnnotations source="http:///org/eclipse/fordiac/ide/model/HashMetaData">
+        <details key="transformer" value="org.eclipse.fordiac.ide.model.util.StringTransformer"/>
+      </eAnnotations>
+    </eStructuralFeatures>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="TextMethod" abstract="true" eSuperTypes="#//Method">
     <eStructuralFeatures xsi:type="ecore:EReference" name="inputParameters" upperBound="-1"
@@ -2205,7 +2234,11 @@
         eType="#//ITypedElement" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="returnType" eType="ecore:EClass data.ecore#//DataType"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="varargs" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="text" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="text" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString">
+      <eAnnotations source="http:///org/eclipse/fordiac/ide/model/HashMetaData">
+        <details key="transformer" value="org.eclipse.fordiac.ide.model.util.StringTransformer"/>
+      </eAnnotations>
+    </eStructuralFeatures>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="TypedConfigureableObject" eSuperTypes="#//ITypedElement #//ConfigurableObject">
     <eOperations name="getTypeName" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString">

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/ConnectionRoutingData.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/ConnectionRoutingData.java
@@ -34,7 +34,7 @@ import org.eclipse.emf.ecore.EObject;
  * </ul>
  *
  * @see org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage#getConnectionRoutingData()
- * @model
+ * @model annotation="http:///org/eclipse/fordiac/ide/model/HashMetaData ignored='true'"
  * @generated
  */
 public interface ConnectionRoutingData extends EObject {

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/ECTransition.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/ECTransition.java
@@ -73,6 +73,7 @@ public interface ECTransition extends PositionableElement {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage#getECTransition_ConditionExpression()
 	 * @model default="1" dataType="org.eclipse.emf.ecore.xml.type.String"
 	 *        extendedMetaData="kind='attribute' name='Condition'"
+	 *        annotation="http:///org/eclipse/fordiac/ide/model/HashMetaData transformer='org.eclipse.fordiac.ide.model.util.StringTransformer'"
 	 * @generated
 	 */
 	String getConditionExpression();

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/INamedElement.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/INamedElement.java
@@ -71,6 +71,7 @@ public interface INamedElement extends EObject {
 	 * @see #setComment(String)
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage#getINamedElement_Comment()
 	 * @model default="" dataType="org.eclipse.emf.ecore.xml.type.String"
+	 *        annotation="http:///org/eclipse/fordiac/ide/model/HashMetaData ignored='true'"
 	 * @generated
 	 */
 	String getComment();

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/Position.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/Position.java
@@ -34,7 +34,7 @@ import org.eclipse.emf.ecore.EObject;
  * </ul>
  *
  * @see org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage#getPosition()
- * @model
+ * @model annotation="http:///org/eclipse/fordiac/ide/model/HashMetaData ignored='true'"
  * @generated
  */
 public interface Position extends EObject {

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/Service.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/Service.java
@@ -106,6 +106,7 @@ public interface Service extends EObject {
 	 * @see #setComment(String)
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage#getService_Comment()
 	 * @model default="" dataType="org.eclipse.emf.ecore.xml.type.String"
+	 *        annotation="http:///org/eclipse/fordiac/ide/model/HashMetaData ignored='true'"
 	 * @generated
 	 */
 	String getComment();

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/TextAlgorithm.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/TextAlgorithm.java
@@ -41,7 +41,7 @@ public interface TextAlgorithm extends Algorithm {
 	 * @return the value of the '<em>Text</em>' attribute.
 	 * @see #setText(String)
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage#getTextAlgorithm_Text()
-	 * @model
+	 * @model annotation="http:///org/eclipse/fordiac/ide/model/HashMetaData transformer='org.eclipse.fordiac.ide.model.util.StringTransformer'"
 	 * @generated
 	 */
 	String getText();

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/TextFunction.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/TextFunction.java
@@ -129,7 +129,7 @@ public interface TextFunction extends Function {
 	 * @return the value of the '<em>Text</em>' attribute.
 	 * @see #setText(String)
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage#getTextFunction_Text()
-	 * @model
+	 * @model annotation="http:///org/eclipse/fordiac/ide/model/HashMetaData transformer='org.eclipse.fordiac.ide.model.util.StringTransformer'"
 	 * @generated
 	 */
 	String getText();

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/TextFunctionBody.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/TextFunctionBody.java
@@ -41,7 +41,7 @@ public interface TextFunctionBody extends FunctionBody {
 	 * @return the value of the '<em>Text</em>' attribute.
 	 * @see #setText(String)
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage#getTextFunctionBody_Text()
-	 * @model
+	 * @model annotation="http:///org/eclipse/fordiac/ide/model/HashMetaData transformer='org.eclipse.fordiac.ide.model.util.StringTransformer'"
 	 * @generated
 	 */
 	String getText();

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/TextMethod.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/TextMethod.java
@@ -129,7 +129,7 @@ public interface TextMethod extends Method {
 	 * @return the value of the '<em>Text</em>' attribute.
 	 * @see #setText(String)
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage#getTextMethod_Text()
-	 * @model
+	 * @model annotation="http:///org/eclipse/fordiac/ide/model/HashMetaData transformer='org.eclipse.fordiac.ide.model.util.StringTransformer'"
 	 * @generated
 	 */
 	String getText();

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
@@ -5562,6 +5562,8 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 		createExtendedMetaDataAnnotations();
 		// http://www.eclipse.org/emf/2002/Ecore
 		createEcoreAnnotations();
+		// http:///org/eclipse/fordiac/ide/model/HashMetaData
+		createHashMetaDataAnnotations();
 		// http:///org/eclipse/fordiac/ide/model/MetaData
 		createMetaDataAnnotations();
 	}
@@ -6372,6 +6374,70 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 		   source,
 		   new String[] {
 			   "invariant", "true" //$NON-NLS-1$ //$NON-NLS-2$
+		   });
+	}
+
+	/**
+	 * Initializes the annotations for <b>http:///org/eclipse/fordiac/ide/model/HashMetaData</b>.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected void createHashMetaDataAnnotations() {
+		String source = "http:///org/eclipse/fordiac/ide/model/HashMetaData"; //$NON-NLS-1$
+		addAnnotation
+		  (connectionRoutingDataEClass,
+		   source,
+		   new String[] {
+			   "ignored", "true" //$NON-NLS-1$ //$NON-NLS-2$
+		   });
+		addAnnotation
+		  (getECTransition_ConditionExpression(),
+		   source,
+		   new String[] {
+			   "transformer", "org.eclipse.fordiac.ide.model.util.StringTransformer" //$NON-NLS-1$ //$NON-NLS-2$
+		   });
+		addAnnotation
+		  (getINamedElement_Comment(),
+		   source,
+		   new String[] {
+			   "ignored", "true" //$NON-NLS-1$ //$NON-NLS-2$
+		   });
+		addAnnotation
+		  (positionEClass,
+		   source,
+		   new String[] {
+			   "ignored", "true" //$NON-NLS-1$ //$NON-NLS-2$
+		   });
+		addAnnotation
+		  (getService_Comment(),
+		   source,
+		   new String[] {
+			   "ignored", "true" //$NON-NLS-1$ //$NON-NLS-2$
+		   });
+		addAnnotation
+		  (getTextAlgorithm_Text(),
+		   source,
+		   new String[] {
+			   "transformer", "org.eclipse.fordiac.ide.model.util.StringTransformer" //$NON-NLS-1$ //$NON-NLS-2$
+		   });
+		addAnnotation
+		  (getTextFunction_Text(),
+		   source,
+		   new String[] {
+			   "transformer", "org.eclipse.fordiac.ide.model.util.StringTransformer" //$NON-NLS-1$ //$NON-NLS-2$
+		   });
+		addAnnotation
+		  (getTextFunctionBody_Text(),
+		   source,
+		   new String[] {
+			   "transformer", "org.eclipse.fordiac.ide.model.util.StringTransformer" //$NON-NLS-1$ //$NON-NLS-2$
+		   });
+		addAnnotation
+		  (getTextMethod_Text(),
+		   source,
+		   new String[] {
+			   "transformer", "org.eclipse.fordiac.ide.model.util.StringTransformer" //$NON-NLS-1$ //$NON-NLS-2$
 		   });
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/emf/HashMetaData.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/emf/HashMetaData.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2025 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Felix Roithmayr - initial API and implementation and/or initial documentation
+ ******************************************************************************/
+package org.eclipse.fordiac.ide.model.emf;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.eclipse.emf.ecore.EModelElement;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.fordiac.ide.model.util.ITransformer;
+import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
+
+public class HashMetaData {
+	public static final String ANNOTATION_URI = "http:///org/eclipse/fordiac/ide/model/HashMetaData"; //$NON-NLS-1$
+
+	public static final String IGNORED_KEY = "ignored"; //$NON-NLS-1$
+	public static final String TRANSFORMER_KEY = "transformer"; //$NON-NLS-1$
+
+	public static boolean isIgnored(final EModelElement element) {
+		if (element == null) {
+			return false;
+		}
+		final String annotation = EcoreUtil.getAnnotation(element, ANNOTATION_URI, IGNORED_KEY);
+		return annotation != null && Boolean.parseBoolean(annotation);
+	}
+
+	public static Object transform(final EModelElement element, final Object value) {
+		if (element == null) {
+			return value;
+		}
+		final String annotation = EcoreUtil.getAnnotation(element, ANNOTATION_URI, TRANSFORMER_KEY);
+		if (annotation == null) {
+			return value;
+		}
+		try {
+			if (Class.forName(annotation).getConstructor().newInstance() instanceof final ITransformer itransformer) {
+				return itransformer.transform(value);
+			}
+		} catch (final ClassNotFoundException | InstantiationException | IllegalAccessException
+				| IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException e) {
+			FordiacLogHelper.logError("Could not transform model element!", e); //$NON-NLS-1$
+		}
+		return value;
+	}
+
+	private HashMetaData() {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/TypeEntry.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/TypeEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2022 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
+ * Copyright (c) 2008, 2025 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
  * 							Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
@@ -26,6 +26,7 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
+import org.eclipse.fordiac.ide.model.util.LibraryElementHashException;
 
 public interface TypeEntry extends Notifier {
 
@@ -103,6 +104,8 @@ public interface TypeEntry extends Notifier {
 	}
 
 	Set<TypeEntry> getDependencies();
+
+	String getTypeHash() throws LibraryElementHashException;
 
 	void refresh();
 

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/util/ITransformer.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/util/ITransformer.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2025 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Felix Roithmayr - initial API and implementation and/or initial documentation
+ ******************************************************************************/
+package org.eclipse.fordiac.ide.model.util;
+
+public interface ITransformer {
+	Object transform(final Object obj);
+}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/util/LibraryElementHashException.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/util/LibraryElementHashException.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Alois Zoitl - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.model.util;
+
+public class LibraryElementHashException extends Exception {
+
+	private static final long serialVersionUID = -3086076523632402160L;
+
+	public LibraryElementHashException(final String message) {
+		super(message);
+	}
+
+	public LibraryElementHashException(final String message, final Throwable cause) {
+		super(message, cause);
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/util/LibraryElementHasher.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/util/LibraryElementHasher.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2025 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Felix Roithmayr - initial API and implementation and/or initial documentation
+ ******************************************************************************/
+package org.eclipse.fordiac.ide.model.util;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.security.DigestOutputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.text.MessageFormat;
+import java.util.HashMap;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EAttribute;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.emf.ecore.util.EcoreUtil.Copier;
+import org.eclipse.emf.ecore.xmi.XMLResource;
+import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
+import org.eclipse.fordiac.ide.model.emf.HashMetaData;
+import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+
+public final class LibraryElementHasher {
+	public static final String DEFAULT_HASH_ALG = "SHA3-512"; //$NON-NLS-1$
+	public static final String HASH_VERSION = "v1"; //$NON-NLS-1$ // increment this whenever anything is changed in the
+													// hashing algorithm
+	public static final String FULL_HASH_STRING = HASH_VERSION + ":" + DEFAULT_HASH_ALG; //$NON-NLS-1$
+	private static final String XMI_EXTENSION = "xmi"; //$NON-NLS-1$
+	private static final String TOHASH_XMI_URI = "tohash.xmi"; //$NON-NLS-1$
+
+	public static String getHashType() {
+		return FULL_HASH_STRING;
+	}
+
+	public static String getLibraryElementHash(final INamedElement libelem, final String version)
+			throws LibraryElementHashException {
+		final String[] versionParts = version.split(":"); //$NON-NLS-1$
+		if (versionParts.length != 2) {
+			throw new LibraryElementHashException("Library hash version in wrong format"); //$NON-NLS-1$
+		}
+		if (!versionParts[0].equals(HASH_VERSION)) {
+			throw new LibraryElementHashException(
+					MessageFormat.format("Wrong library hash version: {0}", versionParts[0])); //$NON-NLS-1$
+		}
+		return hash(libelem, versionParts[1]);
+	}
+
+	private static String hash(final EObject eobj, final String version) throws LibraryElementHashException {
+		MessageDigest digest = null;
+		try {
+			digest = MessageDigest.getInstance(version);
+		} catch (final NoSuchAlgorithmException e) {
+			throw new LibraryElementHashException("could not aquire hashing algorithm", e); //$NON-NLS-1$
+		}
+
+		final ResourceSetImpl xmiResourceSet = new ResourceSetImpl();
+		Resource.Factory.Registry.INSTANCE.getExtensionToFactoryMap().putIfAbsent(XMI_EXTENSION,
+				new XMIResourceFactoryImpl());
+		final Resource xmiResource = xmiResourceSet.createResource(URI.createFileURI(TOHASH_XMI_URI));
+		xmiResource.getContents().add(copyLibraryElementForHashing(eobj));
+
+		final StringBuilder sb = new StringBuilder();
+
+		try (OutputStream nullOut = OutputStream.nullOutputStream();
+				DigestOutputStream dos = new DigestOutputStream(nullOut, digest)
+
+		) {
+			final HashMap<String, Object> options = new HashMap<>();
+			options.put(XMLResource.OPTION_PROCESS_DANGLING_HREF, XMLResource.OPTION_PROCESS_DANGLING_HREF_DISCARD);
+			options.put(XMLResource.OPTION_SKIP_ESCAPE_URI, Boolean.FALSE);
+
+			xmiResource.save(dos, options);
+			for (final byte b : digest.digest()) {
+				sb.append(String.format("%02x", b)); //$NON-NLS-1$
+			}
+
+		} catch (final IOException e) {
+			throw new LibraryElementHashException("Problem with generating library element hash", e); //$NON-NLS-1$
+		}
+
+		return sb.toString();
+	}
+
+	public static String getLibraryElementHash(final INamedElement libelem) throws LibraryElementHashException {
+		return hash(libelem, DEFAULT_HASH_ALG);
+	}
+
+	private static EObject copyLibraryElementForHashing(final EObject libraryElement) {
+		final Copier copier = new HashCopier();
+		final EObject result = copier.copy(libraryElement);
+		copier.copyReferences();
+		return result;
+	}
+
+	private static class HashCopier extends EcoreUtil.Copier {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public EObject copy(final EObject eObject) {
+			if (eObject == null) {
+				return null;
+			}
+			if (!HashMetaData.isIgnored(eObject.eClass())) {
+				return super.copy(eObject);
+			}
+			return null;
+		}
+
+		@Override
+		protected void copyAttribute(final EAttribute eAttribute, final EObject eObject, final EObject copyEObject) {
+			if (!HashMetaData.isIgnored(eAttribute)) {
+				super.copyAttribute(eAttribute, eObject, copyEObject);
+			}
+		}
+
+		@Override
+		protected void copyAttributeValue(final EAttribute eAttribute, final EObject eObject, final Object value,
+				final EStructuralFeature.Setting setting) {
+			super.copyAttributeValue(eAttribute, eObject, HashMetaData.transform(eAttribute, value), setting);
+		}
+	}
+
+	private LibraryElementHasher() {
+		throw new UnsupportedOperationException("Utility class shall not be instantiated"); //$NON-NLS-1$
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/util/StringTransformer.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/util/StringTransformer.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2024, 2025 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Felix Roithmayr - initial API and implementation and/or initial documentation
+ ******************************************************************************/
+package org.eclipse.fordiac.ide.model.util;
+
+public class StringTransformer implements ITransformer {
+	@Override
+	public Object transform(final Object obj) {
+		if (obj instanceof final String str) {
+			return transformString(str);
+		}
+		return obj;
+	}
+
+	private static String transformString(final String str) {
+		final StringBuilder result = new StringBuilder();
+		int i = 0;
+
+		while (i < str.length()) {
+			final char c = str.charAt(i);
+
+			if (Character.isWhitespace(c)) {
+				i = skipWhitespace(str, i, result);
+				continue;
+			}
+			switch (c) {
+			case '/' -> {
+				if (i + 1 < str.length() && str.charAt(i + 1) == '*') {
+					i = skipMultiLineComment(str, i, '/');
+				} else if (i + 1 < str.length() && str.charAt(i + 1) == '/') {
+					i = skipSingleLineComment(str, i);
+				} else {
+					result.append(c);
+				}
+			}
+			case '(' -> {
+				if (i + 1 < str.length() && str.charAt(i + 1) == '*') {
+					i = skipMultiLineComment(str, i, ')');
+				} else {
+					result.append(c);
+				}
+			}
+			case '"' -> i = processStringLiteral(str, i, result, '"');
+			case '\'' -> i = processStringLiteral(str, i, result, '\'');
+
+			default -> result.append(c);
+			}
+			i++;
+		}
+
+		return result.toString();
+	}
+
+	private static int skipWhitespace(final String str, int i, final StringBuilder result) {
+		final boolean startsWithIdentifier = (i > 0 && isIdentifierChar(str.charAt(i - 1)));
+		while (i < str.length() && Character.isWhitespace(str.charAt(i))) {
+			i++;
+		}
+		if (i < str.length() && isIdentifierChar(str.charAt(i)) && startsWithIdentifier) {
+			// if we have whitespaces between two identifier characters insert a single
+			// space
+			result.append(' ');
+		}
+		return i;
+	}
+
+	private static int skipMultiLineComment(final String str, int i, final char delimiter) {
+		i += 2; // Skip the opening chars
+		while (i < str.length() - 1) {
+			if (str.charAt(i) == '*' && str.charAt(i + 1) == delimiter) {
+				return i + 1;
+			}
+			i++;
+		}
+		return i;
+	}
+
+	private static int skipSingleLineComment(final String str, int i) {
+		i += 2; // Skip the opening chars
+		while (i < str.length() && str.charAt(i) != '\n' && str.charAt(i) != '\r') {
+			i++;
+		}
+		return i;
+	}
+
+	private static int processStringLiteral(final String str, int i, final StringBuilder result, final char delimiter) {
+		result.append(delimiter);
+		i++;
+
+		while (i < str.length()) {
+			final char c = str.charAt(i);
+			result.append(c);
+
+			if (c == delimiter && str.charAt(i - 1) != '$') {
+				// we have not a dollar escaped delimiter so we are at the end of the string
+				// literal
+				return i;
+			}
+			i++;
+		}
+
+		return i;
+	}
+
+	private static boolean isIdentifierChar(final char c) {
+		return Character.isLetterOrDigit(c) || c == '_';
+	}
+
+}

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/AttributeTypeEntryMock.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/AttributeTypeEntryMock.java
@@ -134,6 +134,11 @@ public class AttributeTypeEntryMock extends BasicNotifierImpl implements Attribu
 	}
 
 	@Override
+	public String getTypeHash() {
+		return ""; //$NON-NLS-1$
+	}
+
+	@Override
 	public String getComment() {
 		return attributeDeclaration.getComment();
 	}

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/DataTypeEntryMock.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/DataTypeEntryMock.java
@@ -135,6 +135,11 @@ public final class DataTypeEntryMock extends BasicNotifierImpl implements DataTy
 	}
 
 	@Override
+	public String getTypeHash() {
+		return ""; //$NON-NLS-1$
+	}
+
+	@Override
 	public String getComment() {
 		return dataType.getComment();
 	}

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/FBTypeEntryMock.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/FBTypeEntryMock.java
@@ -133,6 +133,11 @@ public class FBTypeEntryMock extends BasicNotifierImpl implements FBTypeEntry {
 	}
 
 	@Override
+	public String getTypeHash() {
+		return ""; //$NON-NLS-1$
+	}
+
+	@Override
 	public String getComment() {
 		return fbType.getComment();
 	}

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/SubAppTypeEntryMock.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/SubAppTypeEntryMock.java
@@ -134,6 +134,11 @@ public final class SubAppTypeEntryMock extends BasicNotifierImpl implements SubA
 	}
 
 	@Override
+	public String getTypeHash() {
+		return ""; //$NON-NLS-1$
+	}
+
+	@Override
 	public String getComment() {
 		return subAppType.getComment();
 	}

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/util/StringTransformTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/util/StringTransformTest.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Alois Zoitl - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.test.model.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+
+import org.eclipse.fordiac.ide.model.util.StringTransformer;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class StringTransformTest {
+
+	static Stream<Arguments> createStringTransformerTestCases() {
+		return Stream.of(Arguments.of("Test:=\"Hello   World!  // Not a comment\";", //$NON-NLS-1$
+				"Test:=\"Hello   World!  // Not a comment\";"), //$NON-NLS-1$
+				Arguments.of("Test:=\"Hello   World! $\" \";", "Test:=\"Hello   World! $\" \";"), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("Test:='Hello   World!  // Not a comment';", "Test:='Hello   World!  // Not a comment';"), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("Test:='Hello   World! $\' ';", "Test:='Hello   World! $' ';"), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("(* This is a multi-line \n \n comment *)", ""), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("/* This is a multi-line \n \n comment */", ""), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("// This is a single-line   ", ""), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("// This is a single-line  \ntest", "test"), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("""
+						// This is a comment
+						x :=  10;
+						""", //$NON-NLS-1$
+						"x:=10;"), //$NON-NLS-1$
+				Arguments.of("""
+						(*
+						 Multi-line comment
+						*)
+						s := "Hello   World!";
+						""", "s:=\"Hello   World!\";"), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("""
+						/*
+						 Multi-line comment
+						*/
+						s := "Hello   World!";
+						""", "s:=\"Hello   World!\";"), //$NON-NLS-1$ //$NON-NLS-2$
+
+				Arguments.of("testVar1 AND \t \t varTest2 \t THEN", "testVar1 AND varTest2 THEN"), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("testVar1_ AND \t \t _varTest2 \t THEN", "testVar1_ AND _varTest2 THEN"), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("testVar AND \t \t varTest2", "testVar AND varTest2"), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("whitespace at the end \n", "whitespace at the end"), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("whitespace and ( test", "whitespace and(test"), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("whitespace and / test", "whitespace and/test"), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("whitespace and ( at end (", "whitespace and(at end("), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("whitespace and / at end /", "whitespace and/at end/"), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("   whitespace at beginning", "whitespace at beginning"), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("// single line comment with \r test", "test"), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("""
+						test unclosed multine comment
+						(*
+								Multi-line comment
+								*
+						""", "test unclosed multine comment"), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("""
+						test unclosed multine comment
+						(*
+								Multi-line comment
+
+						""", "test unclosed multine comment"), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("""
+						test unclosed multine comment
+						/*
+								Multi-line comment
+								*
+						""", "test unclosed multine comment"), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("""
+						test unclosed multine comment
+						/*
+								Multi-line comment
+
+						""", "test unclosed multine comment"), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("Test unclosed string \"Hello   World! ", "Test unclosed string\"Hello   World! "), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("Test unclosed string 'Hello   World! ", "Test unclosed string'Hello   World! "), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("\"Hello   World!  // Not a comment\";", "\"Hello   World!  // Not a comment\";"), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("'Hello   World!  // Not a comment';", "'Hello   World!  // Not a comment';"), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("  Test  :=  'Hello   World! $\' '  ;  ", "Test:='Hello   World! $' ';"), //$NON-NLS-1$ //$NON-NLS-2$
+				Arguments.of("testVar + varTest2", "testVar+varTest2") //$NON-NLS-1$ //$NON-NLS-2$
+
+		);
+	}
+
+	@ParameterizedTest(name = "{index}: {0}->{1}")
+	@MethodSource("createStringTransformerTestCases")
+	@SuppressWarnings({ "squid:S5803", "squid:S5960", "static-method" })
+	void transformStringName(final String input, final String expectedOutput) {
+		final StringTransformer transf = new StringTransformer();
+		assertEquals(expectedOutput, transf.transform(input));
+	}
+
+}


### PR DESCRIPTION
Added infrastructure for getting hashes on a types content. Only type relevant information is used as basis for the hash. Comments, positions (e.g., CFB internals, connections), algorithm formating are ignored.

Also-by: Felix Roithmayr <felix.roithmayr@jku.at>