### PR TITLE
Add query for FB and data types in deployment

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.deployment.iec61499/src/org/eclipse/fordiac/ide/deployment/iec61499/executors/DeploymentExecutor.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.iec61499/src/org/eclipse/fordiac/ide/deployment/iec61499/executors/DeploymentExecutor.java
@@ -39,15 +39,15 @@ import org.eclipse.fordiac.ide.deployment.iec61499.ResponseMapping;
 import org.eclipse.fordiac.ide.deployment.iec61499.handlers.EthernetDeviceManagementCommunicationHandler;
 import org.eclipse.fordiac.ide.deployment.interactors.AbstractDeviceManagementInteractor;
 import org.eclipse.fordiac.ide.deployment.interactors.ForteTypeNameCreator;
-import org.eclipse.fordiac.ide.model.data.DataType;
 import org.eclipse.fordiac.ide.model.libraryElement.Device;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
-import org.eclipse.fordiac.ide.model.libraryElement.FBType;
-import org.eclipse.fordiac.ide.model.libraryElement.GlobalConstants;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
-import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.Resource;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.typelibrary.DataTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.FBTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.GlobalConstantsEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.model.util.LibraryElementHashException;
 import org.xml.sax.InputSource;
 
@@ -379,41 +379,45 @@ public class DeploymentExecutor extends AbstractDeviceManagementInteractor {
 	}
 
 	@Override
-	public Response queryFBType(final FBType type) throws DeploymentException {
+	public Response queryFBType(final FBTypeEntry entry) throws DeploymentException {
 		try {
-			final String request = MessageFormat.format(QUERY_FB_TYPE, getNextId(), getTypeNameWithHash(type));
+			final String request = MessageFormat.format(QUERY_FB_TYPE, getNextId(), getTypeNameWithHash(entry));
 			return parseResponse(sendREQ("", request)); //$NON-NLS-1$
 		} catch (final IOException | LibraryElementHashException e) {
 			throw new DeploymentException(
-					MessageFormat.format(Messages.DeploymentExecutor_QueryFBTypeFailed, type.getName()), e);
+					MessageFormat.format(Messages.DeploymentExecutor_QueryFBTypeFailed, entry.getFullTypeName()), e);
 		}
 	}
 
 	@Override
-	public Response queryDataType(final DataType type) throws DeploymentException {
+	public Response queryDataType(final DataTypeEntry entry) throws DeploymentException {
 		try {
-			final String request = MessageFormat.format(QUERY_DATA_TYPE, getNextId(), getTypeNameWithHash(type));
+			final String request = MessageFormat.format(QUERY_DATA_TYPE, getNextId(), getTypeNameWithHash(entry));
 			return parseResponse(sendREQ("", request)); //$NON-NLS-1$
 		} catch (final IOException | LibraryElementHashException e) {
 			throw new DeploymentException(
-					MessageFormat.format(Messages.DeploymentExecutor_QueryDataTypeFailed, type.getName()), e);
+					MessageFormat.format(Messages.DeploymentExecutor_QueryDataTypeFailed, entry.getFullTypeName()), e);
 		}
 	}
 
 	@Override
-	public Response queryGlobalConstType(final GlobalConstants type) throws DeploymentException {
+	public Response queryGlobalConstType(final GlobalConstantsEntry entry) throws DeploymentException {
 		try {
 			final String request = MessageFormat.format(QUERY_GLOBAL_CONST_TYPE, getNextId(),
-					getTypeNameWithHash(type));
+					getTypeNameWithHash(entry));
 			return parseResponse(sendREQ("", request)); //$NON-NLS-1$
 		} catch (final IOException | LibraryElementHashException e) {
-			throw new DeploymentException(
-					MessageFormat.format(Messages.DeploymentExecutor_QueryGlobalConstTypeFailed, type.getName()), e);
+			throw new DeploymentException(MessageFormat.format(Messages.DeploymentExecutor_QueryGlobalConstTypeFailed,
+					entry.getFullTypeName()), e);
 		}
 	}
 
-	private static String getTypeNameWithHash(final LibraryElement type) throws LibraryElementHashException {
-		return type.getName() + '#' + type.getTypeEntry().getTypeHash();
+	private static String getTypeNameWithHash(final TypeEntry entry) throws LibraryElementHashException {
+		final String hash = entry.getTypeHash();
+		if (hash.isEmpty()) {
+			return ForteTypeNameCreator.getForteTypeName(entry);
+		}
+		return ForteTypeNameCreator.getForteTypeName(entry) + '#' + hash;
 	}
 
 	protected Response parseResponse(final String result) throws IOException {

--- a/plugins/org.eclipse.fordiac.ide.deployment.opcua/src/org/eclipse/fordiac/ide/deployment/opcua/OPCUADeploymentExecutor.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.opcua/src/org/eclipse/fordiac/ide/deployment/opcua/OPCUADeploymentExecutor.java
@@ -46,14 +46,14 @@ import org.eclipse.fordiac.ide.deployment.opcua.helpers.Constants;
 import org.eclipse.fordiac.ide.deployment.util.DeploymentHelper;
 import org.eclipse.fordiac.ide.deployment.util.IDeploymentListener;
 import org.eclipse.fordiac.ide.deployment.util.IDeploymentListener2;
-import org.eclipse.fordiac.ide.model.data.DataType;
 import org.eclipse.fordiac.ide.model.libraryElement.Device;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
-import org.eclipse.fordiac.ide.model.libraryElement.FBType;
-import org.eclipse.fordiac.ide.model.libraryElement.GlobalConstants;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.Resource;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.typelibrary.DataTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.FBTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.GlobalConstantsEntry;
 import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
 import org.eclipse.milo.opcua.sdk.client.SessionActivityListener;
@@ -571,19 +571,19 @@ public class OPCUADeploymentExecutor implements IDeviceManagementInteractor {
 	}
 
 	@Override
-	public Response queryFBType(final FBType type) throws DeploymentException {
+	public Response queryFBType(final FBTypeEntry entry) throws DeploymentException {
 		// TODO implement when the API and infrastructure is fully tested
 		throw new DeploymentException("Query FB Type not yet supported!"); //$NON-NLS-1$
 	}
 
 	@Override
-	public Response queryDataType(final DataType type) throws DeploymentException {
+	public Response queryDataType(final DataTypeEntry entry) throws DeploymentException {
 		// TODO implement when the API and infrastructure is fully tested
 		throw new DeploymentException("Query Data Type Type not yet supported!"); //$NON-NLS-1$
 	}
 
 	@Override
-	public Response queryGlobalConstType(final GlobalConstants type) throws DeploymentException {
+	public Response queryGlobalConstType(final GlobalConstantsEntry entry) throws DeploymentException {
 		// TODO implement when the API and infrastructure is fully tested
 		throw new DeploymentException("Query Global Const Type not yet supported!"); //$NON-NLS-1$
 	}

--- a/plugins/org.eclipse.fordiac.ide.deployment/model/devResponse.ecore
+++ b/plugins/org.eclipse.fordiac.ide.deployment/model/devResponse.ecore
@@ -13,6 +13,14 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="ports" upperBound="-1"
         eType="#//Port" containment="true"/>
   </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="FBType">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString">
+      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="name" value="Name"/>
+        <details key="kind" value="attribute"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Port">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="dataValues" upperBound="-1"
@@ -27,6 +35,12 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="Watches" eType="#//Watches"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="Reason" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="fblist" eType="#//FBList"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="fbType" eType="#//FBType">
+      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="kind" value="element"/>
+        <details key="name" value="FBType"/>
+      </eAnnotations>
+    </eStructuralFeatures>
     <eStructuralFeatures xsi:type="ecore:EReference" name="endpointlist" eType="#//EndpointList"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="connection" eType="#//Connection"/>
   </eClassifiers>

--- a/plugins/org.eclipse.fordiac.ide.deployment/model/devResponse.genmodel
+++ b/plugins/org.eclipse.fordiac.ide.deployment/model/devResponse.genmodel
@@ -20,6 +20,9 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute devResponse.ecore#//FB/type"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference devResponse.ecore#//FB/ports"/>
     </genClasses>
+    <genClasses ecoreClass="devResponse.ecore#//FBType">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute devResponse.ecore#//FBType/name"/>
+    </genClasses>
     <genClasses ecoreClass="devResponse.ecore#//Port">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute devResponse.ecore#//Port/name"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference devResponse.ecore#//Port/dataValues"/>
@@ -33,6 +36,7 @@
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference devResponse.ecore#//Response/Watches"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute devResponse.ecore#//Response/Reason"/>
       <genFeatures property="None" notify="false" createChild="false" ecoreFeature="ecore:EReference devResponse.ecore#//Response/fblist"/>
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference devResponse.ecore#//Response/fbType"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference devResponse.ecore#//Response/endpointlist"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference devResponse.ecore#//Response/connection"/>
     </genClasses>

--- a/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/DevResponseFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/DevResponseFactory.java
@@ -1,7 +1,7 @@
 /**
  * ******************************************************************************
  * * Copyright (c) 2012, 2013, 2018 Profactor GmbH, fortiss GmbH, Johannes Kepler University
- * * 
+ * *
  * * This program and the accompanying materials are made available under the
  * * terms of the Eclipse Public License 2.0 which is available at
  * * http://www.eclipse.org/legal/epl-2.0.
@@ -13,117 +13,125 @@
  * *     - initial API and implementation and/or initial documentation
  * *   Alois Zoitl - moved to deployment and reworked it to a device response model
  * ******************************************************************************
- * 
+ *
  */
 package org.eclipse.fordiac.ide.deployment.devResponse;
 
 import org.eclipse.emf.ecore.EFactory;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Factory</b> for the model.
- * It provides a create method for each non-abstract class of the model.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> The <b>Factory</b> for the model. It provides a
+ * create method for each non-abstract class of the model. <!-- end-user-doc -->
+ *
  * @see org.eclipse.fordiac.ide.deployment.devResponse.DevResponsePackage
  * @generated
  */
 public interface DevResponseFactory extends EFactory {
 	/**
-	 * The singleton instance of the factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The singleton instance of the factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 *
 	 * @generated
 	 */
 	DevResponseFactory eINSTANCE = org.eclipse.fordiac.ide.deployment.devResponse.impl.DevResponseFactoryImpl.init();
 
 	/**
-	 * Returns a new object of class '<em>Resource</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Resource</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 *
 	 * @return a new object of class '<em>Resource</em>'.
 	 * @generated
 	 */
 	Resource createResource();
 
 	/**
-	 * Returns a new object of class '<em>FB</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>FB</em>'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 *
 	 * @return a new object of class '<em>FB</em>'.
 	 * @generated
 	 */
 	FB createFB();
 
 	/**
-	 * Returns a new object of class '<em>Port</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>FB Type</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 *
+	 * @return a new object of class '<em>FB Type</em>'.
+	 * @generated
+	 */
+	FBType createFBType();
+
+	/**
+	 * Returns a new object of class '<em>Port</em>'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 *
 	 * @return a new object of class '<em>Port</em>'.
 	 * @generated
 	 */
 	Port createPort();
 
 	/**
-	 * Returns a new object of class '<em>Data</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Data</em>'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 *
 	 * @return a new object of class '<em>Data</em>'.
 	 * @generated
 	 */
 	Data createData();
 
 	/**
-	 * Returns a new object of class '<em>Response</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Response</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 *
 	 * @return a new object of class '<em>Response</em>'.
 	 * @generated
 	 */
 	Response createResponse();
 
 	/**
-	 * Returns a new object of class '<em>Watches</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Watches</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 *
 	 * @return a new object of class '<em>Watches</em>'.
 	 * @generated
 	 */
 	Watches createWatches();
 
 	/**
-	 * Returns a new object of class '<em>FB List</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>FB List</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 *
 	 * @return a new object of class '<em>FB List</em>'.
 	 * @generated
 	 */
 	FBList createFBList();
 
 	/**
-	 * Returns a new object of class '<em>Endpoint List</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Endpoint List</em>'. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 *
 	 * @return a new object of class '<em>Endpoint List</em>'.
 	 * @generated
 	 */
 	EndpointList createEndpointList();
 
 	/**
-	 * Returns a new object of class '<em>Connection</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Connection</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 *
 	 * @return a new object of class '<em>Connection</em>'.
 	 * @generated
 	 */
 	Connection createConnection();
 
 	/**
-	 * Returns the package supported by this factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the package supported by this factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 *
 	 * @return the package supported by this factory.
 	 * @generated
 	 */
 	DevResponsePackage getDevResponsePackage();
 
-} //DevResponseFactory
+} // DevResponseFactory

--- a/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/DevResponsePackage.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/DevResponsePackage.java
@@ -32,43 +32,46 @@ import org.eclipse.emf.ecore.EReference;
  * <li>and each data type</li>
  * </ul>
  * <!-- end-user-doc -->
+ *
  * @see org.eclipse.fordiac.ide.deployment.devResponse.DevResponseFactory
  * @model kind="package"
  * @generated
  */
 public interface DevResponsePackage extends EPackage {
 	/**
-	 * The package name.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * The package name. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	String eNAME = "devResponse"; //$NON-NLS-1$
 
 	/**
-	 * The package namespace URI.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * The package namespace URI. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	String eNS_URI = "org.eclipse.fordiac.ide.deployment"; //$NON-NLS-1$
 
 	/**
-	 * The package namespace name.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * The package namespace name. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	String eNS_PREFIX = "devResponse"; //$NON-NLS-1$
 
 	/**
-	 * The singleton instance of the package.
-	 * <!-- begin-user-doc --> <!--
+	 * The singleton instance of the package. <!-- begin-user-doc --> <!--
 	 * end-user-doc -->
+	 *
 	 * @generated
 	 */
 	DevResponsePackage eINSTANCE = org.eclipse.fordiac.ide.deployment.devResponse.impl.DevResponsePackageImpl.init();
 
 	/**
-	 * The meta object id for the '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResourceImpl <em>Resource</em>}' class.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResourceImpl
+	 * <em>Resource</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.ResourceImpl
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.DevResponsePackageImpl#getResource()
 	 * @generated
@@ -76,18 +79,18 @@ public interface DevResponsePackage extends EPackage {
 	int RESOURCE = 0;
 
 	/**
-	 * The feature id for the '<em><b>Name</b></em>' attribute.
-	 * <!-- begin-user-doc
+	 * The feature id for the '<em><b>Name</b></em>' attribute. <!-- begin-user-doc
 	 * --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 * @ordered
 	 */
 	int RESOURCE__NAME = 0;
 
 	/**
-	 * The feature id for the '<em><b>Type</b></em>' attribute.
-	 * <!-- begin-user-doc
+	 * The feature id for the '<em><b>Type</b></em>' attribute. <!-- begin-user-doc
 	 * --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 * @ordered
 	 */
@@ -112,8 +115,10 @@ public interface DevResponsePackage extends EPackage {
 	int RESOURCE_FEATURE_COUNT = 3;
 
 	/**
-	 * The meta object id for the '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.FBImpl <em>FB</em>}' class.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.FBImpl
+	 * <em>FB</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.FBImpl
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.DevResponsePackageImpl#getFB()
 	 * @generated
@@ -121,18 +126,18 @@ public interface DevResponsePackage extends EPackage {
 	int FB = 1;
 
 	/**
-	 * The feature id for the '<em><b>Name</b></em>' attribute.
-	 * <!-- begin-user-doc
+	 * The feature id for the '<em><b>Name</b></em>' attribute. <!-- begin-user-doc
 	 * --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 * @ordered
 	 */
 	int FB__NAME = 0;
 
 	/**
-	 * The feature id for the '<em><b>Type</b></em>' attribute.
-	 * <!-- begin-user-doc
+	 * The feature id for the '<em><b>Type</b></em>' attribute. <!-- begin-user-doc
 	 * --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 * @ordered
 	 */
@@ -141,6 +146,7 @@ public interface DevResponsePackage extends EPackage {
 	/**
 	 * The feature id for the '<em><b>Ports</b></em>' containment reference list.
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 * @ordered
 	 */
@@ -156,26 +162,58 @@ public interface DevResponsePackage extends EPackage {
 	int FB_FEATURE_COUNT = 3;
 
 	/**
-	 * The meta object id for the '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.PortImpl <em>Port</em>}' class.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.FBTypeImpl <em>FB
+	 * Type</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.FBTypeImpl
+	 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.DevResponsePackageImpl#getFBType()
+	 * @generated
+	 */
+	int FB_TYPE = 2;
+
+	/**
+	 * The feature id for the '<em><b>Name</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 * @ordered
+	 */
+	int FB_TYPE__NAME = 0;
+
+	/**
+	 * The number of structural features of the '<em>FB Type</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 * @ordered
+	 */
+	int FB_TYPE_FEATURE_COUNT = 1;
+
+	/**
+	 * The meta object id for the
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.PortImpl
+	 * <em>Port</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.PortImpl
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.DevResponsePackageImpl#getPort()
 	 * @generated
 	 */
-	int PORT = 2;
+	int PORT = 3;
 
 	/**
-	 * The feature id for the '<em><b>Name</b></em>' attribute.
-	 * <!-- begin-user-doc
+	 * The feature id for the '<em><b>Name</b></em>' attribute. <!-- begin-user-doc
 	 * --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 * @ordered
 	 */
 	int PORT__NAME = 0;
 
 	/**
-	 * The feature id for the '<em><b>Data Values</b></em>' containment reference list.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Data Values</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 * @ordered
 	 */
@@ -191,18 +229,20 @@ public interface DevResponsePackage extends EPackage {
 	int PORT_FEATURE_COUNT = 2;
 
 	/**
-	 * The meta object id for the '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.DataImpl <em>Data</em>}' class.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.DataImpl
+	 * <em>Data</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.DataImpl
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.DevResponsePackageImpl#getData()
 	 * @generated
 	 */
-	int DATA = 3;
+	int DATA = 4;
 
 	/**
-	 * The feature id for the '<em><b>Value</b></em>' attribute.
-	 * <!-- begin-user-doc
+	 * The feature id for the '<em><b>Value</b></em>' attribute. <!-- begin-user-doc
 	 * --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 * @ordered
 	 */
@@ -227,18 +267,20 @@ public interface DevResponsePackage extends EPackage {
 	int DATA_FEATURE_COUNT = 2;
 
 	/**
-	 * The meta object id for the '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResponseImpl <em>Response</em>}' class.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResponseImpl
+	 * <em>Response</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.ResponseImpl
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.DevResponsePackageImpl#getResponse()
 	 * @generated
 	 */
-	int RESPONSE = 4;
+	int RESPONSE = 5;
 
 	/**
-	 * The feature id for the '<em><b>ID</b></em>' attribute.
-	 * <!-- begin-user-doc
+	 * The feature id for the '<em><b>ID</b></em>' attribute. <!-- begin-user-doc
 	 * --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 * @ordered
 	 */
@@ -272,13 +314,22 @@ public interface DevResponsePackage extends EPackage {
 	int RESPONSE__FBLIST = 3;
 
 	/**
+	 * The feature id for the '<em><b>Fb Type</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 * @ordered
+	 */
+	int RESPONSE__FB_TYPE = 4;
+
+	/**
 	 * The feature id for the '<em><b>Endpointlist</b></em>' reference. <!--
 	 * begin-user-doc --> <!-- end-user-doc -->
 	 *
 	 * @generated
 	 * @ordered
 	 */
-	int RESPONSE__ENDPOINTLIST = 4;
+	int RESPONSE__ENDPOINTLIST = 5;
 
 	/**
 	 * The feature id for the '<em><b>Connection</b></em>' reference. <!--
@@ -287,7 +338,7 @@ public interface DevResponsePackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int RESPONSE__CONNECTION = 5;
+	int RESPONSE__CONNECTION = 6;
 
 	/**
 	 * The number of structural features of the '<em>Response</em>' class. <!--
@@ -296,16 +347,18 @@ public interface DevResponsePackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int RESPONSE_FEATURE_COUNT = 6;
+	int RESPONSE_FEATURE_COUNT = 7;
 
 	/**
-	 * The meta object id for the '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.WatchesImpl <em>Watches</em>}' class.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.WatchesImpl
+	 * <em>Watches</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.WatchesImpl
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.DevResponsePackageImpl#getWatches()
 	 * @generated
 	 */
-	int WATCHES = 5;
+	int WATCHES = 6;
 
 	/**
 	 * The feature id for the '<em><b>Resources</b></em>' reference list. <!--
@@ -326,13 +379,15 @@ public interface DevResponsePackage extends EPackage {
 	int WATCHES_FEATURE_COUNT = 1;
 
 	/**
-	 * The meta object id for the '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.FBListImpl <em>FB List</em>}' class.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.FBListImpl <em>FB
+	 * List</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.FBListImpl
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.DevResponsePackageImpl#getFBList()
 	 * @generated
 	 */
-	int FB_LIST = 6;
+	int FB_LIST = 7;
 
 	/**
 	 * The feature id for the '<em><b>Fbs</b></em>' reference list. <!--
@@ -353,13 +408,15 @@ public interface DevResponsePackage extends EPackage {
 	int FB_LIST_FEATURE_COUNT = 1;
 
 	/**
-	 * The meta object id for the '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.EndpointListImpl <em>Endpoint List</em>}' class.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.EndpointListImpl
+	 * <em>Endpoint List</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.EndpointListImpl
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.DevResponsePackageImpl#getEndpointList()
 	 * @generated
 	 */
-	int ENDPOINT_LIST = 7;
+	int ENDPOINT_LIST = 8;
 
 	/**
 	 * The feature id for the '<em><b>Connection</b></em>' reference list. <!--
@@ -380,13 +437,15 @@ public interface DevResponsePackage extends EPackage {
 	int ENDPOINT_LIST_FEATURE_COUNT = 1;
 
 	/**
-	 * The meta object id for the '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ConnectionImpl <em>Connection</em>}' class.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ConnectionImpl
+	 * <em>Connection</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.ConnectionImpl
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.DevResponsePackageImpl#getConnection()
 	 * @generated
 	 */
-	int CONNECTION = 8;
+	int CONNECTION = 9;
 
 	/**
 	 * The feature id for the '<em><b>Source</b></em>' attribute. <!--
@@ -416,8 +475,10 @@ public interface DevResponsePackage extends EPackage {
 	int CONNECTION_FEATURE_COUNT = 2;
 
 	/**
-	 * Returns the meta object for class '{@link org.eclipse.fordiac.ide.deployment.devResponse.Resource <em>Resource</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Resource
+	 * <em>Resource</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for class '<em>Resource</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Resource
 	 * @generated
@@ -425,8 +486,10 @@ public interface DevResponsePackage extends EPackage {
 	EClass getResource();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.eclipse.fordiac.ide.deployment.devResponse.Resource#getName <em>Name</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Resource#getName
+	 * <em>Name</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for the attribute '<em>Name</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Resource#getName()
 	 * @see #getResource()
@@ -435,8 +498,10 @@ public interface DevResponsePackage extends EPackage {
 	EAttribute getResource_Name();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.eclipse.fordiac.ide.deployment.devResponse.Resource#getType <em>Type</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Resource#getType
+	 * <em>Type</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for the attribute '<em>Type</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Resource#getType()
 	 * @see #getResource()
@@ -445,8 +510,10 @@ public interface DevResponsePackage extends EPackage {
 	EAttribute getResource_Type();
 
 	/**
-	 * Returns the meta object for the containment reference list '{@link org.eclipse.fordiac.ide.deployment.devResponse.Resource#getFbs <em>Fbs</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference list
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Resource#getFbs
+	 * <em>Fbs</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for the containment reference list '<em>Fbs</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Resource#getFbs()
 	 * @see #getResource()
@@ -466,8 +533,10 @@ public interface DevResponsePackage extends EPackage {
 	EClass getFB();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.eclipse.fordiac.ide.deployment.devResponse.FB#getName <em>Name</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.FB#getName
+	 * <em>Name</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for the attribute '<em>Name</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.FB#getName()
 	 * @see #getFB()
@@ -476,8 +545,10 @@ public interface DevResponsePackage extends EPackage {
 	EAttribute getFB_Name();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.eclipse.fordiac.ide.deployment.devResponse.FB#getType <em>Type</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.FB#getType
+	 * <em>Type</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for the attribute '<em>Type</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.FB#getType()
 	 * @see #getFB()
@@ -486,8 +557,10 @@ public interface DevResponsePackage extends EPackage {
 	EAttribute getFB_Type();
 
 	/**
-	 * Returns the meta object for the containment reference list '{@link org.eclipse.fordiac.ide.deployment.devResponse.FB#getPorts <em>Ports</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference list
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.FB#getPorts
+	 * <em>Ports</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for the containment reference list '<em>Ports</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.FB#getPorts()
 	 * @see #getFB()
@@ -496,8 +569,33 @@ public interface DevResponsePackage extends EPackage {
 	EReference getFB_Ports();
 
 	/**
-	 * Returns the meta object for class '{@link org.eclipse.fordiac.ide.deployment.devResponse.Port <em>Port</em>}'.
+	 * Returns the meta object for class
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.FBType <em>FB
+	 * Type</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @return the meta object for class '<em>FB Type</em>'.
+	 * @see org.eclipse.fordiac.ide.deployment.devResponse.FBType
+	 * @generated
+	 */
+	EClass getFBType();
+
+	/**
+	 * Returns the meta object for the attribute
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.FBType#getName
+	 * <em>Name</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @return the meta object for the attribute '<em>Name</em>'.
+	 * @see org.eclipse.fordiac.ide.deployment.devResponse.FBType#getName()
+	 * @see #getFBType()
+	 * @generated
+	 */
+	EAttribute getFBType_Name();
+
+	/**
+	 * Returns the meta object for class
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Port <em>Port</em>}'.
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for class '<em>Port</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Port
 	 * @generated
@@ -505,8 +603,10 @@ public interface DevResponsePackage extends EPackage {
 	EClass getPort();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.eclipse.fordiac.ide.deployment.devResponse.Port#getName <em>Name</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Port#getName
+	 * <em>Name</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for the attribute '<em>Name</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Port#getName()
 	 * @see #getPort()
@@ -515,9 +615,12 @@ public interface DevResponsePackage extends EPackage {
 	EAttribute getPort_Name();
 
 	/**
-	 * Returns the meta object for the containment reference list '{@link org.eclipse.fordiac.ide.deployment.devResponse.Port#getDataValues <em>Data Values</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * @return the meta object for the containment reference list '<em>Data Values</em>'.
+	 * Returns the meta object for the containment reference list
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Port#getDataValues
+	 * <em>Data Values</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @return the meta object for the containment reference list '<em>Data
+	 *         Values</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Port#getDataValues()
 	 * @see #getPort()
 	 * @generated
@@ -525,8 +628,10 @@ public interface DevResponsePackage extends EPackage {
 	EReference getPort_DataValues();
 
 	/**
-	 * Returns the meta object for class '{@link org.eclipse.fordiac.ide.deployment.devResponse.Data <em>Data</em>}'.
+	 * Returns the meta object for class
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Data <em>Data</em>}'.
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for class '<em>Data</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Data
 	 * @generated
@@ -534,8 +639,10 @@ public interface DevResponsePackage extends EPackage {
 	EClass getData();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.eclipse.fordiac.ide.deployment.devResponse.Data#getValue <em>Value</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Data#getValue
+	 * <em>Value</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for the attribute '<em>Value</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Data#getValue()
 	 * @see #getData()
@@ -544,8 +651,10 @@ public interface DevResponsePackage extends EPackage {
 	EAttribute getData_Value();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.eclipse.fordiac.ide.deployment.devResponse.Data#getForced <em>Forced</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Data#getForced
+	 * <em>Forced</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for the attribute '<em>Forced</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Data#getForced()
 	 * @see #getData()
@@ -554,8 +663,10 @@ public interface DevResponsePackage extends EPackage {
 	EAttribute getData_Forced();
 
 	/**
-	 * Returns the meta object for class '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response <em>Response</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response
+	 * <em>Response</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for class '<em>Response</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Response
 	 * @generated
@@ -563,8 +674,10 @@ public interface DevResponsePackage extends EPackage {
 	EClass getResponse();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getID <em>ID</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getID
+	 * <em>ID</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for the attribute '<em>ID</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Response#getID()
 	 * @see #getResponse()
@@ -573,8 +686,10 @@ public interface DevResponsePackage extends EPackage {
 	EAttribute getResponse_ID();
 
 	/**
-	 * Returns the meta object for the reference '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getWatches <em>Watches</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * Returns the meta object for the reference
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getWatches
+	 * <em>Watches</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for the reference '<em>Watches</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Response#getWatches()
 	 * @see #getResponse()
@@ -583,8 +698,10 @@ public interface DevResponsePackage extends EPackage {
 	EReference getResponse_Watches();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getReason <em>Reason</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getReason
+	 * <em>Reason</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for the attribute '<em>Reason</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Response#getReason()
 	 * @see #getResponse()
@@ -593,8 +710,10 @@ public interface DevResponsePackage extends EPackage {
 	EAttribute getResponse_Reason();
 
 	/**
-	 * Returns the meta object for the reference '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getFblist <em>Fblist</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * Returns the meta object for the reference
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getFblist
+	 * <em>Fblist</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for the reference '<em>Fblist</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Response#getFblist()
 	 * @see #getResponse()
@@ -603,8 +722,22 @@ public interface DevResponsePackage extends EPackage {
 	EReference getResponse_Fblist();
 
 	/**
-	 * Returns the meta object for the reference '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getEndpointlist <em>Endpointlist</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * Returns the meta object for the reference
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getFbType
+	 * <em>Fb Type</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @return the meta object for the reference '<em>Fb Type</em>'.
+	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Response#getFbType()
+	 * @see #getResponse()
+	 * @generated
+	 */
+	EReference getResponse_FbType();
+
+	/**
+	 * Returns the meta object for the reference
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getEndpointlist
+	 * <em>Endpointlist</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for the reference '<em>Endpointlist</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Response#getEndpointlist()
 	 * @see #getResponse()
@@ -613,8 +746,10 @@ public interface DevResponsePackage extends EPackage {
 	EReference getResponse_Endpointlist();
 
 	/**
-	 * Returns the meta object for the reference '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getConnection <em>Connection</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * Returns the meta object for the reference
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getConnection
+	 * <em>Connection</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for the reference '<em>Connection</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Response#getConnection()
 	 * @see #getResponse()
@@ -623,8 +758,10 @@ public interface DevResponsePackage extends EPackage {
 	EReference getResponse_Connection();
 
 	/**
-	 * Returns the meta object for class '{@link org.eclipse.fordiac.ide.deployment.devResponse.Watches <em>Watches</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Watches
+	 * <em>Watches</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for class '<em>Watches</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Watches
 	 * @generated
@@ -632,8 +769,10 @@ public interface DevResponsePackage extends EPackage {
 	EClass getWatches();
 
 	/**
-	 * Returns the meta object for the reference list '{@link org.eclipse.fordiac.ide.deployment.devResponse.Watches#getResources <em>Resources</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * Returns the meta object for the reference list
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Watches#getResources
+	 * <em>Resources</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for the reference list '<em>Resources</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Watches#getResources()
 	 * @see #getWatches()
@@ -642,8 +781,10 @@ public interface DevResponsePackage extends EPackage {
 	EReference getWatches_Resources();
 
 	/**
-	 * Returns the meta object for class '{@link org.eclipse.fordiac.ide.deployment.devResponse.FBList <em>FB List</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.FBList <em>FB
+	 * List</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for class '<em>FB List</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.FBList
 	 * @generated
@@ -651,8 +792,10 @@ public interface DevResponsePackage extends EPackage {
 	EClass getFBList();
 
 	/**
-	 * Returns the meta object for the reference list '{@link org.eclipse.fordiac.ide.deployment.devResponse.FBList#getFbs <em>Fbs</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * Returns the meta object for the reference list
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.FBList#getFbs
+	 * <em>Fbs</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for the reference list '<em>Fbs</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.FBList#getFbs()
 	 * @see #getFBList()
@@ -661,8 +804,10 @@ public interface DevResponsePackage extends EPackage {
 	EReference getFBList_Fbs();
 
 	/**
-	 * Returns the meta object for class '{@link org.eclipse.fordiac.ide.deployment.devResponse.EndpointList <em>Endpoint List</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.EndpointList
+	 * <em>Endpoint List</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for class '<em>Endpoint List</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.EndpointList
 	 * @generated
@@ -670,8 +815,10 @@ public interface DevResponsePackage extends EPackage {
 	EClass getEndpointList();
 
 	/**
-	 * Returns the meta object for the reference list '{@link org.eclipse.fordiac.ide.deployment.devResponse.EndpointList#getConnection <em>Connection</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * Returns the meta object for the reference list
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.EndpointList#getConnection
+	 * <em>Connection</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for the reference list '<em>Connection</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.EndpointList#getConnection()
 	 * @see #getEndpointList()
@@ -680,8 +827,10 @@ public interface DevResponsePackage extends EPackage {
 	EReference getEndpointList_Connection();
 
 	/**
-	 * Returns the meta object for class '{@link org.eclipse.fordiac.ide.deployment.devResponse.Connection <em>Connection</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Connection
+	 * <em>Connection</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for class '<em>Connection</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Connection
 	 * @generated
@@ -689,8 +838,10 @@ public interface DevResponsePackage extends EPackage {
 	EClass getConnection();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.eclipse.fordiac.ide.deployment.devResponse.Connection#getSource <em>Source</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Connection#getSource
+	 * <em>Source</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for the attribute '<em>Source</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Connection#getSource()
 	 * @see #getConnection()
@@ -699,8 +850,10 @@ public interface DevResponsePackage extends EPackage {
 	EAttribute getConnection_Source();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.eclipse.fordiac.ide.deployment.devResponse.Connection#getDestination <em>Destination</em>}'.
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Connection#getDestination
+	 * <em>Destination</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @return the meta object for the attribute '<em>Destination</em>'.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Connection#getDestination()
 	 * @see #getConnection()
@@ -726,12 +879,15 @@ public interface DevResponsePackage extends EPackage {
 	 * <li>and each data type</li>
 	 * </ul>
 	 * <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	interface Literals {
 		/**
-		 * The meta object literal for the '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResourceImpl <em>Resource</em>}' class.
-		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResourceImpl
+		 * <em>Resource</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.ResourceImpl
 		 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.DevResponsePackageImpl#getResource()
 		 * @generated
@@ -741,6 +897,7 @@ public interface DevResponsePackage extends EPackage {
 		/**
 		 * The meta object literal for the '<em><b>Name</b></em>' attribute feature.
 		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @generated
 		 */
 		EAttribute RESOURCE__NAME = eINSTANCE.getResource_Name();
@@ -748,20 +905,24 @@ public interface DevResponsePackage extends EPackage {
 		/**
 		 * The meta object literal for the '<em><b>Type</b></em>' attribute feature.
 		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @generated
 		 */
 		EAttribute RESOURCE__TYPE = eINSTANCE.getResource_Type();
 
 		/**
-		 * The meta object literal for the '<em><b>Fbs</b></em>' containment reference list feature.
-		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Fbs</b></em>' containment reference
+		 * list feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @generated
 		 */
 		EReference RESOURCE__FBS = eINSTANCE.getResource_Fbs();
 
 		/**
-		 * The meta object literal for the '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.FBImpl <em>FB</em>}' class.
-		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.FBImpl
+		 * <em>FB</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.FBImpl
 		 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.DevResponsePackageImpl#getFB()
 		 * @generated
@@ -771,6 +932,7 @@ public interface DevResponsePackage extends EPackage {
 		/**
 		 * The meta object literal for the '<em><b>Name</b></em>' attribute feature.
 		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @generated
 		 */
 		EAttribute FB__NAME = eINSTANCE.getFB_Name();
@@ -778,20 +940,43 @@ public interface DevResponsePackage extends EPackage {
 		/**
 		 * The meta object literal for the '<em><b>Type</b></em>' attribute feature.
 		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @generated
 		 */
 		EAttribute FB__TYPE = eINSTANCE.getFB_Type();
 
 		/**
-		 * The meta object literal for the '<em><b>Ports</b></em>' containment reference list feature.
-		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Ports</b></em>' containment reference
+		 * list feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @generated
 		 */
 		EReference FB__PORTS = eINSTANCE.getFB_Ports();
 
 		/**
-		 * The meta object literal for the '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.PortImpl <em>Port</em>}' class.
+		 * The meta object literal for the
+		 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.FBTypeImpl <em>FB
+		 * Type</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
+		 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.FBTypeImpl
+		 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.DevResponsePackageImpl#getFBType()
+		 * @generated
+		 */
+		EClass FB_TYPE = eINSTANCE.getFBType();
+
+		/**
+		 * The meta object literal for the '<em><b>Name</b></em>' attribute feature.
 		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
+		 * @generated
+		 */
+		EAttribute FB_TYPE__NAME = eINSTANCE.getFBType_Name();
+
+		/**
+		 * The meta object literal for the
+		 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.PortImpl
+		 * <em>Port</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.PortImpl
 		 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.DevResponsePackageImpl#getPort()
 		 * @generated
@@ -801,20 +986,24 @@ public interface DevResponsePackage extends EPackage {
 		/**
 		 * The meta object literal for the '<em><b>Name</b></em>' attribute feature.
 		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @generated
 		 */
 		EAttribute PORT__NAME = eINSTANCE.getPort_Name();
 
 		/**
-		 * The meta object literal for the '<em><b>Data Values</b></em>' containment reference list feature.
-		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Data Values</b></em>' containment
+		 * reference list feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @generated
 		 */
 		EReference PORT__DATA_VALUES = eINSTANCE.getPort_DataValues();
 
 		/**
-		 * The meta object literal for the '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.DataImpl <em>Data</em>}' class.
-		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.DataImpl
+		 * <em>Data</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.DataImpl
 		 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.DevResponsePackageImpl#getData()
 		 * @generated
@@ -824,6 +1013,7 @@ public interface DevResponsePackage extends EPackage {
 		/**
 		 * The meta object literal for the '<em><b>Value</b></em>' attribute feature.
 		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @generated
 		 */
 		EAttribute DATA__VALUE = eINSTANCE.getData_Value();
@@ -831,13 +1021,16 @@ public interface DevResponsePackage extends EPackage {
 		/**
 		 * The meta object literal for the '<em><b>Forced</b></em>' attribute feature.
 		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @generated
 		 */
 		EAttribute DATA__FORCED = eINSTANCE.getData_Forced();
 
 		/**
-		 * The meta object literal for the '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResponseImpl <em>Response</em>}' class.
-		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResponseImpl
+		 * <em>Response</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.ResponseImpl
 		 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.DevResponsePackageImpl#getResponse()
 		 * @generated
@@ -855,6 +1048,7 @@ public interface DevResponsePackage extends EPackage {
 		/**
 		 * The meta object literal for the '<em><b>Watches</b></em>' reference feature.
 		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @generated
 		 */
 		EReference RESPONSE__WATCHES = eINSTANCE.getResponse_Watches();
@@ -862,6 +1056,7 @@ public interface DevResponsePackage extends EPackage {
 		/**
 		 * The meta object literal for the '<em><b>Reason</b></em>' attribute feature.
 		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @generated
 		 */
 		EAttribute RESPONSE__REASON = eINSTANCE.getResponse_Reason();
@@ -869,27 +1064,40 @@ public interface DevResponsePackage extends EPackage {
 		/**
 		 * The meta object literal for the '<em><b>Fblist</b></em>' reference feature.
 		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @generated
 		 */
 		EReference RESPONSE__FBLIST = eINSTANCE.getResponse_Fblist();
 
 		/**
-		 * The meta object literal for the '<em><b>Endpointlist</b></em>' reference feature.
+		 * The meta object literal for the '<em><b>Fb Type</b></em>' reference feature.
 		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
+		 * @generated
+		 */
+		EReference RESPONSE__FB_TYPE = eINSTANCE.getResponse_FbType();
+
+		/**
+		 * The meta object literal for the '<em><b>Endpointlist</b></em>' reference
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @generated
 		 */
 		EReference RESPONSE__ENDPOINTLIST = eINSTANCE.getResponse_Endpointlist();
 
 		/**
-		 * The meta object literal for the '<em><b>Connection</b></em>' reference feature.
-		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Connection</b></em>' reference
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @generated
 		 */
 		EReference RESPONSE__CONNECTION = eINSTANCE.getResponse_Connection();
 
 		/**
-		 * The meta object literal for the '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.WatchesImpl <em>Watches</em>}' class.
-		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.WatchesImpl
+		 * <em>Watches</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.WatchesImpl
 		 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.DevResponsePackageImpl#getWatches()
 		 * @generated
@@ -897,15 +1105,18 @@ public interface DevResponsePackage extends EPackage {
 		EClass WATCHES = eINSTANCE.getWatches();
 
 		/**
-		 * The meta object literal for the '<em><b>Resources</b></em>' reference list feature.
-		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Resources</b></em>' reference list
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @generated
 		 */
 		EReference WATCHES__RESOURCES = eINSTANCE.getWatches_Resources();
 
 		/**
-		 * The meta object literal for the '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.FBListImpl <em>FB List</em>}' class.
-		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.FBListImpl <em>FB
+		 * List</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.FBListImpl
 		 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.DevResponsePackageImpl#getFBList()
 		 * @generated
@@ -915,13 +1126,16 @@ public interface DevResponsePackage extends EPackage {
 		/**
 		 * The meta object literal for the '<em><b>Fbs</b></em>' reference list feature.
 		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @generated
 		 */
 		EReference FB_LIST__FBS = eINSTANCE.getFBList_Fbs();
 
 		/**
-		 * The meta object literal for the '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.EndpointListImpl <em>Endpoint List</em>}' class.
-		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.EndpointListImpl
+		 * <em>Endpoint List</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.EndpointListImpl
 		 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.DevResponsePackageImpl#getEndpointList()
 		 * @generated
@@ -929,15 +1143,18 @@ public interface DevResponsePackage extends EPackage {
 		EClass ENDPOINT_LIST = eINSTANCE.getEndpointList();
 
 		/**
-		 * The meta object literal for the '<em><b>Connection</b></em>' reference list feature.
-		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Connection</b></em>' reference list
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @generated
 		 */
 		EReference ENDPOINT_LIST__CONNECTION = eINSTANCE.getEndpointList_Connection();
 
 		/**
-		 * The meta object literal for the '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ConnectionImpl <em>Connection</em>}' class.
-		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ConnectionImpl
+		 * <em>Connection</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.ConnectionImpl
 		 * @see org.eclipse.fordiac.ide.deployment.devResponse.impl.DevResponsePackageImpl#getConnection()
 		 * @generated
@@ -947,13 +1164,15 @@ public interface DevResponsePackage extends EPackage {
 		/**
 		 * The meta object literal for the '<em><b>Source</b></em>' attribute feature.
 		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @generated
 		 */
 		EAttribute CONNECTION__SOURCE = eINSTANCE.getConnection_Source();
 
 		/**
-		 * The meta object literal for the '<em><b>Destination</b></em>' attribute feature.
-		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Destination</b></em>' attribute
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
 		 * @generated
 		 */
 		EAttribute CONNECTION__DESTINATION = eINSTANCE.getConnection_Destination();

--- a/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/FBType.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/FBType.java
@@ -1,0 +1,62 @@
+/**
+ * ******************************************************************************
+ * Copyright (c) 2012, 2013, 2018 Profactor GmbH, fortiss GmbH, Johannes Kepler University
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Gerhard Ebenhofer, Alois Zoitl
+ *      - initial API and implementation and/or initial documentation
+ *    Alois Zoitl - moved to deployment and reworked it to a device response model
+ * ******************************************************************************
+ *
+ */
+package org.eclipse.fordiac.ide.deployment.devResponse;
+
+import org.eclipse.emf.ecore.EObject;
+
+/**
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>FB
+ * Type</b></em>'. <!-- end-user-doc -->
+ *
+ * <p>
+ * The following features are supported:
+ * </p>
+ * <ul>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.FBType#getName
+ * <em>Name</em>}</li>
+ * </ul>
+ *
+ * @see org.eclipse.fordiac.ide.deployment.devResponse.DevResponsePackage#getFBType()
+ * @model
+ * @generated
+ */
+public interface FBType extends EObject {
+	/**
+	 * Returns the value of the '<em><b>Name</b></em>' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @return the value of the '<em>Name</em>' attribute.
+	 * @see #setName(String)
+	 * @see org.eclipse.fordiac.ide.deployment.devResponse.DevResponsePackage#getFBType_Name()
+	 * @model
+	 * @generated
+	 */
+	String getName();
+
+	/**
+	 * Sets the value of the
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.FBType#getName
+	 * <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @param value the new value of the '<em>Name</em>' attribute.
+	 * @see #getName()
+	 * @generated
+	 */
+	void setName(String value);
+
+} // FBType

--- a/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/Response.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/Response.java
@@ -1,7 +1,7 @@
 /**
  * ******************************************************************************
  * * Copyright (c) 2012, 2013, 2018 Profactor GmbH, fortiss GmbH, Johannes Kepler University
- * * 
+ * *
  * * This program and the accompanying materials are made available under the
  * * terms of the Eclipse Public License 2.0 which is available at
  * * http://www.eclipse.org/legal/epl-2.0.
@@ -13,27 +13,34 @@
  * *     - initial API and implementation and/or initial documentation
  * *   Alois Zoitl - moved to deployment and reworked it to a device response model
  * ******************************************************************************
- * 
+ *
  */
 package org.eclipse.fordiac.ide.deployment.devResponse;
 
 import org.eclipse.emf.ecore.EObject;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Response</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Response</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * </p>
  * <ul>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getID <em>ID</em>}</li>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getWatches <em>Watches</em>}</li>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getReason <em>Reason</em>}</li>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getFblist <em>Fblist</em>}</li>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getEndpointlist <em>Endpointlist</em>}</li>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getConnection <em>Connection</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getID
+ * <em>ID</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getWatches
+ * <em>Watches</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getReason
+ * <em>Reason</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getFblist
+ * <em>Fblist</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getFbType
+ * <em>Fb Type</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getEndpointlist
+ * <em>Endpointlist</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getConnection
+ * <em>Connection</em>}</li>
  * </ul>
  *
  * @see org.eclipse.fordiac.ide.deployment.devResponse.DevResponsePackage#getResponse()
@@ -42,13 +49,14 @@ import org.eclipse.emf.ecore.EObject;
  */
 public interface Response extends EObject {
 	/**
-	 * Returns the value of the '<em><b>ID</b></em>' attribute.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>ID</b></em>' attribute. <!-- begin-user-doc
+	 * -->
 	 * <p>
-	 * If the meaning of the '<em>ID</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>ID</em>' attribute isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 *
 	 * @return the value of the '<em>ID</em>' attribute.
 	 * @see #setID(String)
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.DevResponsePackage#getResponse_ID()
@@ -58,9 +66,10 @@ public interface Response extends EObject {
 	String getID();
 
 	/**
-	 * Sets the value of the '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getID <em>ID</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getID
+	 * <em>ID</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @param value the new value of the '<em>ID</em>' attribute.
 	 * @see #getID()
 	 * @generated
@@ -68,13 +77,14 @@ public interface Response extends EObject {
 	void setID(String value);
 
 	/**
-	 * Returns the value of the '<em><b>Watches</b></em>' reference.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Watches</b></em>' reference. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Watches</em>' reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Watches</em>' reference isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 *
 	 * @return the value of the '<em>Watches</em>' reference.
 	 * @see #setWatches(Watches)
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.DevResponsePackage#getResponse_Watches()
@@ -84,9 +94,10 @@ public interface Response extends EObject {
 	Watches getWatches();
 
 	/**
-	 * Sets the value of the '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getWatches <em>Watches</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getWatches
+	 * <em>Watches</em>}' reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @param value the new value of the '<em>Watches</em>' reference.
 	 * @see #getWatches()
 	 * @generated
@@ -94,13 +105,14 @@ public interface Response extends EObject {
 	void setWatches(Watches value);
 
 	/**
-	 * Returns the value of the '<em><b>Reason</b></em>' attribute.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Reason</b></em>' attribute. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Reason</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Reason</em>' attribute isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 *
 	 * @return the value of the '<em>Reason</em>' attribute.
 	 * @see #setReason(String)
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.DevResponsePackage#getResponse_Reason()
@@ -110,9 +122,10 @@ public interface Response extends EObject {
 	String getReason();
 
 	/**
-	 * Sets the value of the '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getReason <em>Reason</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getReason
+	 * <em>Reason</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @param value the new value of the '<em>Reason</em>' attribute.
 	 * @see #getReason()
 	 * @generated
@@ -120,13 +133,14 @@ public interface Response extends EObject {
 	void setReason(String value);
 
 	/**
-	 * Returns the value of the '<em><b>Fblist</b></em>' reference.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Fblist</b></em>' reference. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Fblist</em>' reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Fblist</em>' reference isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 *
 	 * @return the value of the '<em>Fblist</em>' reference.
 	 * @see #setFblist(FBList)
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.DevResponsePackage#getResponse_Fblist()
@@ -136,9 +150,10 @@ public interface Response extends EObject {
 	FBList getFblist();
 
 	/**
-	 * Sets the value of the '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getFblist <em>Fblist</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getFblist
+	 * <em>Fblist</em>}' reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @param value the new value of the '<em>Fblist</em>' reference.
 	 * @see #getFblist()
 	 * @generated
@@ -146,13 +161,37 @@ public interface Response extends EObject {
 	void setFblist(FBList value);
 
 	/**
-	 * Returns the value of the '<em><b>Endpointlist</b></em>' reference.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Fb Type</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @return the value of the '<em>Fb Type</em>' reference.
+	 * @see #setFbType(FBType)
+	 * @see org.eclipse.fordiac.ide.deployment.devResponse.DevResponsePackage#getResponse_FbType()
+	 * @model extendedMetaData="kind='element' name='FBType'"
+	 * @generated
+	 */
+	FBType getFbType();
+
+	/**
+	 * Sets the value of the
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getFbType
+	 * <em>Fb Type</em>}' reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @param value the new value of the '<em>Fb Type</em>' reference.
+	 * @see #getFbType()
+	 * @generated
+	 */
+	void setFbType(FBType value);
+
+	/**
+	 * Returns the value of the '<em><b>Endpointlist</b></em>' reference. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Endpointlist</em>' reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Endpointlist</em>' reference isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 *
 	 * @return the value of the '<em>Endpointlist</em>' reference.
 	 * @see #setEndpointlist(EndpointList)
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.DevResponsePackage#getResponse_Endpointlist()
@@ -162,9 +201,11 @@ public interface Response extends EObject {
 	EndpointList getEndpointlist();
 
 	/**
-	 * Sets the value of the '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getEndpointlist <em>Endpointlist</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getEndpointlist
+	 * <em>Endpointlist</em>}' reference. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 *
 	 * @param value the new value of the '<em>Endpointlist</em>' reference.
 	 * @see #getEndpointlist()
 	 * @generated
@@ -172,13 +213,14 @@ public interface Response extends EObject {
 	void setEndpointlist(EndpointList value);
 
 	/**
-	 * Returns the value of the '<em><b>Connection</b></em>' reference.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Connection</b></em>' reference. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Connection</em>' reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Connection</em>' reference isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 *
 	 * @return the value of the '<em>Connection</em>' reference.
 	 * @see #setConnection(Connection)
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.DevResponsePackage#getResponse_Connection()
@@ -188,9 +230,11 @@ public interface Response extends EObject {
 	Connection getConnection();
 
 	/**
-	 * Sets the value of the '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getConnection <em>Connection</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response#getConnection
+	 * <em>Connection</em>}' reference. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 *
 	 * @param value the new value of the '<em>Connection</em>' reference.
 	 * @see #getConnection()
 	 * @generated

--- a/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/impl/DataImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/impl/DataImpl.java
@@ -25,24 +25,25 @@ import org.eclipse.fordiac.ide.deployment.devResponse.Data;
 import org.eclipse.fordiac.ide.deployment.devResponse.DevResponsePackage;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Data</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Data</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * </p>
  * <ul>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.DataImpl#getValue <em>Value</em>}</li>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.DataImpl#getForced <em>Forced</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.DataImpl#getValue
+ * <em>Value</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.DataImpl#getForced
+ * <em>Forced</em>}</li>
  * </ul>
  *
  * @generated
  */
 public class DataImpl extends EObjectImpl implements Data {
 	/**
-	 * The default value of the '{@link #getValue() <em>Value</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getValue() <em>Value</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getValue()
 	 * @generated
 	 * @ordered
@@ -50,9 +51,9 @@ public class DataImpl extends EObjectImpl implements Data {
 	protected static final String VALUE_EDEFAULT = null;
 
 	/**
-	 * The cached value of the '{@link #getValue() <em>Value</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getValue() <em>Value</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getValue()
 	 * @generated
 	 * @ordered
@@ -61,8 +62,8 @@ public class DataImpl extends EObjectImpl implements Data {
 
 	/**
 	 * The default value of the '{@link #getForced() <em>Forced</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getForced()
 	 * @generated
 	 * @ordered
@@ -71,8 +72,8 @@ public class DataImpl extends EObjectImpl implements Data {
 
 	/**
 	 * The cached value of the '{@link #getForced() <em>Forced</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getForced()
 	 * @generated
 	 * @ordered
@@ -80,17 +81,16 @@ public class DataImpl extends EObjectImpl implements Data {
 	protected String forced = FORCED_EDEFAULT;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	protected DataImpl() {
-		super();
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -99,8 +99,8 @@ public class DataImpl extends EObjectImpl implements Data {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -109,13 +109,13 @@ public class DataImpl extends EObjectImpl implements Data {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public void setValue(String newValue) {
-		String oldValue = value;
+	public void setValue(final String newValue) {
+		final String oldValue = value;
 		value = newValue;
 		if (eNotificationRequired()) {
 			eNotify(new ENotificationImpl(this, Notification.SET, DevResponsePackage.DATA__VALUE, oldValue, value));
@@ -123,8 +123,8 @@ public class DataImpl extends EObjectImpl implements Data {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -133,13 +133,13 @@ public class DataImpl extends EObjectImpl implements Data {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public void setForced(String newForced) {
-		String oldForced = forced;
+	public void setForced(final String newForced) {
+		final String oldForced = forced;
 		forced = newForced;
 		if (eNotificationRequired()) {
 			eNotify(new ENotificationImpl(this, Notification.SET, DevResponsePackage.DATA__FORCED, oldForced, forced));
@@ -147,82 +147,74 @@ public class DataImpl extends EObjectImpl implements Data {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public Object eGet(int featureID, boolean resolve, boolean coreType) {
+	public Object eGet(final int featureID, final boolean resolve, final boolean coreType) {
+		return switch (featureID) {
+		case DevResponsePackage.DATA__VALUE -> getValue();
+		case DevResponsePackage.DATA__FORCED -> getForced();
+		default -> super.eGet(featureID, resolve, coreType);
+		};
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	@Override
+	public void eSet(final int featureID, final Object newValue) {
 		switch (featureID) {
-			case DevResponsePackage.DATA__VALUE:
-				return getValue();
-			case DevResponsePackage.DATA__FORCED:
-				return getForced();
-			default:
-				return super.eGet(featureID, resolve, coreType);
+		case DevResponsePackage.DATA__VALUE:
+			setValue((String) newValue);
+			return;
+		case DevResponsePackage.DATA__FORCED:
+			setForced((String) newValue);
+			return;
+		default:
+			super.eSet(featureID, newValue);
 		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public void eSet(int featureID, Object newValue) {
+	public void eUnset(final int featureID) {
 		switch (featureID) {
-			case DevResponsePackage.DATA__VALUE:
-				setValue((String)newValue);
-				return;
-			case DevResponsePackage.DATA__FORCED:
-				setForced((String)newValue);
-				return;
-			default:
-				super.eSet(featureID, newValue);
-				return;
+		case DevResponsePackage.DATA__VALUE:
+			setValue(VALUE_EDEFAULT);
+			return;
+		case DevResponsePackage.DATA__FORCED:
+			setForced(FORCED_EDEFAULT);
+			return;
+		default:
+			super.eUnset(featureID);
 		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public void eUnset(int featureID) {
-		switch (featureID) {
-			case DevResponsePackage.DATA__VALUE:
-				setValue(VALUE_EDEFAULT);
-				return;
-			case DevResponsePackage.DATA__FORCED:
-				setForced(FORCED_EDEFAULT);
-				return;
-			default:
-				super.eUnset(featureID);
-				return;
-		}
+	public boolean eIsSet(final int featureID) {
+		return switch (featureID) {
+		case DevResponsePackage.DATA__VALUE -> VALUE_EDEFAULT == null ? value != null : !VALUE_EDEFAULT.equals(value);
+		case DevResponsePackage.DATA__FORCED -> FORCED_EDEFAULT == null ? forced != null : !FORCED_EDEFAULT.equals(forced);
+		default -> super.eIsSet(featureID);
+		};
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	@Override
-	public boolean eIsSet(int featureID) {
-		switch (featureID) {
-			case DevResponsePackage.DATA__VALUE:
-				return VALUE_EDEFAULT == null ? value != null : !VALUE_EDEFAULT.equals(value);
-			case DevResponsePackage.DATA__FORCED:
-				return FORCED_EDEFAULT == null ? forced != null : !FORCED_EDEFAULT.equals(forced);
-			default:
-				return super.eIsSet(featureID);
-		}
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -231,7 +223,7 @@ public class DataImpl extends EObjectImpl implements Data {
 			return super.toString();
 		}
 
-		StringBuilder result = new StringBuilder(super.toString());
+		final StringBuilder result = new StringBuilder(super.toString());
 		result.append(" (value: "); //$NON-NLS-1$
 		result.append(value);
 		result.append(", forced: "); //$NON-NLS-1$
@@ -240,4 +232,4 @@ public class DataImpl extends EObjectImpl implements Data {
 		return result.toString();
 	}
 
-} //DataImpl
+} // DataImpl

--- a/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/impl/DevResponseFactoryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/impl/DevResponseFactoryImpl.java
@@ -1,7 +1,7 @@
 /**
  * ******************************************************************************
  * * Copyright (c) 2012, 2013, 2018 Profactor GmbH, fortiss GmbH, Johannes Kepler University
- * * 
+ * *
  * * This program and the accompanying materials are made available under the
  * * terms of the Eclipse Public License 2.0 which is available at
  * * http://www.eclipse.org/legal/epl-2.0.
@@ -13,7 +13,7 @@
  * *     - initial API and implementation and/or initial documentation
  * *   Alois Zoitl - moved to deployment and reworked it to a device response model
  * ******************************************************************************
- * 
+ *
  */
 package org.eclipse.fordiac.ide.deployment.devResponse.impl;
 
@@ -29,181 +29,182 @@ import org.eclipse.fordiac.ide.deployment.devResponse.DevResponsePackage;
 import org.eclipse.fordiac.ide.deployment.devResponse.EndpointList;
 import org.eclipse.fordiac.ide.deployment.devResponse.FB;
 import org.eclipse.fordiac.ide.deployment.devResponse.FBList;
+import org.eclipse.fordiac.ide.deployment.devResponse.FBType;
 import org.eclipse.fordiac.ide.deployment.devResponse.Port;
 import org.eclipse.fordiac.ide.deployment.devResponse.Resource;
 import org.eclipse.fordiac.ide.deployment.devResponse.Response;
 import org.eclipse.fordiac.ide.deployment.devResponse.Watches;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model <b>Factory</b>.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model <b>Factory</b>. <!--
+ * end-user-doc -->
+ *
  * @generated
  */
 public class DevResponseFactoryImpl extends EFactoryImpl implements DevResponseFactory {
 	/**
-	 * Creates the default factory implementation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates the default factory implementation. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 *
 	 * @generated
 	 */
 	public static DevResponseFactory init() {
 		try {
-			DevResponseFactory theDevResponseFactory = (DevResponseFactory)EPackage.Registry.INSTANCE.getEFactory(DevResponsePackage.eNS_URI);
+			final DevResponseFactory theDevResponseFactory = (DevResponseFactory) EPackage.Registry.INSTANCE
+					.getEFactory(DevResponsePackage.eNS_URI);
 			if (theDevResponseFactory != null) {
 				return theDevResponseFactory;
 			}
-		}
-		catch (Exception exception) {
+		} catch (final Exception exception) {
 			EcorePlugin.INSTANCE.log(exception);
 		}
 		return new DevResponseFactoryImpl();
 	}
 
 	/**
-	 * Creates an instance of the factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the factory. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 *
 	 * @generated
 	 */
 	public DevResponseFactoryImpl() {
-		super();
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public EObject create(EClass eClass) {
-		switch (eClass.getClassifierID()) {
-			case DevResponsePackage.RESOURCE: return createResource();
-			case DevResponsePackage.FB: return createFB();
-			case DevResponsePackage.PORT: return createPort();
-			case DevResponsePackage.DATA: return createData();
-			case DevResponsePackage.RESPONSE: return createResponse();
-			case DevResponsePackage.WATCHES: return createWatches();
-			case DevResponsePackage.FB_LIST: return createFBList();
-			case DevResponsePackage.ENDPOINT_LIST: return createEndpointList();
-			case DevResponsePackage.CONNECTION: return createConnection();
-			default:
-				throw new IllegalArgumentException("The class '" + eClass.getName() + "' is not a valid classifier"); //$NON-NLS-1$ //$NON-NLS-2$
-		}
+	public EObject create(final EClass eClass) {
+		return switch (eClass.getClassifierID()) {
+		case DevResponsePackage.RESOURCE -> createResource();
+		case DevResponsePackage.FB -> createFB();
+		case DevResponsePackage.FB_TYPE -> createFBType();
+		case DevResponsePackage.PORT -> createPort();
+		case DevResponsePackage.DATA -> createData();
+		case DevResponsePackage.RESPONSE -> createResponse();
+		case DevResponsePackage.WATCHES -> createWatches();
+		case DevResponsePackage.FB_LIST -> createFBList();
+		case DevResponsePackage.ENDPOINT_LIST -> createEndpointList();
+		case DevResponsePackage.CONNECTION -> createConnection();
+		default -> throw new IllegalArgumentException("The class '" + eClass.getName() + "' is not a valid classifier"); //$NON-NLS-1$ //$NON-NLS-2$
+		};
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public Resource createResource() {
-		ResourceImpl resource = new ResourceImpl();
-		return resource;
+		return new ResourceImpl();
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public FB createFB() {
-		FBImpl fb = new FBImpl();
-		return fb;
+		return new FBImpl();
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	@Override
+	public FBType createFBType() {
+		return new FBTypeImpl();
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public Port createPort() {
-		PortImpl port = new PortImpl();
-		return port;
+		return new PortImpl();
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public Data createData() {
-		DataImpl data = new DataImpl();
-		return data;
+		return new DataImpl();
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public Response createResponse() {
-		ResponseImpl response = new ResponseImpl();
-		return response;
+		return new ResponseImpl();
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public Watches createWatches() {
-		WatchesImpl watches = new WatchesImpl();
-		return watches;
+		return new WatchesImpl();
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public FBList createFBList() {
-		FBListImpl fbList = new FBListImpl();
-		return fbList;
+		return new FBListImpl();
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public EndpointList createEndpointList() {
-		EndpointListImpl endpointList = new EndpointListImpl();
-		return endpointList;
+		return new EndpointListImpl();
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public Connection createConnection() {
-		ConnectionImpl connection = new ConnectionImpl();
-		return connection;
+		return new ConnectionImpl();
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public DevResponsePackage getDevResponsePackage() {
-		return (DevResponsePackage)getEPackage();
+		return (DevResponsePackage) getEPackage();
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @deprecated
 	 * @generated
 	 */
@@ -212,4 +213,4 @@ public class DevResponseFactoryImpl extends EFactoryImpl implements DevResponseF
 		return DevResponsePackage.eINSTANCE;
 	}
 
-} //DevResponseFactoryImpl
+} // DevResponseFactoryImpl

--- a/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/impl/DevResponsePackageImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/impl/DevResponsePackageImpl.java
@@ -30,91 +30,99 @@ import org.eclipse.fordiac.ide.deployment.devResponse.DevResponseFactory;
 import org.eclipse.fordiac.ide.deployment.devResponse.DevResponsePackage;
 import org.eclipse.fordiac.ide.deployment.devResponse.EndpointList;
 import org.eclipse.fordiac.ide.deployment.devResponse.FBList;
+import org.eclipse.fordiac.ide.deployment.devResponse.FBType;
 import org.eclipse.fordiac.ide.deployment.devResponse.Port;
 import org.eclipse.fordiac.ide.deployment.devResponse.Resource;
 import org.eclipse.fordiac.ide.deployment.devResponse.Response;
 import org.eclipse.fordiac.ide.deployment.devResponse.Watches;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model <b>Package</b>.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model <b>Package</b>. <!--
+ * end-user-doc -->
+ *
  * @generated
  */
 public class DevResponsePackageImpl extends EPackageImpl implements DevResponsePackage {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	private EClass resourceEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	private EClass fbEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	private EClass fbTypeEClass = null;
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	private EClass portEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	private EClass dataEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	private EClass responseEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	private EClass watchesEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	private EClass fbListEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	private EClass endpointListEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	private EClass connectionEClass = null;
 
 	/**
 	 * Creates an instance of the model <b>Package</b>, registered with
-	 * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the package
-	 * package URI value.
-	 * <p>Note: the correct way to create the package is via the static
-	 * factory method {@link #init init()}, which also performs
-	 * initialization of the package, or returns the registered package,
-	 * if one already exists.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the
+	 * package package URI value.
+	 * <p>
+	 * Note: the correct way to create the package is via the static factory method
+	 * {@link #init init()}, which also performs initialization of the package, or
+	 * returns the registered package, if one already exists. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 *
 	 * @see org.eclipse.emf.ecore.EPackage.Registry
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.DevResponsePackage#eNS_URI
 	 * @see #init()
@@ -125,19 +133,22 @@ public class DevResponsePackageImpl extends EPackageImpl implements DevResponseP
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	private static boolean isInited = false;
 
 	/**
-	 * Creates, registers, and initializes the <b>Package</b> for this model, and for any others upon which it depends.
+	 * Creates, registers, and initializes the <b>Package</b> for this model, and
+	 * for any others upon which it depends.
 	 *
-	 * <p>This method is used to initialize {@link DevResponsePackage#eINSTANCE} when that field is accessed.
-	 * Clients should not invoke it directly. Instead, they should simply access that field to obtain the package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <p>
+	 * This method is used to initialize {@link DevResponsePackage#eINSTANCE} when
+	 * that field is accessed. Clients should not invoke it directly. Instead, they
+	 * should simply access that field to obtain the package. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 *
 	 * @see #eNS_URI
 	 * @see #createPackageContents()
 	 * @see #initializePackageContents()
@@ -145,12 +156,14 @@ public class DevResponsePackageImpl extends EPackageImpl implements DevResponseP
 	 */
 	public static DevResponsePackage init() {
 		if (isInited) {
-			return (DevResponsePackage)EPackage.Registry.INSTANCE.getEPackage(DevResponsePackage.eNS_URI);
+			return (DevResponsePackage) EPackage.Registry.INSTANCE.getEPackage(DevResponsePackage.eNS_URI);
 		}
 
 		// Obtain or create and register package
-		Object registeredDevResponsePackage = EPackage.Registry.INSTANCE.get(eNS_URI);
-		DevResponsePackageImpl theDevResponsePackage = registeredDevResponsePackage instanceof DevResponsePackageImpl ? (DevResponsePackageImpl)registeredDevResponsePackage : new DevResponsePackageImpl();
+		final Object registeredDevResponsePackage = EPackage.Registry.INSTANCE.get(eNS_URI);
+		final DevResponsePackageImpl theDevResponsePackage = registeredDevResponsePackage instanceof DevResponsePackageImpl
+				? (DevResponsePackageImpl) registeredDevResponsePackage
+				: new DevResponsePackageImpl();
 
 		isInited = true;
 
@@ -169,8 +182,8 @@ public class DevResponsePackageImpl extends EPackageImpl implements DevResponseP
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -179,38 +192,38 @@ public class DevResponsePackageImpl extends EPackageImpl implements DevResponseP
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public EAttribute getResource_Name() {
-		return (EAttribute)resourceEClass.getEStructuralFeatures().get(0);
+		return (EAttribute) resourceEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public EAttribute getResource_Type() {
-		return (EAttribute)resourceEClass.getEStructuralFeatures().get(1);
+		return (EAttribute) resourceEClass.getEStructuralFeatures().get(1);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public EReference getResource_Fbs() {
-		return (EReference)resourceEClass.getEStructuralFeatures().get(2);
+		return (EReference) resourceEClass.getEStructuralFeatures().get(2);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -219,38 +232,58 @@ public class DevResponsePackageImpl extends EPackageImpl implements DevResponseP
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public EAttribute getFB_Name() {
-		return (EAttribute)fbEClass.getEStructuralFeatures().get(0);
+		return (EAttribute) fbEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public EAttribute getFB_Type() {
-		return (EAttribute)fbEClass.getEStructuralFeatures().get(1);
+		return (EAttribute) fbEClass.getEStructuralFeatures().get(1);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public EReference getFB_Ports() {
-		return (EReference)fbEClass.getEStructuralFeatures().get(2);
+		return (EReference) fbEClass.getEStructuralFeatures().get(2);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	@Override
+	public EClass getFBType() {
+		return fbTypeEClass;
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	@Override
+	public EAttribute getFBType_Name() {
+		return (EAttribute) fbTypeEClass.getEStructuralFeatures().get(0);
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -259,28 +292,28 @@ public class DevResponsePackageImpl extends EPackageImpl implements DevResponseP
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public EAttribute getPort_Name() {
-		return (EAttribute)portEClass.getEStructuralFeatures().get(0);
+		return (EAttribute) portEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public EReference getPort_DataValues() {
-		return (EReference)portEClass.getEStructuralFeatures().get(1);
+		return (EReference) portEClass.getEStructuralFeatures().get(1);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -289,28 +322,28 @@ public class DevResponsePackageImpl extends EPackageImpl implements DevResponseP
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public EAttribute getData_Value() {
-		return (EAttribute)dataEClass.getEStructuralFeatures().get(0);
+		return (EAttribute) dataEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public EAttribute getData_Forced() {
-		return (EAttribute)dataEClass.getEStructuralFeatures().get(1);
+		return (EAttribute) dataEClass.getEStructuralFeatures().get(1);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -319,68 +352,78 @@ public class DevResponsePackageImpl extends EPackageImpl implements DevResponseP
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public EAttribute getResponse_ID() {
-		return (EAttribute)responseEClass.getEStructuralFeatures().get(0);
+		return (EAttribute) responseEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public EReference getResponse_Watches() {
-		return (EReference)responseEClass.getEStructuralFeatures().get(1);
+		return (EReference) responseEClass.getEStructuralFeatures().get(1);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public EAttribute getResponse_Reason() {
-		return (EAttribute)responseEClass.getEStructuralFeatures().get(2);
+		return (EAttribute) responseEClass.getEStructuralFeatures().get(2);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public EReference getResponse_Fblist() {
-		return (EReference)responseEClass.getEStructuralFeatures().get(3);
+		return (EReference) responseEClass.getEStructuralFeatures().get(3);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	@Override
+	public EReference getResponse_FbType() {
+		return (EReference) responseEClass.getEStructuralFeatures().get(4);
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public EReference getResponse_Endpointlist() {
-		return (EReference)responseEClass.getEStructuralFeatures().get(4);
+		return (EReference) responseEClass.getEStructuralFeatures().get(5);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public EReference getResponse_Connection() {
-		return (EReference)responseEClass.getEStructuralFeatures().get(5);
+		return (EReference) responseEClass.getEStructuralFeatures().get(6);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -389,18 +432,18 @@ public class DevResponsePackageImpl extends EPackageImpl implements DevResponseP
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public EReference getWatches_Resources() {
-		return (EReference)watchesEClass.getEStructuralFeatures().get(0);
+		return (EReference) watchesEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -409,18 +452,18 @@ public class DevResponsePackageImpl extends EPackageImpl implements DevResponseP
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public EReference getFBList_Fbs() {
-		return (EReference)fbListEClass.getEStructuralFeatures().get(0);
+		return (EReference) fbListEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -429,18 +472,18 @@ public class DevResponsePackageImpl extends EPackageImpl implements DevResponseP
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public EReference getEndpointList_Connection() {
-		return (EReference)endpointListEClass.getEStructuralFeatures().get(0);
+		return (EReference) endpointListEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -449,47 +492,47 @@ public class DevResponsePackageImpl extends EPackageImpl implements DevResponseP
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public EAttribute getConnection_Source() {
-		return (EAttribute)connectionEClass.getEStructuralFeatures().get(0);
+		return (EAttribute) connectionEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public EAttribute getConnection_Destination() {
-		return (EAttribute)connectionEClass.getEStructuralFeatures().get(1);
+		return (EAttribute) connectionEClass.getEStructuralFeatures().get(1);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public DevResponseFactory getDevResponseFactory() {
-		return (DevResponseFactory)getEFactoryInstance();
+		return (DevResponseFactory) getEFactoryInstance();
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	private boolean isCreated = false;
 
 	/**
-	 * Creates the meta-model objects for the package.  This method is
-	 * guarded to have no affect on any invocation but its first.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates the meta-model objects for the package. This method is guarded to
+	 * have no affect on any invocation but its first. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 *
 	 * @generated
 	 */
 	public void createPackageContents() {
@@ -509,6 +552,9 @@ public class DevResponsePackageImpl extends EPackageImpl implements DevResponseP
 		createEAttribute(fbEClass, FB__TYPE);
 		createEReference(fbEClass, FB__PORTS);
 
+		fbTypeEClass = createEClass(FB_TYPE);
+		createEAttribute(fbTypeEClass, FB_TYPE__NAME);
+
 		portEClass = createEClass(PORT);
 		createEAttribute(portEClass, PORT__NAME);
 		createEReference(portEClass, PORT__DATA_VALUES);
@@ -522,6 +568,7 @@ public class DevResponsePackageImpl extends EPackageImpl implements DevResponseP
 		createEReference(responseEClass, RESPONSE__WATCHES);
 		createEAttribute(responseEClass, RESPONSE__REASON);
 		createEReference(responseEClass, RESPONSE__FBLIST);
+		createEReference(responseEClass, RESPONSE__FB_TYPE);
 		createEReference(responseEClass, RESPONSE__ENDPOINTLIST);
 		createEReference(responseEClass, RESPONSE__CONNECTION);
 
@@ -540,17 +587,17 @@ public class DevResponsePackageImpl extends EPackageImpl implements DevResponseP
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	private boolean isInitialized = false;
 
 	/**
-	 * Complete the initialization of the package and its meta-model.  This
-	 * method is guarded to have no affect on any invocation but its first.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Complete the initialization of the package and its meta-model. This method is
+	 * guarded to have no affect on any invocation but its first. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	public void initializePackageContents() {
@@ -571,47 +618,113 @@ public class DevResponsePackageImpl extends EPackageImpl implements DevResponseP
 		// Add supertypes to classes
 
 		// Initialize classes and features; add operations and parameters
-		initEClass(resourceEClass, Resource.class, "Resource", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
-		initEAttribute(getResource_Name(), ecorePackage.getEString(), "name", null, 0, 1, Resource.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
-		initEAttribute(getResource_Type(), ecorePackage.getEString(), "type", null, 0, 1, Resource.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
-		initEReference(getResource_Fbs(), this.getFB(), null, "fbs", null, 0, -1, Resource.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
+		initEClass(resourceEClass, Resource.class, "Resource", !IS_ABSTRACT, !IS_INTERFACE, //$NON-NLS-1$
+				IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getResource_Name(), ecorePackage.getEString(), "name", null, 0, 1, Resource.class, !IS_TRANSIENT, //$NON-NLS-1$
+				!IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getResource_Type(), ecorePackage.getEString(), "type", null, 0, 1, Resource.class, !IS_TRANSIENT, //$NON-NLS-1$
+				!IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getResource_Fbs(), getFB(), null, "fbs", null, 0, -1, Resource.class, !IS_TRANSIENT, //$NON-NLS-1$
+				!IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED,
+				IS_ORDERED);
 
-		initEClass(fbEClass, org.eclipse.fordiac.ide.deployment.devResponse.FB.class, "FB", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
-		initEAttribute(getFB_Name(), ecorePackage.getEString(), "name", null, 0, 1, org.eclipse.fordiac.ide.deployment.devResponse.FB.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
-		initEAttribute(getFB_Type(), ecorePackage.getEString(), "type", null, 0, 1, org.eclipse.fordiac.ide.deployment.devResponse.FB.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
-		initEReference(getFB_Ports(), this.getPort(), null, "ports", null, 0, -1, org.eclipse.fordiac.ide.deployment.devResponse.FB.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
+		initEClass(fbEClass, org.eclipse.fordiac.ide.deployment.devResponse.FB.class, "FB", !IS_ABSTRACT, !IS_INTERFACE, //$NON-NLS-1$
+				IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getFB_Name(), ecorePackage.getEString(), "name", null, 0, 1, //$NON-NLS-1$
+				org.eclipse.fordiac.ide.deployment.devResponse.FB.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE,
+				!IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getFB_Type(), ecorePackage.getEString(), "type", null, 0, 1, //$NON-NLS-1$
+				org.eclipse.fordiac.ide.deployment.devResponse.FB.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE,
+				!IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getFB_Ports(), getPort(), null, "ports", null, 0, -1, //$NON-NLS-1$
+				org.eclipse.fordiac.ide.deployment.devResponse.FB.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE,
+				IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+
+		initEClass(fbTypeEClass, FBType.class, "FBType", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
+		initEAttribute(getFBType_Name(), ecorePackage.getEString(), "name", null, 0, 1, FBType.class, !IS_TRANSIENT, //$NON-NLS-1$
+				!IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(portEClass, Port.class, "Port", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
-		initEAttribute(getPort_Name(), ecorePackage.getEString(), "name", null, 0, 1, Port.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
-		initEReference(getPort_DataValues(), this.getData(), null, "dataValues", null, 0, -1, Port.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
+		initEAttribute(getPort_Name(), ecorePackage.getEString(), "name", null, 0, 1, Port.class, !IS_TRANSIENT, //$NON-NLS-1$
+				!IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getPort_DataValues(), getData(), null, "dataValues", null, 0, -1, Port.class, !IS_TRANSIENT, //$NON-NLS-1$
+				!IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED,
+				IS_ORDERED);
 
 		initEClass(dataEClass, Data.class, "Data", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
-		initEAttribute(getData_Value(), ecorePackage.getEString(), "value", null, 0, 1, Data.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
-		initEAttribute(getData_Forced(), ecorePackage.getEString(), "forced", null, 0, 1, Data.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
+		initEAttribute(getData_Value(), ecorePackage.getEString(), "value", null, 0, 1, Data.class, !IS_TRANSIENT, //$NON-NLS-1$
+				!IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getData_Forced(), ecorePackage.getEString(), "forced", null, 0, 1, Data.class, !IS_TRANSIENT, //$NON-NLS-1$
+				!IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-		initEClass(responseEClass, Response.class, "Response", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
-		initEAttribute(getResponse_ID(), ecorePackage.getEString(), "ID", null, 0, 1, Response.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
-		initEReference(getResponse_Watches(), this.getWatches(), null, "Watches", null, 0, 1, Response.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
-		initEAttribute(getResponse_Reason(), ecorePackage.getEString(), "Reason", null, 0, 1, Response.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
-		initEReference(getResponse_Fblist(), this.getFBList(), null, "fblist", null, 0, 1, Response.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
-		initEReference(getResponse_Endpointlist(), this.getEndpointList(), null, "endpointlist", null, 0, 1, Response.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
-		initEReference(getResponse_Connection(), this.getConnection(), null, "connection", null, 0, 1, Response.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
+		initEClass(responseEClass, Response.class, "Response", !IS_ABSTRACT, !IS_INTERFACE, //$NON-NLS-1$
+				IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getResponse_ID(), ecorePackage.getEString(), "ID", null, 0, 1, Response.class, !IS_TRANSIENT, //$NON-NLS-1$
+				!IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getResponse_Watches(), getWatches(), null, "Watches", null, 0, 1, Response.class, !IS_TRANSIENT, //$NON-NLS-1$
+				!IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED,
+				IS_ORDERED);
+		initEAttribute(getResponse_Reason(), ecorePackage.getEString(), "Reason", null, 0, 1, Response.class, //$NON-NLS-1$
+				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getResponse_Fblist(), getFBList(), null, "fblist", null, 0, 1, Response.class, !IS_TRANSIENT, //$NON-NLS-1$
+				!IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED,
+				IS_ORDERED);
+		initEReference(getResponse_FbType(), getFBType(), null, "fbType", null, 0, 1, Response.class, !IS_TRANSIENT, //$NON-NLS-1$
+				!IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED,
+				IS_ORDERED);
+		initEReference(getResponse_Endpointlist(), getEndpointList(), null, "endpointlist", null, 0, 1, Response.class, //$NON-NLS-1$
+				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE,
+				IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getResponse_Connection(), getConnection(), null, "connection", null, 0, 1, Response.class, //$NON-NLS-1$
+				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE,
+				IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(watchesEClass, Watches.class, "Watches", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
-		initEReference(getWatches_Resources(), this.getResource(), null, "resources", null, 0, -1, Watches.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
+		initEReference(getWatches_Resources(), getResource(), null, "resources", null, 0, -1, Watches.class, //$NON-NLS-1$
+				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE,
+				IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(fbListEClass, FBList.class, "FBList", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
-		initEReference(getFBList_Fbs(), this.getFB(), null, "fbs", null, 0, -1, FBList.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
+		initEReference(getFBList_Fbs(), getFB(), null, "fbs", null, 0, -1, FBList.class, !IS_TRANSIENT, !IS_VOLATILE, //$NON-NLS-1$
+				IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-		initEClass(endpointListEClass, EndpointList.class, "EndpointList", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
-		initEReference(getEndpointList_Connection(), this.getConnection(), null, "connection", null, 0, -1, EndpointList.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
+		initEClass(endpointListEClass, EndpointList.class, "EndpointList", !IS_ABSTRACT, !IS_INTERFACE, //$NON-NLS-1$
+				IS_GENERATED_INSTANCE_CLASS);
+		initEReference(getEndpointList_Connection(), getConnection(), null, "connection", null, 0, -1, //$NON-NLS-1$
+				EndpointList.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES,
+				!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-		initEClass(connectionEClass, Connection.class, "Connection", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
-		initEAttribute(getConnection_Source(), ecorePackage.getEString(), "Source", null, 0, 1, Connection.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
-		initEAttribute(getConnection_Destination(), ecorePackage.getEString(), "Destination", null, 0, 1, Connection.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
+		initEClass(connectionEClass, Connection.class, "Connection", !IS_ABSTRACT, !IS_INTERFACE, //$NON-NLS-1$
+				IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getConnection_Source(), ecorePackage.getEString(), "Source", null, 0, 1, Connection.class, //$NON-NLS-1$
+				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getConnection_Destination(), ecorePackage.getEString(), "Destination", null, 0, 1, //$NON-NLS-1$
+				Connection.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
+				!IS_DERIVED, IS_ORDERED);
 
 		// Create resource
 		createResource(eNS_URI);
+
+		// Create annotations
+		// http:///org/eclipse/emf/ecore/util/ExtendedMetaData
+		createExtendedMetaDataAnnotations();
 	}
 
-} //DevResponsePackageImpl
+	/**
+	 * Initializes the annotations for
+	 * <b>http:///org/eclipse/emf/ecore/util/ExtendedMetaData</b>. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	protected void createExtendedMetaDataAnnotations() {
+		final String source = "http:///org/eclipse/emf/ecore/util/ExtendedMetaData"; //$NON-NLS-1$
+		addAnnotation(getFBType_Name(), source, new String[] { "name", "Name", //$NON-NLS-1$ //$NON-NLS-2$
+				"kind", "attribute" //$NON-NLS-1$ //$NON-NLS-2$
+		});
+		addAnnotation(getResponse_FbType(), source, new String[] { "kind", "element", //$NON-NLS-1$ //$NON-NLS-2$
+				"name", "FBType" //$NON-NLS-1$ //$NON-NLS-2$
+		});
+	}
+
+} // DevResponsePackageImpl

--- a/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/impl/EndpointListImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/impl/EndpointListImpl.java
@@ -28,23 +28,23 @@ import org.eclipse.fordiac.ide.deployment.devResponse.DevResponsePackage;
 import org.eclipse.fordiac.ide.deployment.devResponse.EndpointList;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Endpoint List</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Endpoint List</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * </p>
  * <ul>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.EndpointListImpl#getConnection <em>Connection</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.EndpointListImpl#getConnection
+ * <em>Connection</em>}</li>
  * </ul>
  *
  * @generated
  */
 public class EndpointListImpl extends EObjectImpl implements EndpointList {
 	/**
-	 * The cached value of the '{@link #getConnection() <em>Connection</em>}' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getConnection() <em>Connection</em>}'
+	 * reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getConnection()
 	 * @generated
 	 * @ordered
@@ -52,17 +52,16 @@ public class EndpointListImpl extends EObjectImpl implements EndpointList {
 	protected EList<Connection> connection;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	protected EndpointListImpl() {
-		super();
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -71,82 +70,77 @@ public class EndpointListImpl extends EObjectImpl implements EndpointList {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public EList<Connection> getConnection() {
 		if (connection == null) {
-			connection = new EObjectResolvingEList<>(Connection.class, this, DevResponsePackage.ENDPOINT_LIST__CONNECTION);
+			connection = new EObjectResolvingEList<>(Connection.class, this,
+					DevResponsePackage.ENDPOINT_LIST__CONNECTION);
 		}
 		return connection;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public Object eGet(int featureID, boolean resolve, boolean coreType) {
-		switch (featureID) {
-			case DevResponsePackage.ENDPOINT_LIST__CONNECTION:
-				return getConnection();
-			default:
-				return super.eGet(featureID, resolve, coreType);
-		}
+	public Object eGet(final int featureID, final boolean resolve, final boolean coreType) {
+		return switch (featureID) {
+		case DevResponsePackage.ENDPOINT_LIST__CONNECTION -> getConnection();
+		default -> super.eGet(featureID, resolve, coreType);
+		};
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public void eSet(int featureID, Object newValue) {
+	public void eSet(final int featureID, final Object newValue) {
 		switch (featureID) {
-			case DevResponsePackage.ENDPOINT_LIST__CONNECTION:
-				getConnection().clear();
-				getConnection().addAll((Collection<? extends Connection>)newValue);
-				return;
-			default:
-				super.eSet(featureID, newValue);
-				return;
+		case DevResponsePackage.ENDPOINT_LIST__CONNECTION:
+			getConnection().clear();
+			getConnection().addAll((Collection<? extends Connection>) newValue);
+			return;
+		default:
+			super.eSet(featureID, newValue);
 		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public void eUnset(int featureID) {
+	public void eUnset(final int featureID) {
 		switch (featureID) {
-			case DevResponsePackage.ENDPOINT_LIST__CONNECTION:
-				getConnection().clear();
-				return;
-			default:
-				super.eUnset(featureID);
-				return;
+		case DevResponsePackage.ENDPOINT_LIST__CONNECTION:
+			getConnection().clear();
+			return;
+		default:
+			super.eUnset(featureID);
 		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public boolean eIsSet(int featureID) {
-		switch (featureID) {
-			case DevResponsePackage.ENDPOINT_LIST__CONNECTION:
-				return connection != null && !connection.isEmpty();
-			default:
-				return super.eIsSet(featureID);
-		}
+	public boolean eIsSet(final int featureID) {
+		return switch (featureID) {
+		case DevResponsePackage.ENDPOINT_LIST__CONNECTION -> connection != null && !connection.isEmpty();
+		default -> super.eIsSet(featureID);
+		};
 	}
 
-} //EndpointListImpl
+} // EndpointListImpl

--- a/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/impl/FBImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/impl/FBImpl.java
@@ -33,25 +33,27 @@ import org.eclipse.fordiac.ide.deployment.devResponse.FB;
 import org.eclipse.fordiac.ide.deployment.devResponse.Port;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>FB</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>FB</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * </p>
  * <ul>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.FBImpl#getName <em>Name</em>}</li>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.FBImpl#getType <em>Type</em>}</li>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.FBImpl#getPorts <em>Ports</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.FBImpl#getName
+ * <em>Name</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.FBImpl#getType
+ * <em>Type</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.FBImpl#getPorts
+ * <em>Ports</em>}</li>
  * </ul>
  *
  * @generated
  */
 public class FBImpl extends EObjectImpl implements FB {
 	/**
-	 * The default value of the '{@link #getName() <em>Name</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getName() <em>Name</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getName()
 	 * @generated
 	 * @ordered
@@ -59,9 +61,9 @@ public class FBImpl extends EObjectImpl implements FB {
 	protected static final String NAME_EDEFAULT = null;
 
 	/**
-	 * The cached value of the '{@link #getName() <em>Name</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getName() <em>Name</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getName()
 	 * @generated
 	 * @ordered
@@ -69,9 +71,9 @@ public class FBImpl extends EObjectImpl implements FB {
 	protected String name = NAME_EDEFAULT;
 
 	/**
-	 * The default value of the '{@link #getType() <em>Type</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getType() <em>Type</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getType()
 	 * @generated
 	 * @ordered
@@ -79,9 +81,9 @@ public class FBImpl extends EObjectImpl implements FB {
 	protected static final String TYPE_EDEFAULT = null;
 
 	/**
-	 * The cached value of the '{@link #getType() <em>Type</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getType() <em>Type</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getType()
 	 * @generated
 	 * @ordered
@@ -89,9 +91,9 @@ public class FBImpl extends EObjectImpl implements FB {
 	protected String type = TYPE_EDEFAULT;
 
 	/**
-	 * The cached value of the '{@link #getPorts() <em>Ports</em>}' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getPorts() <em>Ports</em>}' containment
+	 * reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getPorts()
 	 * @generated
 	 * @ordered
@@ -99,17 +101,16 @@ public class FBImpl extends EObjectImpl implements FB {
 	protected EList<Port> ports;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	protected FBImpl() {
-		super();
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -118,8 +119,8 @@ public class FBImpl extends EObjectImpl implements FB {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -128,21 +129,22 @@ public class FBImpl extends EObjectImpl implements FB {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public void setName(String newName) {
-		String oldName = name;
+	public void setName(final String newName) {
+		final String oldName = name;
 		name = newName;
-		if (eNotificationRequired())
+		if (eNotificationRequired()) {
 			eNotify(new ENotificationImpl(this, Notification.SET, DevResponsePackage.FB__NAME, oldName, name));
+		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -151,21 +153,22 @@ public class FBImpl extends EObjectImpl implements FB {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public void setType(String newType) {
-		String oldType = type;
+	public void setType(final String newType) {
+		final String oldType = type;
 		type = newType;
-		if (eNotificationRequired())
+		if (eNotificationRequired()) {
 			eNotify(new ENotificationImpl(this, Notification.SET, DevResponsePackage.FB__TYPE, oldType, type));
+		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -177,116 +180,107 @@ public class FBImpl extends EObjectImpl implements FB {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
-		switch (featureID) {
-			case DevResponsePackage.FB__PORTS:
-				return ((InternalEList<?>)getPorts()).basicRemove(otherEnd, msgs);
-			default:
-				return super.eInverseRemove(otherEnd, featureID, msgs);
-		}
+	public NotificationChain eInverseRemove(final InternalEObject otherEnd, final int featureID,
+			final NotificationChain msgs) {
+		return switch (featureID) {
+		case DevResponsePackage.FB__PORTS -> ((InternalEList<?>) getPorts()).basicRemove(otherEnd, msgs);
+		default -> super.eInverseRemove(otherEnd, featureID, msgs);
+		};
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public Object eGet(int featureID, boolean resolve, boolean coreType) {
-		switch (featureID) {
-			case DevResponsePackage.FB__NAME:
-				return getName();
-			case DevResponsePackage.FB__TYPE:
-				return getType();
-			case DevResponsePackage.FB__PORTS:
-				return getPorts();
-			default:
-				return super.eGet(featureID, resolve, coreType);
-		}
+	public Object eGet(final int featureID, final boolean resolve, final boolean coreType) {
+		return switch (featureID) {
+		case DevResponsePackage.FB__NAME -> getName();
+		case DevResponsePackage.FB__TYPE -> getType();
+		case DevResponsePackage.FB__PORTS -> getPorts();
+		default -> super.eGet(featureID, resolve, coreType);
+		};
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public void eSet(int featureID, Object newValue) {
+	public void eSet(final int featureID, final Object newValue) {
 		switch (featureID) {
-			case DevResponsePackage.FB__NAME:
-				setName((String)newValue);
-				return;
-			case DevResponsePackage.FB__TYPE:
-				setType((String)newValue);
-				return;
-			case DevResponsePackage.FB__PORTS:
-				getPorts().clear();
-				getPorts().addAll((Collection<? extends Port>)newValue);
-				return;
-			default:
-				super.eSet(featureID, newValue);
-				return;
+		case DevResponsePackage.FB__NAME:
+			setName((String) newValue);
+			return;
+		case DevResponsePackage.FB__TYPE:
+			setType((String) newValue);
+			return;
+		case DevResponsePackage.FB__PORTS:
+			getPorts().clear();
+			getPorts().addAll((Collection<? extends Port>) newValue);
+			return;
+		default:
+			super.eSet(featureID, newValue);
 		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public void eUnset(int featureID) {
+	public void eUnset(final int featureID) {
 		switch (featureID) {
-			case DevResponsePackage.FB__NAME:
-				setName(NAME_EDEFAULT);
-				return;
-			case DevResponsePackage.FB__TYPE:
-				setType(TYPE_EDEFAULT);
-				return;
-			case DevResponsePackage.FB__PORTS:
-				getPorts().clear();
-				return;
-			default:
-				super.eUnset(featureID);
-				return;
+		case DevResponsePackage.FB__NAME:
+			setName(NAME_EDEFAULT);
+			return;
+		case DevResponsePackage.FB__TYPE:
+			setType(TYPE_EDEFAULT);
+			return;
+		case DevResponsePackage.FB__PORTS:
+			getPorts().clear();
+			return;
+		default:
+			super.eUnset(featureID);
 		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public boolean eIsSet(int featureID) {
-		switch (featureID) {
-			case DevResponsePackage.FB__NAME:
-				return NAME_EDEFAULT == null ? name != null : !NAME_EDEFAULT.equals(name);
-			case DevResponsePackage.FB__TYPE:
-				return TYPE_EDEFAULT == null ? type != null : !TYPE_EDEFAULT.equals(type);
-			case DevResponsePackage.FB__PORTS:
-				return ports != null && !ports.isEmpty();
-			default:
-				return super.eIsSet(featureID);
-		}
+	public boolean eIsSet(final int featureID) {
+		return switch (featureID) {
+		case DevResponsePackage.FB__NAME -> NAME_EDEFAULT == null ? name != null : !NAME_EDEFAULT.equals(name);
+		case DevResponsePackage.FB__TYPE -> TYPE_EDEFAULT == null ? type != null : !TYPE_EDEFAULT.equals(type);
+		case DevResponsePackage.FB__PORTS -> ports != null && !ports.isEmpty();
+		default -> super.eIsSet(featureID);
+		};
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public String toString() {
-		if (eIsProxy()) return super.toString();
+		if (eIsProxy()) {
+			return super.toString();
+		}
 
-		StringBuilder result = new StringBuilder(super.toString());
+		final StringBuilder result = new StringBuilder(super.toString());
 		result.append(" (name: "); //$NON-NLS-1$
 		result.append(name);
 		result.append(", type: "); //$NON-NLS-1$
@@ -295,4 +289,4 @@ public class FBImpl extends EObjectImpl implements FB {
 		return result.toString();
 	}
 
-} //FBImpl
+} // FBImpl

--- a/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/impl/FBListImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/impl/FBListImpl.java
@@ -28,40 +28,40 @@ import org.eclipse.fordiac.ide.deployment.devResponse.FB;
 import org.eclipse.fordiac.ide.deployment.devResponse.FBList;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>FB List</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>FB
+ * List</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * </p>
  * <ul>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.FBListImpl#getFbs <em>Fbs</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.FBListImpl#getFbs
+ * <em>Fbs</em>}</li>
  * </ul>
  *
  * @generated
  */
 public class FBListImpl extends EObjectImpl implements FBList {
 	/**
-	 * The cached value of the '{@link #getFbs() <em>Fbs</em>}' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getFbs() <em>Fbs</em>}' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getFbs()
 	 * @generated
 	 * @ordered
 	 */
 	protected EList<FB> fbs;
+
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	protected FBListImpl() {
-		super();
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -70,8 +70,8 @@ public class FBListImpl extends EObjectImpl implements FBList {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -83,69 +83,63 @@ public class FBListImpl extends EObjectImpl implements FBList {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public Object eGet(int featureID, boolean resolve, boolean coreType) {
-		switch (featureID) {
-			case DevResponsePackage.FB_LIST__FBS:
-				return getFbs();
-			default:
-				return super.eGet(featureID, resolve, coreType);
-		}
+	public Object eGet(final int featureID, final boolean resolve, final boolean coreType) {
+		return switch (featureID) {
+		case DevResponsePackage.FB_LIST__FBS -> getFbs();
+		default -> super.eGet(featureID, resolve, coreType);
+		};
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public void eSet(int featureID, Object newValue) {
+	public void eSet(final int featureID, final Object newValue) {
 		switch (featureID) {
-			case DevResponsePackage.FB_LIST__FBS:
-				getFbs().clear();
-				getFbs().addAll((Collection<? extends FB>)newValue);
-				return;
-			default:
-				super.eSet(featureID, newValue);
-				return;
+		case DevResponsePackage.FB_LIST__FBS:
+			getFbs().clear();
+			getFbs().addAll((Collection<? extends FB>) newValue);
+			return;
+		default:
+			super.eSet(featureID, newValue);
 		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public void eUnset(int featureID) {
+	public void eUnset(final int featureID) {
 		switch (featureID) {
-			case DevResponsePackage.FB_LIST__FBS:
-				getFbs().clear();
-				return;
-			default:
-				super.eUnset(featureID);
-				return;
+		case DevResponsePackage.FB_LIST__FBS:
+			getFbs().clear();
+			return;
+		default:
+			super.eUnset(featureID);
 		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public boolean eIsSet(int featureID) {
-		switch (featureID) {
-			case DevResponsePackage.FB_LIST__FBS:
-				return fbs != null && !fbs.isEmpty();
-			default:
-				return super.eIsSet(featureID);
-		}
+	public boolean eIsSet(final int featureID) {
+		return switch (featureID) {
+		case DevResponsePackage.FB_LIST__FBS -> fbs != null && !fbs.isEmpty();
+		default -> super.eIsSet(featureID);
+		};
 	}
 
-} //FBListImpl
+} // FBListImpl

--- a/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/impl/FBTypeImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/impl/FBTypeImpl.java
@@ -1,0 +1,179 @@
+/**
+ * ******************************************************************************
+ * Copyright (c) 2012, 2013, 2018 Profactor GmbH, fortiss GmbH, Johannes Kepler University
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Gerhard Ebenhofer, Alois Zoitl
+ *      - initial API and implementation and/or initial documentation
+ *    Alois Zoitl - moved to deployment and reworked it to a device response model
+ * ******************************************************************************
+ *
+ */
+package org.eclipse.fordiac.ide.deployment.devResponse.impl;
+
+import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.impl.ENotificationImpl;
+import org.eclipse.emf.ecore.impl.EObjectImpl;
+import org.eclipse.fordiac.ide.deployment.devResponse.DevResponsePackage;
+import org.eclipse.fordiac.ide.deployment.devResponse.FBType;
+
+/**
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>FB
+ * Type</b></em>'. <!-- end-user-doc -->
+ * <p>
+ * The following features are implemented:
+ * </p>
+ * <ul>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.FBTypeImpl#getName
+ * <em>Name</em>}</li>
+ * </ul>
+ *
+ * @generated
+ */
+public class FBTypeImpl extends EObjectImpl implements FBType {
+	/**
+	 * The default value of the '{@link #getName() <em>Name</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @see #getName()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final String NAME_EDEFAULT = null;
+
+	/**
+	 * The cached value of the '{@link #getName() <em>Name</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @see #getName()
+	 * @generated
+	 * @ordered
+	 */
+	protected String name = NAME_EDEFAULT;
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	protected FBTypeImpl() {
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	@Override
+	protected EClass eStaticClass() {
+		return DevResponsePackage.Literals.FB_TYPE;
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	@Override
+	public void setName(final String newName) {
+		final String oldName = name;
+		name = newName;
+		if (eNotificationRequired()) {
+			eNotify(new ENotificationImpl(this, Notification.SET, DevResponsePackage.FB_TYPE__NAME, oldName, name));
+		}
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	@Override
+	public Object eGet(final int featureID, final boolean resolve, final boolean coreType) {
+		return switch (featureID) {
+		case DevResponsePackage.FB_TYPE__NAME -> getName();
+		default -> super.eGet(featureID, resolve, coreType);
+		};
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	@Override
+	public void eSet(final int featureID, final Object newValue) {
+		switch (featureID) {
+		case DevResponsePackage.FB_TYPE__NAME:
+			setName((String) newValue);
+			return;
+		default:
+			super.eSet(featureID, newValue);
+		}
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	@Override
+	public void eUnset(final int featureID) {
+		switch (featureID) {
+		case DevResponsePackage.FB_TYPE__NAME:
+			setName(NAME_EDEFAULT);
+			return;
+		default:
+			super.eUnset(featureID);
+		}
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	@Override
+	public boolean eIsSet(final int featureID) {
+		return switch (featureID) {
+		case DevResponsePackage.FB_TYPE__NAME -> NAME_EDEFAULT == null ? name != null : !NAME_EDEFAULT.equals(name);
+		default -> super.eIsSet(featureID);
+		};
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	@Override
+	public String toString() {
+		if (eIsProxy()) {
+			return super.toString();
+		}
+
+		final StringBuilder result = new StringBuilder(super.toString());
+		result.append(" (name: "); //$NON-NLS-1$
+		result.append(name);
+		result.append(')');
+		return result.toString();
+	}
+
+} // FBTypeImpl

--- a/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/impl/PortImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/impl/PortImpl.java
@@ -33,24 +33,25 @@ import org.eclipse.fordiac.ide.deployment.devResponse.DevResponsePackage;
 import org.eclipse.fordiac.ide.deployment.devResponse.Port;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Port</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Port</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * </p>
  * <ul>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.PortImpl#getName <em>Name</em>}</li>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.PortImpl#getDataValues <em>Data Values</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.PortImpl#getName
+ * <em>Name</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.PortImpl#getDataValues
+ * <em>Data Values</em>}</li>
  * </ul>
  *
  * @generated
  */
 public class PortImpl extends EObjectImpl implements Port {
 	/**
-	 * The default value of the '{@link #getName() <em>Name</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getName() <em>Name</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getName()
 	 * @generated
 	 * @ordered
@@ -58,9 +59,9 @@ public class PortImpl extends EObjectImpl implements Port {
 	protected static final String NAME_EDEFAULT = null;
 
 	/**
-	 * The cached value of the '{@link #getName() <em>Name</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getName() <em>Name</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getName()
 	 * @generated
 	 * @ordered
@@ -68,9 +69,9 @@ public class PortImpl extends EObjectImpl implements Port {
 	protected String name = NAME_EDEFAULT;
 
 	/**
-	 * The cached value of the '{@link #getDataValues() <em>Data Values</em>}' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getDataValues() <em>Data Values</em>}'
+	 * containment reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getDataValues()
 	 * @generated
 	 * @ordered
@@ -78,17 +79,16 @@ public class PortImpl extends EObjectImpl implements Port {
 	protected EList<Data> dataValues;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	protected PortImpl() {
-		super();
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -97,8 +97,8 @@ public class PortImpl extends EObjectImpl implements Port {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -107,21 +107,22 @@ public class PortImpl extends EObjectImpl implements Port {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public void setName(String newName) {
-		String oldName = name;
+	public void setName(final String newName) {
+		final String oldName = name;
 		name = newName;
-		if (eNotificationRequired())
+		if (eNotificationRequired()) {
 			eNotify(new ENotificationImpl(this, Notification.SET, DevResponsePackage.PORT__NAME, oldName, name));
+		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -133,110 +134,103 @@ public class PortImpl extends EObjectImpl implements Port {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
-		switch (featureID) {
-			case DevResponsePackage.PORT__DATA_VALUES:
-				return ((InternalEList<?>)getDataValues()).basicRemove(otherEnd, msgs);
-			default:
-				return super.eInverseRemove(otherEnd, featureID, msgs);
-		}
+	public NotificationChain eInverseRemove(final InternalEObject otherEnd, final int featureID,
+			final NotificationChain msgs) {
+		return switch (featureID) {
+		case DevResponsePackage.PORT__DATA_VALUES -> ((InternalEList<?>) getDataValues()).basicRemove(otherEnd, msgs);
+		default -> super.eInverseRemove(otherEnd, featureID, msgs);
+		};
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public Object eGet(int featureID, boolean resolve, boolean coreType) {
-		switch (featureID) {
-			case DevResponsePackage.PORT__NAME:
-				return getName();
-			case DevResponsePackage.PORT__DATA_VALUES:
-				return getDataValues();
-			default:
-				return super.eGet(featureID, resolve, coreType);
-		}
+	public Object eGet(final int featureID, final boolean resolve, final boolean coreType) {
+		return switch (featureID) {
+		case DevResponsePackage.PORT__NAME -> getName();
+		case DevResponsePackage.PORT__DATA_VALUES -> getDataValues();
+		default -> super.eGet(featureID, resolve, coreType);
+		};
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public void eSet(int featureID, Object newValue) {
+	public void eSet(final int featureID, final Object newValue) {
 		switch (featureID) {
-			case DevResponsePackage.PORT__NAME:
-				setName((String)newValue);
-				return;
-			case DevResponsePackage.PORT__DATA_VALUES:
-				getDataValues().clear();
-				getDataValues().addAll((Collection<? extends Data>)newValue);
-				return;
-			default:
-				super.eSet(featureID, newValue);
-				return;
+		case DevResponsePackage.PORT__NAME:
+			setName((String) newValue);
+			return;
+		case DevResponsePackage.PORT__DATA_VALUES:
+			getDataValues().clear();
+			getDataValues().addAll((Collection<? extends Data>) newValue);
+			return;
+		default:
+			super.eSet(featureID, newValue);
 		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public void eUnset(int featureID) {
+	public void eUnset(final int featureID) {
 		switch (featureID) {
-			case DevResponsePackage.PORT__NAME:
-				setName(NAME_EDEFAULT);
-				return;
-			case DevResponsePackage.PORT__DATA_VALUES:
-				getDataValues().clear();
-				return;
-			default:
-				super.eUnset(featureID);
-				return;
+		case DevResponsePackage.PORT__NAME:
+			setName(NAME_EDEFAULT);
+			return;
+		case DevResponsePackage.PORT__DATA_VALUES:
+			getDataValues().clear();
+			return;
+		default:
+			super.eUnset(featureID);
 		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public boolean eIsSet(int featureID) {
-		switch (featureID) {
-			case DevResponsePackage.PORT__NAME:
-				return NAME_EDEFAULT == null ? name != null : !NAME_EDEFAULT.equals(name);
-			case DevResponsePackage.PORT__DATA_VALUES:
-				return dataValues != null && !dataValues.isEmpty();
-			default:
-				return super.eIsSet(featureID);
-		}
+	public boolean eIsSet(final int featureID) {
+		return switch (featureID) {
+		case DevResponsePackage.PORT__NAME -> NAME_EDEFAULT == null ? name != null : !NAME_EDEFAULT.equals(name);
+		case DevResponsePackage.PORT__DATA_VALUES -> dataValues != null && !dataValues.isEmpty();
+		default -> super.eIsSet(featureID);
+		};
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public String toString() {
-		if (eIsProxy()) return super.toString();
+		if (eIsProxy()) {
+			return super.toString();
+		}
 
-		StringBuilder result = new StringBuilder(super.toString());
+		final StringBuilder result = new StringBuilder(super.toString());
 		result.append(" (name: "); //$NON-NLS-1$
 		result.append(name);
 		result.append(')');
 		return result.toString();
 	}
 
-} //PortImpl
+} // PortImpl

--- a/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/impl/ResourceImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/impl/ResourceImpl.java
@@ -33,25 +33,27 @@ import org.eclipse.fordiac.ide.deployment.devResponse.FB;
 import org.eclipse.fordiac.ide.deployment.devResponse.Resource;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Resource</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Resource</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * </p>
  * <ul>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResourceImpl#getName <em>Name</em>}</li>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResourceImpl#getType <em>Type</em>}</li>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResourceImpl#getFbs <em>Fbs</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResourceImpl#getName
+ * <em>Name</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResourceImpl#getType
+ * <em>Type</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResourceImpl#getFbs
+ * <em>Fbs</em>}</li>
  * </ul>
  *
  * @generated
  */
 public class ResourceImpl extends EObjectImpl implements Resource {
 	/**
-	 * The default value of the '{@link #getName() <em>Name</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getName() <em>Name</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getName()
 	 * @generated
 	 * @ordered
@@ -59,9 +61,9 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 	protected static final String NAME_EDEFAULT = null;
 
 	/**
-	 * The cached value of the '{@link #getName() <em>Name</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getName() <em>Name</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getName()
 	 * @generated
 	 * @ordered
@@ -69,9 +71,9 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 	protected String name = NAME_EDEFAULT;
 
 	/**
-	 * The default value of the '{@link #getType() <em>Type</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getType() <em>Type</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getType()
 	 * @generated
 	 * @ordered
@@ -79,9 +81,9 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 	protected static final String TYPE_EDEFAULT = null;
 
 	/**
-	 * The cached value of the '{@link #getType() <em>Type</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getType() <em>Type</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getType()
 	 * @generated
 	 * @ordered
@@ -89,9 +91,9 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 	protected String type = TYPE_EDEFAULT;
 
 	/**
-	 * The cached value of the '{@link #getFbs() <em>Fbs</em>}' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getFbs() <em>Fbs</em>}' containment
+	 * reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getFbs()
 	 * @generated
 	 * @ordered
@@ -99,17 +101,16 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 	protected EList<FB> fbs;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	protected ResourceImpl() {
-		super();
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -118,8 +119,8 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -128,21 +129,22 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public void setName(String newName) {
-		String oldName = name;
+	public void setName(final String newName) {
+		final String oldName = name;
 		name = newName;
-		if (eNotificationRequired())
+		if (eNotificationRequired()) {
 			eNotify(new ENotificationImpl(this, Notification.SET, DevResponsePackage.RESOURCE__NAME, oldName, name));
+		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -151,21 +153,22 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public void setType(String newType) {
-		String oldType = type;
+	public void setType(final String newType) {
+		final String oldType = type;
 		type = newType;
-		if (eNotificationRequired())
+		if (eNotificationRequired()) {
 			eNotify(new ENotificationImpl(this, Notification.SET, DevResponsePackage.RESOURCE__TYPE, oldType, type));
+		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -177,116 +180,107 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
-		switch (featureID) {
-			case DevResponsePackage.RESOURCE__FBS:
-				return ((InternalEList<?>)getFbs()).basicRemove(otherEnd, msgs);
-			default:
-				return super.eInverseRemove(otherEnd, featureID, msgs);
-		}
+	public NotificationChain eInverseRemove(final InternalEObject otherEnd, final int featureID,
+			final NotificationChain msgs) {
+		return switch (featureID) {
+		case DevResponsePackage.RESOURCE__FBS -> ((InternalEList<?>) getFbs()).basicRemove(otherEnd, msgs);
+		default -> super.eInverseRemove(otherEnd, featureID, msgs);
+		};
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public Object eGet(int featureID, boolean resolve, boolean coreType) {
-		switch (featureID) {
-			case DevResponsePackage.RESOURCE__NAME:
-				return getName();
-			case DevResponsePackage.RESOURCE__TYPE:
-				return getType();
-			case DevResponsePackage.RESOURCE__FBS:
-				return getFbs();
-			default:
-				return super.eGet(featureID, resolve, coreType);
-		}
+	public Object eGet(final int featureID, final boolean resolve, final boolean coreType) {
+		return switch (featureID) {
+		case DevResponsePackage.RESOURCE__NAME -> getName();
+		case DevResponsePackage.RESOURCE__TYPE -> getType();
+		case DevResponsePackage.RESOURCE__FBS -> getFbs();
+		default -> super.eGet(featureID, resolve, coreType);
+		};
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public void eSet(int featureID, Object newValue) {
+	public void eSet(final int featureID, final Object newValue) {
 		switch (featureID) {
-			case DevResponsePackage.RESOURCE__NAME:
-				setName((String)newValue);
-				return;
-			case DevResponsePackage.RESOURCE__TYPE:
-				setType((String)newValue);
-				return;
-			case DevResponsePackage.RESOURCE__FBS:
-				getFbs().clear();
-				getFbs().addAll((Collection<? extends FB>)newValue);
-				return;
-			default:
-				super.eSet(featureID, newValue);
-				return;
+		case DevResponsePackage.RESOURCE__NAME:
+			setName((String) newValue);
+			return;
+		case DevResponsePackage.RESOURCE__TYPE:
+			setType((String) newValue);
+			return;
+		case DevResponsePackage.RESOURCE__FBS:
+			getFbs().clear();
+			getFbs().addAll((Collection<? extends FB>) newValue);
+			return;
+		default:
+			super.eSet(featureID, newValue);
 		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public void eUnset(int featureID) {
+	public void eUnset(final int featureID) {
 		switch (featureID) {
-			case DevResponsePackage.RESOURCE__NAME:
-				setName(NAME_EDEFAULT);
-				return;
-			case DevResponsePackage.RESOURCE__TYPE:
-				setType(TYPE_EDEFAULT);
-				return;
-			case DevResponsePackage.RESOURCE__FBS:
-				getFbs().clear();
-				return;
-			default:
-				super.eUnset(featureID);
-				return;
+		case DevResponsePackage.RESOURCE__NAME:
+			setName(NAME_EDEFAULT);
+			return;
+		case DevResponsePackage.RESOURCE__TYPE:
+			setType(TYPE_EDEFAULT);
+			return;
+		case DevResponsePackage.RESOURCE__FBS:
+			getFbs().clear();
+			return;
+		default:
+			super.eUnset(featureID);
 		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public boolean eIsSet(int featureID) {
-		switch (featureID) {
-			case DevResponsePackage.RESOURCE__NAME:
-				return NAME_EDEFAULT == null ? name != null : !NAME_EDEFAULT.equals(name);
-			case DevResponsePackage.RESOURCE__TYPE:
-				return TYPE_EDEFAULT == null ? type != null : !TYPE_EDEFAULT.equals(type);
-			case DevResponsePackage.RESOURCE__FBS:
-				return fbs != null && !fbs.isEmpty();
-			default:
-				return super.eIsSet(featureID);
-		}
+	public boolean eIsSet(final int featureID) {
+		return switch (featureID) {
+		case DevResponsePackage.RESOURCE__NAME -> NAME_EDEFAULT == null ? name != null : !NAME_EDEFAULT.equals(name);
+		case DevResponsePackage.RESOURCE__TYPE -> TYPE_EDEFAULT == null ? type != null : !TYPE_EDEFAULT.equals(type);
+		case DevResponsePackage.RESOURCE__FBS -> fbs != null && !fbs.isEmpty();
+		default -> super.eIsSet(featureID);
+		};
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public String toString() {
-		if (eIsProxy()) return super.toString();
+		if (eIsProxy()) {
+			return super.toString();
+		}
 
-		StringBuilder result = new StringBuilder(super.toString());
+		final StringBuilder result = new StringBuilder(super.toString());
 		result.append(" (name: "); //$NON-NLS-1$
 		result.append(name);
 		result.append(", type: "); //$NON-NLS-1$
@@ -295,4 +289,4 @@ public class ResourceImpl extends EObjectImpl implements Resource {
 		return result.toString();
 	}
 
-} //ResourceImpl
+} // ResourceImpl

--- a/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/impl/ResponseImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/impl/ResponseImpl.java
@@ -26,32 +26,40 @@ import org.eclipse.fordiac.ide.deployment.devResponse.Connection;
 import org.eclipse.fordiac.ide.deployment.devResponse.DevResponsePackage;
 import org.eclipse.fordiac.ide.deployment.devResponse.EndpointList;
 import org.eclipse.fordiac.ide.deployment.devResponse.FBList;
+import org.eclipse.fordiac.ide.deployment.devResponse.FBType;
 import org.eclipse.fordiac.ide.deployment.devResponse.Response;
 import org.eclipse.fordiac.ide.deployment.devResponse.Watches;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Response</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Response</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * </p>
  * <ul>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResponseImpl#getID <em>ID</em>}</li>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResponseImpl#getWatches <em>Watches</em>}</li>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResponseImpl#getReason <em>Reason</em>}</li>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResponseImpl#getFblist <em>Fblist</em>}</li>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResponseImpl#getEndpointlist <em>Endpointlist</em>}</li>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResponseImpl#getConnection <em>Connection</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResponseImpl#getID
+ * <em>ID</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResponseImpl#getWatches
+ * <em>Watches</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResponseImpl#getReason
+ * <em>Reason</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResponseImpl#getFblist
+ * <em>Fblist</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResponseImpl#getFbType
+ * <em>Fb Type</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResponseImpl#getEndpointlist
+ * <em>Endpointlist</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.ResponseImpl#getConnection
+ * <em>Connection</em>}</li>
  * </ul>
  *
  * @generated
  */
 public class ResponseImpl extends EObjectImpl implements Response {
 	/**
-	 * The default value of the '{@link #getID() <em>ID</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getID() <em>ID</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getID()
 	 * @generated
 	 * @ordered
@@ -59,9 +67,9 @@ public class ResponseImpl extends EObjectImpl implements Response {
 	protected static final String ID_EDEFAULT = null;
 
 	/**
-	 * The cached value of the '{@link #getID() <em>ID</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getID() <em>ID</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getID()
 	 * @generated
 	 * @ordered
@@ -70,8 +78,8 @@ public class ResponseImpl extends EObjectImpl implements Response {
 
 	/**
 	 * The cached value of the '{@link #getWatches() <em>Watches</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getWatches()
 	 * @generated
 	 * @ordered
@@ -80,8 +88,8 @@ public class ResponseImpl extends EObjectImpl implements Response {
 
 	/**
 	 * The default value of the '{@link #getReason() <em>Reason</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getReason()
 	 * @generated
 	 * @ordered
@@ -90,8 +98,8 @@ public class ResponseImpl extends EObjectImpl implements Response {
 
 	/**
 	 * The cached value of the '{@link #getReason() <em>Reason</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getReason()
 	 * @generated
 	 * @ordered
@@ -100,8 +108,8 @@ public class ResponseImpl extends EObjectImpl implements Response {
 
 	/**
 	 * The cached value of the '{@link #getFblist() <em>Fblist</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getFblist()
 	 * @generated
 	 * @ordered
@@ -109,9 +117,19 @@ public class ResponseImpl extends EObjectImpl implements Response {
 	protected FBList fblist;
 
 	/**
-	 * The cached value of the '{@link #getEndpointlist() <em>Endpointlist</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getFbType() <em>Fb Type</em>}' reference.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @see #getFbType()
+	 * @generated
+	 * @ordered
+	 */
+	protected FBType fbType;
+
+	/**
+	 * The cached value of the '{@link #getEndpointlist() <em>Endpointlist</em>}'
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getEndpointlist()
 	 * @generated
 	 * @ordered
@@ -119,9 +137,9 @@ public class ResponseImpl extends EObjectImpl implements Response {
 	protected EndpointList endpointlist;
 
 	/**
-	 * The cached value of the '{@link #getConnection() <em>Connection</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getConnection() <em>Connection</em>}'
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getConnection()
 	 * @generated
 	 * @ordered
@@ -129,17 +147,16 @@ public class ResponseImpl extends EObjectImpl implements Response {
 	protected Connection connection;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	protected ResponseImpl() {
-		super();
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -148,8 +165,8 @@ public class ResponseImpl extends EObjectImpl implements Response {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -158,39 +175,40 @@ public class ResponseImpl extends EObjectImpl implements Response {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public void setID(String newID) {
-		String oldID = id;
+	public void setID(final String newID) {
+		final String oldID = id;
 		id = newID;
-		if (eNotificationRequired())
+		if (eNotificationRequired()) {
 			eNotify(new ENotificationImpl(this, Notification.SET, DevResponsePackage.RESPONSE__ID, oldID, id));
+		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public Watches getWatches() {
 		if (watches != null && watches.eIsProxy()) {
-			InternalEObject oldWatches = (InternalEObject)watches;
-			watches = (Watches)eResolveProxy(oldWatches);
-			if (watches != oldWatches) {
-				if (eNotificationRequired())
-					eNotify(new ENotificationImpl(this, Notification.RESOLVE, DevResponsePackage.RESPONSE__WATCHES, oldWatches, watches));
+			final InternalEObject oldWatches = (InternalEObject) watches;
+			watches = (Watches) eResolveProxy(oldWatches);
+			if ((watches != oldWatches) && eNotificationRequired()) {
+				eNotify(new ENotificationImpl(this, Notification.RESOLVE, DevResponsePackage.RESPONSE__WATCHES,
+						oldWatches, watches));
 			}
 		}
 		return watches;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	public Watches basicGetWatches() {
@@ -198,21 +216,23 @@ public class ResponseImpl extends EObjectImpl implements Response {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public void setWatches(Watches newWatches) {
-		Watches oldWatches = watches;
+	public void setWatches(final Watches newWatches) {
+		final Watches oldWatches = watches;
 		watches = newWatches;
-		if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, DevResponsePackage.RESPONSE__WATCHES, oldWatches, watches));
+		if (eNotificationRequired()) {
+			eNotify(new ENotificationImpl(this, Notification.SET, DevResponsePackage.RESPONSE__WATCHES, oldWatches,
+					watches));
+		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -221,39 +241,41 @@ public class ResponseImpl extends EObjectImpl implements Response {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public void setReason(String newReason) {
-		String oldReason = reason;
+	public void setReason(final String newReason) {
+		final String oldReason = reason;
 		reason = newReason;
-		if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, DevResponsePackage.RESPONSE__REASON, oldReason, reason));
+		if (eNotificationRequired()) {
+			eNotify(new ENotificationImpl(this, Notification.SET, DevResponsePackage.RESPONSE__REASON, oldReason,
+					reason));
+		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public FBList getFblist() {
 		if (fblist != null && fblist.eIsProxy()) {
-			InternalEObject oldFblist = (InternalEObject)fblist;
-			fblist = (FBList)eResolveProxy(oldFblist);
-			if (fblist != oldFblist) {
-				if (eNotificationRequired())
-					eNotify(new ENotificationImpl(this, Notification.RESOLVE, DevResponsePackage.RESPONSE__FBLIST, oldFblist, fblist));
+			final InternalEObject oldFblist = (InternalEObject) fblist;
+			fblist = (FBList) eResolveProxy(oldFblist);
+			if ((fblist != oldFblist) && eNotificationRequired()) {
+				eNotify(new ENotificationImpl(this, Notification.RESOLVE, DevResponsePackage.RESPONSE__FBLIST,
+						oldFblist, fblist));
 			}
 		}
 		return fblist;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	public FBList basicGetFblist() {
@@ -261,39 +283,83 @@ public class ResponseImpl extends EObjectImpl implements Response {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public void setFblist(FBList newFblist) {
-		FBList oldFblist = fblist;
+	public void setFblist(final FBList newFblist) {
+		final FBList oldFblist = fblist;
 		fblist = newFblist;
-		if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, DevResponsePackage.RESPONSE__FBLIST, oldFblist, fblist));
+		if (eNotificationRequired()) {
+			eNotify(new ENotificationImpl(this, Notification.SET, DevResponsePackage.RESPONSE__FBLIST, oldFblist,
+					fblist));
+		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	@Override
+	public FBType getFbType() {
+		if (fbType != null && fbType.eIsProxy()) {
+			final InternalEObject oldFbType = (InternalEObject) fbType;
+			fbType = (FBType) eResolveProxy(oldFbType);
+			if ((fbType != oldFbType) && eNotificationRequired()) {
+				eNotify(new ENotificationImpl(this, Notification.RESOLVE, DevResponsePackage.RESPONSE__FB_TYPE,
+						oldFbType, fbType));
+			}
+		}
+		return fbType;
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	public FBType basicGetFbType() {
+		return fbType;
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	@Override
+	public void setFbType(final FBType newFbType) {
+		final FBType oldFbType = fbType;
+		fbType = newFbType;
+		if (eNotificationRequired()) {
+			eNotify(new ENotificationImpl(this, Notification.SET, DevResponsePackage.RESPONSE__FB_TYPE, oldFbType,
+					fbType));
+		}
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public EndpointList getEndpointlist() {
 		if (endpointlist != null && endpointlist.eIsProxy()) {
-			InternalEObject oldEndpointlist = (InternalEObject)endpointlist;
-			endpointlist = (EndpointList)eResolveProxy(oldEndpointlist);
-			if (endpointlist != oldEndpointlist) {
-				if (eNotificationRequired())
-					eNotify(new ENotificationImpl(this, Notification.RESOLVE, DevResponsePackage.RESPONSE__ENDPOINTLIST, oldEndpointlist, endpointlist));
+			final InternalEObject oldEndpointlist = (InternalEObject) endpointlist;
+			endpointlist = (EndpointList) eResolveProxy(oldEndpointlist);
+			if ((endpointlist != oldEndpointlist) && eNotificationRequired()) {
+				eNotify(new ENotificationImpl(this, Notification.RESOLVE, DevResponsePackage.RESPONSE__ENDPOINTLIST,
+						oldEndpointlist, endpointlist));
 			}
 		}
 		return endpointlist;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	public EndpointList basicGetEndpointlist() {
@@ -301,39 +367,41 @@ public class ResponseImpl extends EObjectImpl implements Response {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public void setEndpointlist(EndpointList newEndpointlist) {
-		EndpointList oldEndpointlist = endpointlist;
+	public void setEndpointlist(final EndpointList newEndpointlist) {
+		final EndpointList oldEndpointlist = endpointlist;
 		endpointlist = newEndpointlist;
-		if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, DevResponsePackage.RESPONSE__ENDPOINTLIST, oldEndpointlist, endpointlist));
+		if (eNotificationRequired()) {
+			eNotify(new ENotificationImpl(this, Notification.SET, DevResponsePackage.RESPONSE__ENDPOINTLIST,
+					oldEndpointlist, endpointlist));
+		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public Connection getConnection() {
 		if (connection != null && connection.eIsProxy()) {
-			InternalEObject oldConnection = (InternalEObject)connection;
-			connection = (Connection)eResolveProxy(oldConnection);
-			if (connection != oldConnection) {
-				if (eNotificationRequired())
-					eNotify(new ENotificationImpl(this, Notification.RESOLVE, DevResponsePackage.RESPONSE__CONNECTION, oldConnection, connection));
+			final InternalEObject oldConnection = (InternalEObject) connection;
+			connection = (Connection) eResolveProxy(oldConnection);
+			if ((connection != oldConnection) && eNotificationRequired()) {
+				eNotify(new ENotificationImpl(this, Notification.RESOLVE, DevResponsePackage.RESPONSE__CONNECTION,
+						oldConnection, connection));
 			}
 		}
 		return connection;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	public Connection basicGetConnection() {
@@ -341,146 +409,161 @@ public class ResponseImpl extends EObjectImpl implements Response {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public void setConnection(Connection newConnection) {
-		Connection oldConnection = connection;
+	public void setConnection(final Connection newConnection) {
+		final Connection oldConnection = connection;
 		connection = newConnection;
-		if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, DevResponsePackage.RESPONSE__CONNECTION, oldConnection, connection));
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	@Override
-	public Object eGet(int featureID, boolean resolve, boolean coreType) {
-		switch (featureID) {
-			case DevResponsePackage.RESPONSE__ID:
-				return getID();
-			case DevResponsePackage.RESPONSE__WATCHES:
-				if (resolve) return getWatches();
-				return basicGetWatches();
-			case DevResponsePackage.RESPONSE__REASON:
-				return getReason();
-			case DevResponsePackage.RESPONSE__FBLIST:
-				if (resolve) return getFblist();
-				return basicGetFblist();
-			case DevResponsePackage.RESPONSE__ENDPOINTLIST:
-				if (resolve) return getEndpointlist();
-				return basicGetEndpointlist();
-			case DevResponsePackage.RESPONSE__CONNECTION:
-				if (resolve) return getConnection();
-				return basicGetConnection();
-			default:
-				return super.eGet(featureID, resolve, coreType);
+		if (eNotificationRequired()) {
+			eNotify(new ENotificationImpl(this, Notification.SET, DevResponsePackage.RESPONSE__CONNECTION,
+					oldConnection, connection));
 		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public void eSet(int featureID, Object newValue) {
+	public Object eGet(final int featureID, final boolean resolve, final boolean coreType) {
 		switch (featureID) {
-			case DevResponsePackage.RESPONSE__ID:
-				setID((String)newValue);
-				return;
-			case DevResponsePackage.RESPONSE__WATCHES:
-				setWatches((Watches)newValue);
-				return;
-			case DevResponsePackage.RESPONSE__REASON:
-				setReason((String)newValue);
-				return;
-			case DevResponsePackage.RESPONSE__FBLIST:
-				setFblist((FBList)newValue);
-				return;
-			case DevResponsePackage.RESPONSE__ENDPOINTLIST:
-				setEndpointlist((EndpointList)newValue);
-				return;
-			case DevResponsePackage.RESPONSE__CONNECTION:
-				setConnection((Connection)newValue);
-				return;
-			default:
-				super.eSet(featureID, newValue);
-				return;
+		case DevResponsePackage.RESPONSE__ID:
+			return getID();
+		case DevResponsePackage.RESPONSE__WATCHES:
+			if (resolve) {
+				return getWatches();
+			}
+			return basicGetWatches();
+		case DevResponsePackage.RESPONSE__REASON:
+			return getReason();
+		case DevResponsePackage.RESPONSE__FBLIST:
+			if (resolve) {
+				return getFblist();
+			}
+			return basicGetFblist();
+		case DevResponsePackage.RESPONSE__FB_TYPE:
+			if (resolve) {
+				return getFbType();
+			}
+			return basicGetFbType();
+		case DevResponsePackage.RESPONSE__ENDPOINTLIST:
+			if (resolve) {
+				return getEndpointlist();
+			}
+			return basicGetEndpointlist();
+		case DevResponsePackage.RESPONSE__CONNECTION:
+			if (resolve) {
+				return getConnection();
+			}
+			return basicGetConnection();
+		default:
+			return super.eGet(featureID, resolve, coreType);
 		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public void eUnset(int featureID) {
+	public void eSet(final int featureID, final Object newValue) {
 		switch (featureID) {
-			case DevResponsePackage.RESPONSE__ID:
-				setID(ID_EDEFAULT);
-				return;
-			case DevResponsePackage.RESPONSE__WATCHES:
-				setWatches((Watches)null);
-				return;
-			case DevResponsePackage.RESPONSE__REASON:
-				setReason(REASON_EDEFAULT);
-				return;
-			case DevResponsePackage.RESPONSE__FBLIST:
-				setFblist((FBList)null);
-				return;
-			case DevResponsePackage.RESPONSE__ENDPOINTLIST:
-				setEndpointlist((EndpointList)null);
-				return;
-			case DevResponsePackage.RESPONSE__CONNECTION:
-				setConnection((Connection)null);
-				return;
-			default:
-				super.eUnset(featureID);
-				return;
+		case DevResponsePackage.RESPONSE__ID:
+			setID((String) newValue);
+			return;
+		case DevResponsePackage.RESPONSE__WATCHES:
+			setWatches((Watches) newValue);
+			return;
+		case DevResponsePackage.RESPONSE__REASON:
+			setReason((String) newValue);
+			return;
+		case DevResponsePackage.RESPONSE__FBLIST:
+			setFblist((FBList) newValue);
+			return;
+		case DevResponsePackage.RESPONSE__FB_TYPE:
+			setFbType((FBType) newValue);
+			return;
+		case DevResponsePackage.RESPONSE__ENDPOINTLIST:
+			setEndpointlist((EndpointList) newValue);
+			return;
+		case DevResponsePackage.RESPONSE__CONNECTION:
+			setConnection((Connection) newValue);
+			return;
+		default:
+			super.eSet(featureID, newValue);
 		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public boolean eIsSet(int featureID) {
+	public void eUnset(final int featureID) {
 		switch (featureID) {
-			case DevResponsePackage.RESPONSE__ID:
-				return ID_EDEFAULT == null ? id != null : !ID_EDEFAULT.equals(id);
-			case DevResponsePackage.RESPONSE__WATCHES:
-				return watches != null;
-			case DevResponsePackage.RESPONSE__REASON:
-				return REASON_EDEFAULT == null ? reason != null : !REASON_EDEFAULT.equals(reason);
-			case DevResponsePackage.RESPONSE__FBLIST:
-				return fblist != null;
-			case DevResponsePackage.RESPONSE__ENDPOINTLIST:
-				return endpointlist != null;
-			case DevResponsePackage.RESPONSE__CONNECTION:
-				return connection != null;
-			default:
-				return super.eIsSet(featureID);
+		case DevResponsePackage.RESPONSE__ID:
+			setID(ID_EDEFAULT);
+			return;
+		case DevResponsePackage.RESPONSE__WATCHES:
+			setWatches((Watches) null);
+			return;
+		case DevResponsePackage.RESPONSE__REASON:
+			setReason(REASON_EDEFAULT);
+			return;
+		case DevResponsePackage.RESPONSE__FBLIST:
+			setFblist((FBList) null);
+			return;
+		case DevResponsePackage.RESPONSE__FB_TYPE:
+			setFbType((FBType) null);
+			return;
+		case DevResponsePackage.RESPONSE__ENDPOINTLIST:
+			setEndpointlist((EndpointList) null);
+			return;
+		case DevResponsePackage.RESPONSE__CONNECTION:
+			setConnection((Connection) null);
+			return;
+		default:
+			super.eUnset(featureID);
 		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	@Override
+	public boolean eIsSet(final int featureID) {
+		return switch (featureID) {
+		case DevResponsePackage.RESPONSE__ID -> ID_EDEFAULT == null ? id != null : !ID_EDEFAULT.equals(id);
+		case DevResponsePackage.RESPONSE__WATCHES -> watches != null;
+		case DevResponsePackage.RESPONSE__REASON -> REASON_EDEFAULT == null ? reason != null : !REASON_EDEFAULT.equals(reason);
+		case DevResponsePackage.RESPONSE__FBLIST -> fblist != null;
+		case DevResponsePackage.RESPONSE__FB_TYPE -> fbType != null;
+		case DevResponsePackage.RESPONSE__ENDPOINTLIST -> endpointlist != null;
+		case DevResponsePackage.RESPONSE__CONNECTION -> connection != null;
+		default -> super.eIsSet(featureID);
+		};
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public String toString() {
-		if (eIsProxy()) return super.toString();
+		if (eIsProxy()) {
+			return super.toString();
+		}
 
-		StringBuilder result = new StringBuilder(super.toString());
+		final StringBuilder result = new StringBuilder(super.toString());
 		result.append(" (ID: "); //$NON-NLS-1$
 		result.append(id);
 		result.append(", Reason: "); //$NON-NLS-1$
@@ -489,4 +572,4 @@ public class ResponseImpl extends EObjectImpl implements Response {
 		return result.toString();
 	}
 
-} //ResponseImpl
+} // ResponseImpl

--- a/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/impl/WatchesImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/impl/WatchesImpl.java
@@ -28,23 +28,23 @@ import org.eclipse.fordiac.ide.deployment.devResponse.Resource;
 import org.eclipse.fordiac.ide.deployment.devResponse.Watches;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Watches</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Watches</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * </p>
  * <ul>
- *   <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.WatchesImpl#getResources <em>Resources</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.deployment.devResponse.impl.WatchesImpl#getResources
+ * <em>Resources</em>}</li>
  * </ul>
  *
  * @generated
  */
 public class WatchesImpl extends EObjectImpl implements Watches {
 	/**
-	 * The cached value of the '{@link #getResources() <em>Resources</em>}' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getResources() <em>Resources</em>}'
+	 * reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getResources()
 	 * @generated
 	 * @ordered
@@ -52,17 +52,16 @@ public class WatchesImpl extends EObjectImpl implements Watches {
 	protected EList<Resource> resources;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	protected WatchesImpl() {
-		super();
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
@@ -71,82 +70,77 @@ public class WatchesImpl extends EObjectImpl implements Watches {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
 	public EList<Resource> getResources() {
 		if (resources == null) {
-			resources = new EObjectResolvingEList<>(Resource.class, this, DevResponsePackage.WATCHES__RESOURCES);
+			resources = new EObjectResolvingEList<>(Resource.class, this,
+					DevResponsePackage.WATCHES__RESOURCES);
 		}
 		return resources;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public Object eGet(int featureID, boolean resolve, boolean coreType) {
-		switch (featureID) {
-			case DevResponsePackage.WATCHES__RESOURCES:
-				return getResources();
-			default:
-				return super.eGet(featureID, resolve, coreType);
-		}
+	public Object eGet(final int featureID, final boolean resolve, final boolean coreType) {
+		return switch (featureID) {
+		case DevResponsePackage.WATCHES__RESOURCES -> getResources();
+		default -> super.eGet(featureID, resolve, coreType);
+		};
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public void eSet(int featureID, Object newValue) {
+	public void eSet(final int featureID, final Object newValue) {
 		switch (featureID) {
-			case DevResponsePackage.WATCHES__RESOURCES:
-				getResources().clear();
-				getResources().addAll((Collection<? extends Resource>)newValue);
-				return;
-			default:
-				super.eSet(featureID, newValue);
-				return;
+		case DevResponsePackage.WATCHES__RESOURCES:
+			getResources().clear();
+			getResources().addAll((Collection<? extends Resource>) newValue);
+			return;
+		default:
+			super.eSet(featureID, newValue);
 		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public void eUnset(int featureID) {
+	public void eUnset(final int featureID) {
 		switch (featureID) {
-			case DevResponsePackage.WATCHES__RESOURCES:
-				getResources().clear();
-				return;
-			default:
-				super.eUnset(featureID);
-				return;
+		case DevResponsePackage.WATCHES__RESOURCES:
+			getResources().clear();
+			return;
+		default:
+			super.eUnset(featureID);
 		}
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	@Override
-	public boolean eIsSet(int featureID) {
-		switch (featureID) {
-			case DevResponsePackage.WATCHES__RESOURCES:
-				return resources != null && !resources.isEmpty();
-			default:
-				return super.eIsSet(featureID);
-		}
+	public boolean eIsSet(final int featureID) {
+		return switch (featureID) {
+		case DevResponsePackage.WATCHES__RESOURCES -> resources != null && !resources.isEmpty();
+		default -> super.eIsSet(featureID);
+		};
 	}
 
-} //WatchesImpl
+} // WatchesImpl

--- a/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/util/DevResponseAdapterFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/util/DevResponseAdapterFactory.java
@@ -1,7 +1,7 @@
 /**
  * ******************************************************************************
  * * Copyright (c) 2012, 2013, 2018 Profactor GmbH, fortiss GmbH, Johannes Kepler University
- * * 
+ * *
  * * This program and the accompanying materials are made available under the
  * * terms of the Eclipse Public License 2.0 which is available at
  * * http://www.eclipse.org/legal/epl-2.0.
@@ -13,7 +13,7 @@
  * *     - initial API and implementation and/or initial documentation
  * *   Alois Zoitl - moved to deployment and reworked it to a device response model
  * ******************************************************************************
- * 
+ *
  */
 package org.eclipse.fordiac.ide.deployment.devResponse.util;
 
@@ -27,32 +27,32 @@ import org.eclipse.fordiac.ide.deployment.devResponse.DevResponsePackage;
 import org.eclipse.fordiac.ide.deployment.devResponse.EndpointList;
 import org.eclipse.fordiac.ide.deployment.devResponse.FB;
 import org.eclipse.fordiac.ide.deployment.devResponse.FBList;
+import org.eclipse.fordiac.ide.deployment.devResponse.FBType;
 import org.eclipse.fordiac.ide.deployment.devResponse.Port;
 import org.eclipse.fordiac.ide.deployment.devResponse.Resource;
 import org.eclipse.fordiac.ide.deployment.devResponse.Response;
 import org.eclipse.fordiac.ide.deployment.devResponse.Watches;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Adapter Factory</b> for the model.
- * It provides an adapter <code>createXXX</code> method for each class of the model.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> The <b>Adapter Factory</b> for the model. It provides
+ * an adapter <code>createXXX</code> method for each class of the model. <!--
+ * end-user-doc -->
+ *
  * @see org.eclipse.fordiac.ide.deployment.devResponse.DevResponsePackage
  * @generated
  */
 public class DevResponseAdapterFactory extends AdapterFactoryImpl {
 	/**
-	 * The cached model package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached model package. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	protected static DevResponsePackage modelPackage;
 
 	/**
-	 * Creates an instance of the adapter factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the adapter factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 *
 	 * @generated
 	 */
 	public DevResponseAdapterFactory() {
@@ -62,94 +62,108 @@ public class DevResponseAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Returns whether this factory is applicable for the type of the object.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns <code>true</code> if the object is either the model's package or is an instance object of the model.
+	 * Returns whether this factory is applicable for the type of the object. <!--
+	 * begin-user-doc --> This implementation returns <code>true</code> if the
+	 * object is either the model's package or is an instance object of the model.
 	 * <!-- end-user-doc -->
+	 *
 	 * @return whether this factory is applicable for the type of the object.
 	 * @generated
 	 */
 	@Override
-	public boolean isFactoryForType(Object object) {
+	public boolean isFactoryForType(final Object object) {
 		if (object == modelPackage) {
 			return true;
 		}
 		if (object instanceof EObject) {
-			return ((EObject)object).eClass().getEPackage() == modelPackage;
+			return ((EObject) object).eClass().getEPackage() == modelPackage;
 		}
 		return false;
 	}
 
 	/**
-	 * The switch that delegates to the <code>createXXX</code> methods.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The switch that delegates to the <code>createXXX</code> methods. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
-	protected DevResponseSwitch<Adapter> modelSwitch =
-		new DevResponseSwitch<Adapter>() {
-			@Override
-			public Adapter caseResource(Resource object) {
-				return createResourceAdapter();
-			}
-			@Override
-			public Adapter caseFB(FB object) {
-				return createFBAdapter();
-			}
-			@Override
-			public Adapter casePort(Port object) {
-				return createPortAdapter();
-			}
-			@Override
-			public Adapter caseData(Data object) {
-				return createDataAdapter();
-			}
-			@Override
-			public Adapter caseResponse(Response object) {
-				return createResponseAdapter();
-			}
-			@Override
-			public Adapter caseWatches(Watches object) {
-				return createWatchesAdapter();
-			}
-			@Override
-			public Adapter caseFBList(FBList object) {
-				return createFBListAdapter();
-			}
-			@Override
-			public Adapter caseEndpointList(EndpointList object) {
-				return createEndpointListAdapter();
-			}
-			@Override
-			public Adapter caseConnection(Connection object) {
-				return createConnectionAdapter();
-			}
-			@Override
-			public Adapter defaultCase(EObject object) {
-				return createEObjectAdapter();
-			}
-		};
+	protected DevResponseSwitch<Adapter> modelSwitch = new DevResponseSwitch<>() {
+		@Override
+		public Adapter caseResource(final Resource object) {
+			return createResourceAdapter();
+		}
+
+		@Override
+		public Adapter caseFB(final FB object) {
+			return createFBAdapter();
+		}
+
+		@Override
+		public Adapter caseFBType(final FBType object) {
+			return createFBTypeAdapter();
+		}
+
+		@Override
+		public Adapter casePort(final Port object) {
+			return createPortAdapter();
+		}
+
+		@Override
+		public Adapter caseData(final Data object) {
+			return createDataAdapter();
+		}
+
+		@Override
+		public Adapter caseResponse(final Response object) {
+			return createResponseAdapter();
+		}
+
+		@Override
+		public Adapter caseWatches(final Watches object) {
+			return createWatchesAdapter();
+		}
+
+		@Override
+		public Adapter caseFBList(final FBList object) {
+			return createFBListAdapter();
+		}
+
+		@Override
+		public Adapter caseEndpointList(final EndpointList object) {
+			return createEndpointListAdapter();
+		}
+
+		@Override
+		public Adapter caseConnection(final Connection object) {
+			return createConnectionAdapter();
+		}
+
+		@Override
+		public Adapter defaultCase(final EObject object) {
+			return createEObjectAdapter();
+		}
+	};
 
 	/**
-	 * Creates an adapter for the <code>target</code>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an adapter for the <code>target</code>. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 *
 	 * @param target the object to adapt.
 	 * @return the adapter for the <code>target</code>.
 	 * @generated
 	 */
 	@Override
-	public Adapter createAdapter(Notifier target) {
-		return modelSwitch.doSwitch((EObject)target);
+	public Adapter createAdapter(final Notifier target) {
+		return modelSwitch.doSwitch((EObject) target);
 	}
 
-
 	/**
-	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.deployment.devResponse.Resource <em>Resource</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Resource
+	 * <em>Resource</em>}'. <!-- begin-user-doc --> This default implementation
+	 * returns null so that we can easily ignore cases; it's useful to ignore a case
+	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Resource
 	 * @generated
@@ -159,11 +173,12 @@ public class DevResponseAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.deployment.devResponse.FB <em>FB</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.FB <em>FB</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.FB
 	 * @generated
@@ -173,11 +188,27 @@ public class DevResponseAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.deployment.devResponse.Port <em>Port</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.FBType <em>FB
+	 * Type</em>}'. <!-- begin-user-doc --> This default implementation returns null
+	 * so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 *
+	 * @return the new adapter.
+	 * @see org.eclipse.fordiac.ide.deployment.devResponse.FBType
+	 * @generated
+	 */
+	public Adapter createFBTypeAdapter() {
+		return null;
+	}
+
+	/**
+	 * Creates a new adapter for an object of class
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Port <em>Port</em>}'.
+	 * <!-- begin-user-doc --> This default implementation returns null so that we
+	 * can easily ignore cases; it's useful to ignore a case when inheritance will
+	 * catch all the cases anyway. <!-- end-user-doc -->
+	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Port
 	 * @generated
@@ -187,11 +218,12 @@ public class DevResponseAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.deployment.devResponse.Data <em>Data</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Data <em>Data</em>}'.
+	 * <!-- begin-user-doc --> This default implementation returns null so that we
+	 * can easily ignore cases; it's useful to ignore a case when inheritance will
+	 * catch all the cases anyway. <!-- end-user-doc -->
+	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Data
 	 * @generated
@@ -201,11 +233,12 @@ public class DevResponseAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response <em>Response</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Response
+	 * <em>Response</em>}'. <!-- begin-user-doc --> This default implementation
+	 * returns null so that we can easily ignore cases; it's useful to ignore a case
+	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Response
 	 * @generated
@@ -215,11 +248,12 @@ public class DevResponseAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.deployment.devResponse.Watches <em>Watches</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Watches
+	 * <em>Watches</em>}'. <!-- begin-user-doc --> This default implementation
+	 * returns null so that we can easily ignore cases; it's useful to ignore a case
+	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Watches
 	 * @generated
@@ -229,11 +263,12 @@ public class DevResponseAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.deployment.devResponse.FBList <em>FB List</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.FBList <em>FB
+	 * List</em>}'. <!-- begin-user-doc --> This default implementation returns null
+	 * so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.FBList
 	 * @generated
@@ -243,11 +278,12 @@ public class DevResponseAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.deployment.devResponse.EndpointList <em>Endpoint List</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.EndpointList
+	 * <em>Endpoint List</em>}'. <!-- begin-user-doc --> This default implementation
+	 * returns null so that we can easily ignore cases; it's useful to ignore a case
+	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.EndpointList
 	 * @generated
@@ -257,11 +293,12 @@ public class DevResponseAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.deployment.devResponse.Connection <em>Connection</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link org.eclipse.fordiac.ide.deployment.devResponse.Connection
+	 * <em>Connection</em>}'. <!-- begin-user-doc --> This default implementation
+	 * returns null so that we can easily ignore cases; it's useful to ignore a case
+	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 *
 	 * @return the new adapter.
 	 * @see org.eclipse.fordiac.ide.deployment.devResponse.Connection
 	 * @generated
@@ -271,10 +308,9 @@ public class DevResponseAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for the default case.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for the default case. <!-- begin-user-doc --> This
+	 * default implementation returns null. <!-- end-user-doc -->
+	 *
 	 * @return the new adapter.
 	 * @generated
 	 */
@@ -282,4 +318,4 @@ public class DevResponseAdapterFactory extends AdapterFactoryImpl {
 		return null;
 	}
 
-} //DevResponseAdapterFactory
+} // DevResponseAdapterFactory

--- a/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/util/DevResponseSwitch.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src-gen/org/eclipse/fordiac/ide/deployment/devResponse/util/DevResponseSwitch.java
@@ -1,7 +1,7 @@
 /**
  * ******************************************************************************
  * * Copyright (c) 2012, 2013, 2018 Profactor GmbH, fortiss GmbH, Johannes Kepler University
- * * 
+ * *
  * * This program and the accompanying materials are made available under the
  * * terms of the Eclipse Public License 2.0 which is available at
  * * http://www.eclipse.org/legal/epl-2.0.
@@ -13,7 +13,7 @@
  * *     - initial API and implementation and/or initial documentation
  * *   Alois Zoitl - moved to deployment and reworked it to a device response model
  * ******************************************************************************
- * 
+ *
  */
 package org.eclipse.fordiac.ide.deployment.devResponse.util;
 
@@ -26,37 +26,35 @@ import org.eclipse.fordiac.ide.deployment.devResponse.DevResponsePackage;
 import org.eclipse.fordiac.ide.deployment.devResponse.EndpointList;
 import org.eclipse.fordiac.ide.deployment.devResponse.FB;
 import org.eclipse.fordiac.ide.deployment.devResponse.FBList;
+import org.eclipse.fordiac.ide.deployment.devResponse.FBType;
 import org.eclipse.fordiac.ide.deployment.devResponse.Port;
 import org.eclipse.fordiac.ide.deployment.devResponse.Resource;
 import org.eclipse.fordiac.ide.deployment.devResponse.Response;
 import org.eclipse.fordiac.ide.deployment.devResponse.Watches;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Switch</b> for the model's inheritance hierarchy.
- * It supports the call {@link #doSwitch(EObject) doSwitch(object)}
+ * <!-- begin-user-doc --> The <b>Switch</b> for the model's inheritance
+ * hierarchy. It supports the call {@link #doSwitch(EObject) doSwitch(object)}
  * to invoke the <code>caseXXX</code> method for each class of the model,
- * starting with the actual class of the object
- * and proceeding up the inheritance hierarchy
- * until a non-null result is returned,
- * which is the result of the switch.
- * <!-- end-user-doc -->
+ * starting with the actual class of the object and proceeding up the
+ * inheritance hierarchy until a non-null result is returned, which is the
+ * result of the switch. <!-- end-user-doc -->
+ *
  * @see org.eclipse.fordiac.ide.deployment.devResponse.DevResponsePackage
  * @generated
  */
 public class DevResponseSwitch<T> extends Switch<T> {
 	/**
-	 * The cached model package
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached model package <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @generated
 	 */
 	protected static DevResponsePackage modelPackage;
 
 	/**
-	 * Creates an instance of the switch.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the switch. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 *
 	 * @generated
 	 */
 	public DevResponseSwitch() {
@@ -66,235 +64,282 @@ public class DevResponseSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Checks whether this is a switch for the given package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Checks whether this is a switch for the given package. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 *
 	 * @param ePackage the package in question.
 	 * @return whether this is a switch for the given package.
 	 * @generated
 	 */
 	@Override
-	protected boolean isSwitchFor(EPackage ePackage) {
+	protected boolean isSwitchFor(final EPackage ePackage) {
 		return ePackage == modelPackage;
 	}
 
 	/**
-	 * Calls <code>caseXXX</code> for each class of the model until one returns a non null result; it yields that result.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Calls <code>caseXXX</code> for each class of the model until one returns a
+	 * non null result; it yields that result. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 *
 	 * @return the first non-null result returned by a <code>caseXXX</code> call.
 	 * @generated
 	 */
 	@Override
-	protected T doSwitch(int classifierID, EObject theEObject) {
+	protected T doSwitch(final int classifierID, final EObject theEObject) {
 		switch (classifierID) {
-			case DevResponsePackage.RESOURCE: {
-				Resource resource = (Resource)theEObject;
-				T result = caseResource(resource);
-				if (result == null) result = defaultCase(theEObject);
-				return result;
+		case DevResponsePackage.RESOURCE: {
+			final Resource resource = (Resource) theEObject;
+			T result = caseResource(resource);
+			if (result == null) {
+				result = defaultCase(theEObject);
 			}
-			case DevResponsePackage.FB: {
-				FB fb = (FB)theEObject;
-				T result = caseFB(fb);
-				if (result == null) result = defaultCase(theEObject);
-				return result;
+			return result;
+		}
+		case DevResponsePackage.FB: {
+			final FB fb = (FB) theEObject;
+			T result = caseFB(fb);
+			if (result == null) {
+				result = defaultCase(theEObject);
 			}
-			case DevResponsePackage.PORT: {
-				Port port = (Port)theEObject;
-				T result = casePort(port);
-				if (result == null) result = defaultCase(theEObject);
-				return result;
+			return result;
+		}
+		case DevResponsePackage.FB_TYPE: {
+			final FBType fbType = (FBType) theEObject;
+			T result = caseFBType(fbType);
+			if (result == null) {
+				result = defaultCase(theEObject);
 			}
-			case DevResponsePackage.DATA: {
-				Data data = (Data)theEObject;
-				T result = caseData(data);
-				if (result == null) result = defaultCase(theEObject);
-				return result;
+			return result;
+		}
+		case DevResponsePackage.PORT: {
+			final Port port = (Port) theEObject;
+			T result = casePort(port);
+			if (result == null) {
+				result = defaultCase(theEObject);
 			}
-			case DevResponsePackage.RESPONSE: {
-				Response response = (Response)theEObject;
-				T result = caseResponse(response);
-				if (result == null) result = defaultCase(theEObject);
-				return result;
+			return result;
+		}
+		case DevResponsePackage.DATA: {
+			final Data data = (Data) theEObject;
+			T result = caseData(data);
+			if (result == null) {
+				result = defaultCase(theEObject);
 			}
-			case DevResponsePackage.WATCHES: {
-				Watches watches = (Watches)theEObject;
-				T result = caseWatches(watches);
-				if (result == null) result = defaultCase(theEObject);
-				return result;
+			return result;
+		}
+		case DevResponsePackage.RESPONSE: {
+			final Response response = (Response) theEObject;
+			T result = caseResponse(response);
+			if (result == null) {
+				result = defaultCase(theEObject);
 			}
-			case DevResponsePackage.FB_LIST: {
-				FBList fbList = (FBList)theEObject;
-				T result = caseFBList(fbList);
-				if (result == null) result = defaultCase(theEObject);
-				return result;
+			return result;
+		}
+		case DevResponsePackage.WATCHES: {
+			final Watches watches = (Watches) theEObject;
+			T result = caseWatches(watches);
+			if (result == null) {
+				result = defaultCase(theEObject);
 			}
-			case DevResponsePackage.ENDPOINT_LIST: {
-				EndpointList endpointList = (EndpointList)theEObject;
-				T result = caseEndpointList(endpointList);
-				if (result == null) result = defaultCase(theEObject);
-				return result;
+			return result;
+		}
+		case DevResponsePackage.FB_LIST: {
+			final FBList fbList = (FBList) theEObject;
+			T result = caseFBList(fbList);
+			if (result == null) {
+				result = defaultCase(theEObject);
 			}
-			case DevResponsePackage.CONNECTION: {
-				Connection connection = (Connection)theEObject;
-				T result = caseConnection(connection);
-				if (result == null) result = defaultCase(theEObject);
-				return result;
+			return result;
+		}
+		case DevResponsePackage.ENDPOINT_LIST: {
+			final EndpointList endpointList = (EndpointList) theEObject;
+			T result = caseEndpointList(endpointList);
+			if (result == null) {
+				result = defaultCase(theEObject);
 			}
-			default: return defaultCase(theEObject);
+			return result;
+		}
+		case DevResponsePackage.CONNECTION: {
+			final Connection connection = (Connection) theEObject;
+			T result = caseConnection(connection);
+			if (result == null) {
+				result = defaultCase(theEObject);
+			}
+			return result;
+		}
+		default:
+			return defaultCase(theEObject);
 		}
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Resource</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Resource</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 *
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Resource</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Resource</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseResource(Resource object) {
+	public T caseResource(final Resource object) {
 		return null;
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>FB</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>FB</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 *
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>FB</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>FB</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseFB(FB object) {
+	public T caseFB(final FB object) {
 		return null;
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Port</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>FB
+	 * Type</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 *
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Port</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>FB
+	 *         Type</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T casePort(Port object) {
+	public T caseFBType(final FBType object) {
 		return null;
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Data</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Port</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 *
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Data</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Port</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseData(Data object) {
+	public T casePort(final Port object) {
 		return null;
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Response</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Data</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 *
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Response</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Data</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseResponse(Response object) {
+	public T caseData(final Data object) {
 		return null;
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Watches</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Response</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 *
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Watches</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Response</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseWatches(Watches object) {
+	public T caseResponse(final Response object) {
 		return null;
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>FB List</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Watches</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 *
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>FB List</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Watches</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseFBList(FBList object) {
+	public T caseWatches(final Watches object) {
 		return null;
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Endpoint List</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>FB
+	 * List</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 *
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Endpoint List</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>FB
+	 *         List</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseEndpointList(EndpointList object) {
+	public T caseFBList(final FBList object) {
 		return null;
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Connection</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Endpoint
+	 * List</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 *
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Connection</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Endpoint
+	 *         List</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseConnection(Connection object) {
+	public T caseEndpointList(final EndpointList object) {
 		return null;
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>EObject</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch, but this is the last case anyway.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Connection</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 *
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>EObject</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Connection</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
+	public T caseConnection(final Connection object) {
+		return null;
+	}
+
+	/**
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>EObject</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch, but this is the last
+	 * case anyway. <!-- end-user-doc -->
+	 *
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>EObject</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject)
 	 * @generated
 	 */
 	@Override
-	public T defaultCase(EObject object) {
+	public T defaultCase(final EObject object) {
 		return null;
 	}
 
-} //DevResponseSwitch
+} // DevResponseSwitch

--- a/plugins/org.eclipse.fordiac.ide.deployment/src/org/eclipse/fordiac/ide/deployment/DownloadRunnable.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src/org/eclipse/fordiac/ide/deployment/DownloadRunnable.java
@@ -43,6 +43,8 @@ import org.eclipse.fordiac.ide.model.libraryElement.Device;
 import org.eclipse.fordiac.ide.model.libraryElement.FB;
 import org.eclipse.fordiac.ide.model.libraryElement.Resource;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.typelibrary.DataTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.FBTypeEntry;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.swt.SWT;
@@ -113,6 +115,7 @@ public class DownloadRunnable implements IRunnableWithProgress, IDeploymentListe
 			addDeploymentListener(executor);
 			try (IDeviceManagementInteractorCloser closer = executor::disconnect) {
 				executor.connect();
+				queryTypes(devData, executor);
 				deployResources(devData, executor);
 				deployDeviceData(devData, executor);
 			} catch (final DeploymentException e) {
@@ -123,6 +126,24 @@ public class DownloadRunnable implements IRunnableWithProgress, IDeploymentListe
 
 		} else {
 			DeploymentCoordinator.printUnsupportedDeviceProfileMessageBox(devData.getDevice(), null);
+		}
+	}
+
+	private void queryTypes(final DeviceDeploymentData devData, final IDeviceManagementInteractor executor)
+			throws DeploymentException, InterruptedException {
+		for (final FBTypeEntry entry : devData.getFbTypes()) {
+			if (curMonitor.isCanceled()) {
+				throw new InterruptedException(Messages.DeploymentCoordinator_LABEL_DownloadAborted);
+			}
+			executor.queryFBType(entry);
+			curMonitor.worked(1);
+		}
+		for (final DataTypeEntry entry : devData.getDataTypes()) {
+			if (curMonitor.isCanceled()) {
+				throw new InterruptedException(Messages.DeploymentCoordinator_LABEL_DownloadAborted);
+			}
+			executor.queryDataType(entry);
+			curMonitor.worked(1);
 		}
 	}
 
@@ -206,6 +227,8 @@ public class DownloadRunnable implements IRunnableWithProgress, IDeploymentListe
 		for (final DeviceDeploymentData devData : deploymentData) {
 			retVal += devData.getSelectedDevParams().size();
 			retVal += devData.getResData().size();
+			retVal += devData.getFbTypes().size();
+			retVal += devData.getDataTypes().size();
 			for (final ResourceDeploymentData resDepData : devData.getResData()) {
 				retVal += countResourceParams(resDepData.getRes());
 				retVal += resDepData.getFbs().size() + resDepData.getConnections().size()

--- a/plugins/org.eclipse.fordiac.ide.deployment/src/org/eclipse/fordiac/ide/deployment/data/DeviceDeploymentData.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src/org/eclipse/fordiac/ide/deployment/data/DeviceDeploymentData.java
@@ -13,20 +13,28 @@ package org.eclipse.fordiac.ide.deployment.data;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.SequencedSet;
 
 import org.eclipse.fordiac.ide.model.libraryElement.Device;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.typelibrary.DataTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.FBTypeEntry;
 
 public class DeviceDeploymentData {
 
 	private final Device dev;
 
-	private List<ResourceDeploymentData> resData = new ArrayList<>();
+	private final List<ResourceDeploymentData> resData = new ArrayList<>();
 
 	private List<VarDeclaration> selectedDevParams = Collections.emptyList();
 
-	public DeviceDeploymentData(Device device) {
+	private final SequencedSet<FBTypeEntry> fbTypes = new LinkedHashSet<>();
+
+	private final SequencedSet<DataTypeEntry> dataTypes = new LinkedHashSet<>();
+
+	public DeviceDeploymentData(final Device device) {
 		dev = device;
 	}
 
@@ -34,15 +42,17 @@ public class DeviceDeploymentData {
 		return dev;
 	}
 
-	public void addResourceData(ResourceDeploymentData data) {
+	public void addResourceData(final ResourceDeploymentData data) {
 		resData.add(data);
+		fbTypes.addAll(data.getFbTypes());
+		dataTypes.addAll(data.getDataTypes());
 	}
 
 	public List<ResourceDeploymentData> getResData() {
 		return resData;
 	}
 
-	public void setSeltectedDevParams(List<VarDeclaration> selParams) {
+	public void setSeltectedDevParams(final List<VarDeclaration> selParams) {
 		selectedDevParams = Collections.unmodifiableList(new ArrayList<>(selParams));
 	}
 
@@ -54,4 +64,11 @@ public class DeviceDeploymentData {
 		return selectedDevParams;
 	}
 
+	public SequencedSet<FBTypeEntry> getFbTypes() {
+		return fbTypes;
+	}
+
+	public SequencedSet<DataTypeEntry> getDataTypes() {
+		return dataTypes;
+	}
 }

--- a/plugins/org.eclipse.fordiac.ide.deployment/src/org/eclipse/fordiac/ide/deployment/data/ResourceDeploymentData.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src/org/eclipse/fordiac/ide/deployment/data/ResourceDeploymentData.java
@@ -18,11 +18,14 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.SequencedSet;
 
 import org.eclipse.fordiac.ide.deployment.Messages;
 import org.eclipse.fordiac.ide.deployment.exceptions.DeploymentException;
 import org.eclipse.fordiac.ide.deployment.util.DeploymentHelper;
+import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableFB;
 import org.eclipse.fordiac.ide.model.libraryElement.Connection;
 import org.eclipse.fordiac.ide.model.libraryElement.FB;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
@@ -35,6 +38,8 @@ import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
 import org.eclipse.fordiac.ide.model.libraryElement.TypedSubApp;
 import org.eclipse.fordiac.ide.model.libraryElement.UntypedSubApp;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.typelibrary.DataTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.FBTypeEntry;
 
 /**
  * Class for storing the information for deploying a resource
@@ -52,6 +57,10 @@ public class ResourceDeploymentData {
 
 	private final List<ParameterDeploymentData> params = new ArrayList<>();
 
+	private final SequencedSet<FBTypeEntry> fbTypes = new LinkedHashSet<>();
+
+	private final SequencedSet<DataTypeEntry> dataTypes = new LinkedHashSet<>();
+
 	public Resource getRes() {
 		return res;
 	}
@@ -66,6 +75,14 @@ public class ResourceDeploymentData {
 
 	public List<ParameterDeploymentData> getParams() {
 		return params;
+	}
+
+	public SequencedSet<FBTypeEntry> getFbTypes() {
+		return fbTypes;
+	}
+
+	public SequencedSet<DataTypeEntry> getDataTypes() {
+		return dataTypes;
 	}
 
 	public void addFbs(final FBDeploymentData fb) {
@@ -106,6 +123,13 @@ public class ResourceDeploymentData {
 	private void addFB(final Deque<SubApp> subAppHierarchy, final StringBuilder prefix, final FB fb)
 			throws DeploymentException {
 		fbs.add(new FBDeploymentData(ensurePrefix(prefix, fb), fb));
+		if (fb.getTypeEntry() instanceof final FBTypeEntry entry) {
+			fbTypes.add(entry);
+		}
+		if (fb instanceof final ConfigurableFB configurableFB && configurableFB.getDataType() != null
+				&& configurableFB.getDataType().getTypeEntry() instanceof final DataTypeEntry entry) {
+			dataTypes.add(entry);
+		}
 		for (final VarDeclaration inputVar : fb.getInterface().getInputVars()) {
 			addInputParam(subAppHierarchy, prefix, inputVar);
 		}

--- a/plugins/org.eclipse.fordiac.ide.deployment/src/org/eclipse/fordiac/ide/deployment/interactors/AbstractDelegatingDeviceManagementInteractor.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src/org/eclipse/fordiac/ide/deployment/interactors/AbstractDelegatingDeviceManagementInteractor.java
@@ -19,12 +19,12 @@ import org.eclipse.fordiac.ide.deployment.data.FBDeploymentData;
 import org.eclipse.fordiac.ide.deployment.devResponse.Response;
 import org.eclipse.fordiac.ide.deployment.exceptions.DeploymentException;
 import org.eclipse.fordiac.ide.deployment.util.IDeploymentListener;
-import org.eclipse.fordiac.ide.model.data.DataType;
 import org.eclipse.fordiac.ide.model.libraryElement.Device;
-import org.eclipse.fordiac.ide.model.libraryElement.FBType;
-import org.eclipse.fordiac.ide.model.libraryElement.GlobalConstants;
 import org.eclipse.fordiac.ide.model.libraryElement.Resource;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.typelibrary.DataTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.FBTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.GlobalConstantsEntry;
 
 public abstract class AbstractDelegatingDeviceManagementInteractor implements IDeviceManagementInteractor {
 	private final IDeviceManagementInteractor delegate;
@@ -154,18 +154,18 @@ public abstract class AbstractDelegatingDeviceManagementInteractor implements ID
 	}
 
 	@Override
-	public Response queryFBType(final FBType type) throws DeploymentException {
-		return delegate.queryFBType(type);
+	public Response queryFBType(final FBTypeEntry entry) throws DeploymentException {
+		return delegate.queryFBType(entry);
 	}
 
 	@Override
-	public Response queryDataType(final DataType type) throws DeploymentException {
-		return delegate.queryDataType(type);
+	public Response queryDataType(final DataTypeEntry entry) throws DeploymentException {
+		return delegate.queryDataType(entry);
 	}
 
 	@Override
-	public Response queryGlobalConstType(final GlobalConstants type) throws DeploymentException {
-		return delegate.queryGlobalConstType(type);
+	public Response queryGlobalConstType(final GlobalConstantsEntry entry) throws DeploymentException {
+		return delegate.queryGlobalConstType(entry);
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.deployment/src/org/eclipse/fordiac/ide/deployment/interactors/DeviceManagementExecutorService.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src/org/eclipse/fordiac/ide/deployment/interactors/DeviceManagementExecutorService.java
@@ -25,12 +25,12 @@ import org.eclipse.fordiac.ide.deployment.data.ConnectionDeploymentData;
 import org.eclipse.fordiac.ide.deployment.data.FBDeploymentData;
 import org.eclipse.fordiac.ide.deployment.devResponse.Response;
 import org.eclipse.fordiac.ide.deployment.exceptions.DeploymentException;
-import org.eclipse.fordiac.ide.model.data.DataType;
 import org.eclipse.fordiac.ide.model.libraryElement.Device;
-import org.eclipse.fordiac.ide.model.libraryElement.FBType;
-import org.eclipse.fordiac.ide.model.libraryElement.GlobalConstants;
 import org.eclipse.fordiac.ide.model.libraryElement.Resource;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.typelibrary.DataTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.FBTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.GlobalConstantsEntry;
 
 public class DeviceManagementExecutorService extends AbstractDelegatingDeviceManagementInteractor
 		implements IDeviceManagementExecutorService {
@@ -147,18 +147,18 @@ public class DeviceManagementExecutorService extends AbstractDelegatingDeviceMan
 	}
 
 	@Override
-	public Response queryFBType(final FBType type) throws DeploymentException {
-		return unwrap(queryFBTypeAsync(type));
+	public Response queryFBType(final FBTypeEntry entry) throws DeploymentException {
+		return unwrap(queryFBTypeAsync(entry));
 	}
 
 	@Override
-	public Response queryDataType(final DataType type) throws DeploymentException {
-		return unwrap(queryDataTypeAsync(type));
+	public Response queryDataType(final DataTypeEntry entry) throws DeploymentException {
+		return unwrap(queryDataTypeAsync(entry));
 	}
 
 	@Override
-	public Response queryGlobalConstType(final GlobalConstants type) throws DeploymentException {
-		return unwrap(queryGlobalConstTypeAsync(type));
+	public Response queryGlobalConstType(final GlobalConstantsEntry entry) throws DeploymentException {
+		return unwrap(queryGlobalConstTypeAsync(entry));
 	}
 
 	@Override
@@ -352,18 +352,18 @@ public class DeviceManagementExecutorService extends AbstractDelegatingDeviceMan
 	}
 
 	@Override
-	public Future<Response> queryFBTypeAsync(final FBType type) {
-		return executorService.submit(() -> getDelegate().queryFBType(type));
+	public Future<Response> queryFBTypeAsync(final FBTypeEntry entry) {
+		return executorService.submit(() -> getDelegate().queryFBType(entry));
 	}
 
 	@Override
-	public Future<Response> queryDataTypeAsync(final DataType type) {
-		return executorService.submit(() -> getDelegate().queryDataType(type));
+	public Future<Response> queryDataTypeAsync(final DataTypeEntry entry) {
+		return executorService.submit(() -> getDelegate().queryDataType(entry));
 	}
 
 	@Override
-	public Future<Response> queryGlobalConstTypeAsync(final GlobalConstants type) {
-		return executorService.submit(() -> getDelegate().queryGlobalConstType(type));
+	public Future<Response> queryGlobalConstTypeAsync(final GlobalConstantsEntry entry) {
+		return executorService.submit(() -> getDelegate().queryGlobalConstType(entry));
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.deployment/src/org/eclipse/fordiac/ide/deployment/interactors/ForteTypeNameCreator.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src/org/eclipse/fordiac/ide/deployment/interactors/ForteTypeNameCreator.java
@@ -22,8 +22,13 @@ import org.eclipse.fordiac.ide.model.libraryElement.Demultiplexer;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.Resource;
 import org.eclipse.fordiac.ide.model.libraryElement.impl.ConfigurableFBManagement;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 
 public class ForteTypeNameCreator {
+
+	public static String getForteTypeName(final TypeEntry entry) {
+		return convertFullTypeNameToFORTE(entry.getFullTypeName());
+	}
 
 	public static String getForteTypeName(final FBNetworkElement fb) {
 		if (fb != null && fb.getTypeEntry() != null) {

--- a/plugins/org.eclipse.fordiac.ide.deployment/src/org/eclipse/fordiac/ide/deployment/interactors/IDeviceManagementExecutorService.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src/org/eclipse/fordiac/ide/deployment/interactors/IDeviceManagementExecutorService.java
@@ -22,12 +22,12 @@ import org.eclipse.fordiac.ide.deployment.data.ConnectionDeploymentData;
 import org.eclipse.fordiac.ide.deployment.data.FBDeploymentData;
 import org.eclipse.fordiac.ide.deployment.devResponse.Response;
 import org.eclipse.fordiac.ide.deployment.exceptions.DeploymentException;
-import org.eclipse.fordiac.ide.model.data.DataType;
 import org.eclipse.fordiac.ide.model.libraryElement.Device;
-import org.eclipse.fordiac.ide.model.libraryElement.FBType;
-import org.eclipse.fordiac.ide.model.libraryElement.GlobalConstants;
 import org.eclipse.fordiac.ide.model.libraryElement.Resource;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.typelibrary.DataTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.FBTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.GlobalConstantsEntry;
 
 public interface IDeviceManagementExecutorService extends IDeviceManagementInteractor, AutoCloseable {
 
@@ -233,11 +233,11 @@ public interface IDeviceManagementExecutorService extends IDeviceManagementInter
 	 */
 	Future<List<org.eclipse.fordiac.ide.deployment.devResponse.Resource>> queryResourcesAsync();
 
-	Future<Response> queryFBTypeAsync(final FBType type);
+	Future<Response> queryFBTypeAsync(final FBTypeEntry entry);
 
-	Future<Response> queryDataTypeAsync(final DataType type);
+	Future<Response> queryDataTypeAsync(final DataTypeEntry entry);
 
-	Future<Response> queryGlobalConstTypeAsync(final GlobalConstants type);
+	Future<Response> queryGlobalConstTypeAsync(final GlobalConstantsEntry entry);
 
 	/**
 	 * Query resources periodically

--- a/plugins/org.eclipse.fordiac.ide.deployment/src/org/eclipse/fordiac/ide/deployment/interactors/IDeviceManagementInteractor.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src/org/eclipse/fordiac/ide/deployment/interactors/IDeviceManagementInteractor.java
@@ -24,12 +24,12 @@ import org.eclipse.fordiac.ide.deployment.data.FBDeploymentData;
 import org.eclipse.fordiac.ide.deployment.devResponse.Response;
 import org.eclipse.fordiac.ide.deployment.exceptions.DeploymentException;
 import org.eclipse.fordiac.ide.deployment.util.IDeploymentListener;
-import org.eclipse.fordiac.ide.model.data.DataType;
 import org.eclipse.fordiac.ide.model.libraryElement.Device;
-import org.eclipse.fordiac.ide.model.libraryElement.FBType;
-import org.eclipse.fordiac.ide.model.libraryElement.GlobalConstants;
 import org.eclipse.fordiac.ide.model.libraryElement.Resource;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.typelibrary.DataTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.FBTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.GlobalConstantsEntry;
 
 /**
  * Interface for classes that allow deployment and monitoring to interact with a
@@ -255,11 +255,11 @@ public interface IDeviceManagementInteractor {
 	 */
 	List<org.eclipse.fordiac.ide.deployment.devResponse.Resource> queryResources() throws DeploymentException;
 
-	Response queryFBType(FBType type) throws DeploymentException;
+	Response queryFBType(FBTypeEntry entry) throws DeploymentException;
 
-	Response queryDataType(DataType type) throws DeploymentException;
+	Response queryDataType(DataTypeEntry entry) throws DeploymentException;
 
-	Response queryGlobalConstType(GlobalConstants type) throws DeploymentException;
+	Response queryGlobalConstType(GlobalConstantsEntry entry) throws DeploymentException;
 
 	/***********************
 	 * monitoring commands


### PR DESCRIPTION
Please note that without https://github.com/eclipse-4diac/4diac-ide/pull/1372 this will break deployments, because the hash for all FB types in the typelib needs to be set to an empty string or queries will fail for those types.