### PR TITLE
Fix watch for in-out pin with variable array length in monitoring

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/DeploymentDebugWatchUtils.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/DeploymentDebugWatchUtils.java
@@ -15,6 +15,9 @@ package org.eclipse.fordiac.ide.deployment.debug.watch;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import org.eclipse.fordiac.ide.model.datatype.helper.TypeDeclarationParser;
+import org.eclipse.fordiac.ide.model.eval.variable.VariableOperations;
+import org.eclipse.fordiac.ide.model.helpers.VarInOutHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.AdapterDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.AdapterFB;
 import org.eclipse.fordiac.ide.model.libraryElement.Connection;
@@ -24,6 +27,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.Resource;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 
 public final class DeploymentDebugWatchUtils {
 
@@ -129,6 +133,15 @@ public final class DeploymentDebugWatchUtils {
 				.map(resolved -> new SubAppConnectionEndpoint<>((T) resolved));
 		default -> Stream.of(new SubAppConnectionEndpoint<>(element, negate));
 		};
+	}
+
+	public static INamedElement evaluateWatchType(final VarDeclaration varDeclaration) {
+		if (varDeclaration.isInOutVar() && varDeclaration.isArray()
+				&& TypeDeclarationParser.isVariableArrayBounds(varDeclaration.getArraySize().getValue())) {
+			// use type of defining InOut declaration for arrays with variable length
+			return VariableOperations.evaluateResultType(VarInOutHelper.getDefiningVarInOutDeclaration(varDeclaration));
+		}
+		return VariableOperations.evaluateResultType(varDeclaration);
 	}
 
 	private DeploymentDebugWatchUtils() {

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/FBNetworkElementValue.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/FBNetworkElementValue.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.deployment.debug.watch;
 
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Predicate;
@@ -32,6 +33,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.Group;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.libraryElement.Resource;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
 
@@ -58,8 +60,19 @@ public class FBNetworkElementValue extends DeploymentDebugElement implements IVa
 	}
 
 	private Stream<INamedElement> getSubElements() throws UnsupportedOperationException {
-		return Stream.concat(element.getInterface().getAllInterfaceElements().stream(), getAdditionalSubElements())
+		return Stream.concat(getInterfaceSubElements(), getAdditionalSubElements())
 				.sorted(Comparator.comparing(INamedElement::getName));
+	}
+
+	private Stream<INamedElement> getInterfaceSubElements() throws UnsupportedOperationException {
+		final InterfaceList interfaceList = element.getInterface();
+		return Stream.of(
+				// include events
+				interfaceList.getEventInputs(), interfaceList.getEventOutputs(),
+				// include variables (except out-mapped InOut vars)
+				interfaceList.getInputVars(), interfaceList.getOutputVars(), interfaceList.getInOutVars(),
+				// include adapters
+				interfaceList.getSockets(), interfaceList.getPlugs()).flatMap(Collection::stream);
 	}
 
 	private Stream<? extends INamedElement> getAdditionalSubElements() throws UnsupportedOperationException {

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/SubAppVarDeclarationWatch.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/SubAppVarDeclarationWatch.java
@@ -28,7 +28,7 @@ public class SubAppVarDeclarationWatch extends AbstractSubAppInterfaceWatch impl
 
 	public SubAppVarDeclarationWatch(final String name, final VarDeclaration varDeclaration,
 			final DeploymentDebugDevice debugTarget) throws EvaluatorException {
-		super(VariableOperations.newVariable(name, VariableOperations.evaluateResultType(varDeclaration)),
+		super(VariableOperations.newVariable(name, DeploymentDebugWatchUtils.evaluateWatchType(varDeclaration)),
 				varDeclaration, debugTarget);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/VarDeclarationWatch.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/VarDeclarationWatch.java
@@ -35,13 +35,13 @@ public class VarDeclarationWatch extends AbstractRuntimeWatch implements IVarDec
 
 	public VarDeclarationWatch(final String name, final VarDeclaration varDeclaration,
 			final DeploymentDebugDevice debugTarget) throws EvaluatorException {
-		super(VariableOperations.newVariable(name, VariableOperations.evaluateResultType(varDeclaration)),
+		super(VariableOperations.newVariable(name, DeploymentDebugWatchUtils.evaluateWatchType(varDeclaration)),
 				varDeclaration, debugTarget);
 	}
 
 	public VarDeclarationWatch(final String name, final VarDeclaration varDeclaration, final Resource resource,
 			final String resourceRelativeName, final DeploymentDebugDevice debugTarget) throws EvaluatorException {
-		super(VariableOperations.newVariable(name, VariableOperations.evaluateResultType(varDeclaration)),
+		super(VariableOperations.newVariable(name, DeploymentDebugWatchUtils.evaluateWatchType(varDeclaration)),
 				varDeclaration, resource, resourceRelativeName, debugTarget);
 	}
 


### PR DESCRIPTION
Use the type of the defining in-out variable, which must have a fixed length, for in-out pins with variable array length. Also avoid duplicate out-mapped in-out pins or error marker pins in sub-watches of FB network elements.