### PR TITLE
Reorganize ST preference and property pages

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/plugin.xml
@@ -89,9 +89,10 @@
 	<extension
 			point="org.eclipse.ui.preferencePages">
 		<page
+			category="org.eclipse.fordiac.ide.structuredtextcore.STCore"
 			class="org.eclipse.fordiac.ide.globalconstantseditor.ui.GlobalConstantsExecutableExtensionFactory:org.eclipse.xtext.ui.editor.preferences.LanguageRootPreferencePage"
 			id="org.eclipse.fordiac.ide.globalconstantseditor.GlobalConstants"
-			name="GlobalConstants">
+			name="Constants">
 			<keywordReference id="org.eclipse.fordiac.ide.globalconstantseditor.ui.keyword_GlobalConstants"/>
 		</page>
 		<page
@@ -112,9 +113,10 @@
 	<extension
 			point="org.eclipse.ui.propertyPages">
 		<page
+			category="org.eclipse.fordiac.ide.structuredtextcore.STCore"
 			class="org.eclipse.fordiac.ide.globalconstantseditor.ui.GlobalConstantsExecutableExtensionFactory:org.eclipse.xtext.ui.editor.preferences.LanguageRootPreferencePage"
 			id="org.eclipse.fordiac.ide.globalconstantseditor.GlobalConstants"
-			name="GlobalConstants">
+			name="Constants">
 			<keywordReference id="org.eclipse.fordiac.ide.globalconstantseditor.ui.keyword_GlobalConstants"/>
 			<enabledWhen>
 				<adapt type="org.eclipse.core.resources.IProject"/>
@@ -290,28 +292,6 @@
 		<participant
 			class="org.eclipse.fordiac.ide.globalconstantseditor.ui.GlobalConstantsExecutableExtensionFactory:org.eclipse.xtext.builder.IXtextBuilderParticipant"
 			fileExtensions="globalconsts"/>
-	</extension>
-	<extension point="org.eclipse.ui.preferencePages">
-		<page
-			category="org.eclipse.fordiac.ide.globalconstantseditor.GlobalConstants"
-			class="org.eclipse.fordiac.ide.globalconstantseditor.ui.GlobalConstantsExecutableExtensionFactory:org.eclipse.xtext.builder.preferences.BuilderPreferencePage"
-			id="org.eclipse.fordiac.ide.globalconstantseditor.GlobalConstants.compiler.preferencePage"
-			name="Compiler">
-			<keywordReference id="org.eclipse.fordiac.ide.globalconstantseditor.ui.keyword_GlobalConstants"/>
-		</page>
-	</extension>
-	<extension point="org.eclipse.ui.propertyPages">
-		<page
-			category="org.eclipse.fordiac.ide.globalconstantseditor.GlobalConstants"
-			class="org.eclipse.fordiac.ide.globalconstantseditor.ui.GlobalConstantsExecutableExtensionFactory:org.eclipse.xtext.builder.preferences.BuilderPreferencePage"
-			id="org.eclipse.fordiac.ide.globalconstantseditor.GlobalConstants.compiler.propertyPage"
-			name="Compiler">
-			<keywordReference id="org.eclipse.fordiac.ide.globalconstantseditor.ui.keyword_GlobalConstants"/>
-			<enabledWhen>
-				<adapt type="org.eclipse.core.resources.IProject"/>
-			</enabledWhen>
-			<filter name="projectNature" value="org.eclipse.xtext.ui.shared.xtextNature"/>
-		</page>
 	</extension>
 	<extension point="org.eclipse.ui.menus">
 		<menuContribution locationURI="popup:#TextEditorContext?after=xtext.ui.openDeclaration">

--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/plugin.xml
@@ -486,7 +486,7 @@
     <page
           category="org.eclipse.fordiac.ide.globalconstantseditor.GlobalConstants"
           class="org.eclipse.fordiac.ide.globalconstantseditor.ui.GlobalConstantsExecutableExtensionFactory:org.eclipse.fordiac.ide.structuredtextcore.ui.cleanup.STCoreSaveActionsPreferencePage"
-          id="oorg.eclipse.fordiac.ide.globalconstantseditor.GlobalConstants.saveActions"
+          id="org.eclipse.fordiac.ide.globalconstantseditor.GlobalConstants.saveActions.preferencePage"
           name="Save Actions">
        <keywordReference
              id="org.eclipse.fordiac.ide.globalconstantseditor.ui.keyword_GlobalConstants">
@@ -495,11 +495,32 @@
     <page
           category="org.eclipse.fordiac.ide.globalconstantseditor.GlobalConstants"
           class="org.eclipse.fordiac.ide.globalconstantseditor.ui.GlobalConstantsExecutableExtensionFactory:org.eclipse.fordiac.ide.structuredtextcore.ui.editor.STCoreEditorPreferencePage"
-          id="oorg.eclipse.fordiac.ide.globalconstantseditor.ui.editor"
+          id="org.eclipse.fordiac.ide.globalconstantseditor.ui.editor"
           name="Editor">
        <keywordReference
              id="org.eclipse.fordiac.ide.structuredtextcore.ui.keyword_STCore">
        </keywordReference>
+    </page>
+ </extension>
+ <extension
+       point="org.eclipse.ui.propertyPages">
+    <page
+          category="org.eclipse.fordiac.ide.globalconstantseditor.GlobalConstants"
+          class="org.eclipse.fordiac.ide.globalconstantseditor.ui.GlobalConstantsExecutableExtensionFactory:org.eclipse.fordiac.ide.structuredtextcore.ui.cleanup.STCoreSaveActionsPreferencePage"
+          id="org.eclipse.fordiac.ide.globalconstantseditor.GlobalConstants.saveActions.propertyPage"
+          name="Save Actions">
+       <keywordReference
+             id="org.eclipse.fordiac.ide.globalconstantseditor.ui.keyword_GlobalConstants">
+       </keywordReference>
+       <enabledWhen>
+          <adapt
+                type="org.eclipse.core.resources.IProject">
+          </adapt>
+       </enabledWhen>
+       <filter
+             name="projectNature"
+             value="org.eclipse.xtext.ui.shared.xtextNature">
+       </filter>
     </page>
  </extension>
  <extension

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/plugin.xml
@@ -78,9 +78,10 @@
 	<extension
 			point="org.eclipse.ui.preferencePages">
 		<page
+			category="org.eclipse.fordiac.ide.structuredtextcore.STCore"
 			class="org.eclipse.fordiac.ide.structuredtextalgorithm.ui.STAlgorithmExecutableExtensionFactory:org.eclipse.xtext.ui.editor.preferences.LanguageRootPreferencePage"
 			id="org.eclipse.fordiac.ide.structuredtextalgorithm.STAlgorithm"
-			name="STAlgorithm">
+			name="General">
 			<keywordReference id="org.eclipse.fordiac.ide.structuredtextalgorithm.ui.keyword_STAlgorithm"/>
 		</page>
 		<page
@@ -101,9 +102,10 @@
 	<extension
 			point="org.eclipse.ui.propertyPages">
 		<page
+			category="org.eclipse.fordiac.ide.structuredtextcore.STCore"
 			class="org.eclipse.fordiac.ide.structuredtextalgorithm.ui.STAlgorithmExecutableExtensionFactory:org.eclipse.xtext.ui.editor.preferences.LanguageRootPreferencePage"
 			id="org.eclipse.fordiac.ide.structuredtextalgorithm.STAlgorithm"
-			name="STAlgorithm">
+			name="General">
 			<keywordReference id="org.eclipse.fordiac.ide.structuredtextalgorithm.ui.keyword_STAlgorithm"/>
 			<enabledWhen>
 				<adapt type="org.eclipse.core.resources.IProject"/>

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/plugin.xml
@@ -599,7 +599,7 @@
     <page
           category="org.eclipse.fordiac.ide.structuredtextalgorithm.STAlgorithm"
           class="org.eclipse.fordiac.ide.structuredtextalgorithm.ui.STAlgorithmExecutableExtensionFactory:org.eclipse.fordiac.ide.structuredtextcore.ui.cleanup.STCoreSaveActionsPreferencePage"
-          id="org.eclipse.fordiac.ide.structuredtextalgorithm.STAlgorithm.saveActions"
+          id="org.eclipse.fordiac.ide.structuredtextalgorithm.STAlgorithm.saveActions.preferencePage"
           name="Save Actions">
        <keywordReference
              id="org.eclipse.fordiac.ide.structuredtextalgorithm.ui.keyword_STAlgorithm">
@@ -613,6 +613,27 @@
        <keywordReference
              id="org.eclipse.fordiac.ide.structuredtextcore.ui.keyword_STCore">
        </keywordReference>
+    </page>
+ </extension>
+ <extension
+       point="org.eclipse.ui.propertyPages">
+    <page
+          category="org.eclipse.fordiac.ide.structuredtextalgorithm.STAlgorithm"
+          class="org.eclipse.fordiac.ide.structuredtextalgorithm.ui.STAlgorithmExecutableExtensionFactory:org.eclipse.fordiac.ide.structuredtextcore.ui.cleanup.STCoreSaveActionsPreferencePage"
+          id="org.eclipse.fordiac.ide.structuredtextalgorithm.STAlgorithm.saveActions.propertyPage"
+          name="Save Actions">
+       <keywordReference
+             id="org.eclipse.fordiac.ide.structuredtextalgorithm.ui.keyword_STAlgorithm">
+       </keywordReference>
+       <enabledWhen>
+          <adapt
+                type="org.eclipse.core.resources.IProject">
+          </adapt>
+       </enabledWhen>
+       <filter
+             name="projectNature"
+             value="org.eclipse.xtext.ui.shared.xtextNature">
+       </filter>
     </page>
  </extension>
  <extension

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/plugin.xml
@@ -78,32 +78,20 @@
 	<extension
 			point="org.eclipse.ui.preferencePages">
 		<page
+			category="org.eclipse.fordiac.ide.preferences.FordiacPreferencePage"
 			class="org.eclipse.fordiac.ide.structuredtextcore.ui.STCoreExecutableExtensionFactory:org.eclipse.xtext.ui.editor.preferences.LanguageRootPreferencePage"
 			id="org.eclipse.fordiac.ide.structuredtextcore.STCore"
-			name="STCore">
-			<keywordReference id="org.eclipse.fordiac.ide.structuredtextcore.ui.keyword_STCore"/>
-		</page>
-		<page
-			category="org.eclipse.fordiac.ide.structuredtextcore.STCore"
-			class="org.eclipse.fordiac.ide.structuredtextcore.ui.STCoreExecutableExtensionFactory:org.eclipse.xtext.ui.editor.syntaxcoloring.SyntaxColoringPreferencePage"
-			id="org.eclipse.fordiac.ide.structuredtextcore.STCore.coloring"
-			name="Syntax Coloring">
-			<keywordReference id="org.eclipse.fordiac.ide.structuredtextcore.ui.keyword_STCore"/>
-		</page>
-		<page
-			category="org.eclipse.fordiac.ide.structuredtextcore.STCore"
-			class="org.eclipse.fordiac.ide.structuredtextcore.ui.STCoreExecutableExtensionFactory:org.eclipse.xtext.ui.editor.templates.XtextTemplatePreferencePage"
-			id="org.eclipse.fordiac.ide.structuredtextcore.STCore.templates"
-			name="Templates">
+			name="Structured Text">
 			<keywordReference id="org.eclipse.fordiac.ide.structuredtextcore.ui.keyword_STCore"/>
 		</page>
 	</extension>
 	<extension
 			point="org.eclipse.ui.propertyPages">
 		<page
+			category="org.eclipse.fordiac.ide.properties.FordiacPropertyPage"
 			class="org.eclipse.fordiac.ide.structuredtextcore.ui.STCoreExecutableExtensionFactory:org.eclipse.xtext.ui.editor.preferences.LanguageRootPreferencePage"
 			id="org.eclipse.fordiac.ide.structuredtextcore.STCore"
-			name="STCore">
+			name="Structured Text">
 			<keywordReference id="org.eclipse.fordiac.ide.structuredtextcore.ui.keyword_STCore"/>
 			<enabledWhen>
 				<adapt type="org.eclipse.core.resources.IProject"/>
@@ -282,54 +270,10 @@
        </markerTypeReference>
     </markerTypeCategory>
  </extension>
-	<extension point="org.eclipse.ui.preferencePages">
-		<page
-			category="org.eclipse.fordiac.ide.structuredtextcore.STCore"
-			class="org.eclipse.fordiac.ide.structuredtextcore.ui.STCoreExecutableExtensionFactory:org.eclipse.xtext.ui.validation.ValidatorPreferencePage"
-			id="org.eclipse.fordiac.ide.structuredtextcore.STCore.validator.preferencePage"
-			name="Errors/Warnings">
-			<keywordReference id="org.eclipse.fordiac.ide.structuredtextcore.ui.keyword_STCore"/>
-		</page>
-	</extension>
-	<extension point="org.eclipse.ui.propertyPages">
-		<page
-			category="org.eclipse.fordiac.ide.structuredtextcore.STCore"
-			class="org.eclipse.fordiac.ide.structuredtextcore.ui.STCoreExecutableExtensionFactory:org.eclipse.xtext.ui.validation.ValidatorPreferencePage"
-			id="org.eclipse.fordiac.ide.structuredtextcore.STCore.validator.propertyPage"
-			name="Errors/Warnings">
-			<keywordReference id="org.eclipse.fordiac.ide.structuredtextcore.ui.keyword_STCore"/>
-			<enabledWhen>
-				<adapt type="org.eclipse.core.resources.IProject"/>
-			</enabledWhen>
-			<filter name="projectNature" value="org.eclipse.xtext.ui.shared.xtextNature"/>
-		</page>
-	</extension>
 	<extension point="org.eclipse.xtext.builder.participant">
 		<participant
 			class="org.eclipse.fordiac.ide.structuredtextcore.ui.STCoreExecutableExtensionFactory:org.eclipse.xtext.builder.IXtextBuilderParticipant"
 			fileExtensions="stcore"/>
-	</extension>
-	<extension point="org.eclipse.ui.preferencePages">
-		<page
-			category="org.eclipse.fordiac.ide.structuredtextcore.STCore"
-			class="org.eclipse.fordiac.ide.structuredtextcore.ui.STCoreExecutableExtensionFactory:org.eclipse.xtext.builder.preferences.BuilderPreferencePage"
-			id="org.eclipse.fordiac.ide.structuredtextcore.STCore.compiler.preferencePage"
-			name="Compiler">
-			<keywordReference id="org.eclipse.fordiac.ide.structuredtextcore.ui.keyword_STCore"/>
-		</page>
-	</extension>
-	<extension point="org.eclipse.ui.propertyPages">
-		<page
-			category="org.eclipse.fordiac.ide.structuredtextcore.STCore"
-			class="org.eclipse.fordiac.ide.structuredtextcore.ui.STCoreExecutableExtensionFactory:org.eclipse.xtext.builder.preferences.BuilderPreferencePage"
-			id="org.eclipse.fordiac.ide.structuredtextcore.STCore.compiler.propertyPage"
-			name="Compiler">
-			<keywordReference id="org.eclipse.fordiac.ide.structuredtextcore.ui.keyword_STCore"/>
-			<enabledWhen>
-				<adapt type="org.eclipse.core.resources.IProject"/>
-			</enabledWhen>
-			<filter name="projectNature" value="org.eclipse.xtext.ui.shared.xtextNature"/>
-		</page>
 	</extension>
 	<extension point="org.eclipse.ui.menus">
 		<menuContribution locationURI="popup:#TextEditorContext?after=xtext.ui.openDeclaration">
@@ -544,15 +488,6 @@
 			</command>
 		</menuContribution>
 	</extension>
-	<extension point="org.eclipse.ui.preferencePages">
-		<page
-			category="org.eclipse.fordiac.ide.structuredtextcore.STCore"
-			class="org.eclipse.fordiac.ide.structuredtextcore.ui.STCoreExecutableExtensionFactory:org.eclipse.xtext.ui.refactoring.ui.RefactoringPreferencePage"
-			id="org.eclipse.fordiac.ide.structuredtextcore.STCore.refactoring"
-			name="Refactoring">
-			<keywordReference id="org.eclipse.fordiac.ide.structuredtextcore.ui.keyword_STCore"/>
-		</page>
-	</extension>
 	<extension point="org.eclipse.compare.contentViewers">
 		<viewer id="org.eclipse.fordiac.ide.structuredtextcore.STCore.compare.contentViewers"
 			class="org.eclipse.fordiac.ide.structuredtextcore.ui.STCoreExecutableExtensionFactory:org.eclipse.xtext.ui.compare.InjectableViewerCreator"
@@ -613,45 +548,6 @@
 			uriExtension="DTP">
 		</resourceServiceProvider>
 	</extension>
- <extension
-       point="org.eclipse.ui.preferencePages">
-    <page
-          category="org.eclipse.fordiac.ide.structuredtextcore.STCore"
-          class="org.eclipse.fordiac.ide.structuredtextcore.ui.STCoreExecutableExtensionFactory:org.eclipse.fordiac.ide.structuredtextcore.ui.codemining.STCoreCodeMiningPreferencePage"
-          id="org.eclipse.fordiac.ide.structuredtextcore.ui.codeMining"
-          name="Code Minings">
-       <keywordReference
-             id="org.eclipse.fordiac.ide.structuredtextcore.ui.keyword_STCore">
-       </keywordReference>
-    </page>
-    <page
-          category="org.eclipse.fordiac.ide.structuredtextcore.STCore"
-          class="org.eclipse.fordiac.ide.structuredtextcore.ui.STCoreExecutableExtensionFactory:org.eclipse.fordiac.ide.structuredtextcore.ui.contentassist.STCoreContentAssistPreferencePage"
-          id="org.eclipse.fordiac.ide.structuredtextcore.ui.contentAssist"
-          name="Content Assist">
-       <keywordReference
-             id="org.eclipse.fordiac.ide.structuredtextcore.ui.keyword_STCore">
-       </keywordReference>
-    </page>
-    <page
-          category="org.eclipse.fordiac.ide.structuredtextcore.STCore"
-          class="org.eclipse.fordiac.ide.structuredtextcore.ui.STCoreExecutableExtensionFactory:org.eclipse.fordiac.ide.structuredtextcore.ui.cleanup.STCoreSaveActionsPreferencePage"
-          id="org.eclipse.fordiac.ide.structuredtextcore.ui.saveActions"
-          name="Save Actions">
-       <keywordReference
-             id="org.eclipse.fordiac.ide.structuredtextcore.ui.keyword_STCore">
-       </keywordReference>
-    </page>
-    <page
-          category="org.eclipse.fordiac.ide.structuredtextcore.STCore"
-          class="org.eclipse.fordiac.ide.structuredtextcore.ui.STCoreExecutableExtensionFactory:org.eclipse.fordiac.ide.structuredtextcore.ui.editor.STCoreEditorPreferencePage"
-          id="org.eclipse.fordiac.ide.structuredtextcore.ui.editor"
-          name="Editor">
-       <keywordReference
-             id="org.eclipse.fordiac.ide.structuredtextcore.ui.keyword_STCore">
-       </keywordReference>
-    </page>
- </extension>
  <extension
        point="org.eclipse.ltk.core.refactoring.renameParticipants">
     <renameParticipant

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/cleanup/STCoreCleanupEditorCallback.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/cleanup/STCoreCleanupEditorCallback.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.structuredtextcore.ui.cleanup;
 
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.text.DocumentRewriteSession;
 import org.eclipse.jface.text.DocumentRewriteSessionType;
@@ -36,7 +38,7 @@ public class STCoreCleanupEditorCallback extends IXtextEditorCallback.NullImpl {
 
 	@Override
 	public void afterSave(final XtextEditor editor) {
-		if (!running && preferences.isEnableSaveActions()) {
+		if (!running && preferences.isEnableSaveActions(getProject(editor))) {
 			try {
 				running = true;
 				performSaveActions(editor);
@@ -50,7 +52,7 @@ public class STCoreCleanupEditorCallback extends IXtextEditorCallback.NullImpl {
 	}
 
 	protected void performSaveActions(final XtextEditor editor) {
-		if (preferences.isEnableFormat()) {
+		if (preferences.isEnableFormat(getProject(editor))) {
 			performFormat(editor);
 		}
 	}
@@ -74,5 +76,13 @@ public class STCoreCleanupEditorCallback extends IXtextEditorCallback.NullImpl {
 		} finally {
 			document.stopRewriteSession(rewriteSession);
 		}
+	}
+
+	private static IProject getProject(final XtextEditor editor) {
+		final IResource resource = editor.getResource();
+		if (resource != null) {
+			return resource.getProject();
+		}
+		return null;
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/cleanup/STCoreSaveActionsConfigurationBlock.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/cleanup/STCoreSaveActionsConfigurationBlock.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Martin Erich Jobst
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Martin Jobst - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.structuredtextcore.ui.cleanup;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.fordiac.ide.structuredtextcore.ui.Messages;
+import org.eclipse.jface.layout.GridLayoutFactory;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.xtext.ui.preferences.OptionsConfigurationBlock;
+
+@SuppressWarnings("restriction")
+public class STCoreSaveActionsConfigurationBlock extends OptionsConfigurationBlock {
+
+	private static final String PROPERTY_PREFIX = "SaveActionsConfiguration"; //$NON-NLS-1$
+	protected static final String[] BOOLEAN_VALUES = new String[] { IPreferenceStore.TRUE, IPreferenceStore.FALSE };
+
+	@Override
+	protected Control doCreateContents(final Composite parent) {
+		setShell(parent.getShell());
+		final Composite composite = new Composite(parent, SWT.NONE);
+		GridLayoutFactory.fillDefaults().applyTo(composite);
+		addCheckBox(composite, Messages.STCoreSaveActionsPreferencePage_EnableSaveActions,
+				STCoreSaveActionsPreferences.ENABLE_SAVE_ACTIONS, BOOLEAN_VALUES, 0);
+		addCheckBox(composite, Messages.STCoreSaveActionsPreferencePage_EnableFormat,
+				STCoreSaveActionsPreferences.ENABLE_FORMAT, BOOLEAN_VALUES, 32);
+		return composite;
+	}
+
+	@Override
+	protected void validateSettings(final String changedKey, final String oldValue, final String newValue) {
+		// do nothing
+	}
+
+	@Override
+	public String getPropertyPrefix() {
+		return PROPERTY_PREFIX;
+	}
+
+	@Override
+	protected Job getBuildJob(final IProject project) {
+		return null; // no build necessary
+	}
+
+	@Override
+	protected String[] getFullBuildDialogStrings(final boolean workspaceSettings) {
+		return null; // do not ask for build //NOSONAR
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/cleanup/STCoreSaveActionsPreferencePage.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/cleanup/STCoreSaveActionsPreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Martin Erich Jobst
+ * Copyright (c) 2022, 2025 Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,64 +12,107 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.structuredtextcore.ui.cleanup;
 
-import org.eclipse.fordiac.ide.structuredtextcore.ui.Messages;
-import org.eclipse.jface.preference.BooleanFieldEditor;
-import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.jface.preference.IPreferencePageContainer;
 import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.jface.util.PropertyChangeEvent;
-import org.eclipse.ui.IWorkbench;
-import org.eclipse.ui.IWorkbenchPreferencePage;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.ui.preferences.IWorkbenchPreferenceContainer;
+import org.eclipse.xtext.Constants;
 import org.eclipse.xtext.ui.editor.preferences.IPreferenceStoreAccess;
+import org.eclipse.xtext.ui.preferences.PropertyAndPreferencePage;
 
 import com.google.inject.Inject;
+import com.google.inject.name.Named;
 
-public class STCoreSaveActionsPreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
-
-	private BooleanFieldEditor enableSaveActions;
-	private BooleanFieldEditor enableFormat;
+@SuppressWarnings("restriction")
+public class STCoreSaveActionsPreferencePage extends PropertyAndPreferencePage {
 
 	@Inject
 	private IPreferenceStoreAccess preferenceStoreAccess;
 
-	public STCoreSaveActionsPreferencePage() {
-		super(GRID);
+	@Inject
+	private STCoreSaveActionsConfigurationBlock saveActionsConfigurationBlock;
+
+	@Inject
+	@Named(Constants.LANGUAGE_NAME)
+	private String languageName;
+
+	@Override
+	public void createControl(final Composite parent) {
+		final IWorkbenchPreferenceContainer container = (IWorkbenchPreferenceContainer) getContainer();
+		final IPreferenceStore preferenceStore = preferenceStoreAccess.getWritablePreferenceStore(getProject());
+		saveActionsConfigurationBlock.setProject(getProject());
+		saveActionsConfigurationBlock.setPreferenceStore(preferenceStore);
+		saveActionsConfigurationBlock.setWorkbenchPreferenceContainer(container);
+		saveActionsConfigurationBlock.setStatusChangeListener(getNewStatusChangedListener());
+		super.createControl(parent);
 	}
 
 	@Override
-	protected IPreferenceStore doGetPreferenceStore() {
-		return preferenceStoreAccess.getWritablePreferenceStore();
+	protected Control createPreferenceContent(final Composite composite,
+			final IPreferencePageContainer preferencePageContainer) {
+		return saveActionsConfigurationBlock.createContents(composite);
 	}
 
 	@Override
-	protected void createFieldEditors() {
-		enableSaveActions = new BooleanFieldEditor(STCoreSaveActionsPreferences.ENABLE_SAVE_ACTIONS,
-				Messages.STCoreSaveActionsPreferencePage_EnableSaveActions, getFieldEditorParent());
-		addField(enableSaveActions);
-		enableFormat = new BooleanFieldEditor(STCoreSaveActionsPreferences.ENABLE_FORMAT,
-				Messages.STCoreSaveActionsPreferencePage_EnableFormat, getFieldEditorParent());
-		enableFormat.setEnabled(getPreferenceStore().getBoolean(STCoreSaveActionsPreferences.ENABLE_SAVE_ACTIONS),
-				getFieldEditorParent());
-		addField(enableFormat);
+	protected boolean hasProjectSpecificOptions(final IProject project) {
+		return saveActionsConfigurationBlock.hasProjectSpecificOptions(project);
+	}
+
+	@Override
+	protected String getPreferencePageID() {
+		return languageName + ".saveActions.preferencePage"; //$NON-NLS-1$
+	}
+
+	@Override
+	protected String getPropertyPageID() {
+		return languageName + ".saveActions.propertyPage"; //$NON-NLS-1$
+	}
+
+	@Override
+	public void dispose() {
+		if (saveActionsConfigurationBlock != null) {
+			saveActionsConfigurationBlock.dispose();
+		}
+		super.dispose();
+	}
+
+	@Override
+	protected void enableProjectSpecificSettings(final boolean useProjectSpecificSettings) {
+		super.enableProjectSpecificSettings(useProjectSpecificSettings);
+		if (saveActionsConfigurationBlock != null) {
+			saveActionsConfigurationBlock.useProjectSpecificSettings(useProjectSpecificSettings);
+		}
 	}
 
 	@Override
 	protected void performDefaults() {
 		super.performDefaults();
-		updateFieldEnablement();
+		if (saveActionsConfigurationBlock != null) {
+			saveActionsConfigurationBlock.performDefaults();
+		}
 	}
 
 	@Override
-	public void propertyChange(final PropertyChangeEvent event) {
-		super.propertyChange(event);
-		updateFieldEnablement();
-	}
-
-	protected void updateFieldEnablement() {
-		enableFormat.setEnabled(enableSaveActions.getBooleanValue(), getFieldEditorParent());
+	public boolean performOk() {
+		if (saveActionsConfigurationBlock != null && !saveActionsConfigurationBlock.performOk()) {
+			return false;
+		}
+		return super.performOk();
 	}
 
 	@Override
-	public void init(final IWorkbench workbench) {
-		// do nothing
+	public void performApply() {
+		if (saveActionsConfigurationBlock != null) {
+			saveActionsConfigurationBlock.performApply();
+		}
+	}
+
+	@Override
+	public void setElement(final IAdaptable element) {
+		super.setElement(element);
+		setDescription(null); // no description for property page
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/cleanup/STCoreSaveActionsPreferences.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/cleanup/STCoreSaveActionsPreferences.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.structuredtextcore.ui.cleanup;
 
+import org.eclipse.core.resources.IProject;
 import org.eclipse.xtext.ui.editor.preferences.IPreferenceStoreAccess;
 import org.eclipse.xtext.ui.editor.preferences.IPreferenceStoreInitializer;
 
@@ -32,19 +33,19 @@ public class STCoreSaveActionsPreferences {
 	@Inject
 	private IPreferenceStoreAccess preferenceStoreAccess;
 
-	public boolean isEnableSaveActions() {
-		return preferenceStoreAccess.getPreferenceStore().getBoolean(ENABLE_SAVE_ACTIONS);
+	public boolean isEnableSaveActions(final IProject project) {
+		return preferenceStoreAccess.getContextPreferenceStore(project).getBoolean(ENABLE_SAVE_ACTIONS);
 	}
 
-	public boolean isEnableFormat() {
-		return preferenceStoreAccess.getPreferenceStore().getBoolean(ENABLE_FORMAT);
+	public boolean isEnableFormat(final IProject project) {
+		return preferenceStoreAccess.getContextPreferenceStore(project).getBoolean(ENABLE_FORMAT);
 	}
 
-	public void setEnableSaveActions(final boolean isEnableSaveActions) {
-		preferenceStoreAccess.getWritablePreferenceStore().setValue(ENABLE_SAVE_ACTIONS, isEnableSaveActions);
+	public void setEnableSaveActions(final IProject project, final boolean isEnableSaveActions) {
+		preferenceStoreAccess.getWritablePreferenceStore(project).setValue(ENABLE_SAVE_ACTIONS, isEnableSaveActions);
 	}
 
-	public void setEnableFormat(final boolean isEnableFormat) {
-		preferenceStoreAccess.getWritablePreferenceStore().setValue(ENABLE_FORMAT, isEnableFormat);
+	public void setEnableFormat(final IProject project, final boolean isEnableFormat) {
+		preferenceStoreAccess.getWritablePreferenceStore(project).setValue(ENABLE_FORMAT, isEnableFormat);
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui/plugin.xml
@@ -79,9 +79,10 @@
 	<extension
 			point="org.eclipse.ui.preferencePages">
 		<page
+			category="org.eclipse.fordiac.ide.structuredtextcore.STCore"
 			class="org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.STFunctionExecutableExtensionFactory:org.eclipse.xtext.ui.editor.preferences.LanguageRootPreferencePage"
 			id="org.eclipse.fordiac.ide.structuredtextfunctioneditor.STFunction"
-			name="STFunction">
+			name="Functions">
 			<keywordReference id="org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.keyword_STFunction"/>
 		</page>
 		<page
@@ -102,9 +103,10 @@
 	<extension
 			point="org.eclipse.ui.propertyPages">
 		<page
+			category="org.eclipse.fordiac.ide.structuredtextcore.STCore"
 			class="org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.STFunctionExecutableExtensionFactory:org.eclipse.xtext.ui.editor.preferences.LanguageRootPreferencePage"
 			id="org.eclipse.fordiac.ide.structuredtextfunctioneditor.STFunction"
-			name="STFunction">
+			name="Functions">
 			<keywordReference id="org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.keyword_STFunction"/>
 			<enabledWhen>
 				<adapt type="org.eclipse.core.resources.IProject"/>
@@ -295,28 +297,6 @@
 		<participant
 			class="org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.STFunctionExecutableExtensionFactory:org.eclipse.xtext.builder.IXtextBuilderParticipant"
 			fileExtensions="stfunc"/>
-	</extension>
-	<extension point="org.eclipse.ui.preferencePages">
-		<page
-			category="org.eclipse.fordiac.ide.structuredtextfunctioneditor.STFunction"
-			class="org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.STFunctionExecutableExtensionFactory:org.eclipse.xtext.builder.preferences.BuilderPreferencePage"
-			id="org.eclipse.fordiac.ide.structuredtextfunctioneditor.STFunction.compiler.preferencePage"
-			name="Compiler">
-			<keywordReference id="org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.keyword_STFunction"/>
-		</page>
-	</extension>
-	<extension point="org.eclipse.ui.propertyPages">
-		<page
-			category="org.eclipse.fordiac.ide.structuredtextfunctioneditor.STFunction"
-			class="org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.STFunctionExecutableExtensionFactory:org.eclipse.xtext.builder.preferences.BuilderPreferencePage"
-			id="org.eclipse.fordiac.ide.structuredtextfunctioneditor.STFunction.compiler.propertyPage"
-			name="Compiler">
-			<keywordReference id="org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.keyword_STFunction"/>
-			<enabledWhen>
-				<adapt type="org.eclipse.core.resources.IProject"/>
-			</enabledWhen>
-			<filter name="projectNature" value="org.eclipse.xtext.ui.shared.xtextNature"/>
-		</page>
 	</extension>
 	<extension point="org.eclipse.ui.menus">
 		<menuContribution locationURI="popup:#TextEditorContext?after=xtext.ui.openDeclaration">

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui/plugin.xml
@@ -580,7 +580,7 @@
     <page
           category="org.eclipse.fordiac.ide.structuredtextfunctioneditor.STFunction"
           class="org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.STFunctionExecutableExtensionFactory:org.eclipse.fordiac.ide.structuredtextcore.ui.cleanup.STCoreSaveActionsPreferencePage"
-          id="org.eclipse.fordiac.ide.structuredtextfunctioneditor.STFunction.saveActions"
+          id="org.eclipse.fordiac.ide.structuredtextfunctioneditor.STFunction.saveActions.preferencePage"
           name="Save Actions">
        <keywordReference
              id="org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.keyword_STFunction">
@@ -594,6 +594,27 @@
        <keywordReference
              id="org.eclipse.fordiac.ide.structuredtextcore.ui.keyword_STCore">
        </keywordReference>
+    </page>
+ </extension>
+ <extension
+       point="org.eclipse.ui.propertyPages">
+    <page
+          category="org.eclipse.fordiac.ide.structuredtextfunctioneditor.STFunction"
+          class="org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.STFunctionExecutableExtensionFactory:org.eclipse.fordiac.ide.structuredtextcore.ui.cleanup.STCoreSaveActionsPreferencePage"
+          id="org.eclipse.fordiac.ide.structuredtextfunctioneditor.STFunction.saveActions.propertyPage"
+          name="Save Actions">
+       <keywordReference
+             id="org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.keyword_STFunction">
+       </keywordReference>
+       <enabledWhen>
+          <adapt
+                type="org.eclipse.core.resources.IProject">
+          </adapt>
+       </enabledWhen>
+       <filter
+             name="projectNature"
+             value="org.eclipse.xtext.ui.shared.xtextNature">
+       </filter>
     </page>
  </extension>
  <extension


### PR DESCRIPTION
Move and rename ST language root preference and property pages and remove unnecessary pages for ST core and Xtext compiler settings. Also add project-specific save actions for ST editor.