### PR TITLE
Add type to search match

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/Match.java
+++ b/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/Match.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Martin Erich Jobst
+ * Copyright (c) 2024, 2025 Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -25,6 +25,7 @@ import org.eclipse.fordiac.ide.model.errormarker.FordiacMarkerHelper;
 public class Match {
 	private final URI uri;
 	private final String location;
+	private final String type;
 
 	/**
 	 * Create a new generic search match based on an object
@@ -32,7 +33,8 @@ public class Match {
 	 * @param object The object
 	 */
 	public Match(final EObject object) {
-		this(EcoreUtil.getURI(object), FordiacMarkerHelper.getLocation(object));
+		this(EcoreUtil.getURI(object), FordiacMarkerHelper.getLocation(object),
+				object.eClass().getEPackage().getName());
 	}
 
 	/**
@@ -40,10 +42,12 @@ public class Match {
 	 *
 	 * @param uri      The uri of the match (must not be null)
 	 * @param location The location string of the match (must not be null)
+	 * @param type     The type of the match
 	 */
-	public Match(final URI uri, final String location) {
+	public Match(final URI uri, final String location, final String type) {
 		this.uri = Objects.requireNonNull(uri);
 		this.location = Objects.requireNonNull(location);
+		this.type = type;
 	}
 
 	public final URI getUri() {
@@ -54,9 +58,13 @@ public class Match {
 		return location;
 	}
 
+	public String getType() {
+		return type;
+	}
+
 	@Override
 	public int hashCode() {
-		return Objects.hash(uri, location);
+		return Objects.hash(uri, location, type);
 	}
 
 	@Override
@@ -71,11 +79,12 @@ public class Match {
 			return false;
 		}
 		final Match other = (Match) obj;
-		return Objects.equals(uri, other.uri) && Objects.equals(location, other.location);
+		return Objects.equals(uri, other.uri) && Objects.equals(location, other.location)
+				&& Objects.equals(type, other.type);
 	}
 
 	@Override
 	public String toString() {
-		return String.format("%s [uri=%s, location=%s]", getClass().getName(), uri, location); //$NON-NLS-1$
+		return String.format("%s [uri=%s, location=%s, type=%s]", getClass().getName(), uri, location, type); //$NON-NLS-1$
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/TextMatch.java
+++ b/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/TextMatch.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Martin Erich Jobst
+ * Copyright (c) 2024, 2025 Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -32,10 +32,11 @@ public class TextMatch extends Match {
 	 * @param line   The line of the match (may be -1 if unknown)
 	 * @param offset The offset of the match (may be -1 if unknown)
 	 * @param length The length of the match (may be -1 if unknown)
+	 * @param type   The type of the match
 	 */
-	public TextMatch(final URI uri, final int line, final int offset, final int length) {
+	public TextMatch(final URI uri, final int line, final int offset, final int length, final String type) {
 		super(uri, MessageFormat.format(Messages.TextMatch_Location, Integer.valueOf(line), Integer.valueOf(offset),
-				Integer.valueOf(length)));
+				Integer.valueOf(length)), type);
 		this.line = line;
 		this.offset = offset;
 		this.length = length;
@@ -90,8 +91,7 @@ public class TextMatch extends Match {
 
 	@Override
 	public String toString() {
-		return String.format("%s [uri=%s, location=%s, line=%s, offset=%s, length=%s]", getClass().getName(), getUri(), //$NON-NLS-1$
-				getLocation(), Integer.valueOf(line), Integer.valueOf(offset), Integer.valueOf(length));
+		return String.format("%s [uri=%s, location=%s, type=%s, line=%s, offset=%s, length=%s]", getClass().getName(), //$NON-NLS-1$
+				getUri(), getLocation(), getType(), Integer.valueOf(line), Integer.valueOf(offset), Integer.valueOf(length));
 	}
-
 }


### PR DESCRIPTION
Add type to search matches, corresponding to the marker type prefix expected by the respective editor.