### PR TITLE
Remove redundant set action handlers in multi-page editor contributor

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editors/GraphicalMultipageEditorContributor.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editors/GraphicalMultipageEditorContributor.java
@@ -37,13 +37,6 @@ public class GraphicalMultipageEditorContributor extends MultiPageEditorActionBa
 	private final List<String> globalActionKeys = new ArrayList<>();
 
 	@Override
-	public void setActiveEditor(final IEditorPart editor) {
-		setGlobalActionHandler(Adapters.adapt(editor, ActionRegistry.class));
-		super.setActiveEditor(editor);
-
-	}
-
-	@Override
 	public void setActivePage(final IEditorPart activeEditor) {
 		setGlobalActionHandler(Adapters.adapt(activeEditor, ActionRegistry.class));
 	}


### PR DESCRIPTION
The global action handlers were set for the active editor, but the super method would immediately set the active page, which would overwrite the action handlers with those of the page again. This removes the redundant setting of the action handlers from the editor.