### PR TITLE
Fixing System Explorer File DnD Issues [1285]

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/plugin.xml
@@ -243,8 +243,7 @@
               <!-- <contentExtension pattern="org.eclipse.fordiac.ide.typemanagement.navigator.filters.showonly61499Types"/> -->
                <contentExtension pattern="org.eclipse.fordiac.ide.typemanagement.fbTypeContent"/> 
                <contentExtension pattern="org.eclipse.fordiac.ide.typemanagement.typelib.systemexplorer"/> 
-      		   <contentExtension pattern="org.eclipse.ui.navigator.resourceContent"/>             
-               <contentExtension pattern="org.eclipse.ui.navigator.resources.filters.*"/>
+      		   <contentExtension pattern="org.eclipse.ui.navigator.resourceContent"/>
                <contentExtension pattern="org.eclipse.fordiac.ide.systemmanagement.ui.systemexplorer.systemExplorerLinkHelper" />
                <contentExtension pattern="org.eclipse.fordiac.ide.typemanagement.navigator.FBContentSorter" />
             </includes>
@@ -254,6 +253,11 @@
          </viewer>
       <dragAssistant
             class="org.eclipse.fordiac.ide.systemmanagement.ui.systemexplorer.SystemExplorerDragAssistant"
+            viewerId="org.eclipse.fordiac.ide.systemmanagement.ui.systemexplorer">
+      </dragAssistant>
+      <!-- The resource drag adpater assistent is needed for drag and drop of all file -->
+      <dragAssistant   
+            class="org.eclipse.ui.navigator.resources.ResourceDragAdapterAssistant"
             viewerId="org.eclipse.fordiac.ide.systemmanagement.ui.systemexplorer">
       </dragAssistant>
       </extension>


### PR DESCRIPTION
Drag and Drop of files in the system explorer had two issues fixed with this PR:
  - it was not possible to drag files between two 4diac IDE instances
  - it was not possible to drag any none IEC 61499 file

Fixes: https://github.com/eclipse-4diac/4diac-ide/issues/1285