### PR TITLE
Rework watch error handling to avoid race condition in monitoring

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/DeploymentDebugDevice.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/DeploymentDebugDevice.java
@@ -90,7 +90,8 @@ public class DeploymentDebugDevice extends DeploymentDebugElement implements IDe
 
 	protected void terminated() {
 		DebugPlugin.getDefault().getBreakpointManager().removeBreakpointListener(this);
-		incrementVariableUpdateCount(); // mark watch values as stale
+		incrementVariableUpdateCount();
+		watches.values().forEach(IWatch::disconnected);
 		getPrimaryDebugTarget().updateWatches(false);
 		fireTerminateEvent();
 	}

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/Messages.java
@@ -21,6 +21,7 @@ public class Messages extends NLS {
 	public static String AbstractRuntimeWatch_RemoveWatch;
 	public static String AbstractVariableWatch_Disconnected;
 	public static String AbstractVariableWatch_ElementNotInResource;
+	public static String AbstractVariableWatch_InconsistentValues;
 	public static String AbstractVariableWatch_InvalidValue;
 	public static String AbstractVariableWatch_NoValue;
 	public static String AbstractVariableWatch_UnknownError;

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/messages.properties
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/messages.properties
@@ -2,6 +2,7 @@ AbstractRuntimeWatch_AddWatch=Cannot add watch {0}
 AbstractRuntimeWatch_RemoveWatch=Cannot remove watch {0}
 AbstractVariableWatch_Disconnected=Disconnected
 AbstractVariableWatch_ElementNotInResource=The watched element {0} is not contained in a resource
+AbstractVariableWatch_InconsistentValues=Inconsistent values
 AbstractVariableWatch_InvalidValue=Invalid value: {0}
 AbstractVariableWatch_NoValue=No value
 AbstractVariableWatch_UnknownError=Unknown

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/AbstractContainerWatch.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/AbstractContainerWatch.java
@@ -62,8 +62,8 @@ public abstract class AbstractContainerWatch extends DeploymentDebugElement impl
 	}
 
 	@Override
-	public boolean isAlive() {
-		return getSubWatches().stream().allMatch(IWatch::isAlive);
+	public void disconnected() {
+		getSubWatches().forEach(IWatch::disconnected);
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/AbstractRuntimeWatch.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/AbstractRuntimeWatch.java
@@ -74,11 +74,14 @@ public abstract class AbstractRuntimeWatch extends AbstractVariableWatch {
 	public final void updateValue(final DeploymentDebugWatchData watchData) {
 		final Resource resource = getResource();
 		if (resource == null) {
+			setError(Messages.AbstractVariableWatch_NoValue);
 			return; // silently ignore
 		}
 		final Data data = watchData.getLastData(resource, getResourceRelativeName());
 		if (data != null) {
 			updateValue(data);
+		} else {
+			setError(Messages.AbstractVariableWatch_NoValue);
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/AbstractVariableWatch.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/AbstractVariableWatch.java
@@ -31,9 +31,8 @@ public abstract class AbstractVariableWatch extends DeploymentDebugVariable impl
 
 	private final Resource resource;
 	private final ITypedElement element;
-	private long aliveCount;
-	private String invalidValue;
-	private DeploymentDebugErrorValue cachedErrorValue;
+	private boolean error;
+	private DeploymentDebugErrorValue errorValue;
 	private boolean pinned;
 	private Source source = Source.BREAKPOINT;
 
@@ -51,61 +50,49 @@ public abstract class AbstractVariableWatch extends DeploymentDebugVariable impl
 
 	@Override
 	public IEvaluatorDebugValue getValue() {
-		if (hasError()) {
-			return getErrorValue();
+		if (error) {
+			return errorValue;
 		}
 		return super.getValue();
 	}
 
 	protected void updateValue(final String value) {
-		aliveCount = getDebugTarget().getVariableUpdateCount();
 		try {
 			getInternalVariable().setValue(value, getDebugTarget().getTypeLibrary());
-			invalidValue = null;
+			clearError();
 		} catch (final Exception e) {
-			invalidValue = value;
+			setError(MessageFormat.format(Messages.AbstractVariableWatch_InvalidValue, value));
 		}
 	}
 
 	protected void updateValue(final Value value) {
-		aliveCount = getDebugTarget().getVariableUpdateCount();
 		try {
 			getInternalVariable().setValue(value);
-			invalidValue = null;
+			clearError();
 		} catch (final Exception e) {
-			invalidValue = value.toString();
+			setError(MessageFormat.format(Messages.AbstractVariableWatch_InvalidValue, value.toString()));
 		}
 	}
 
 	@Override
-	public boolean isAlive() {
-		return aliveCount == getDebugTarget().getVariableUpdateCount();
+	public void disconnected() {
+		setError(Messages.AbstractVariableWatch_Disconnected);
 	}
 
 	@Override
 	public boolean hasError() {
-		return !isAlive() || invalidValue != null;
+		return error;
 	}
 
-	protected IEvaluatorDebugValue getErrorValue() {
-		final String errorMessage = getErrorMessage();
-		if (cachedErrorValue == null || !cachedErrorValue.getMessage().equals(errorMessage)) {
-			cachedErrorValue = new DeploymentDebugErrorValue(errorMessage, getDebugTarget());
+	protected void setError(final String message) {
+		if (errorValue == null || !errorValue.getMessage().equals(message)) {
+			errorValue = new DeploymentDebugErrorValue(message, getDebugTarget());
 		}
-		return cachedErrorValue;
+		error = true;
 	}
 
-	protected String getErrorMessage() {
-		if (!isAlive()) {
-			if (!getDebugTarget().isAlive()) {
-				return Messages.AbstractVariableWatch_Disconnected;
-			}
-			return Messages.AbstractVariableWatch_NoValue;
-		}
-		if (invalidValue != null) {
-			return MessageFormat.format(Messages.AbstractVariableWatch_InvalidValue, invalidValue);
-		}
-		return Messages.AbstractVariableWatch_UnknownError;
+	protected void clearError() {
+		error = false;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/AbstractVirtualWatch.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/AbstractVirtualWatch.java
@@ -17,6 +17,7 @@ import java.util.SequencedSet;
 
 import org.eclipse.debug.core.DebugException;
 import org.eclipse.fordiac.ide.deployment.debug.DeploymentDebugDevice;
+import org.eclipse.fordiac.ide.deployment.debug.Messages;
 import org.eclipse.fordiac.ide.model.eval.value.Value;
 import org.eclipse.fordiac.ide.model.eval.variable.Variable;
 import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement;
@@ -48,11 +49,13 @@ public abstract class AbstractVirtualWatch extends AbstractVariableWatch {
 	@Override
 	public void updateValue(final DeploymentDebugWatchData watchData) {
 		if (watches.isEmpty()) {
+			setError(Messages.AbstractVariableWatch_NoValue);
 			return;
 		}
 		for (final IWatch watch : watches) {
 			watch.updateValue(watchData);
 			if (watch.hasError()) {
+				setError(Messages.AbstractVariableWatch_NoValue);
 				return;
 			}
 		}

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/IWatch.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/IWatch.java
@@ -87,11 +87,9 @@ public interface IWatch extends IVariable, IDeploymentDebugElement {
 	void updateValue(DeploymentDebugWatchData watchData);
 
 	/**
-	 * Check if the watch was recently updated
-	 *
-	 * @return true if alive, false otherwise
+	 * Update the watch that the target has been disconnected
 	 */
-	boolean isAlive();
+	void disconnected();
 
 	/**
 	 * Check if the watch is in an error state

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/SubAppEventWatch.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/SubAppEventWatch.java
@@ -18,6 +18,7 @@ import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.model.IValue;
 import org.eclipse.fordiac.ide.deployment.debug.DeploymentDebugDevice;
 import org.eclipse.fordiac.ide.deployment.debug.DeploymentDebugElement;
+import org.eclipse.fordiac.ide.deployment.debug.Messages;
 import org.eclipse.fordiac.ide.model.data.EventType;
 import org.eclipse.fordiac.ide.model.eval.value.EventValue;
 import org.eclipse.fordiac.ide.model.eval.value.Value;
@@ -43,6 +44,8 @@ public class SubAppEventWatch extends AbstractSubAppInterfaceWatch implements IE
 			// all counts must be equal for input events (fan-out)
 			if (values.stream().distinct().count() == 1) {
 				updateValue(values.getFirst());
+			} else {
+				setError(Messages.AbstractVariableWatch_InconsistentValues);
 			}
 		} else {
 			// calculate sum of all counts for output events (fan-in)

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/SubAppVarDeclarationWatch.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/SubAppVarDeclarationWatch.java
@@ -17,6 +17,7 @@ import java.util.List;
 import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.model.IValue;
 import org.eclipse.fordiac.ide.deployment.debug.DeploymentDebugDevice;
+import org.eclipse.fordiac.ide.deployment.debug.Messages;
 import org.eclipse.fordiac.ide.model.eval.EvaluatorException;
 import org.eclipse.fordiac.ide.model.eval.value.AnyValue;
 import org.eclipse.fordiac.ide.model.eval.value.Value;
@@ -97,6 +98,8 @@ public class SubAppVarDeclarationWatch extends AbstractSubAppInterfaceWatch impl
 		// all values must be equal
 		if (values.stream().distinct().count() == 1) {
 			updateValue(values.getFirst());
+		} else {
+			setError(Messages.AbstractVariableWatch_InconsistentValues);
 		}
 	}
 


### PR DESCRIPTION
There was a potential race condition when the variable update count was incremeneted but the watches had not been updated and a previous UI update was still going through the watches. This could cause false positives when determining if a watch had errors, leading to a blinking effect.

This changes the watch error handling to explicitly update the error state and not rely on the variable update count. It also introduces a separate error message for inconsitent values on subapp interfaces.