### PR TITLE
Cleaned UpdateFBNElementCommand and protect against multi deletes #1243

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractReconnectConnectionCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractReconnectConnectionCommand.java
@@ -1,6 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 fortiss GmbH
- * 				 2019 Johannes Keppler University Linz
+ * Copyright (c) 2016, 2025 fortiss GmbH, Johannes Keppler University Linz
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -92,12 +91,7 @@ public abstract class AbstractReconnectConnectionCommand extends Command impleme
 	public void execute() {
 		final Connection con = getConnnection();
 		deleteConnectionCmd = new DeleteConnectionCommand(con);
-		connectionCreateCmd = createConnectionCreateCommand(parent);
-		connectionCreateCmd.setSource(getNewSource());
-		connectionCreateCmd.setDestination(getNewDestination());
-		connectionCreateCmd.setArrangementConstraints(con.getRoutingData());
-		connectionCreateCmd.setVisible(con.isVisible());
-		connectionCreateCmd.setElementIndex(parent.getConnectionIndex(con));
+		getCreateConnectionCommand(con);
 		connectionCreateCmd.execute(); // perform adding the connection first to preserve any error markers
 		deleteConnectionCmd.execute();
 		copyAttributes(connectionCreateCmd.getConnection(), deleteConnectionCmd.getConnection());
@@ -132,6 +126,18 @@ public abstract class AbstractReconnectConnectionCommand extends Command impleme
 			result.addAll(deleteConnectionCmd.getAffectedObjects());
 		}
 		return Set.copyOf(result);
+	}
+
+	private void getCreateConnectionCommand(final Connection con) {
+		connectionCreateCmd = createConnectionCreateCommand(parent);
+		// when updating the following list also update the similar list in
+		// AbstractUpdateFBNElementCommand::replaceConnection
+		connectionCreateCmd.setSource(getNewSource());
+		connectionCreateCmd.setDestination(getNewDestination());
+		connectionCreateCmd.setArrangementConstraints(con.getRoutingData());
+		connectionCreateCmd.setVisible(con.isVisible());
+		connectionCreateCmd.setNegated(con.isNegated());
+		connectionCreateCmd.setElementIndex(parent.getConnectionIndex(con));
 	}
 
 	protected abstract AbstractConnectionCreateCommand createConnectionCreateCommand(FBNetwork parent);

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractUpdateFBNElementCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractUpdateFBNElementCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 Primetals Technologies Austria GmbH
+ * Copyright (c) 2021, 2025 Primetals Technologies Austria GmbH
  *                			Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
@@ -236,7 +237,7 @@ public abstract class AbstractUpdateFBNElementCommand extends Command implements
 		});
 	}
 
-	protected void recreateResourceConns(final List<ConnData> resourceConns) {
+	private void recreateResourceConns(final List<ConnData> resourceConns) {
 		final FBNetworkElement orgMappedElement = unmapCmd.getMappedFBNetworkElement();
 		final FBNetworkElement copiedMappedElement = newElement.getOpposite();
 		for (final ConnData connData : resourceConns) {
@@ -259,7 +260,7 @@ public abstract class AbstractUpdateFBNElementCommand extends Command implements
 		}
 	}
 
-	protected static IInterfaceElement findUpdatedInterfaceElement(final FBNetworkElement newElement,
+	private static IInterfaceElement findUpdatedInterfaceElement(final FBNetworkElement newElement,
 			final FBNetworkElement oldElement, final IInterfaceElement oldInterface) {
 		if ((oldInterface != null) && (oldInterface.getFBNetworkElement() == oldElement)) {
 			// origView is an interface of the original FB => find same interface on copied
@@ -269,24 +270,24 @@ public abstract class AbstractUpdateFBNElementCommand extends Command implements
 		return oldInterface;
 	}
 
-	protected static List<Connection> getAllConnections(final FBNetworkElement element) {
+	private static Stream<Connection> getAllConnections(final FBNetworkElement element) {
 		return element.getInterface().getAllInterfaceElements().stream().map((final IInterfaceElement ifEle) -> {
 			if (ifEle.isIsInput()) {
 				return ifEle.getInputConnections();
 			}
 			return ifEle.getOutputConnections();
-		}).flatMap(List::stream).toList();
-
+		}).flatMap(List::stream).distinct();
+		// distinct filters duplicated connection objects originating from self loops
 	}
 
-	protected void createValues() {
+	private void createValues() {
 		newElement.getInterface().getInputVars().stream().forEach(inVar -> {
 			inVar.setValue(LibraryElementFactory.eINSTANCE.createValue());
 			checkSourceParam(inVar);
 		});
 	}
 
-	protected void transferInstanceComments() {
+	private void transferInstanceComments() {
 		oldElement.getInterface().getAllInterfaceElements().stream().filter(ie -> !ie.getComment().isBlank())
 				.forEach(ie -> {
 					final IInterfaceElement newIE = newElement.getInterfaceElement(ie.getName());
@@ -306,7 +307,8 @@ public abstract class AbstractUpdateFBNElementCommand extends Command implements
 	protected List<ConnData> getResourceCons() {
 		final List<ConnData> retVal = new ArrayList<>();
 		final FBNetworkElement resElement = oldElement.getOpposite();
-		for (final Connection conn : getAllConnections(resElement)) {
+
+		getAllConnections(resElement).forEach(conn -> {
 			final IInterfaceElement source = conn.getSource();
 			final IInterfaceElement dest = conn.getDestination();
 			if (!source.getFBNetworkElement().isMapped() || !dest.getFBNetworkElement().isMapped()) {
@@ -321,7 +323,7 @@ public abstract class AbstractUpdateFBNElementCommand extends Command implements
 				// this is also a resource specific connection
 				retVal.add(new ConnData(conn.getSource(), conn.getDestination()));
 			}
-		}
+		});
 		return retVal;
 	}
 
@@ -448,7 +450,7 @@ public abstract class AbstractUpdateFBNElementCommand extends Command implements
 		return updatedSelected;
 	}
 
-	protected void handleConnections() {
+	private void handleConnections() {
 		getAllConnections(oldElement).forEach(this::handleConnection);
 	}
 
@@ -464,51 +466,30 @@ public abstract class AbstractUpdateFBNElementCommand extends Command implements
 			destination = updateSelectedInterface(destination, newElement);
 		}
 
-		// reconnect/replace connection
+		// reconnect/replace connection, we can not use AbstractReconnectCommand as
+		// source and destination could be our block
 		replaceConnection(connection, source, destination);
 	}
 
-	protected void replaceConnection(final Connection oldConn, final IInterfaceElement source,
+	private void replaceConnection(final Connection oldConn, final IInterfaceElement source,
 			final IInterfaceElement dest) {
-		if (!isConnectionInList(oldConn)) {
-			reconnCmds.add(new DeleteConnectionCommand(oldConn, true));
-		}
-		if (!isConnectionToBeCreated(source, dest)) {
-			final FBNetwork fbn = oldConn.getFBNetwork();
-			final AbstractConnectionCreateCommand cmd = createConnectionCreateCommand(fbn, source.getType());
-			cmd.setSource(source);
-			cmd.setDestination(dest);
-			cmd.setNegated(oldConn.isNegated());
-			cmd.setVisible(oldConn.isVisible());
-			cmd.setArrangementConstraints(oldConn.getRoutingData());
-			cmd.setElementIndex(fbn.getConnectionIndex(oldConn));
-			reconnCmds.add(cmd);
-		}
+		reconnCmds.add(new DeleteConnectionCommand(oldConn, true));
+
+		final FBNetwork fbn = oldConn.getFBNetwork();
+		final AbstractConnectionCreateCommand cmd = createConnectionCreateCommand(fbn, source.getType());
+		// when changing this list also update the list in
+		// AbstractReconnectCommand::getCreateConnectionCommand
+		cmd.setSource(source);
+		cmd.setDestination(dest);
+		cmd.setNegated(oldConn.isNegated());
+		cmd.setVisible(oldConn.isVisible());
+		cmd.setArrangementConstraints(oldConn.getRoutingData());
+		cmd.setElementIndex(fbn.getConnectionIndex(oldConn));
+		reconnCmds.add(cmd);
 	}
 
-	protected boolean isConnectionInList(final Connection conn) {
-		for (final Object cmd : reconnCmds.getCommands()) {
-			if ((cmd instanceof final DeleteConnectionCommand deleteConnectionCommand)
-					&& deleteConnectionCommand.getConnection().equals(conn)) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	protected boolean isConnectionToBeCreated(final IInterfaceElement source, final IInterfaceElement dest) {
-		for (final Object cmd : reconnCmds.getCommands()) {
-			if ((cmd instanceof final AbstractConnectionCreateCommand abstractConnectionCreateCommand)
-					&& (abstractConnectionCreateCommand.getSource() == source)
-					&& (abstractConnectionCreateCommand.getDestination() == dest)) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	@SuppressWarnings("static-method")
-	protected AbstractConnectionCreateCommand createConnectionCreateCommand(final FBNetwork fbn, final DataType type) {
+	private static AbstractConnectionCreateCommand createConnectionCreateCommand(final FBNetwork fbn,
+			final DataType type) {
 		if (type instanceof EventType) {
 			return new EventConnectionCreateCommand(fbn);
 		}


### PR DESCRIPTION
The connection handling code in AbstractUpdateFBNElementCommand did a rather complicate check for self loops. Especially the creation code could result in mismatches to the deletion. With this clean-up it should not happen anymore.

Fixes https://github.com/eclipse-4diac/4diac-ide/issues/1243