### PR TITLE
Fix IdentifierVerifier allowing dots

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/IdentifierVerifier.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/IdentifierVerifier.java
@@ -63,7 +63,7 @@ public final class IdentifierVerifier {
 	 *         message is contained in the Optional
 	 */
 	public static Optional<String> verifyIdentifier(final String identifier, final Object context) {
-		if (identifier == null || (!IDENTIFIER_PATTERN.matcher(identifier).matches() && !identifier.contains("."))) { //$NON-NLS-1$
+		if (identifier == null || !IDENTIFIER_PATTERN.matcher(identifier).matches()) {
 			return Optional.of(MessageFormat.format(Messages.IdentifierVerifier_NameNotAValidIdentifier, identifier));
 		}
 		if (identifier.contains("__")) { //$NON-NLS-1$

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/model/IdentifierVerifierTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/model/IdentifierVerifierTest.java
@@ -34,7 +34,7 @@ class IdentifierVerifierTest {
 
 	@ParameterizedTest
 	@ValueSource(strings = { "", "TEST$", "Test\u00c4", "4test", "__test", "test__name", "test_", "test name",
-			"test\\nname", "ANY" })
+			"test\\nname", "ANY", "test.name" })
 	void testVerifyInvalidIdentifier(final String identifier) {
 		assertTrue(IdentifierVerifier.verifyIdentifier(identifier.translateEscapes()).isPresent());
 	}


### PR DESCRIPTION
The current IdentifierVerifier allowed names with dots ("."). I believe this was a mistake and names with dots are not IEC 61499 compliant identifiers.
I also added such an identifier to the test cases.