### PR TITLE
Add CBasicFB::setInitialValues call in Basic FB 4diac FORTE Exporter

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteFBTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteFBTemplate.xtend
@@ -388,27 +388,20 @@ abstract class ForteFBTemplate<T extends FBType> extends ForteLibraryElementTemp
 	'''
 
 	def protected generateSetInitialValuesDeclaration(Iterable<VarDeclaration> variables) '''
-		«IF containsNonRetainedVariable(variables)»
-			void setInitialValues() override;
-		«ENDIF»
+		void setInitialValues() override;
 	'''
 
 	def protected generateSetInitialValuesDefinition(Iterable<VarDeclaration> variables) '''
-		«IF (containsNonRetainedVariable(variables))»
-			void «className»::setInitialValues() {
-			  «generateVariableDefaultAssignment(variables.filter[!isRetainedVariable(it)])»
-			}
-			
-		«ENDIF»	
+		void «className»::setInitialValues() {
+		  «baseClass»::setInitialValues();
+		  «generateVariableDefaultAssignment(variables.filter[!isRetainedVariable(it)])»
+		}
+		
 	'''
 
 	def private boolean isRetainedVariable(VarDeclaration variable) {
 		return variable.getAttributeValue(LibraryElementTags.RETAIN_ATTRIBUTE) !== null &&
 			variable.getAttributeValue(LibraryElementTags.RETAIN_ATTRIBUTE).equals(RetainTag.RETAIN.string);
-	}
-
-	def private boolean containsNonRetainedVariable(Iterable<VarDeclaration> variables) {
-		return variables.exists[!isRetainedVariable(it)];
 	}
 
 	def protected generateVariableDefaultAssignment(Iterable<VarDeclaration> variables) '''

--- a/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/forte_ng/ForteNgBasicFBTest.xtend
+++ b/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/forte_ng/ForteNgBasicFBTest.xtend
@@ -81,6 +81,7 @@ class ForteNgBasicFBTest extends ExporterTestBasicFBTypeBase {
 						
 						    void readInputData(TEventID paEIID) override;
 						    void writeOutputData(TEventID paEIID) override;
+						    void setInitialValues() override;
 						
 						  public:
 						    «EXPORTED_FUNCTIONBLOCK_NAME»(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
@@ -134,6 +135,10 @@ class ForteNgBasicFBTest extends ExporterTestBasicFBTypeBase {
 						
 						«EXPORTED_FUNCTIONBLOCK_NAME»::«EXPORTED_FUNCTIONBLOCK_NAME»(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
 						    CBasicFB(paContainer, scmFBInterfaceSpec, paInstanceNameId, nullptr) {
+						}
+						
+						void «EXPORTED_FUNCTIONBLOCK_NAME»::setInitialValues() {
+						  CBasicFB::setInitialValues();
 						}
 						
 						void «EXPORTED_FUNCTIONBLOCK_NAME»::executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) {

--- a/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/forte_ng/ForteNgTest.xtend
+++ b/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/forte_ng/ForteNgTest.xtend
@@ -266,6 +266,7 @@ class ForteNgTest extends ExporterTestBasicFBTypeBase {
 						
 						    void readInputData(TEventID paEIID) override;
 						    void writeOutputData(TEventID paEIID) override;
+						    void setInitialValues() override;
 						
 						  public:
 						    «EXPORTED_FUNCTIONBLOCK_NAME»(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
@@ -317,6 +318,10 @@ class ForteNgTest extends ExporterTestBasicFBTypeBase {
 						
 						FORTE_«ExporterTestBase.BASICFUNCTIONBLOCK_NAME»::FORTE_«ExporterTestBase.BASICFUNCTIONBLOCK_NAME»(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
 						    CBasicFB(paContainer, scmFBInterfaceSpec, paInstanceNameId, nullptr) {
+						}
+						
+						void FORTE_«ExporterTestBase.BASICFUNCTIONBLOCK_NAME»::setInitialValues() {
+						  CBasicFB::setInitialValues();
 						}
 						
 						void FORTE_«ExporterTestBase.BASICFUNCTIONBLOCK_NAME»::executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) {


### PR DESCRIPTION
In order that the ECC State is also correctly reset a call to CBasicFB::setInitialValues shall be done for all basic fbs.