### PR TITLE
Reworked layout graph generation to not have root graph

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.elk/src/org/eclipse/fordiac/ide/elk/FordiacGraphBuilder.java
+++ b/plugins/org.eclipse.fordiac.ide.elk/src/org/eclipse/fordiac/ide/elk/FordiacGraphBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 Johannes Kepler University Linz,
+ * Copyright (c) 2020, 2025 Johannes Kepler University Linz,
  * 							Primetals Technologies Germany GmbH,
  * 							Primetals Technologies Austria GmbH
  *
@@ -17,8 +17,7 @@ package org.eclipse.fordiac.ide.elk;
 
 import java.util.List;
 
-import org.eclipse.draw2d.geometry.Point;
-import org.eclipse.draw2d.geometry.PrecisionPoint;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.elk.core.options.CoreOptions;
 import org.eclipse.elk.core.options.PortConstraints;
@@ -31,30 +30,30 @@ import org.eclipse.elk.graph.util.ElkGraphUtil;
 import org.eclipse.fordiac.ide.application.editparts.AbstractFBNElementEditPart;
 import org.eclipse.fordiac.ide.application.editparts.CommentEditPart;
 import org.eclipse.fordiac.ide.application.editparts.ConnectionEditPart;
+import org.eclipse.fordiac.ide.application.editparts.EditorWithInterfaceEditPart;
 import org.eclipse.fordiac.ide.application.editparts.GroupContentEditPart;
 import org.eclipse.fordiac.ide.application.editparts.GroupEditPart;
 import org.eclipse.fordiac.ide.application.editparts.UnfoldedSubappContentEditPart;
 import org.eclipse.fordiac.ide.application.editparts.UntypedSubAppInterfaceElementEditPart;
 import org.eclipse.fordiac.ide.application.figures.FBNetworkConnection;
-import org.eclipse.fordiac.ide.elk.FordiacLayoutMapping.LayoutType;
+import org.eclipse.fordiac.ide.gef.editparts.AbstractFBNetworkEditPart;
 import org.eclipse.fordiac.ide.gef.editparts.InterfaceEditPart;
 import org.eclipse.fordiac.ide.gef.editparts.ValueEditPart;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.GraphicalEditPart;
+import org.eclipse.ui.IEditorPart;
 
 public final class FordiacGraphBuilder {
 
-	private static final PrecisionPoint START_POINT = new PrecisionPoint();
-	private static final PrecisionPoint END_POINT = new PrecisionPoint();
-
 	private final FordiacLayoutMapping mapping;
 
-	public FordiacGraphBuilder(final FordiacLayoutMapping mapping) {
-		this.mapping = mapping;
+	public FordiacGraphBuilder(final IEditorPart part, final AbstractFBNetworkEditPart ep) {
+		this.mapping = createFordiacLayoutMapping(part, ep);
 	}
 
-	public void build() {
-		if (mapping.type != LayoutType.Application) {
+	public FordiacLayoutMapping build() {
+		if (isParentInterfaceLayout(mapping.getParentElement())) {
 			processParentInterfaces();
 		}
 
@@ -63,23 +62,60 @@ public final class FordiacGraphBuilder {
 		}
 
 		processConnections();
+
+		return mapping;
 	}
 
 	private void processParentInterfaces() {
-		final List<? extends EditPart> children = switch (mapping.type) {
-		case LayoutType.Typed -> mapping.getParentElement().getChildren();
-		case LayoutType.Unfolded -> mapping.getParentElement().getParent().getChildren();
-		default -> throw new IllegalArgumentException("Unexpected value: " + mapping.type); //$NON-NLS-1$
+		final ElkNode inputInterfaceBarNode = createInputIBNode();
+		final ElkNode outputInterfaceBarNode = createOutputIBNode();
+
+		final List<? extends GraphicalEditPart> children = switch (mapping.getParentElement()) {
+		case final EditorWithInterfaceEditPart edWithEp -> edWithEp.getChildren();
+		case final UnfoldedSubappContentEditPart unfoldedSubappContentEP ->
+			unfoldedSubappContentEP.getParent().getChildren();
+		default -> throw new IllegalArgumentException("Wrong parent editpart given"); //$NON-NLS-1$
 		};
+
 		// @formatter:off
 		children.stream()
 				.filter(InterfaceEditPart.class::isInstance)
 				.map(InterfaceEditPart.class::cast)
 				.forEach(ie -> {
-					createParentElementPort(ie);
+					createParentElementPort(ie, inputInterfaceBarNode, outputInterfaceBarNode);
 					processInterface(ie);
 				});
 		// @formatter:on
+	}
+
+	private ElkNode createInputIBNode() {
+		final ElkNode inputNode = createNode(getInputIBFigure());
+		inputNode.setProperty(CoreOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_POS);
+		return inputNode;
+	}
+
+	private ElkNode createOutputIBNode() {
+		final ElkNode outputNode = createNode(getOutputIBFigure());
+		outputNode.setProperty(CoreOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_POS);
+		return outputNode;
+	}
+
+	private IFigure getInputIBFigure() {
+		return switch (mapping.getParentElement()) {
+		case final EditorWithInterfaceEditPart edWithEp -> edWithEp.getLeftInterfaceContainer();
+		case final UnfoldedSubappContentEditPart unfoldedSubappContentEP ->
+			unfoldedSubappContentEP.getParent().getFigure().getExpandedInputFigure();
+		default -> throw new IllegalArgumentException("Wrong parent editpart given"); //$NON-NLS-1$
+		};
+	}
+
+	private IFigure getOutputIBFigure() {
+		return switch (mapping.getParentElement()) {
+		case final EditorWithInterfaceEditPart edWithEp -> edWithEp.getRightInterfaceContainer();
+		case final UnfoldedSubappContentEditPart unfoldedSubappContentEP ->
+			unfoldedSubappContentEP.getParent().getFigure().getExpandedOutputFigure();
+		default -> throw new IllegalArgumentException("Wrong parent editpart given"); //$NON-NLS-1$
+		};
 	}
 
 	private void processChild(final Object child) {
@@ -127,14 +163,23 @@ public final class FordiacGraphBuilder {
 	}
 
 	private void processValue(final ValueEditPart valueEditPart) {
+		if (valueEditPart.getModel().eContainer() instanceof final VarDeclaration varDecl
+				&& !varDecl.getInputConnections().isEmpty()) {
+			// ignore values for connected pins
+			return;
+		}
 		final EditPart iePart = valueEditPart.getViewer().getEditPartForModel(valueEditPart.getModel().getParentIE());
-		final Point point = ((InterfaceEditPart) iePart).getFigure().getBounds().getTopLeft();
-		final ElkPort port = getPort(point, (InterfaceEditPart) iePart);
+		final ElkPort port = getPort((InterfaceEditPart) iePart);
 		final ElkLabel label = ElkGraphUtil.createLabel(valueEditPart.getModel().getValue(), port);
 		final Rectangle bounds = valueEditPart.getFigure().getBounds();
 		label.setLocation(bounds.preciseX() - port.getX() - port.getParent().getX(),
 				bounds.preciseY() - port.getY() - port.getParent().getY());
 		label.setDimensions(bounds.preciseWidth(), bounds.preciseHeight());
+	}
+
+	private static boolean isParentInterfaceLayout(final GraphicalEditPart parentElement) {
+		return parentElement instanceof EditorWithInterfaceEditPart
+				|| parentElement instanceof UnfoldedSubappContentEditPart;
 	}
 
 	private static boolean isVisible(final ConnectionEditPart con) {
@@ -159,21 +204,16 @@ public final class FordiacGraphBuilder {
 		}
 	}
 
-	private ElkNode createNode(final GraphicalEditPart editPart) {
+	private ElkNode createNode(final IFigure figure) {
 		final ElkNode node = ElkGraphUtil.createNode(mapping.getLayoutGraph());
-		final Rectangle bounds = editPart.getFigure().getBounds();
-		if (mapping.type != LayoutType.Application) {
-			// @formatter:off
-			node.setLocation(
-					bounds.x - mapping.getLayoutGraph().getX(),
-					bounds.y - mapping.getLayoutGraph().getY()
-				);
-			// @formatter:on
-		} else {
-			node.setLocation(bounds.x, bounds.y);
-		}
-
+		final Rectangle bounds = figure.getBounds();
+		node.setLocation(bounds.x, bounds.y);
 		node.setDimensions(bounds.preciseWidth(), bounds.preciseHeight());
+		return node;
+	}
+
+	private ElkNode createNode(final GraphicalEditPart editPart) {
+		final ElkNode node = createNode(editPart.getFigure());
 
 		mapping.getGraphMap().put(node, editPart);
 		mapping.getReverseMapping().put(editPart, node);
@@ -191,17 +231,8 @@ public final class FordiacGraphBuilder {
 
 	private void processConnections() {
 		for (final ConnectionEditPart conn : mapping.getConnections()) {
-			final org.eclipse.draw2d.Connection connFig = conn.getFigure();
-
-			START_POINT
-					.setLocation(connFig.getSourceAnchor().getLocation(connFig.getSourceAnchor().getReferencePoint()));
-			END_POINT.setLocation(connFig.getTargetAnchor().getLocation(connFig.getTargetAnchor().getReferencePoint()));
-
-			connFig.translateToRelative(START_POINT);
-			connFig.translateToRelative(END_POINT);
-
-			final ElkPort sourcePort = getPort(START_POINT, (InterfaceEditPart) conn.getSource());
-			final ElkPort destinationPort = getPort(END_POINT, (InterfaceEditPart) conn.getTarget());
+			final ElkPort sourcePort = getPort((InterfaceEditPart) conn.getSource());
+			final ElkPort destinationPort = getPort((InterfaceEditPart) conn.getTarget());
 
 			final ElkEdge edge = ElkGraphUtil.createSimpleEdge(sourcePort, destinationPort);
 
@@ -210,7 +241,7 @@ public final class FordiacGraphBuilder {
 		}
 	}
 
-	private ElkPort getPort(final Point point, final InterfaceEditPart interfaceEditPart) {
+	private ElkPort getPort(final InterfaceEditPart interfaceEditPart) {
 		return (ElkPort) mapping.getReverseMapping().computeIfAbsent(interfaceEditPart,
 				ie -> createPort(interfaceEditPart));
 	}
@@ -240,34 +271,48 @@ public final class FordiacGraphBuilder {
 		port.setDimensions(1, figure.getBounds().preciseHeight());
 	}
 
-	private void setPortLocation(final ElkPort port, final InterfaceEditPart interfaceEditPart,
+	private static void setPortLocation(final ElkPort port, final InterfaceEditPart interfaceEditPart,
 			final ElkNode parentNode) {
-		final int x = interfaceEditPart.isInput() ? 0 : (int) parentNode.getWidth();
-		final int yOffset = interfaceEditPart.getFigure().getLocation().y - (int) parentNode.getY();
-		final int y = (mapping.type == LayoutType.Application) ? yOffset
-				: yOffset - (int) mapping.getLayoutGraph().getY();
+		final int x = interfaceEditPart.isInput() ? 0 : (int) parentNode.getWidth() - 1;
+		final int y = interfaceEditPart.getFigure().getLocation().y - (int) parentNode.getY();
 		port.setLocation(x, y);
 	}
 
-	private ElkPort createParentElementPort(final InterfaceEditPart ie) {
-		final var layoutGraph = mapping.getLayoutGraph();
+	private ElkPort createParentElementPort(final InterfaceEditPart ie, final ElkNode inputInterfaceBarNode,
+			final ElkNode outputInterfaceBarNode) {
+		final boolean isInput = ie.getModel().isIsInput();
+		final ElkNode parentNode = isInput ? inputInterfaceBarNode : outputInterfaceBarNode;
 
-		final ElkPort port = ElkGraphUtil.createPort(layoutGraph);
+		final ElkPort port = ElkGraphUtil.createPort(parentNode);
 		port.setDimensions(1, ie.getFigure().getBounds().height);
 
 		final int y = ie.getFigure().getLocation().y;
-		final boolean isInput = mapping.type == LayoutType.Unfolded ? ie.isInput() : !ie.isInput();
 		if (isInput) {
-			port.setLocation(0, y - layoutGraph.getY());
+			port.setLocation(parentNode.getWidth() - 1, y - parentNode.getY());
 		} else {
-			port.setLocation(layoutGraph.getWidth() - 1, y - layoutGraph.getY());
+			port.setLocation(0, y - parentNode.getY());
 		}
 
-		port.setProperty(CoreOptions.PORT_SIDE, isInput ? PortSide.WEST : PortSide.EAST);
+		// this is the opposite of FBs
+		port.setProperty(CoreOptions.PORT_SIDE, isInput ? PortSide.EAST : PortSide.WEST);
 
 		mapping.getGraphMap().put(port, ie.getModel());
 		mapping.getReverseMapping().put(ie, port);
 		return port;
+	}
+
+	private static FordiacLayoutMapping createFordiacLayoutMapping(final IEditorPart part,
+			final AbstractFBNetworkEditPart ep) {
+		final FordiacLayoutMapping newMapping = new FordiacLayoutMapping(part, ep);
+
+		final ElkNode graph = ElkGraphUtil.createGraph();
+
+		newMapping.setLayoutGraph(graph);
+		newMapping.setParentElement(ep);
+
+		newMapping.getGraphMap().put(graph, ep);
+		newMapping.getReverseMapping().put(ep, graph);
+		return newMapping;
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.elk/src/org/eclipse/fordiac/ide/elk/FordiacGraphDataHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.elk/src/org/eclipse/fordiac/ide/elk/FordiacGraphDataHelper.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
- * Copyright (c) 2020 Johannes Kepler University Linz
- * 				 2020 Primetals Technologies Germany GmbH
- * 				 2021, 2022 Primetals Technologies Austria GmbH
+ * Copyright (c) 2020, 2025 Johannes Kepler University Linz,
+ *                          Primetals Technologies Germany GmbH,
+ *                          Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,15 +15,10 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.elk;
 
-import java.util.List;
-
 import org.eclipse.draw2d.geometry.PointList;
 import org.eclipse.elk.graph.ElkBendPoint;
 import org.eclipse.elk.graph.ElkEdge;
 import org.eclipse.elk.graph.ElkEdgeSection;
-import org.eclipse.elk.graph.ElkGraphFactory;
-import org.eclipse.elk.graph.ElkNode;
-import org.eclipse.elk.graph.ElkPort;
 import org.eclipse.fordiac.ide.application.editparts.ConnectionEditPart;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
@@ -34,10 +29,12 @@ public class FordiacGraphDataHelper {
 	public static void calculate(final FordiacLayoutMapping mapping) {
 		mapping.getLayoutGraph().getChildren().forEach(child -> {
 			final var ep = (GraphicalEditPart) mapping.getGraphMap().get(child);
-			final var pos = LibraryElementFactory.eINSTANCE.createPosition();
-			pos.setX((int) child.getX());
-			pos.setY((int) child.getY());
-			mapping.getLayoutData().addPosition((FBNetworkElement) ep.getModel(), pos);
+			if (ep != null) {
+				final var pos = LibraryElementFactory.eINSTANCE.createPosition();
+				pos.setX((int) child.getX());
+				pos.setY((int) child.getY());
+				mapping.getLayoutData().addPosition((FBNetworkElement) ep.getModel(), pos);
+			}
 		});
 
 		mapping.getLayoutGraph().getContainedEdges().forEach(edge -> processConnection(mapping, edge));
@@ -49,40 +46,19 @@ public class FordiacGraphDataHelper {
 		}
 
 		final ConnectionEditPart connEp = (ConnectionEditPart) mapping.getGraphMap().get(edge);
-		final ElkPort startPort = (ElkPort) edge.getSources().get(0);
-		final ElkPort endPort = (ElkPort) edge.getTargets().get(0);
 		final ElkEdgeSection elkEdgeSection = edge.getSections().get(0);
-		final List<ElkBendPoint> bendPoints = elkEdgeSection.getBendPoints();
 
-		mapping.getLayoutData().addConnectionPoints(connEp.getModel(),
-				createPointList(mapping, startPort, endPort, bendPoints));
+		mapping.getLayoutData().addConnectionPoints(connEp.getModel(), createPointList(elkEdgeSection));
 	}
 
-	private static PointList createPointList(final FordiacLayoutMapping mapping, final ElkPort startPort,
-			final ElkPort endPort, final List<ElkBendPoint> bendPoints) {
-		// needs to translate coordinates back from relative to absolute
-
+	private static PointList createPointList(final ElkEdgeSection elkEdgeSection) {
 		final PointList list = new PointList();
-		final ElkNode layoutGraph = mapping.getLayoutGraph();
 
-		ElkNode startNode = startPort.getParent();
-		// edge case for expanded subapps (inside source connections)
-		if (startNode == layoutGraph) {
-			// defaults to (0, 0), effectively acting as toRelative()
-			startNode = ElkGraphFactory.eINSTANCE.createElkNode();
+		list.addPoint((int) elkEdgeSection.getStartX(), (int) elkEdgeSection.getStartY());
+		for (final ElkBendPoint point : elkEdgeSection.getBendPoints()) {
+			list.addPoint((int) (point.getX()), (int) (point.getY()));
 		}
-		final int startX = (int) (startPort.getX() + startNode.getX() + layoutGraph.getX());
-		final int startY = (int) (startPort.getY() + startNode.getY() + layoutGraph.getY());
-		list.addPoint(startX, startY);
-
-		for (final ElkBendPoint point : bendPoints) {
-			list.addPoint((int) (point.getX() + layoutGraph.getX()), (int) (point.getY() + layoutGraph.getY()));
-		}
-
-		final ElkNode endNode = endPort.getParent();
-		final int endX = (int) (endPort.getX() + endNode.getX() + layoutGraph.getX());
-		final int endY = (int) (endPort.getY() + endNode.getY() + layoutGraph.getY());
-		list.addPoint(endX, endY);
+		list.addPoint((int) elkEdgeSection.getEndX(), (int) elkEdgeSection.getEndY());
 
 		return list;
 	}

--- a/plugins/org.eclipse.fordiac.ide.elk/src/org/eclipse/fordiac/ide/elk/FordiacLayout.java
+++ b/plugins/org.eclipse.fordiac.ide.elk/src/org/eclipse/fordiac/ide/elk/FordiacLayout.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Primetals Technologies Austria GmbH
+ * Copyright (c) 2024, 2025 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -60,7 +60,7 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.PlatformUI;
 
-public class FordiacLayout {
+public final class FordiacLayout {
 
 	public static void blockLayout(final IEditorPart part, final AbstractFBNetworkEditPart ep) {
 		executeLayout(part, ep, true);
@@ -99,9 +99,7 @@ public class FordiacLayout {
 
 	private static Command performLayoutRun(final IEditorPart part, final AbstractFBNetworkEditPart ep,
 			final RecursiveGraphLayoutEngine engine, final boolean isBlockLayout) {
-		final FordiacLayoutMapping mapping = new FordiacLayoutMapping(part, ep);
-
-		new FordiacGraphBuilder(mapping).build();
+		final FordiacLayoutMapping mapping = new FordiacGraphBuilder(part, ep).build();
 
 		if (isBlockLayout) {
 			performBlockLayout(mapping, engine);
@@ -193,6 +191,8 @@ public class FordiacLayout {
 
 	private static void configureConnectionLayoutGraph(final ElkGraphElement graph) {
 		graph.setProperty(CoreOptions.ALGORITHM, "org.eclipse.elk.alg.libavoid") //$NON-NLS-1$
+				.setProperty(CoreOptions.OMIT_NODE_MICRO_LAYOUT, Boolean.TRUE)
+				.setProperty(CoreOptions.DEBUG_MODE, Boolean.TRUE)
 				.setProperty(LibavoidMetaDataProvider.SHAPE_BUFFER_DISTANCE, Double.valueOf(10))
 				.setProperty(LibavoidMetaDataProvider.IDEAL_NUDGING_DISTANCE, Double.valueOf(5))
 				.setProperty(LibavoidMetaDataProvider.NUDGE_SHARED_PATHS_WITH_COMMON_END_POINT, Boolean.FALSE)
@@ -228,5 +228,9 @@ public class FordiacLayout {
 				.findAbstractContainerContentEditPartAtPosition((IEditorPart) workbenchPart, point,
 						networkEP.getModel());
 		return (containerEP != null) ? containerEP : networkEP;
+	}
+
+	private FordiacLayout() {
+		throw new UnsupportedOperationException("Helper class shall not be instantiated!"); //$NON-NLS-1$
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.elk/src/org/eclipse/fordiac/ide/elk/FordiacLayoutMapping.java
+++ b/plugins/org.eclipse.fordiac.ide.elk/src/org/eclipse/fordiac/ide/elk/FordiacLayoutMapping.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Primetals Technologies Austria GmbH
+ * Copyright (c) 2021, 2025 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -20,12 +20,7 @@ import java.util.Map;
 
 import org.eclipse.elk.core.service.LayoutMapping;
 import org.eclipse.elk.graph.ElkGraphElement;
-import org.eclipse.elk.graph.ElkNode;
-import org.eclipse.elk.graph.util.ElkGraphUtil;
 import org.eclipse.fordiac.ide.application.editparts.ConnectionEditPart;
-import org.eclipse.fordiac.ide.application.editparts.EditorWithInterfaceEditPart;
-import org.eclipse.fordiac.ide.application.editparts.UnfoldedSubappContentEditPart;
-import org.eclipse.fordiac.ide.fbtypeeditor.network.viewer.CompositeNetworkViewerEditPart;
 import org.eclipse.fordiac.ide.gef.editparts.AbstractFBNetworkEditPart;
 import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.ui.IEditorPart;
@@ -40,40 +35,9 @@ public class FordiacLayoutMapping extends LayoutMapping {
 
 	private final AbstractFBNetworkEditPart ep;
 
-	public enum LayoutType {
-		Application, Unfolded, Typed
-	}
-
-	public LayoutType type;
-
 	public FordiacLayoutMapping(final IEditorPart part, final AbstractFBNetworkEditPart ep) {
 		super(part);
 		this.ep = ep;
-		type = getLayoutType(ep);
-
-		final ElkNode graph = ElkGraphUtil.createGraph();
-		final ElkNode parent = ElkGraphUtil.createGraph();
-		graph.setParent(parent);
-
-		final var bounds = ep.getFigure().getBounds();
-		graph.setDimensions(bounds.preciseWidth(), bounds.preciseHeight());
-		graph.setLocation(bounds.preciseX(), bounds.preciseY());
-
-		setLayoutGraph(graph);
-		setParentElement(ep);
-
-		getGraphMap().put(graph, ep);
-		reverseMapping.put(ep, graph);
-	}
-
-	private static LayoutType getLayoutType(final AbstractFBNetworkEditPart ep) {
-		if (ep instanceof UnfoldedSubappContentEditPart) {
-			return LayoutType.Unfolded;
-		}
-		if (ep instanceof EditorWithInterfaceEditPart && !(ep instanceof CompositeNetworkViewerEditPart)) {
-			return LayoutType.Typed;
-		}
-		return LayoutType.Application;
 	}
 
 	@Override


### PR DESCRIPTION
For libavoid there must not be a bounding graph. This led to wrong or unlayouted connections. With this change the parent graph is removed and the port pins are moved to an input and output dummy node.