### PR TITLE
Fixed Preferences Access through Expanded Subapp Interfacebar Layout

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/TargetInterfaceElementEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/TargetInterfaceElementEditPart.java
@@ -22,6 +22,7 @@ import org.eclipse.emf.common.notify.impl.AdapterImpl;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.fordiac.ide.application.policies.DeleteTargetInterfaceElementPolicy;
 import org.eclipse.fordiac.ide.gef.policies.ModifiedNonResizeableEditPolicy;
+import org.eclipse.fordiac.ide.gef.preferences.PreferenceInitializer;
 import org.eclipse.fordiac.ide.model.libraryElement.AdapterDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.Connection;
 import org.eclipse.fordiac.ide.model.libraryElement.Event;
@@ -47,6 +48,8 @@ public class TargetInterfaceElementEditPart extends AbstractGraphicalEditPart {
 	public static final int LABEL_ALPHA = 120;
 	private static final String NOT_SIGN = "\u00AC"; //$NON-NLS-1$
 
+	private int maxLabelLength = PreferenceInitializer.DEFAULT_MAX_INTERFACE_BAR_SIZE;
+
 	private final Adapter nameChangeAdapter = new AdapterImpl() {
 		@Override
 		public void notifyChanged(final Notification notification) {
@@ -64,6 +67,7 @@ public class TargetInterfaceElementEditPart extends AbstractGraphicalEditPart {
 	@Override
 	public void activate() {
 		if (!isActive()) {
+			initializeMaxLabelLength();
 			super.activate();
 			getRefElement().eAdapters().add(nameChangeAdapter);
 			final FBNetworkElement parent = getRefElement().getFBNetworkElement();
@@ -137,7 +141,7 @@ public class TargetInterfaceElementEditPart extends AbstractGraphicalEditPart {
 		if (getRefElement().getOutputConnections().stream().anyMatch(con -> !con.isVisible() && con.isNegated())) {
 			labelText = NOT_SIGN + labelText;
 		}
-		return labelText + "\n" + labelTruncate(getRefElement().getComment());
+		return labelText + "\n" + labelTruncate(getRefElement().getComment()); //$NON-NLS-1$
 	}
 
 	@Override
@@ -177,8 +181,6 @@ public class TargetInterfaceElementEditPart extends AbstractGraphicalEditPart {
 	}
 
 	private String labelTruncate(final String label) {
-		final int maxLabelLength = ((AdvancedScrollingGraphicalViewer) getViewer()).getPreferencesCache()
-				.getMaxInterfaceBarSize();
 		if (label.length() <= maxLabelLength) {
 			return label;
 		}
@@ -222,4 +224,12 @@ public class TargetInterfaceElementEditPart extends AbstractGraphicalEditPart {
 		}
 		return super.getAdapter(key);
 	}
+
+	private void initializeMaxLabelLength() {
+		final AdvancedScrollingGraphicalViewer viewer = (AdvancedScrollingGraphicalViewer) getViewer();
+		if (viewer != null) {
+			maxLabelLength = viewer.getPreferencesCache().getMaxInterfaceBarSize();
+		}
+	}
+
 }

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/UntypedSubAppInterfaceElementEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/UntypedSubAppInterfaceElementEditPart.java
@@ -39,6 +39,7 @@ import org.eclipse.fordiac.ide.gef.draw2d.ConnectorBorder;
 import org.eclipse.fordiac.ide.gef.editparts.LabelDirectEditManager;
 import org.eclipse.fordiac.ide.gef.figures.ToolTipFigure;
 import org.eclipse.fordiac.ide.gef.policies.INamedElementRenameEditPolicy;
+import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeNameCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
@@ -157,12 +158,7 @@ public class UntypedSubAppInterfaceElementEditPart extends InterfaceEditPartForF
 		if (children.isEmpty()) {
 			return getFigure().getBounds().height;
 		}
-		int height = -(children.size() - 1) * 2;
-		for (final TargetInterfaceElement modelObject : children) {
-			final IFigure child = ((GraphicalEditPart) createChild(modelObject)).getFigure();
-			height += child.getPreferredSize().height;
-		}
-		return height;
+		return -(children.size() - 1) * 2 + getTargetInterfaceLabelHeight() * children.size();
 	}
 
 	public int getCollapsedFigureHeight() {
@@ -170,12 +166,11 @@ public class UntypedSubAppInterfaceElementEditPart extends InterfaceEditPartForF
 		if (children.isEmpty()) {
 			return getFigure().getBounds().height;
 		}
-		int height = -(children.size() - 1) * 2;
-		for (final TargetInterfaceElement modelObject : children) {
-			final IFigure child = ((GraphicalEditPart) createChild(modelObject)).getFigure();
-			height += child.getPreferredSize().height;
-		}
-		return height;
+		return -(children.size() - 1) * 2 + getTargetInterfaceLabelHeight() * children.size();
+	}
+
+	private static int getTargetInterfaceLabelHeight() {
+		return 2 * (int) CoordinateConverter.INSTANCE.getLineHeight();
 	}
 
 	public Label getNameLabel() {
@@ -211,7 +206,7 @@ public class UntypedSubAppInterfaceElementEditPart extends InterfaceEditPartForF
 		final InterfaceFigure figure = new InterfaceFigure() {
 			@Override
 			public String getSubStringText() {
-				return (getChildren().isEmpty()) ? super.getSubStringText() : "";
+				return (getChildren().isEmpty()) ? super.getSubStringText() : ""; //$NON-NLS-1$
 			}
 
 			@Override

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/preferences/PreferenceInitializer.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/preferences/PreferenceInitializer.java
@@ -23,6 +23,8 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 /** Class used to initialize default preference values. */
 public class PreferenceInitializer extends AbstractPreferenceInitializer {
 
+	public static final int DEFAULT_MAX_INTERFACE_BAR_SIZE = 40;
+
 	@Override
 	public void initializeDefaultPreferences() {
 		final IEclipsePreferences preferences = DefaultScope.INSTANCE
@@ -37,7 +39,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 		preferences.putInt(GefPreferenceConstants.MAX_DEFAULT_VALUE_LENGTH, 1000);
 
 		preferences.putInt(GefPreferenceConstants.MAX_PIN_LABEL_SIZE, 12);
-		preferences.putInt(GefPreferenceConstants.MAX_INTERFACE_BAR_SIZE, 40);
+		preferences.putInt(GefPreferenceConstants.MAX_INTERFACE_BAR_SIZE, DEFAULT_MAX_INTERFACE_BAR_SIZE);
 		preferences.putInt(GefPreferenceConstants.MIN_INTERFACE_BAR_SIZE, 40);
 		preferences.putInt(GefPreferenceConstants.MAX_HIDDEN_CONNECTION_LABEL_SIZE, 60);
 		preferences.putInt(GefPreferenceConstants.MAX_TYPE_LABEL_SIZE, 15);


### PR DESCRIPTION
Expanded Subapp Interfacebar layouting created dummy target editparts and figures with no parents. This lead to problems where these dummy object accessed preferences. However this was not really needed and is fixed now.

Furthermore the max interfacebar width property acquisition was moved out of the critical path.