### PR TITLE
Refactoring: Moved isContainedInTypedInstance() to super class

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/model/fordiac.genmodel
+++ b/plugins/org.eclipse.fordiac.ide.model/model/fordiac.genmodel
@@ -478,8 +478,6 @@
           body="final org.eclipse.emf.ecore.EObject parent = this.eContainer();&#xA;if (parent == null) {&#xA;&#x9;return false;&#xA;}&#xA;final org.eclipse.emf.ecore.EObject grandParent = parent.eContainer();&#xA;if (grandParent == null) {&#xA;&#x9;return false;&#xA;}&#xA;return grandParent instanceof org.eclipse.fordiac.ide.model.libraryElement.SubApp;"/>
       <genOperations ecoreOperation="lib.ecore#//FBNetworkElement/getOuterFBNetworkElement"
           body="&#x9;&#x9;if ((this.eContainer() == null) || !(this.eContainer().eContainer() instanceof FBNetworkElement)) {&#xA;&#x9;&#x9;&#x9;return null;&#xA;&#x9;&#x9;}&#xA;&#x9;&#x9;return (FBNetworkElement) this.eContainer().eContainer();"/>
-      <genOperations ecoreOperation="lib.ecore#//FBNetworkElement/isContainedInTypedInstance"
-          body="return org.eclipse.fordiac.ide.model.helpers.FBNetworkElementHelper.isContainedInTypedInstance(this);"/>
       <genOperations ecoreOperation="lib.ecore#//FBNetworkElement/isInGroup" body="return org.eclipse.fordiac.ide.model.annotations.FBNetworkElementAnnotations.isInGroup(this);"/>
       <genOperations ecoreOperation="lib.ecore#//FBNetworkElement/validateName" body="return org.eclipse.fordiac.ide.model.libraryElement.impl.FBNetworkElementAnnotations.validateName(this, diagnostics, context);">
         <genParameters ecoreParameter="lib.ecore#//FBNetworkElement/validateName/diagnostics"/>
@@ -632,6 +630,8 @@
         <genParameters ecoreParameter="lib.ecore#//ITypedElement/validateType/diagnostics"/>
         <genParameters ecoreParameter="lib.ecore#//ITypedElement/validateType/context"/>
       </genOperations>
+      <genOperations ecoreOperation="lib.ecore#//ITypedElement/isContainedInTypedInstance"
+          body="return org.eclipse.fordiac.ide.model.helpers.FBNetworkElementHelper.isContainedInTypedInstance(this);"/>
     </genClasses>
     <genClasses image="false" ecoreClass="lib.ecore#//IVarElement">
       <genFeatures property="None" createChild="true" ecoreFeature="ecore:EReference lib.ecore#//IVarElement/varDeclarations"/>

--- a/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
+++ b/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
@@ -1260,11 +1260,6 @@
         <details key="body" value="&#x9;&#x9;if ((this.eContainer() == null) || !(this.eContainer().eContainer() instanceof FBNetworkElement)) {&#xA;&#x9;&#x9;&#x9;return null;&#xA;&#x9;&#x9;}&#xA;&#x9;&#x9;return (FBNetworkElement) this.eContainer().eContainer();"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="isContainedInTypedInstance" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Boolean">
-      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
-        <details key="body" value="return org.eclipse.fordiac.ide.model.helpers.FBNetworkElementHelper.isContainedInTypedInstance(this);"/>
-      </eAnnotations>
-    </eOperations>
     <eOperations name="isInGroup" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Boolean">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.model.annotations.FBNetworkElementAnnotations.isInGroup(this);"/>
@@ -1736,6 +1731,11 @@
           <eTypeArguments eClassifier="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EJavaObject"/>
         </eGenericType>
       </eParameters>
+    </eOperations>
+    <eOperations name="isContainedInTypedInstance" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="body" value="return org.eclipse.fordiac.ide.model.helpers.FBNetworkElementHelper.isContainedInTypedInstance(this);"/>
+      </eAnnotations>
     </eOperations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="IVarElement" abstract="true" interface="true">

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/FBNetworkElement.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/FBNetworkElement.java
@@ -185,14 +185,6 @@ public interface FBNetworkElement extends TypedConfigureableObject, Positionable
 	 * @model kind="operation" dataType="org.eclipse.emf.ecore.xml.type.Boolean"
 	 * @generated
 	 */
-	boolean isContainedInTypedInstance();
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @model kind="operation" dataType="org.eclipse.emf.ecore.xml.type.Boolean"
-	 * @generated
-	 */
 	boolean isInGroup();
 
 	/**

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/ITypedElement.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/ITypedElement.java
@@ -63,4 +63,12 @@ public interface ITypedElement extends INamedElement {
 	 */
 	boolean validateType(DiagnosticChain diagnostics, Map<Object, Object> context);
 
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @model kind="operation" dataType="org.eclipse.emf.ecore.xml.type.Boolean"
+	 * @generated
+	 */
+	boolean isContainedInTypedInstance();
+
 } // ITypedElement

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/AdapterDeclarationImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/AdapterDeclarationImpl.java
@@ -534,6 +534,16 @@ public class AdapterDeclarationImpl extends EObjectImpl implements AdapterDeclar
 	 * @generated
 	 */
 	@Override
+	public boolean isContainedInTypedInstance() {
+		return org.eclipse.fordiac.ide.model.helpers.FBNetworkElementHelper.isContainedInTypedInstance(this);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public void setVisible(final boolean visible) {
 		org.eclipse.fordiac.ide.model.annotations.HiddenElementAnnotations.setVisible(this,visible);
 	}

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/AttributeDeclarationImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/AttributeDeclarationImpl.java
@@ -711,6 +711,16 @@ public class AttributeDeclarationImpl extends EObjectImpl implements AttributeDe
 	 * @generated
 	 */
 	@Override
+	public boolean isContainedInTypedInstance() {
+		return org.eclipse.fordiac.ide.model.helpers.FBNetworkElementHelper.isContainedInTypedInstance(this);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public Object eGet(int featureID, boolean resolve, boolean coreType) {
 		switch (featureID) {
 			case LibraryElementPackage.ATTRIBUTE_DECLARATION__NAME:

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/AttributeImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/AttributeImpl.java
@@ -368,6 +368,16 @@ public class AttributeImpl extends EObjectImpl implements Attribute {
 	 * @generated
 	 */
 	@Override
+	public boolean isContainedInTypedInstance() {
+		return org.eclipse.fordiac.ide.model.helpers.FBNetworkElementHelper.isContainedInTypedInstance(this);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public Stream<INamedElement> findBySimpleName(final String name) {
 		return org.eclipse.fordiac.ide.model.libraryElement.impl.NamedElementAnnotations.findBySimpleName(this, name);
 	}

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/ErrorMarkerInterfaceImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/ErrorMarkerInterfaceImpl.java
@@ -425,6 +425,16 @@ public class ErrorMarkerInterfaceImpl extends EObjectImpl implements ErrorMarker
 	 * @generated
 	 */
 	@Override
+	public boolean isContainedInTypedInstance() {
+		return org.eclipse.fordiac.ide.model.helpers.FBNetworkElementHelper.isContainedInTypedInstance(this);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public Value getValue() {
 		if (value != null && value.eIsProxy()) {
 			InternalEObject oldValue = (InternalEObject)value;

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/EventImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/EventImpl.java
@@ -480,6 +480,16 @@ public class EventImpl extends EObjectImpl implements Event {
 	 * @generated
 	 */
 	@Override
+	public boolean isContainedInTypedInstance() {
+		return org.eclipse.fordiac.ide.model.helpers.FBNetworkElementHelper.isContainedInTypedInstance(this);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public void setVisible(final boolean visible) {
 		org.eclipse.fordiac.ide.model.annotations.HiddenElementAnnotations.setVisible(this,visible);
 	}

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/FBNetworkElementImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/FBNetworkElementImpl.java
@@ -474,16 +474,6 @@ public abstract class FBNetworkElementImpl extends TypedConfigureableObjectImpl 
 	 * @generated
 	 */
 	@Override
-	public boolean isContainedInTypedInstance() {
-		return org.eclipse.fordiac.ide.model.helpers.FBNetworkElementHelper.isContainedInTypedInstance(this);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	@Override
 	public boolean isInGroup() {
 		return org.eclipse.fordiac.ide.model.annotations.FBNetworkElementAnnotations.isInGroup(this);
 	}

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
@@ -4957,8 +4957,6 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 
 		addEOperation(fbNetworkElementEClass, this.getFBNetworkElement(), "getOuterFBNetworkElement", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(fbNetworkElementEClass, theXMLTypePackage.getBoolean(), "isContainedInTypedInstance", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
-
 		addEOperation(fbNetworkElementEClass, theXMLTypePackage.getBoolean(), "isInGroup", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		op = addEOperation(fbNetworkElementEClass, ecorePackage.getEBoolean(), "validateName", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
@@ -5163,6 +5161,8 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 		g2 = createEGenericType(ecorePackage.getEJavaObject());
 		g1.getETypeArguments().add(g2);
 		addEParameter(op, g1, "context", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+
+		addEOperation(iTypedElementEClass, theXMLTypePackage.getBoolean(), "isContainedInTypedInstance", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(iVarElementEClass, IVarElement.class, "IVarElement", IS_ABSTRACT, IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getIVarElement_VarDeclarations(), this.getVarDeclaration(), null, "varDeclarations", null, 0, -1, IVarElement.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
@@ -6306,7 +6306,7 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 			   "invariant", "true" //$NON-NLS-1$ //$NON-NLS-2$
 		   });
 		addAnnotation
-		  (fbNetworkElementEClass.getEOperations().get(11),
+		  (fbNetworkElementEClass.getEOperations().get(10),
 		   source,
 		   new String[] {
 			   "invariant", "true" //$NON-NLS-1$ //$NON-NLS-2$

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/TypedConfigureableObjectImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/TypedConfigureableObjectImpl.java
@@ -381,6 +381,16 @@ public class TypedConfigureableObjectImpl extends EObjectImpl implements TypedCo
 	 * @generated
 	 */
 	@Override
+	public boolean isContainedInTypedInstance() {
+		return org.eclipse.fordiac.ide.model.helpers.FBNetworkElementHelper.isContainedInTypedInstance(this);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
 		switch (featureID) {
 			case LibraryElementPackage.TYPED_CONFIGUREABLE_OBJECT__ATTRIBUTES:

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/VarDeclarationImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/VarDeclarationImpl.java
@@ -708,6 +708,16 @@ public class VarDeclarationImpl extends EObjectImpl implements VarDeclaration {
 	 * @generated
 	 */
 	@Override
+	public boolean isContainedInTypedInstance() {
+		return org.eclipse.fordiac.ide.model.helpers.FBNetworkElementHelper.isContainedInTypedInstance(this);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public void setVisible(final boolean visible) {
 		org.eclipse.fordiac.ide.model.annotations.HiddenElementAnnotations.setVisible(this,visible);
 	}

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STVarDeclarationImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STVarDeclarationImpl.java
@@ -566,6 +566,16 @@ public class STVarDeclarationImpl extends MinimalEObjectImpl.Container implement
 	 * @generated
 	 */
 	@Override
+	public boolean isContainedInTypedInstance() {
+		return org.eclipse.fordiac.ide.model.helpers.FBNetworkElementHelper.isContainedInTypedInstance(this);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public String getQualifiedName() {
 		return org.eclipse.fordiac.ide.model.libraryElement.impl.NamedElementAnnotations.getQualifiedName(this);
 	}


### PR DESCRIPTION
We might want to check all elements which can be part of an FBnetwork if they are inside a TypedSubappInstance