### PR TITLE
Enabled Hierarchy Delete Update also for typed subapps

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.hierarchymanager.ui/src/org/eclipse/fordiac/ide/hierarchymanager/ui/listeners/HierarchyManagerUpdateListener.java
+++ b/plugins/org.eclipse.fordiac.ide.hierarchymanager.ui/src/org/eclipse/fordiac/ide/hierarchymanager/ui/listeners/HierarchyManagerUpdateListener.java
@@ -32,6 +32,7 @@ import org.eclipse.fordiac.ide.hierarchymanager.ui.util.HierarchyManagerUtil;
 import org.eclipse.fordiac.ide.model.commands.QualNameChange;
 import org.eclipse.fordiac.ide.model.commands.QualNameChangeListener;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.TypedSubApp;
 import org.eclipse.fordiac.ide.model.libraryElement.UntypedSubApp;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 
@@ -102,7 +103,7 @@ public class HierarchyManagerUpdateListener extends QualNameChangeListener {
 
 	@Override
 	protected boolean isEnabled(final INamedElement element) {
-		return element instanceof UntypedSubApp;
+		return element instanceof UntypedSubApp || element instanceof TypedSubApp;
 	}
 
 	protected void storeUndoDeleteOperations(final String qualName, final Leaf leaf) {


### PR DESCRIPTION
Since networks of typed subapps might also contain untyped subapps which are part of a plant hierarchy, they need to be considered for updating after a typed subapp has been deleted