### PR TITLE
Overwrite All didn't write the first file #1248

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/TemplateExportFilter.java
+++ b/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/TemplateExportFilter.java
@@ -164,6 +164,8 @@ public abstract class TemplateExportFilter extends ExportFilter {
 					openMergeEditor(writtenFiles);
 				}
 			} else if (res == BUTTON_OVERWRITE_ALL) {
+				// write the files that were prepared
+				files.write(true);
 				throw (new ExportException.OverwriteAll());
 			} else if (res == BUTTON_CANCEL_ALL) {
 				throw (new ExportException.CancelAll());


### PR DESCRIPTION
When selecting Overwrite All for exporting files the first file was not written. This is fixed now.

Fixes: https://github.com/eclipse-4diac/4diac-ide/issues/1248