### PR TITLE
Fix updating of posix permissions in library manager

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/LibraryManager.java
+++ b/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/LibraryManager.java
@@ -351,9 +351,11 @@ public enum LibraryManager {
 		}
 		final PosixFileAttributeView posixView = Files.getFileAttributeView(path, PosixFileAttributeView.class);
 		if (posixView != null) {
-			final Set<PosixFilePermission> permissions = Set.of(PosixFilePermission.OWNER_READ,
-					PosixFilePermission.GROUP_READ, PosixFilePermission.OTHERS_READ);
 			try {
+				final Set<PosixFilePermission> permissions = posixView.readAttributes().permissions();
+				permissions.remove(PosixFilePermission.OWNER_WRITE);
+				permissions.remove(PosixFilePermission.GROUP_WRITE);
+				permissions.remove(PosixFilePermission.OTHERS_WRITE);
 				posixView.setPermissions(permissions);
 			} catch (final IOException e) {
 				// empty


### PR DESCRIPTION
The library manager removed the search bit from folders when making libraries read-only on posix systems. This meant the libraries could no longer be read. It also overwrote any other prior permissions. This reads the current permissions and only removes the write flags.