### PR TITLE
adding eIO FBs to the typelibrary

### DIFF
--- a/data/typelibrary/io-1.0.0/typelib/eIO/eGenAdapter.adp
+++ b/data/typelibrary/io-1.0.0/typelib/eIO/eGenAdapter.adp
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AdapterType Name="eGenAdapter" Comment="Adapter Interface">
-	<Identification Standard="61499-1">
+	<Identification Standard="61499-2" Description="Copyright (c) 2025 Maximilian Scharf &#10;&#10; This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
 	</Identification>
 	<VersionInfo Version="1.0" Author="Maximilian Scharf" Date="2025-05-05">
 	</VersionInfo>
@@ -8,26 +8,4 @@
 	</CompilerInfo>
 	<InterfaceList>
 	</InterfaceList>
-	<Service RightInterface="SOCKET" LeftInterface="PLUG">
-		<ServiceSequence Name="request_confirm">
-			<ServiceTransaction>
-				<InputPrimitive Interface="SOCKET" Event="REQ" Parameters="REQD"/>
-				<OutputPrimitive Interface="PLUG" Event="REQ" Parameters="REQD"/>
-			</ServiceTransaction>
-			<ServiceTransaction>
-				<InputPrimitive Interface="PLUG" Event="CNF" Parameters="CNFD"/>
-				<OutputPrimitive Interface="SOCKET" Event="CNF" Parameters="CNFD"/>
-			</ServiceTransaction>
-		</ServiceSequence>
-		<ServiceSequence Name="indication_response">
-			<ServiceTransaction>
-				<InputPrimitive Interface="PLUG" Event="IND" Parameters="INDD"/>
-				<OutputPrimitive Interface="SOCKET" Event="IND" Parameters="INDD"/>
-			</ServiceTransaction>
-			<ServiceTransaction>
-				<InputPrimitive Interface="SOCKET" Event="RSP" Parameters="RSPD"/>
-				<OutputPrimitive Interface="PLUG" Event="RSP" Parameters="RSPD"/>
-			</ServiceTransaction>
-		</ServiceSequence>
-	</Service>
 </AdapterType>

--- a/data/typelibrary/io-1.0.0/typelib/eIO/eGenAdapter.adp
+++ b/data/typelibrary/io-1.0.0/typelib/eIO/eGenAdapter.adp
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AdapterType Name="eGenAdapter" Comment="Adapter Interface">
+	<Identification Standard="61499-1">
+	</Identification>
+	<VersionInfo Version="1.0" Author="Maximilian Scharf" Date="2025-05-05">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+	</InterfaceList>
+	<Service RightInterface="SOCKET" LeftInterface="PLUG">
+		<ServiceSequence Name="request_confirm">
+			<ServiceTransaction>
+				<InputPrimitive Interface="SOCKET" Event="REQ" Parameters="REQD"/>
+				<OutputPrimitive Interface="PLUG" Event="REQ" Parameters="REQD"/>
+			</ServiceTransaction>
+			<ServiceTransaction>
+				<InputPrimitive Interface="PLUG" Event="CNF" Parameters="CNFD"/>
+				<OutputPrimitive Interface="SOCKET" Event="CNF" Parameters="CNFD"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="indication_response">
+			<ServiceTransaction>
+				<InputPrimitive Interface="PLUG" Event="IND" Parameters="INDD"/>
+				<OutputPrimitive Interface="SOCKET" Event="IND" Parameters="INDD"/>
+			</ServiceTransaction>
+			<ServiceTransaction>
+				<InputPrimitive Interface="SOCKET" Event="RSP" Parameters="RSPD"/>
+				<OutputPrimitive Interface="PLUG" Event="RSP" Parameters="RSPD"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+	</Service>
+</AdapterType>

--- a/data/typelibrary/io-1.0.0/typelib/eIO/eIW.fbt
+++ b/data/typelibrary/io-1.0.0/typelib/eIO/eIW.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="eIW" Comment="Input service interface function block for word input data with event-base trigger">
-	<Identification>
+	<Identification Standard="61499-2" Description="Copyright (c) 2025 Maximilian Scharf &#10;&#10; This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
 	</Identification>
 	<VersionInfo Version="1.0" Author="Maximilian Scharf" Date="2025-05-05">
 	</VersionInfo>

--- a/data/typelibrary/io-1.0.0/typelib/eIO/eIW.fbt
+++ b/data/typelibrary/io-1.0.0/typelib/eIO/eIW.fbt
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="eIW" Comment="Input service interface function block for word input data with event-base trigger">
+	<Identification>
+	</Identification>
+	<VersionInfo Version="1.0" Author="Maximilian Scharf" Date="2025-05-05">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
+				<With Var="QI"/>
+				<With Var="PARAMS"/>
+			</Event>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="QI"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+				<With Var="IN"/>
+			</Event>
+			<Event Name="IND" Type="Event" Comment="Indication from Resource">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+				<With Var="IN"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="PARAMS" Type="STRING" Comment="Service Parameters"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
+			<VarDeclaration Name="STATUS" Type="STRING" Comment="Service Status"/>
+			<VarDeclaration Name="IN" Type="WORD" Comment="Input data from resource"/>
+		</OutputVars>
+		<Plugs>
+			<AdapterDeclaration Name="eCONF" Type="eGenAdapter" Comment="Configuration of Event-based-Trigger"/>
+		</Plugs>
+	</InterfaceList>
+</FBType>

--- a/data/typelibrary/io-1.0.0/typelib/eIO/eIWconfig.fbt
+++ b/data/typelibrary/io-1.0.0/typelib/eIO/eIWconfig.fbt
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="eIWconfig" Comment="Service Interface Function Block Type">
+	<Identification Standard="61499-2">
+	</Identification>
+	<VersionInfo Version="1.0" Author="Maximilian Scharf" Date="2025-05-05">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="CONF" Type="Event" Comment="Configure Request">
+				<With Var="QI"/>
+				<With Var="ST"/>
+				<With Var="BT"/>
+				<With Var="GRAD"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="ST" Type="WORD" Comment="Smaller than"/>
+			<VarDeclaration Name="BT" Type="WORD" Comment="Bigger than"/>
+			<VarDeclaration Name="GRAD" Type="WORD" Comment="Gradient in %"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
+			<VarDeclaration Name="STATUS" Type="WSTRING" Comment="Service Status"/>
+		</OutputVars>
+		<Sockets>
+			<AdapterDeclaration Name="eIW" Type="eGenAdapter"/>
+		</Sockets>
+	</InterfaceList>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION">
+		<ServiceSequence Name="normal_establishment">
+			<ServiceTransaction>
+				<InputPrimitive Interface="APPLICATION" Event="INIT+" Parameters="PARAMS"/>
+				<OutputPrimitive Interface="RESOURCE" Event="initialize" Parameters="PARAMS"/>
+				<OutputPrimitive Interface="APPLICATION" Event="INITO+"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="unsuccessful_establishment">
+			<ServiceTransaction>
+				<InputPrimitive Interface="APPLICATION" Event="INIT+" Parameters="PARAMS"/>
+				<OutputPrimitive Interface="RESOURCE" Event="initialize" Parameters="PARAMS"/>
+				<OutputPrimitive Interface="APPLICATION" Event="INITO-" Parameters="STATUS"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="request_confirm">
+			<ServiceTransaction>
+				<InputPrimitive Interface="APPLICATION" Event="REQ+" Parameters="SD"/>
+				<OutputPrimitive Interface="RESOURCE" Event="request" Parameters="SD"/>
+				<OutputPrimitive Interface="APPLICATION" Event="CNF+" Parameters="RD"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="request_inhibited">
+			<ServiceTransaction>
+				<InputPrimitive Interface="APPLICATION" Event="REQ-" Parameters="SD"/>
+				<OutputPrimitive Interface="APPLICATION" Event="CNF-" Parameters="STATUS"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="request_error">
+			<ServiceTransaction>
+				<InputPrimitive Interface="APPLICATION" Event="REQ+" Parameters="SD"/>
+				<OutputPrimitive Interface="RESOURCE" Event="request" Parameters="SD"/>
+				<OutputPrimitive Interface="APPLICATION" Event="CNF-" Parameters="STATUS"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="indication_response">
+			<ServiceTransaction>
+				<InputPrimitive Interface="RESOURCE" Event="indicate" Parameters="RD"/>
+				<OutputPrimitive Interface="APPLICATION" Event="IND+" Parameters="RD"/>
+			</ServiceTransaction>
+			<ServiceTransaction>
+				<InputPrimitive Interface="APPLICATION" Event="RSP" Parameters="QI,SD"/>
+				<OutputPrimitive Interface="RESOURCE" Event="response" Parameters="QI,SD"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="indication_inhibited">
+			<ServiceTransaction>
+				<InputPrimitive Interface="RESOURCE" Event="indicate" Parameters="RD,QI=FALSE"/>
+				<OutputPrimitive Interface="RESOURCE" Event="inhibited"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="error_indication">
+			<ServiceTransaction>
+				<InputPrimitive Interface="RESOURCE" Event="error" Parameters="STATUS"/>
+				<OutputPrimitive Interface="APPLICATION" Event="IND-" Parameters="STATUS"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="application_initiated_termination">
+			<ServiceTransaction>
+				<InputPrimitive Interface="APPLICATION" Event="INIT-"/>
+				<OutputPrimitive Interface="RESOURCE" Event="terminate"/>
+				<OutputPrimitive Interface="APPLICATION" Event="INITO-" Parameters="STATUS"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="resource_initiated_termination">
+			<ServiceTransaction>
+				<OutputPrimitive Interface="APPLICATION" Event="INITO-" Parameters="STATUS"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+	</Service>
+</FBType>

--- a/data/typelibrary/io-1.0.0/typelib/eIO/eIWconfig.fbt
+++ b/data/typelibrary/io-1.0.0/typelib/eIO/eIWconfig.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="eIWconfig" Comment="Service Interface Function Block Type">
-	<Identification Standard="61499-2">
+	<Identification Standard="61499-2" Description="Copyright (c) 2025 Maximilian Scharf &#10;&#10; This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
 	</Identification>
 	<VersionInfo Version="1.0" Author="Maximilian Scharf" Date="2025-05-05">
 	</VersionInfo>
@@ -9,7 +9,6 @@
 	<InterfaceList>
 		<EventInputs>
 			<Event Name="CONF" Type="Event" Comment="Configure Request">
-				<With Var="QI"/>
 				<With Var="ST"/>
 				<With Var="BT"/>
 				<With Var="GRAD"/>
@@ -17,92 +16,19 @@
 		</EventInputs>
 		<EventOutputs>
 			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
-				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
 		</EventOutputs>
 		<InputVars>
-			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
 			<VarDeclaration Name="ST" Type="WORD" Comment="Smaller than"/>
 			<VarDeclaration Name="BT" Type="WORD" Comment="Bigger than"/>
 			<VarDeclaration Name="GRAD" Type="WORD" Comment="Gradient in %"/>
 		</InputVars>
 		<OutputVars>
-			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING" Comment="Service Status"/>
 		</OutputVars>
 		<Sockets>
-			<AdapterDeclaration Name="eIW" Type="eGenAdapter"/>
+			<AdapterDeclaration Name="eIW" Type="eGenAdapter" Comment="Connection to eIO Instance"/>
 		</Sockets>
 	</InterfaceList>
-	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION">
-		<ServiceSequence Name="normal_establishment">
-			<ServiceTransaction>
-				<InputPrimitive Interface="APPLICATION" Event="INIT+" Parameters="PARAMS"/>
-				<OutputPrimitive Interface="RESOURCE" Event="initialize" Parameters="PARAMS"/>
-				<OutputPrimitive Interface="APPLICATION" Event="INITO+"/>
-			</ServiceTransaction>
-		</ServiceSequence>
-		<ServiceSequence Name="unsuccessful_establishment">
-			<ServiceTransaction>
-				<InputPrimitive Interface="APPLICATION" Event="INIT+" Parameters="PARAMS"/>
-				<OutputPrimitive Interface="RESOURCE" Event="initialize" Parameters="PARAMS"/>
-				<OutputPrimitive Interface="APPLICATION" Event="INITO-" Parameters="STATUS"/>
-			</ServiceTransaction>
-		</ServiceSequence>
-		<ServiceSequence Name="request_confirm">
-			<ServiceTransaction>
-				<InputPrimitive Interface="APPLICATION" Event="REQ+" Parameters="SD"/>
-				<OutputPrimitive Interface="RESOURCE" Event="request" Parameters="SD"/>
-				<OutputPrimitive Interface="APPLICATION" Event="CNF+" Parameters="RD"/>
-			</ServiceTransaction>
-		</ServiceSequence>
-		<ServiceSequence Name="request_inhibited">
-			<ServiceTransaction>
-				<InputPrimitive Interface="APPLICATION" Event="REQ-" Parameters="SD"/>
-				<OutputPrimitive Interface="APPLICATION" Event="CNF-" Parameters="STATUS"/>
-			</ServiceTransaction>
-		</ServiceSequence>
-		<ServiceSequence Name="request_error">
-			<ServiceTransaction>
-				<InputPrimitive Interface="APPLICATION" Event="REQ+" Parameters="SD"/>
-				<OutputPrimitive Interface="RESOURCE" Event="request" Parameters="SD"/>
-				<OutputPrimitive Interface="APPLICATION" Event="CNF-" Parameters="STATUS"/>
-			</ServiceTransaction>
-		</ServiceSequence>
-		<ServiceSequence Name="indication_response">
-			<ServiceTransaction>
-				<InputPrimitive Interface="RESOURCE" Event="indicate" Parameters="RD"/>
-				<OutputPrimitive Interface="APPLICATION" Event="IND+" Parameters="RD"/>
-			</ServiceTransaction>
-			<ServiceTransaction>
-				<InputPrimitive Interface="APPLICATION" Event="RSP" Parameters="QI,SD"/>
-				<OutputPrimitive Interface="RESOURCE" Event="response" Parameters="QI,SD"/>
-			</ServiceTransaction>
-		</ServiceSequence>
-		<ServiceSequence Name="indication_inhibited">
-			<ServiceTransaction>
-				<InputPrimitive Interface="RESOURCE" Event="indicate" Parameters="RD,QI=FALSE"/>
-				<OutputPrimitive Interface="RESOURCE" Event="inhibited"/>
-			</ServiceTransaction>
-		</ServiceSequence>
-		<ServiceSequence Name="error_indication">
-			<ServiceTransaction>
-				<InputPrimitive Interface="RESOURCE" Event="error" Parameters="STATUS"/>
-				<OutputPrimitive Interface="APPLICATION" Event="IND-" Parameters="STATUS"/>
-			</ServiceTransaction>
-		</ServiceSequence>
-		<ServiceSequence Name="application_initiated_termination">
-			<ServiceTransaction>
-				<InputPrimitive Interface="APPLICATION" Event="INIT-"/>
-				<OutputPrimitive Interface="RESOURCE" Event="terminate"/>
-				<OutputPrimitive Interface="APPLICATION" Event="INITO-" Parameters="STATUS"/>
-			</ServiceTransaction>
-		</ServiceSequence>
-		<ServiceSequence Name="resource_initiated_termination">
-			<ServiceTransaction>
-				<OutputPrimitive Interface="APPLICATION" Event="INITO-" Parameters="STATUS"/>
-			</ServiceTransaction>
-		</ServiceSequence>
-	</Service>
 </FBType>

--- a/data/typelibrary/io-1.0.0/typelib/eIO/eIX.fbt
+++ b/data/typelibrary/io-1.0.0/typelib/eIO/eIX.fbt
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="eIX" Comment="Input service interface function block for boolean input data with event-base trigger">
+	<Identification>
+	</Identification>
+	<VersionInfo Version="1.0" Author="Maximilian Scharf" Date="2025-05-05">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
+				<With Var="QI"/>
+				<With Var="PARAMS"/>
+			</Event>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="QI"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+				<With Var="IN"/>
+			</Event>
+			<Event Name="IND" Type="Event" Comment="Indication from Resource">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+				<With Var="IN"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="PARAMS" Type="STRING" Comment="Service Parameters"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
+			<VarDeclaration Name="STATUS" Type="STRING" Comment="Service Status"/>
+			<VarDeclaration Name="IN" Type="BOOL" Comment="Input data from resource"/>
+		</OutputVars>
+		<Plugs>
+			<AdapterDeclaration Name="eCONF" Type="eGenAdapter" Comment="Configuration of Event-based-Trigger"/>
+		</Plugs>
+	</InterfaceList>
+</FBType>

--- a/data/typelibrary/io-1.0.0/typelib/eIO/eIX.fbt
+++ b/data/typelibrary/io-1.0.0/typelib/eIO/eIX.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="eIX" Comment="Input service interface function block for boolean input data with event-base trigger">
-	<Identification>
+	<Identification Standard="61499-2" Description="Copyright (c) 2025 Maximilian Scharf &#10;&#10; This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
 	</Identification>
 	<VersionInfo Version="1.0" Author="Maximilian Scharf" Date="2025-05-05">
 	</VersionInfo>

--- a/data/typelibrary/io-1.0.0/typelib/eIO/eIXconfig.fbt
+++ b/data/typelibrary/io-1.0.0/typelib/eIO/eIXconfig.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="eIXconfig" Comment="Service Interface Function Block Type">
-	<Identification Standard="61499-2">
+	<Identification Standard="61499-2" Description="Copyright (c) 2025 Maximilian Scharf &#10;&#10; This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0" >
 	</Identification>
 	<VersionInfo Version="1.0" Author="Maximilian Scharf" Date="2025-05-05">
 	</VersionInfo>
@@ -9,98 +9,24 @@
 	<InterfaceList>
 		<EventInputs>
 			<Event Name="CONF" Type="Event" Comment="Configure Request">
-				<With Var="QI"/>
 				<With Var="FE"/>
 				<With Var="RE"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
 			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
-				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>
 		</EventOutputs>
 		<InputVars>
-			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
 			<VarDeclaration Name="FE" Type="BOOL" Comment="Falling Edge Trigger Enable"/>
 			<VarDeclaration Name="RE" Type="BOOL" Comment="Rising Edge Trigger Enable"/>
 		</InputVars>
 		<OutputVars>
-			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
 			<VarDeclaration Name="STATUS" Type="WSTRING" Comment="Service Status"/>
 		</OutputVars>
 		<Sockets>
-			<AdapterDeclaration Name="eIX" Type="eGenAdapter" Comment="eIX Function Block"/>
+			<AdapterDeclaration Name="eIX" Type="eGenAdapter" Comment="Connection to eIO Instance"/>
 		</Sockets>
 	</InterfaceList>
-	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION">
-		<ServiceSequence Name="normal_establishment">
-			<ServiceTransaction>
-				<InputPrimitive Interface="APPLICATION" Event="INIT+" Parameters="PARAMS"/>
-				<OutputPrimitive Interface="RESOURCE" Event="initialize" Parameters="PARAMS"/>
-				<OutputPrimitive Interface="APPLICATION" Event="INITO+"/>
-			</ServiceTransaction>
-		</ServiceSequence>
-		<ServiceSequence Name="unsuccessful_establishment">
-			<ServiceTransaction>
-				<InputPrimitive Interface="APPLICATION" Event="INIT+" Parameters="PARAMS"/>
-				<OutputPrimitive Interface="RESOURCE" Event="initialize" Parameters="PARAMS"/>
-				<OutputPrimitive Interface="APPLICATION" Event="INITO-" Parameters="STATUS"/>
-			</ServiceTransaction>
-		</ServiceSequence>
-		<ServiceSequence Name="request_confirm">
-			<ServiceTransaction>
-				<InputPrimitive Interface="APPLICATION" Event="REQ+" Parameters="SD"/>
-				<OutputPrimitive Interface="RESOURCE" Event="request" Parameters="SD"/>
-				<OutputPrimitive Interface="APPLICATION" Event="CNF+" Parameters="RD"/>
-			</ServiceTransaction>
-		</ServiceSequence>
-		<ServiceSequence Name="request_inhibited">
-			<ServiceTransaction>
-				<InputPrimitive Interface="APPLICATION" Event="REQ-" Parameters="SD"/>
-				<OutputPrimitive Interface="APPLICATION" Event="CNF-" Parameters="STATUS"/>
-			</ServiceTransaction>
-		</ServiceSequence>
-		<ServiceSequence Name="request_error">
-			<ServiceTransaction>
-				<InputPrimitive Interface="APPLICATION" Event="REQ+" Parameters="SD"/>
-				<OutputPrimitive Interface="RESOURCE" Event="request" Parameters="SD"/>
-				<OutputPrimitive Interface="APPLICATION" Event="CNF-" Parameters="STATUS"/>
-			</ServiceTransaction>
-		</ServiceSequence>
-		<ServiceSequence Name="indication_response">
-			<ServiceTransaction>
-				<InputPrimitive Interface="RESOURCE" Event="indicate" Parameters="RD"/>
-				<OutputPrimitive Interface="APPLICATION" Event="IND+" Parameters="RD"/>
-			</ServiceTransaction>
-			<ServiceTransaction>
-				<InputPrimitive Interface="APPLICATION" Event="RSP" Parameters="QI,SD"/>
-				<OutputPrimitive Interface="RESOURCE" Event="response" Parameters="QI,SD"/>
-			</ServiceTransaction>
-		</ServiceSequence>
-		<ServiceSequence Name="indication_inhibited">
-			<ServiceTransaction>
-				<InputPrimitive Interface="RESOURCE" Event="indicate" Parameters="RD,QI=FALSE"/>
-				<OutputPrimitive Interface="RESOURCE" Event="inhibited"/>
-			</ServiceTransaction>
-		</ServiceSequence>
-		<ServiceSequence Name="error_indication">
-			<ServiceTransaction>
-				<InputPrimitive Interface="RESOURCE" Event="error" Parameters="STATUS"/>
-				<OutputPrimitive Interface="APPLICATION" Event="IND-" Parameters="STATUS"/>
-			</ServiceTransaction>
-		</ServiceSequence>
-		<ServiceSequence Name="application_initiated_termination">
-			<ServiceTransaction>
-				<InputPrimitive Interface="APPLICATION" Event="INIT-"/>
-				<OutputPrimitive Interface="RESOURCE" Event="terminate"/>
-				<OutputPrimitive Interface="APPLICATION" Event="INITO-" Parameters="STATUS"/>
-			</ServiceTransaction>
-		</ServiceSequence>
-		<ServiceSequence Name="resource_initiated_termination">
-			<ServiceTransaction>
-				<OutputPrimitive Interface="APPLICATION" Event="INITO-" Parameters="STATUS"/>
-			</ServiceTransaction>
-		</ServiceSequence>
-	</Service>
 </FBType>

--- a/data/typelibrary/io-1.0.0/typelib/eIO/eIXconfig.fbt
+++ b/data/typelibrary/io-1.0.0/typelib/eIO/eIXconfig.fbt
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="eIXconfig" Comment="Service Interface Function Block Type">
+	<Identification Standard="61499-2">
+	</Identification>
+	<VersionInfo Version="1.0" Author="Maximilian Scharf" Date="2025-05-05">
+	</VersionInfo>
+	<CompilerInfo>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="CONF" Type="Event" Comment="Configure Request">
+				<With Var="QI"/>
+				<With Var="FE"/>
+				<With Var="RE"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="FE" Type="BOOL" Comment="Falling Edge Trigger Enable"/>
+			<VarDeclaration Name="RE" Type="BOOL" Comment="Rising Edge Trigger Enable"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
+			<VarDeclaration Name="STATUS" Type="WSTRING" Comment="Service Status"/>
+		</OutputVars>
+		<Sockets>
+			<AdapterDeclaration Name="eIX" Type="eGenAdapter" Comment="eIX Function Block"/>
+		</Sockets>
+	</InterfaceList>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION">
+		<ServiceSequence Name="normal_establishment">
+			<ServiceTransaction>
+				<InputPrimitive Interface="APPLICATION" Event="INIT+" Parameters="PARAMS"/>
+				<OutputPrimitive Interface="RESOURCE" Event="initialize" Parameters="PARAMS"/>
+				<OutputPrimitive Interface="APPLICATION" Event="INITO+"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="unsuccessful_establishment">
+			<ServiceTransaction>
+				<InputPrimitive Interface="APPLICATION" Event="INIT+" Parameters="PARAMS"/>
+				<OutputPrimitive Interface="RESOURCE" Event="initialize" Parameters="PARAMS"/>
+				<OutputPrimitive Interface="APPLICATION" Event="INITO-" Parameters="STATUS"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="request_confirm">
+			<ServiceTransaction>
+				<InputPrimitive Interface="APPLICATION" Event="REQ+" Parameters="SD"/>
+				<OutputPrimitive Interface="RESOURCE" Event="request" Parameters="SD"/>
+				<OutputPrimitive Interface="APPLICATION" Event="CNF+" Parameters="RD"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="request_inhibited">
+			<ServiceTransaction>
+				<InputPrimitive Interface="APPLICATION" Event="REQ-" Parameters="SD"/>
+				<OutputPrimitive Interface="APPLICATION" Event="CNF-" Parameters="STATUS"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="request_error">
+			<ServiceTransaction>
+				<InputPrimitive Interface="APPLICATION" Event="REQ+" Parameters="SD"/>
+				<OutputPrimitive Interface="RESOURCE" Event="request" Parameters="SD"/>
+				<OutputPrimitive Interface="APPLICATION" Event="CNF-" Parameters="STATUS"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="indication_response">
+			<ServiceTransaction>
+				<InputPrimitive Interface="RESOURCE" Event="indicate" Parameters="RD"/>
+				<OutputPrimitive Interface="APPLICATION" Event="IND+" Parameters="RD"/>
+			</ServiceTransaction>
+			<ServiceTransaction>
+				<InputPrimitive Interface="APPLICATION" Event="RSP" Parameters="QI,SD"/>
+				<OutputPrimitive Interface="RESOURCE" Event="response" Parameters="QI,SD"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="indication_inhibited">
+			<ServiceTransaction>
+				<InputPrimitive Interface="RESOURCE" Event="indicate" Parameters="RD,QI=FALSE"/>
+				<OutputPrimitive Interface="RESOURCE" Event="inhibited"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="error_indication">
+			<ServiceTransaction>
+				<InputPrimitive Interface="RESOURCE" Event="error" Parameters="STATUS"/>
+				<OutputPrimitive Interface="APPLICATION" Event="IND-" Parameters="STATUS"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="application_initiated_termination">
+			<ServiceTransaction>
+				<InputPrimitive Interface="APPLICATION" Event="INIT-"/>
+				<OutputPrimitive Interface="RESOURCE" Event="terminate"/>
+				<OutputPrimitive Interface="APPLICATION" Event="INITO-" Parameters="STATUS"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="resource_initiated_termination">
+			<ServiceTransaction>
+				<OutputPrimitive Interface="APPLICATION" Event="INITO-" Parameters="STATUS"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+	</Service>
+</FBType>


### PR DESCRIPTION
This pull request introduces four new service interface function blocks and one adapter. 
The `eIX` and `eIW` function blocks are similar to the standard `IX` and `IW` FBs but include an additional adapter port. Through this adapter (`eGenAdapter`), it becomes possible to configure external triggers for these function blocks using the `eIXconfig` and `eIWconfig` FBs.