### PR TITLE
Fixed Copy of Cells in NatTable without selection

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.ui/src/org/eclipse/fordiac/ide/ui/widget/FordiacCopyDataCommandHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.ui/src/org/eclipse/fordiac/ide/ui/widget/FordiacCopyDataCommandHandler.java
@@ -50,4 +50,10 @@ public class FordiacCopyDataCommandHandler extends CopyDataCommandHandler {
 
 		clipboard.dispose();
 	}
+
+	@Override
+	protected ILayerCell[][] assembleCopiedDataStructure() {
+		final var cells = super.assembleCopiedDataStructure();
+		return cells != null ? cells : new ILayerCell[0][];
+	}
 }


### PR DESCRIPTION
Having no selected cell in a NatTable used to throw an exception when trying to copy