### PR TITLE
Added plugin.properties to build.properties [1432]

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.export/build.properties
+++ b/plugins/org.eclipse.fordiac.ide.export/build.properties
@@ -2,4 +2,5 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               plugin.xml
+               plugin.xml,\
+               plugin.properties


### PR DESCRIPTION
The new plugin.properties where not added to the bin inlcude part of build.properties and therefore the strings where not available in binary distributions.

Fixes: https://github.com/eclipse-4diac/4diac-ide/issues/1432