### PR TITLE
Added option to not search Linked Elements in Bulk Editor

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.bulkeditor/plugin.properties
+++ b/plugins/org.eclipse.fordiac.ide.bulkeditor/plugin.properties
@@ -33,6 +33,8 @@ SearchFor=Search For
 SearchWhere=Where
 SearchIn=In
 
+IgnoreLinkedLibraries=Ignore Linked Libraries
+
 FBandSubappTypes=FB and SubApp Types
 FBandSubappInstances=FB and Typed Subapp Instances
 UntypedSubapps=Untyped Subapps

--- a/plugins/org.eclipse.fordiac.ide.bulkeditor/src/org/eclipse/fordiac/ide/bulkeditor/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.bulkeditor/src/org/eclipse/fordiac/ide/bulkeditor/Messages.java
@@ -37,6 +37,8 @@ public final class Messages extends NLS {
 	public static String SearchWhere;
 	public static String SearchIn;
 
+	public static String IgnoreLinkedLibraries;
+
 	public static String FBandSubappTypes;
 	public static String FBandSubappInstances;
 	public static String UntypedSubapps;

--- a/plugins/org.eclipse.fordiac.ide.bulkeditor/src/org/eclipse/fordiac/ide/bulkeditor/editors/BulkEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.bulkeditor/src/org/eclipse/fordiac/ide/bulkeditor/editors/BulkEditor.java
@@ -74,8 +74,8 @@ import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.jface.widgets.WidgetFactory;
 import org.eclipse.nebula.widgets.nattable.NatTable;
 import org.eclipse.nebula.widgets.nattable.config.AbstractRegistryConfiguration;
+import org.eclipse.nebula.widgets.nattable.config.EditableRule;
 import org.eclipse.nebula.widgets.nattable.config.IConfigRegistry;
-import org.eclipse.nebula.widgets.nattable.config.IEditableRule;
 import org.eclipse.nebula.widgets.nattable.edit.EditConfigAttributes;
 import org.eclipse.nebula.widgets.nattable.edit.editor.TextCellEditor;
 import org.eclipse.nebula.widgets.nattable.layer.DataLayer;
@@ -120,6 +120,8 @@ public class BulkEditor extends EditorPart implements CommandExecutor, CommandSt
 	// Scope
 	private Button workspaceScopeButton;
 	private Button projectScopeButton;
+
+	private Button ignoreLinkedLibrariesButton;
 
 	// NatTable
 	private NatTable natTable;
@@ -208,6 +210,14 @@ public class BulkEditor extends EditorPart implements CommandExecutor, CommandSt
 		attributeTypesFilter = createSearchFilterInGroup(searchGroup, Messages.AttributeTypes,
 				BulkEditorSettings.inAttributeTypesSearchList, settings.attributeTypes,
 				b -> settings.attributeTypes = b.booleanValue());
+
+		ignoreLinkedLibrariesButton = WidgetFactory.button(SWT.CHECK).text(Messages.IgnoreLinkedLibraries)
+				.onSelect(event -> settings.ignoreLinkedLibraries = ignoreLinkedLibrariesButton.getSelection())
+				.create(searchGroup);
+		ignoreLinkedLibrariesButton.setSelection(settings.ignoreLinkedLibraries);
+		final GridData buttonData = new GridData(SWT.FILL, SWT.CENTER, true, false);
+		buttonData.verticalIndent = 10;
+		ignoreLinkedLibrariesButton.setLayoutData(buttonData);
 	}
 
 	private FilterComposite createSearchFilterInGroup(final Composite parent, final String name,
@@ -293,7 +303,8 @@ public class BulkEditor extends EditorPart implements CommandExecutor, CommandSt
 					new SearchHelper.FilterRecordClass(settings.attributeTypes,
 							attributeTypesFilter.getFilter(LIST_WITHOUT_VALUE.get(0)),
 							attributeTypesFilter.getFilter(LIST_WITHOUT_VALUE.get(1)),
-							attributeTypesFilter.getFilter(LIST_WITHOUT_VALUE.get(2))));
+							attributeTypesFilter.getFilter(LIST_WITHOUT_VALUE.get(2))),
+					ignoreLinkedLibrariesButton.getSelection());
 
 			final List<ISearchContext> contexts = helper.createSearchContextList(workspaceScopeButton.getSelection(),
 					projectScopeButton.getSelection(), project);
@@ -359,7 +370,7 @@ public class BulkEditor extends EditorPart implements CommandExecutor, CommandSt
 			final NatTableColumnProvider<VarDeclarationTableColumn> columnProvider = new NatTableColumnProvider<>(
 					VarDeclarationTableColumn.DEFAULT_COLUMNS_WITH_LOCATION);
 			natTable = NatTableWidgetFactory.createRowNatTable(parent, inputDataLayer, columnProvider,
-					new NatTableColumnEditableRule<>(IEditableRule.ALWAYS_EDITABLE,
+					new NatTableColumnEditableRule<>(new LinkedElementsEditableRule(varDeclProvider),
 							VarDeclarationTableColumn.DEFAULT_COLUMNS_WITH_LOCATION,
 							VarDeclarationTableColumn.EDITABLE_NO_LOCATION),
 					null, null, false);
@@ -375,7 +386,7 @@ public class BulkEditor extends EditorPart implements CommandExecutor, CommandSt
 			final NatTableColumnProvider<AttributeTableColumn> columnProvider = new NatTableColumnProvider<>(
 					AttributeTableColumn.DEFAULT_COLUMNS_WITH_LOCATION);
 			natTable = NatTableWidgetFactory.createRowNatTable(parent, dataLayer, columnProvider,
-					new AttributeEditableRule(IEditableRule.ALWAYS_EDITABLE,
+					new AttributeEditableRule(new LinkedElementsEditableRule(attributeProvider),
 							AttributeTableColumn.DEFAULT_COLUMNS_WITH_LOCATION,
 							AttributeTableColumn.EDITABLE_NO_LOCATION, attributeProvider),
 					new TypeSelectionButton(() -> {
@@ -489,6 +500,23 @@ public class BulkEditor extends EditorPart implements CommandExecutor, CommandSt
 					&& !ImportHelper.matchesImports(importProposal.getImportedNamespace(), libraryElement)) {
 				executeCommand(new AddNewImportCommand(libraryElement, importProposal.getImportedNamespace()));
 			}
+		}
+	}
+
+	private class LinkedElementsEditableRule extends EditableRule {
+		private final ChangeableListDataProvider<? extends EObject> provider;
+
+		public LinkedElementsEditableRule(final ChangeableListDataProvider<? extends EObject> provider) {
+			this.provider = provider;
+		}
+
+		@Override
+		public boolean isEditable(final int columnIndex, final int rowIndex) {
+			final var rootElement = EcoreUtil.getRootContainer(provider.getRowObject(rowIndex));
+			if (rootElement instanceof final LibraryElement libElement) {
+				return SearchHelper.linkedElementsFilter.test(libElement.getTypeEntry());
+			}
+			return true;
 		}
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.bulkeditor/src/org/eclipse/fordiac/ide/bulkeditor/editors/BulkEditorSettings.java
+++ b/plugins/org.eclipse.fordiac.ide.bulkeditor/src/org/eclipse/fordiac/ide/bulkeditor/editors/BulkEditorSettings.java
@@ -15,6 +15,7 @@ package org.eclipse.fordiac.ide.bulkeditor.editors;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -37,17 +38,19 @@ public class BulkEditorSettings {
 	public boolean attributeTypes = true;
 	private static final String SCOPE_TAG = "_scope"; //$NON-NLS-1$
 	public boolean projectScope = true;
+	private static final String LINKED_LIBRARIES_TAG = "_ignoreLinkedLibraries"; //$NON-NLS-1$
+	public boolean ignoreLinkedLibraries = true;
 
-	public static final List<String> whereSearchList = List.of("_where-name", "_where-type", "_where-comment",
-			"_where-value");
-	public static final List<String> inFBTypesSearchList = List.of("_inFBType-name", "_inFBType-type",
-			"_inFBType-comment");
-	public static final List<String> inFBInstanceSearchList = List.of("_inFBInstance-name", "_inFBInstance-type",
-			"_inFBInstance-comment");
-	public static final List<String> inUntypedSubAppSearchList = List.of("_inUntypedSubApp-name",
-			"_inUntypedSubApp-type", "_inUntypedSubApp-comment");
-	public static final List<String> inDataTypesSearchList = List.of("_inDT-name", "_inDT-type", "_inDT-comment");
-	public static final List<String> inAttributeTypesSearchList = List.of("_inAT-name", "_inAT-type", "_inAT-comment");
+	public static final List<String> whereSearchList = List.of("_where-name", "_where-type", "_where-comment", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			"_where-value"); //$NON-NLS-1$
+	public static final List<String> inFBTypesSearchList = List.of("_inFBType-name", "_inFBType-type", //$NON-NLS-1$ //$NON-NLS-2$
+			"_inFBType-comment"); //$NON-NLS-1$
+	public static final List<String> inFBInstanceSearchList = List.of("_inFBInstance-name", "_inFBInstance-type", //$NON-NLS-1$ //$NON-NLS-2$
+			"_inFBInstance-comment"); //$NON-NLS-1$
+	public static final List<String> inUntypedSubAppSearchList = List.of("_inUntypedSubApp-name", //$NON-NLS-1$
+			"_inUntypedSubApp-type", "_inUntypedSubApp-comment"); //$NON-NLS-1$ //$NON-NLS-2$
+	public static final List<String> inDataTypesSearchList = List.of("_inDT-name", "_inDT-type", "_inDT-comment"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+	public static final List<String> inAttributeTypesSearchList = List.of("_inAT-name", "_inAT-type", "_inAT-comment"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
 	private final Map<String, BulkEditorSubSettings> subSettingsMap = Stream
 			.of(whereSearchList, inFBTypesSearchList, inFBInstanceSearchList, inUntypedSubAppSearchList,
@@ -73,6 +76,7 @@ public class BulkEditorSettings {
 		childMemento.putBoolean(DATA_TYPES_TAG, dataTypes);
 		childMemento.putBoolean(ATTRIBUTE_TYPES_TAG, attributeTypes);
 		childMemento.putBoolean(SCOPE_TAG, projectScope);
+		childMemento.putBoolean(LINKED_LIBRARIES_TAG, ignoreLinkedLibraries);
 	}
 
 	public static BulkEditorSettings createFromMemento(final IMemento memento) {
@@ -80,13 +84,16 @@ public class BulkEditorSettings {
 		final IMemento childMemento = memento.getChild(TAG_BULKEDITOR_SETTINGS);
 
 		settings.subSettingsMap.values().forEach(subSetting -> subSetting.changeFromMemento(childMemento));
-		settings.modeSelection = childMemento.getInteger(MODE_TAG);
-		settings.fbSubappTypes = childMemento.getBoolean(FB_TYPES_TAG);
-		settings.fbTypedSubappInstance = childMemento.getBoolean(FB_INSTANCES_TAG);
-		settings.untypedSubapp = childMemento.getBoolean(UNTYPED_SUBAPPS_TAG);
-		settings.dataTypes = childMemento.getBoolean(DATA_TYPES_TAG);
-		settings.attributeTypes = childMemento.getBoolean(ATTRIBUTE_TYPES_TAG);
-		settings.projectScope = childMemento.getBoolean(SCOPE_TAG);
+		settings.modeSelection = Optional.ofNullable(memento.getInteger(MODE_TAG)).orElse(Integer.valueOf(0))
+				.intValue();
+		// !Boolean.FALSE.equals for null check with true as fallback value
+		settings.fbSubappTypes = !Boolean.FALSE.equals(childMemento.getBoolean(FB_TYPES_TAG));
+		settings.fbTypedSubappInstance = !Boolean.FALSE.equals(childMemento.getBoolean(FB_INSTANCES_TAG));
+		settings.untypedSubapp = !Boolean.FALSE.equals(childMemento.getBoolean(UNTYPED_SUBAPPS_TAG));
+		settings.dataTypes = !Boolean.FALSE.equals(childMemento.getBoolean(DATA_TYPES_TAG));
+		settings.attributeTypes = !Boolean.FALSE.equals(childMemento.getBoolean(ATTRIBUTE_TYPES_TAG));
+		settings.projectScope = !Boolean.FALSE.equals(childMemento.getBoolean(SCOPE_TAG));
+		settings.ignoreLinkedLibraries = !Boolean.FALSE.equals(childMemento.getBoolean(LINKED_LIBRARIES_TAG));
 
 		return settings;
 	}
@@ -124,12 +131,12 @@ public class BulkEditorSettings {
 
 		public void changeFromMemento(final IMemento memento) {
 			final IMemento childMemento = memento.getChild(tagBulkEditorSubSettings);
-			selected = childMemento.getBoolean(SELECTED_TAG);
+			selected = Boolean.TRUE.equals(childMemento.getBoolean(SELECTED_TAG));
 			textField = childMemento.getString(NAME_TAG);
-			caseSensitive = childMemento.getBoolean(CASE_SENSITIVE_TAG);
-			wholeWord = childMemento.getBoolean(WHOLE_WORD_TAG);
-			exactMatch = childMemento.getBoolean(EXACT_MATCH_TAG);
-			regularExpression = childMemento.getBoolean(REGULAR_EXPRESSION_TAG);
+			caseSensitive = Boolean.TRUE.equals(childMemento.getBoolean(CASE_SENSITIVE_TAG));
+			wholeWord = Boolean.TRUE.equals(childMemento.getBoolean(WHOLE_WORD_TAG));
+			exactMatch = Boolean.TRUE.equals(childMemento.getBoolean(EXACT_MATCH_TAG));
+			regularExpression = Boolean.TRUE.equals(childMemento.getBoolean(REGULAR_EXPRESSION_TAG));
 		}
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.bulkeditor/src/org/eclipse/fordiac/ide/bulkeditor/editors/SearchHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.bulkeditor/src/org/eclipse/fordiac/ide/bulkeditor/editors/SearchHelper.java
@@ -52,8 +52,16 @@ import org.eclipse.fordiac.ide.model.search.types.SearchChildrenProviderHelper;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
 
-// TODO cleanup, rename class and record, better way to handle paramters
 public class SearchHelper {
+	public static final Predicate<TypeEntry> linkedElementsFilter = entry -> {
+		for (final String segment : entry.getFile().getFullPath().segments()) {
+			if (segment.equals("External Libraries") || segment.equals("Standard Libraries")) { //$NON-NLS-1$ //$NON-NLS-2$
+				return false;
+			}
+		}
+		return true;
+	};
+
 	public static class FilterRecordClass {
 		private final boolean selected;
 
@@ -83,16 +91,19 @@ public class SearchHelper {
 	final FilterRecordClass untypedSubappRecord;
 	final FilterRecordClass dataTypesRecord;
 	final FilterRecordClass attributeTypesRecord;
+	final boolean ignoreLinkedLibraries;
 
 	public SearchHelper(final FilterRecordClass fbSubappTypesRecord,
 			final FilterRecordClass fbTypedSubappInstanceRecord, final FilterRecordClass untypedSubappRecord,
-			final FilterRecordClass dataTypesRecord, final FilterRecordClass attributeTypesRecord) {
+			final FilterRecordClass dataTypesRecord, final FilterRecordClass attributeTypesRecord,
+			final boolean ignoreLinkedLibraries) {
 
 		this.fbSubappTypesRecord = fbSubappTypesRecord;
 		this.fbTypedSubappInstanceRecord = fbTypedSubappInstanceRecord;
 		this.untypedSubappRecord = untypedSubappRecord;
 		this.dataTypesRecord = dataTypesRecord;
 		this.attributeTypesRecord = attributeTypesRecord;
+		this.ignoreLinkedLibraries = ignoreLinkedLibraries;
 	}
 
 	public List<ISearchContext> createSearchContextList(final boolean workspace, final boolean project,
@@ -110,10 +121,9 @@ public class SearchHelper {
 
 	private ISearchContext createSearchContext(final IProject project) {
 		return new AbstractLiveSearchContext(project) {
-
 			@Override
 			public Stream<URI> getTypes() {
-				Stream<URI> s = Stream.empty();
+				Stream<TypeEntry> s = Stream.empty();
 				if (fbSubappTypesRecord.selected) {
 					final Predicate<TypeEntry> filter = entry -> (matchesString(entry.getFullTypeName(),
 							fbSubappTypesRecord.nameFilter, fbSubappTypesRecord.namePattern)
@@ -121,12 +131,11 @@ public class SearchHelper {
 									fbSubappTypesRecord.typePattern)
 							&& matchesString(entry.getComment(), fbSubappTypesRecord.commentFilter,
 									fbSubappTypesRecord.commentPattern));
-					s = Stream.concat(s,
-							Stream.concat(getTypelib().getFbTypes().stream().filter(filter).map(TypeEntry::getURI),
-									getTypelib().getSubAppTypes().stream().filter(filter).map(TypeEntry::getURI)));
+					s = Stream.concat(s, Stream.concat(getTypelib().getFbTypes().stream().filter(filter),
+							getTypelib().getSubAppTypes().stream().filter(filter)));
 				}
 				if (fbTypedSubappInstanceRecord.selected || untypedSubappRecord.selected) {
-					s = Stream.concat(s, getTypelib().getSystems().stream().map(TypeEntry::getURI));
+					s = Stream.concat(s, getTypelib().getSystems().stream());
 				}
 				if (dataTypesRecord.selected) {
 					s = Stream.concat(s,
@@ -136,8 +145,7 @@ public class SearchHelper {
 											&& matchesString(dtEntry.getTypeName(), dataTypesRecord.typeFilter,
 													dataTypesRecord.typePattern)
 											&& matchesString(dtEntry.getComment(), dataTypesRecord.commentFilter,
-													dataTypesRecord.commentPattern)))
-									.map(TypeEntry::getURI));
+													dataTypesRecord.commentPattern))));
 				}
 				if (attributeTypesRecord.selected) {
 					s = Stream.concat(s,
@@ -147,10 +155,12 @@ public class SearchHelper {
 											&& matchesString(atEntry.getTypeName(), attributeTypesRecord.typeFilter,
 													attributeTypesRecord.typePattern)
 											&& matchesString(atEntry.getComment(), attributeTypesRecord.commentFilter,
-													attributeTypesRecord.commentPattern)))
-									.map(TypeEntry::getURI));
+													attributeTypesRecord.commentPattern))));
 				}
-				return s.filter(Objects::nonNull);
+				if (ignoreLinkedLibraries) {
+					s = s.filter(linkedElementsFilter);
+				}
+				return s.map(TypeEntry::getURI).filter(Objects::nonNull);
 			}
 
 			@Override


### PR DESCRIPTION
If Option is check, types of Linked Libraries are not search, but instances of them are
If the option is not checked, Linked Library elements are shown but not editable