### PR TITLE
Add Children Provider Schema into Binary Build

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/build.properties
+++ b/plugins/org.eclipse.fordiac.ide.gef/build.properties
@@ -3,5 +3,6 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\
-               plugin.properties
+               plugin.properties,\
+               schema/ChildrenProvider.exsd
 


### PR DESCRIPTION
This schema needs to be included into the binary build so that it can be discovered by external plugins of 4diac IDE. In particular, this schema is used so that external plugins can extend the FB Network graphical editor.

Fixes https://github.com/eclipse-4diac/4diac-ide/issues/1210