### PR TITLE
Fix unintended case-sensitivity of strings with max length in typelib

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/DataTypeLibrary.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/DataTypeLibrary.java
@@ -185,7 +185,7 @@ public final class DataTypeLibrary {
 			try {
 				final String plainTypeName = matcher.group(1);
 				final String maxLengthString = matcher.group(2);
-				final DataType plainType = typeMap.get(plainTypeName);
+				final DataType plainType = typeMap.get(plainTypeName.toUpperCase());
 				if (plainType instanceof AnyStringType) {
 					final int maxLength = Integer.parseUnsignedInt(maxLengthString);
 					return typeMap.computeIfAbsent(typeName.toUpperCase(), name -> {


### PR DESCRIPTION
The lookup of the base string type was performed with the (partial) lowercase name, which meant the type was not found.