### PR TITLE
Fix SubApp self loop StackOverflow crash

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/TargetInterfaceAdapter.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/TargetInterfaceAdapter.java
@@ -87,19 +87,16 @@ public final class TargetInterfaceAdapter extends AdapterImpl {
 	private static void checkInputConns(final Set<EObject> currTargets, final Connection con) {
 		currTargets.add(con);
 		final IInterfaceElement source = con.getSource();
-		if (source != null) {
-			currTargets.add(con.getSource());
-			if (TargetPinManager.followConnections(source.getFBNetworkElement(), source.getInputConnections())) {
-				source.getInputConnections().forEach(srcCon -> checkInputConns(currTargets, srcCon));
-			}
+		if (source != null && currTargets.add(con.getSource())
+				&& TargetPinManager.followConnections(source.getFBNetworkElement(), source.getInputConnections())) {
+			source.getInputConnections().forEach(srcCon -> checkInputConns(currTargets, srcCon));
 		}
 	}
 
 	private static void checkoutOutputConns(final Set<EObject> currTargets, final Connection con) {
 		currTargets.add(con);
 		final IInterfaceElement dest = con.getDestination();
-		if (dest != null) {
-			currTargets.add(dest);
+		if (dest != null && currTargets.add(dest)) {
 			if (TargetPinManager.followConnections(dest.getFBNetworkElement(), dest.getOutputConnections())) {
 				dest.getOutputConnections().forEach(dstCon -> checkoutOutputConns(currTargets, dstCon));
 			} else {


### PR DESCRIPTION
Trying to create this situation caused a StackOverflow exception:
![grafik](https://github.com/user-attachments/assets/570da7a0-ebe6-4d47-91e9-ff2fbbb7cba8)
Such self loops were not correctly handled in TargetInterfaceAdapter. This PR makes changes to no longer look at targets that were already processed.