### PR TITLE
Upgraded Eclipse Tycho on 3.0.x Branch

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho</groupId>
     <artifactId>tycho-build</artifactId>
-    <version>4.0.8</version>
+    <version>4.0.13</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
 		<maven.compiler.release/>
-		<tycho.version>4.0.10</tycho.version>
+		<tycho.version>4.0.13</tycho.version>
 		<tycho-repo.url>https://download.eclipse.org/releases/2024-12</tycho-repo.url>
 		<sonar.exclusions>**/src-gen/**/*,**/xtend-gen/**/*</sonar.exclusions>
 		<sonar.projectName>Eclipse 4diac</sonar.projectName>


### PR DESCRIPTION
3.0.x branch still uses an older Eclipse Tycho, also the versions of the maven extension and in the root pom where not the same.