### PR TITLE
Creating Types in Non-Existing Folders was Broken

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/wizards/AbstractSaveAsWizard.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/wizards/AbstractSaveAsWizard.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.application.wizards;
 
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.fordiac.ide.ui.providers.DialogSettingsProvider;
 import org.eclipse.jface.dialogs.IDialogSettings;
@@ -50,6 +51,16 @@ public abstract class AbstractSaveAsWizard extends Wizard {
 			settings.addNewSection(subappSection);
 		}
 		setDialogSettings(settings);
+	}
+
+	protected static IContainer getFirstExistingParent(final IFile targetFile) {
+		IContainer parent = targetFile.getParent();
+
+		while (parent != null && !parent.exists()) {
+			parent = parent.getParent();
+		}
+
+		return (parent != null) ? parent : targetFile.getProject();
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/wizards/ExtractStructTypeWizard.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/wizards/ExtractStructTypeWizard.java
@@ -60,7 +60,8 @@ public class ExtractStructTypeWizard extends AbstractSaveAsWizard {
 	public boolean performFinish() {
 		if (perform()) {
 			final IFile targetFile = getTargetTypeFile();
-			final WorkspaceModifyOperation operation = new WorkspaceModifyOperation(targetFile.getParent()) {
+			final WorkspaceModifyOperation operation = new WorkspaceModifyOperation(
+					getFirstExistingParent(targetFile)) {
 
 				@Override
 				protected void execute(final IProgressMonitor monitor)

--- a/plugins/org.eclipse.fordiac.ide.datatypeeditor/src/org/eclipse/fordiac/ide/datatypeeditor/wizards/SaveAsStructTypeWizard.java
+++ b/plugins/org.eclipse.fordiac.ide.datatypeeditor/src/org/eclipse/fordiac/ide/datatypeeditor/wizards/SaveAsStructTypeWizard.java
@@ -121,7 +121,7 @@ public class SaveAsStructTypeWizard extends AbstractSaveAsWizard {
 
 	private IFile persistNewType() {
 		final IFile targetFile = getTargetTypeFile();
-		final WorkspaceModifyOperation operation = new WorkspaceModifyOperation(targetFile.getParent()) {
+		final WorkspaceModifyOperation operation = new WorkspaceModifyOperation(getFirstExistingParent(targetFile)) {
 
 			@Override
 			protected void execute(final IProgressMonitor monitor)

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/util/TypeFromTemplateCreator.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/util/TypeFromTemplateCreator.java
@@ -20,6 +20,7 @@ import java.nio.file.Files;
 
 import javax.xml.stream.XMLStreamException;
 
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
@@ -78,7 +79,7 @@ public class TypeFromTemplateCreator {
 
 		final TypeImporter importer = getTypeImporter(entry);
 		if (importer != null) {
-			final WorkspaceModifyOperation operation = new WorkspaceModifyOperation(targetTypeFile.getParent()) {
+			final WorkspaceModifyOperation operation = new WorkspaceModifyOperation(getFirstExistingParent()) {
 
 				@Override
 				protected void execute(final IProgressMonitor monitor)
@@ -107,6 +108,16 @@ public class TypeFromTemplateCreator {
 		} else {
 			entry = null;
 		}
+	}
+
+	private IContainer getFirstExistingParent() {
+		IContainer parent = targetTypeFile.getParent();
+
+		while (parent != null && !parent.exists()) {
+			parent = parent.getParent();
+		}
+
+		return (parent != null) ? parent : targetTypeFile.getProject();
 	}
 
 	@SuppressWarnings("static-method") // allow subclasses to override


### PR DESCRIPTION
When creating types (i.e., new types, extracting subapps and structs) an core exception was thrown because the workspace job was not set to the right parent directory.