### PR TITLE
Scroll to the right position on Graphical Editor opening

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editors/FBInterfaceEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editors/FBInterfaceEditor.java
@@ -34,7 +34,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.libraryElement.SubAppType;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
-import org.eclipse.fordiac.ide.model.ui.editors.AdvancedScrollingGraphicalViewer;
 import org.eclipse.fordiac.ide.typeeditor.TypeEditorInput;
 import org.eclipse.fordiac.ide.ui.FordiacMessages;
 import org.eclipse.fordiac.ide.ui.imageprovider.FordiacImage;
@@ -56,7 +55,6 @@ import org.eclipse.gef.ui.palette.PaletteViewerProvider;
 import org.eclipse.gef.ui.parts.ScrollingGraphicalViewer;
 import org.eclipse.jface.util.TransferDropTargetListener;
 import org.eclipse.swt.graphics.Point;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorSite;
 import org.eclipse.ui.PartInitException;
@@ -230,14 +228,6 @@ public class FBInterfaceEditor extends DiagramEditorWithFlyoutPalette implements
 				// empty to be sure that grid will not be drawn
 			}
 		};
-	}
-
-	@Override
-	protected void performInitialsationScroll(final AdvancedScrollingGraphicalViewer viewer) {
-		// In order that the interface editor can get the size of the canvas we need to
-		// run the initial scroll asynchronously so that SWT will layout the editor
-		// first.
-		Display.getDefault().asyncExec(() -> super.performInitialsationScroll(viewer));
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/DiagramEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/DiagramEditor.java
@@ -19,6 +19,7 @@ import java.util.EventObject;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.draw2d.FigureCanvas;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.zoom.MouseLocationZoomScrollPolicy;
@@ -63,6 +64,7 @@ import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IEditorSite;
@@ -155,14 +157,34 @@ public abstract class DiagramEditor extends GraphicalEditor
 			// do not use getSelection() here because it will return always at least one
 			// element
 			if (viewer.getSelectedEditParts().isEmpty()) {
-				final GraphicalEditPart rootEditPart = (GraphicalEditPart) viewer.getRootEditPart();
-				final Point scrollPos = getInitialScrollPos(rootEditPart);
-				canvas.scrollTo(scrollPos.x, scrollPos.y);
+				performUnselectedInitialisationScroll(viewer);
 			} else {
 				// if we have a selected edit part we want to show it in the middle
 				viewer.revealEditPart(viewer.getSelectedEditParts().get(0));
 			}
 		}
+	}
+
+	private void performUnselectedInitialisationScroll(final AdvancedScrollingGraphicalViewer viewer) {
+		final FigureCanvas canvas = (FigureCanvas) viewer.getControl();
+		final GraphicalEditPart rootEditPart = (GraphicalEditPart) viewer.getRootEditPart();
+		final IFigure figure = rootEditPart.getFigure();
+
+		Display.getDefault().asyncExec(new Runnable() {
+			@Override
+			public void run() {
+				if (canvas != null && !canvas.isDisposed()) {
+					viewer.flush();
+					if (figure.isShowing() && !figure.getBounds().isEmpty()) {
+						final Point scrollPos = getInitialScrollPos(rootEditPart);
+						canvas.scrollTo(scrollPos.x, scrollPos.y);
+					} else {
+						// Retry until the figure is laid out
+						Display.getDefault().timerExec(50, this);
+					}
+				}
+			}
+		});
 	}
 
 	@SuppressWarnings("static-method") // allow subclases to override this method

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/DiagramEditorWithFlyoutPalette.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/DiagramEditorWithFlyoutPalette.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.draw2d.FigureCanvas;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.zoom.MouseLocationZoomScrollPolicy;
@@ -79,6 +80,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IActionBars;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
@@ -159,19 +161,38 @@ public abstract class DiagramEditorWithFlyoutPalette extends GraphicalEditorWith
 		if (canvas != null && !canvas.isDisposed()) {
 			viewer.flush();
 			// if an editpart is selected then the viewer has bee created with something to
-			// be shown centered
-			// therefore we will not show the initial position
+			// be shown centered therefore we will not show the initial position
 			// do not use getSelection() here because it will return always at least one
 			// element
 			if (viewer.getSelectedEditParts().isEmpty()) {
-				final GraphicalEditPart rootEditPart = (GraphicalEditPart) viewer.getRootEditPart();
-				final Point scrollPos = getInitialScrollPos(rootEditPart);
-				canvas.scrollTo(scrollPos.x, scrollPos.y);
+				performUnselectedInitialisationScroll(viewer);
 			} else {
 				// if we have a selected edit part we want to show it in the middle
 				viewer.revealEditPart(viewer.getSelectedEditParts().get(0));
 			}
 		}
+	}
+
+	private void performUnselectedInitialisationScroll(final AdvancedScrollingGraphicalViewer viewer) {
+		final FigureCanvas canvas = (FigureCanvas) viewer.getControl();
+		final GraphicalEditPart rootEditPart = (GraphicalEditPart) viewer.getRootEditPart();
+		final IFigure figure = rootEditPart.getFigure();
+
+		Display.getDefault().asyncExec(new Runnable() {
+			@Override
+			public void run() {
+				if (canvas != null && !canvas.isDisposed()) {
+					viewer.flush();
+					if (figure.isShowing() && !figure.getBounds().isEmpty()) {
+						final Point scrollPos = getInitialScrollPos(rootEditPart);
+						canvas.scrollTo(scrollPos.x, scrollPos.y);
+					} else {
+						// Retry until the figure is laid out
+						Display.getDefault().timerExec(50, this);
+					}
+				}
+			}
+		});
 	}
 
 	@SuppressWarnings("static-method") // allow subclasses to override this method

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/AdvancedScrollingGraphicalViewer.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/AdvancedScrollingGraphicalViewer.java
@@ -31,6 +31,7 @@ import org.eclipse.gef.EditPart;
 import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.ui.parts.ScrollingGraphicalViewer;
 import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.widgets.Display;
 
 /**
  * The Class AdvancedScrollingGraphicalViewer.
@@ -67,7 +68,19 @@ public class AdvancedScrollingGraphicalViewer extends ScrollingGraphicalViewer {
 		if (!(part instanceof ConnectionEditPart)) {
 			super.reveal(part);
 			if (part instanceof final GraphicalEditPart graphicalEP) {
-				centerPartPositionInViewport(graphicalEP);
+				final IFigure figure = graphicalEP.getFigure();
+				Display.getDefault().asyncExec(new Runnable() {
+					@Override
+					public void run() {
+						flush();
+						if (figure.isShowing() && !figure.getBounds().isEmpty()) {
+							centerPartPositionInViewport(graphicalEP);
+						} else {
+							// Retry until the figure is laid out
+							Display.getDefault().timerExec(50, this);
+						}
+					}
+				});
 			}
 		}
 	}


### PR DESCRIPTION
When a graphical editor is opened it either should scroll to an editor specific initial position or it should show selected elements centered. The given fix is now waiting till the editor is fully drawn so that the scroll positions can be correctly calculated.