### PR TITLE
Fix initialization of max width for watch value in monitoring

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.deployment.debug.ui/src/org/eclipse/fordiac/ide/deployment/debug/ui/editparts/WatchValueEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug.ui/src/org/eclipse/fordiac/ide/deployment/debug/ui/editparts/WatchValueEditPart.java
@@ -51,7 +51,7 @@ public class WatchValueEditPart extends AbstractWatchValueEditPart {
 
 	public static final int MONITORING_VALUE_LR_MARGIN = 5;
 
-	private int maxWidth;
+	private int maxWidth = Integer.MAX_VALUE;
 
 	@Override
 	protected IFigure createFigure() {
@@ -86,11 +86,10 @@ public class WatchValueEditPart extends AbstractWatchValueEditPart {
 
 	@Override
 	public void activate() {
+		// initialize maxWidth before super.activate(), since that indirectly calls
+		// calculateSize() above, which in turn uses the maxWidth
+		initializeMaxWidth();
 		super.activate();
-		final int maxLabelSize = ((AdvancedScrollingGraphicalViewer) getViewer()).getPreferencesCache()
-				.getMaxValueLabelSize();
-		final FontMetrics fm = FigureUtilities.getFontMetrics(JFaceResources.getFontRegistry().get(DIAGRAM_FONT));
-		maxWidth = (int) ((maxLabelSize + 2) * fm.getAverageCharacterWidth()) + 2 * MONITORING_VALUE_LR_MARGIN;
 		showPinValues(false);
 	}
 
@@ -172,5 +171,12 @@ public class WatchValueEditPart extends AbstractWatchValueEditPart {
 
 	protected int getMaxWidth() {
 		return maxWidth;
+	}
+
+	private void initializeMaxWidth() {
+		final int maxLabelSize = ((AdvancedScrollingGraphicalViewer) getViewer()).getPreferencesCache()
+				.getMaxValueLabelSize();
+		final FontMetrics fm = FigureUtilities.getFontMetrics(JFaceResources.getFontRegistry().get(DIAGRAM_FONT));
+		maxWidth = (int) ((maxLabelSize + 2) * fm.getAverageCharacterWidth()) + 2 * MONITORING_VALUE_LR_MARGIN;
 	}
 }


### PR DESCRIPTION
There is an exception in `calculateSize()` because the `maxWidth` is `0`, since it has not yet been initialized from the preference.

This initializes the `maxWidth` to the maximum integer value by default and moves the proper initialization before calling `super.activate()`, since that already calls `calculateSize()`.