### PR TITLE
Fix escaping of newline character in strings and chars

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/AbstractStringValueConverter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/AbstractStringValueConverter.java
@@ -156,7 +156,7 @@ public abstract class AbstractStringValueConverter implements ValueConverter<Str
 			}
 			break;
 		case '\n':
-			result.append("$N"); //$NON-NLS-1$
+			result.append("$L"); //$NON-NLS-1$
 			break;
 		case '\f':
 			result.append("$P"); //$NON-NLS-1$

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/value/ValueConverterTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/value/ValueConverterTest.java
@@ -184,7 +184,7 @@ class ValueConverterTest {
 				arguments(StringValueConverter.INSTANCE, "'4diac$'IDE'", NAME_ACUTE), //
 				arguments(StringValueConverter.INSTANCE, "'4diac\"IDE'", NAME_BACKSLASH), //
 				arguments(StringValueConverter.INSTANCE, NAME_TWO_DOLLAR, NAME_DOLLAR), //
-				arguments(StringValueConverter.INSTANCE, "'4diac$NIDE'", NAME_BACKSLASHN), //
+				arguments(StringValueConverter.INSTANCE, "'4diac$LIDE'", NAME_BACKSLASHN), //
 				arguments(StringValueConverter.INSTANCE, "'4diac$P$R$TIDE'", NAME_BACKSLASH_FRT), //
 				arguments(StringValueConverter.INSTANCE, "'4diac$00IDE'", "4diac\u0000IDE"), //
 				arguments(WStringValueConverter.INSTANCE, "\"\"", ""), //
@@ -192,7 +192,7 @@ class ValueConverterTest {
 				arguments(WStringValueConverter.INSTANCE, "\"4diac'IDE\"", NAME_ACUTE), //
 				arguments(WStringValueConverter.INSTANCE, "\"4diac$\"IDE\"", NAME_BACKSLASH), //
 				arguments(WStringValueConverter.INSTANCE, "\"4diac$$IDE\"", NAME_DOLLAR), //
-				arguments(WStringValueConverter.INSTANCE, "\"4diac$NIDE\"", NAME_BACKSLASHN), //
+				arguments(WStringValueConverter.INSTANCE, "\"4diac$LIDE\"", NAME_BACKSLASHN), //
 				arguments(WStringValueConverter.INSTANCE, "\"4diac$P$R$TIDE\"", NAME_BACKSLASH_FRT), //
 				arguments(WStringValueConverter.INSTANCE, "\"4diac$0000IDE\"", "4diac\u0000IDE"), //
 				arguments(new ArrayValueConverter<>(NumericValueConverter.INSTANCE), "[17, 4, 21, 42]",


### PR DESCRIPTION
Both `(W)STRING` and `(W)CHAR` escaped the character value `'\n'` to `$N` or *Newline*, which is an implementation-independent alias for the end of a line. This changes `'\n'` to escape to `$L` or *Line Feed* instead.

Related to https://github.com/eclipse-4diac/4diac-forte/issues/461