### PR TITLE
isTypeEditable Didn't check if network is null for InterfaceElements

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AttributeSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AttributeSection.java
@@ -147,8 +147,9 @@ public class AttributeSection extends AbstractSection implements I4diacNatTableU
 	private boolean isTypeEditable() {
 		final ConfigurableObject type = getType();
 		return !(type instanceof final FBNetworkElement fbne && fbne.isContainedInTypedInstance()
-				|| type instanceof final IInterfaceElement ie && ie.getFBNetworkElement().isContainedInTypedInstance()
-				|| type instanceof final Connection conn && FBNetworkElementHelper.isContainedInTypedInstance(conn));
+				|| (type instanceof final IInterfaceElement ie && ie.getFBNetworkElement() != null
+						&& ie.getFBNetworkElement().isContainedInTypedInstance())
+				|| (type instanceof final Connection conn && FBNetworkElementHelper.isContainedInTypedInstance(conn)));
 	}
 
 	private Attribute getNeighbourListItem(final Attribute ref, final boolean above) {


### PR DESCRIPTION
InterfaceElements not always have a network elements (e.g., struct, type interface). As this was not considered the property sheet for attributes of struct members was broken.