### PR TITLE
Removed time stamp from Data response model

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.deployment/model/devResponse.ecore
+++ b/plugins/org.eclipse.fordiac.ide.deployment/model/devResponse.ecore
@@ -20,7 +20,6 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Data">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="time" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="forced" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Response">

--- a/plugins/org.eclipse.fordiac.ide.deployment/model/devResponse.genmodel
+++ b/plugins/org.eclipse.fordiac.ide.deployment/model/devResponse.genmodel
@@ -26,7 +26,6 @@
     </genClasses>
     <genClasses ecoreClass="devResponse.ecore#//Data">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute devResponse.ecore#//Data/value"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute devResponse.ecore#//Data/time"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute devResponse.ecore#//Data/forced"/>
     </genClasses>
     <genClasses ecoreClass="devResponse.ecore#//Response">

--- a/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/Data.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/Data.java
@@ -1,7 +1,7 @@
 /**
  * ******************************************************************************
  * * Copyright (c) 2012, 2013, 2018 Profactor GmbH, fortiss GmbH, Johannes Kepler University
- * * 
+ * *
  * * This program and the accompanying materials are made available under the
  * * terms of the Eclipse Public License 2.0 which is available at
  * * http://www.eclipse.org/legal/epl-2.0.
@@ -13,7 +13,7 @@
  * *     - initial API and implementation and/or initial documentation
  * *   Alois Zoitl - moved to deployment and reworked it to a device response model
  * ******************************************************************************
- * 
+ *
  */
 package org.eclipse.fordiac.ide.deployment.devResponse;
 
@@ -29,7 +29,6 @@ import org.eclipse.emf.ecore.EObject;
  * </p>
  * <ul>
  *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.Data#getValue <em>Value</em>}</li>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.Data#getTime <em>Time</em>}</li>
  *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.Data#getForced <em>Forced</em>}</li>
  * </ul>
  *
@@ -63,32 +62,6 @@ public interface Data extends EObject {
 	 * @generated
 	 */
 	void setValue(String value);
-
-	/**
-	 * Returns the value of the '<em><b>Time</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Time</em>' attribute isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
-	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Time</em>' attribute.
-	 * @see #setTime(String)
-	 * @see org.eclipse.fordiac.ide.deployment.devResponse.DevResponsePackage#getData_Time()
-	 * @model
-	 * @generated
-	 */
-	String getTime();
-
-	/**
-	 * Sets the value of the '{@link org.eclipse.fordiac.ide.deployment.devResponse.Data#getTime <em>Time</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Time</em>' attribute.
-	 * @see #getTime()
-	 * @generated
-	 */
-	void setTime(String value);
 
 	/**
 	 * Returns the value of the '<em><b>Forced</b></em>' attribute.

--- a/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/DevResponsePackage.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/DevResponsePackage.java
@@ -209,22 +209,13 @@ public interface DevResponsePackage extends EPackage {
 	int DATA__VALUE = 0;
 
 	/**
-	 * The feature id for the '<em><b>Time</b></em>' attribute.
-	 * <!-- begin-user-doc
-	 * --> <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int DATA__TIME = 1;
-
-	/**
 	 * The feature id for the '<em><b>Forced</b></em>' attribute. <!--
 	 * begin-user-doc --> <!-- end-user-doc -->
 	 *
 	 * @generated
 	 * @ordered
 	 */
-	int DATA__FORCED = 2;
+	int DATA__FORCED = 1;
 
 	/**
 	 * The number of structural features of the '<em>Data</em>' class. <!--
@@ -233,7 +224,7 @@ public interface DevResponsePackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int DATA_FEATURE_COUNT = 3;
+	int DATA_FEATURE_COUNT = 2;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResponseImpl <em>Response</em>}' class.
@@ -553,16 +544,6 @@ public interface DevResponsePackage extends EPackage {
 	EAttribute getData_Value();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.eclipse.fordiac.ide.deployment.devResponse.Data#getTime <em>Time</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * @return the meta object for the attribute '<em>Time</em>'.
-	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Data#getTime()
-	 * @see #getData()
-	 * @generated
-	 */
-	EAttribute getData_Time();
-
-	/**
 	 * Returns the meta object for the attribute '{@link org.eclipse.fordiac.ide.deployment.devResponse.Data#getForced <em>Forced</em>}'.
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @return the meta object for the attribute '<em>Forced</em>'.
@@ -846,13 +827,6 @@ public interface DevResponsePackage extends EPackage {
 		 * @generated
 		 */
 		EAttribute DATA__VALUE = eINSTANCE.getData_Value();
-
-		/**
-		 * The meta object literal for the '<em><b>Time</b></em>' attribute feature.
-		 * <!-- begin-user-doc --> <!-- end-user-doc -->
-		 * @generated
-		 */
-		EAttribute DATA__TIME = eINSTANCE.getData_Time();
 
 		/**
 		 * The meta object literal for the '<em><b>Forced</b></em>' attribute feature.

--- a/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/impl/DataImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/impl/DataImpl.java
@@ -33,7 +33,6 @@ import org.eclipse.fordiac.ide.deployment.devResponse.DevResponsePackage;
  * </p>
  * <ul>
  *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.DataImpl#getValue <em>Value</em>}</li>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.DataImpl#getTime <em>Time</em>}</li>
  *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.DataImpl#getForced <em>Forced</em>}</li>
  * </ul>
  *
@@ -59,26 +58,6 @@ public class DataImpl extends EObjectImpl implements Data {
 	 * @ordered
 	 */
 	protected String value = VALUE_EDEFAULT;
-
-	/**
-	 * The default value of the '{@link #getTime() <em>Time</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @see #getTime()
-	 * @generated
-	 * @ordered
-	 */
-	protected static final String TIME_EDEFAULT = null;
-
-	/**
-	 * The cached value of the '{@link #getTime() <em>Time</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @see #getTime()
-	 * @generated
-	 * @ordered
-	 */
-	protected String time = TIME_EDEFAULT;
 
 	/**
 	 * The default value of the '{@link #getForced() <em>Forced</em>}' attribute.
@@ -138,31 +117,9 @@ public class DataImpl extends EObjectImpl implements Data {
 	public void setValue(String newValue) {
 		String oldValue = value;
 		value = newValue;
-		if (eNotificationRequired())
+		if (eNotificationRequired()) {
 			eNotify(new ENotificationImpl(this, Notification.SET, DevResponsePackage.DATA__VALUE, oldValue, value));
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	@Override
-	public String getTime() {
-		return time;
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	@Override
-	public void setTime(String newTime) {
-		String oldTime = time;
-		time = newTime;
-		if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, DevResponsePackage.DATA__TIME, oldTime, time));
+		}
 	}
 
 	/**
@@ -184,8 +141,9 @@ public class DataImpl extends EObjectImpl implements Data {
 	public void setForced(String newForced) {
 		String oldForced = forced;
 		forced = newForced;
-		if (eNotificationRequired())
+		if (eNotificationRequired()) {
 			eNotify(new ENotificationImpl(this, Notification.SET, DevResponsePackage.DATA__FORCED, oldForced, forced));
+		}
 	}
 
 	/**
@@ -198,8 +156,6 @@ public class DataImpl extends EObjectImpl implements Data {
 		switch (featureID) {
 			case DevResponsePackage.DATA__VALUE:
 				return getValue();
-			case DevResponsePackage.DATA__TIME:
-				return getTime();
 			case DevResponsePackage.DATA__FORCED:
 				return getForced();
 			default:
@@ -217,9 +173,6 @@ public class DataImpl extends EObjectImpl implements Data {
 		switch (featureID) {
 			case DevResponsePackage.DATA__VALUE:
 				setValue((String)newValue);
-				return;
-			case DevResponsePackage.DATA__TIME:
-				setTime((String)newValue);
 				return;
 			case DevResponsePackage.DATA__FORCED:
 				setForced((String)newValue);
@@ -241,9 +194,6 @@ public class DataImpl extends EObjectImpl implements Data {
 			case DevResponsePackage.DATA__VALUE:
 				setValue(VALUE_EDEFAULT);
 				return;
-			case DevResponsePackage.DATA__TIME:
-				setTime(TIME_EDEFAULT);
-				return;
 			case DevResponsePackage.DATA__FORCED:
 				setForced(FORCED_EDEFAULT);
 				return;
@@ -263,8 +213,6 @@ public class DataImpl extends EObjectImpl implements Data {
 		switch (featureID) {
 			case DevResponsePackage.DATA__VALUE:
 				return VALUE_EDEFAULT == null ? value != null : !VALUE_EDEFAULT.equals(value);
-			case DevResponsePackage.DATA__TIME:
-				return TIME_EDEFAULT == null ? time != null : !TIME_EDEFAULT.equals(time);
 			case DevResponsePackage.DATA__FORCED:
 				return FORCED_EDEFAULT == null ? forced != null : !FORCED_EDEFAULT.equals(forced);
 			default:
@@ -279,13 +227,13 @@ public class DataImpl extends EObjectImpl implements Data {
 	 */
 	@Override
 	public String toString() {
-		if (eIsProxy()) return super.toString();
+		if (eIsProxy()) {
+			return super.toString();
+		}
 
 		StringBuilder result = new StringBuilder(super.toString());
 		result.append(" (value: "); //$NON-NLS-1$
 		result.append(value);
-		result.append(", time: "); //$NON-NLS-1$
-		result.append(time);
 		result.append(", forced: "); //$NON-NLS-1$
 		result.append(forced);
 		result.append(')');

--- a/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/impl/DevResponsePackageImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/impl/DevResponsePackageImpl.java
@@ -1,7 +1,7 @@
 /**
  * ******************************************************************************
  * * Copyright (c) 2012, 2013, 2018 Profactor GmbH, fortiss GmbH, Johannes Kepler University
- * * 
+ * *
  * * This program and the accompanying materials are made available under the
  * * terms of the Eclipse Public License 2.0 which is available at
  * * http://www.eclipse.org/legal/epl-2.0.
@@ -13,9 +13,11 @@
  * *     - initial API and implementation and/or initial documentation
  * *   Alois Zoitl - moved to deployment and reworked it to a device response model
  * ******************************************************************************
- * 
+ *
  */
 package org.eclipse.fordiac.ide.deployment.devResponse.impl;
+
+import static org.eclipse.fordiac.ide.deployment.devResponse.DevResponsePackage.RESOURCE;
 
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
@@ -142,7 +144,9 @@ public class DevResponsePackageImpl extends EPackageImpl implements DevResponseP
 	 * @generated
 	 */
 	public static DevResponsePackage init() {
-		if (isInited) return (DevResponsePackage)EPackage.Registry.INSTANCE.getEPackage(DevResponsePackage.eNS_URI);
+		if (isInited) {
+			return (DevResponsePackage)EPackage.Registry.INSTANCE.getEPackage(DevResponsePackage.eNS_URI);
+		}
 
 		// Obtain or create and register package
 		Object registeredDevResponsePackage = EPackage.Registry.INSTANCE.get(eNS_URI);
@@ -300,18 +304,8 @@ public class DevResponsePackageImpl extends EPackageImpl implements DevResponseP
 	 * @generated
 	 */
 	@Override
-	public EAttribute getData_Time() {
-		return (EAttribute)dataEClass.getEStructuralFeatures().get(1);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	@Override
 	public EAttribute getData_Forced() {
-		return (EAttribute)dataEClass.getEStructuralFeatures().get(2);
+		return (EAttribute)dataEClass.getEStructuralFeatures().get(1);
 	}
 
 	/**
@@ -499,7 +493,9 @@ public class DevResponsePackageImpl extends EPackageImpl implements DevResponseP
 	 * @generated
 	 */
 	public void createPackageContents() {
-		if (isCreated) return;
+		if (isCreated) {
+			return;
+		}
 		isCreated = true;
 
 		// Create classes and their features
@@ -519,7 +515,6 @@ public class DevResponsePackageImpl extends EPackageImpl implements DevResponseP
 
 		dataEClass = createEClass(DATA);
 		createEAttribute(dataEClass, DATA__VALUE);
-		createEAttribute(dataEClass, DATA__TIME);
 		createEAttribute(dataEClass, DATA__FORCED);
 
 		responseEClass = createEClass(RESPONSE);
@@ -559,7 +554,9 @@ public class DevResponsePackageImpl extends EPackageImpl implements DevResponseP
 	 * @generated
 	 */
 	public void initializePackageContents() {
-		if (isInitialized) return;
+		if (isInitialized) {
+			return;
+		}
 		isInitialized = true;
 
 		// Initialize package
@@ -590,7 +587,6 @@ public class DevResponsePackageImpl extends EPackageImpl implements DevResponseP
 
 		initEClass(dataEClass, Data.class, "Data", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEAttribute(getData_Value(), ecorePackage.getEString(), "value", null, 0, 1, Data.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
-		initEAttribute(getData_Time(), ecorePackage.getEString(), "time", null, 0, 1, Data.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEAttribute(getData_Forced(), ecorePackage.getEString(), "forced", null, 0, 1, Data.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(responseEClass, Response.class, "Response", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$


### PR DESCRIPTION
As 4diac FORTE is not sending timestamps with events anymore and as we are not using them they are removed from the model.