### PR TITLE
Fixes type declaration update in move refactoring

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/AbstractCommandChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/AbstractCommandChange.java
@@ -249,6 +249,10 @@ public abstract class AbstractCommandChange<T extends EObject> extends Change {
 
 	@Override
 	public final IFile getModifiedElement() {
+		if (typeEntry != null) {
+			return typeEntry.getFile();
+		}
+
 		if (elementURI.isPlatformResource()) {
 			return ResourcesPlugin.getWorkspace().getRoot().getFile(new Path(elementURI.toPlatformString(true)));
 		}

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/move/MoveTypeRefactoringParticipant.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/move/MoveTypeRefactoringParticipant.java
@@ -122,10 +122,9 @@ public class MoveTypeRefactoringParticipant extends MoveParticipant {
 		final List<? extends EObject> searchResult = new DataTypeInstanceSearch(dtEntry).performSearch();
 
 		for (final EObject eObject : searchResult) {
-			if (eObject instanceof VarDeclaration) {
-				change.add(
-						new DataTypeChange(Messages.MoveTypeToPackage_UpdateDataTypeInstance, EcoreUtil.getURI(eObject),
-								newPackageName + PackageNameHelper.PACKAGE_NAME_DELIMITER + dtEntry.getTypeName()));
+			if (eObject instanceof final VarDeclaration varDecl) {
+				change.add(new DataTypeChange(Messages.MoveTypeToPackage_UpdateDataTypeInstance,
+						EcoreUtil.getURI(eObject), getNewTypeDeclaration(varDecl)));
 			}
 		}
 
@@ -142,5 +141,17 @@ public class MoveTypeRefactoringParticipant extends MoveParticipant {
 			}
 		}
 		return change;
+	}
+
+	private String getNewTypeDeclaration(final VarDeclaration varDeclaration) {
+		final StringBuilder typeDeclaration = new StringBuilder(varDeclaration.getFullTypeName());
+		final int packageNameEnd = typeDeclaration.lastIndexOf(PackageNameHelper.PACKAGE_NAME_DELIMITER);
+		if (packageNameEnd == -1) {
+			typeDeclaration.insert(typeDeclaration.indexOf(varDeclaration.getTypeName()),
+					newPackageName + PackageNameHelper.PACKAGE_NAME_DELIMITER);
+		} else {
+			typeDeclaration.replace(packageNameEnd - oldPackageName.length(), packageNameEnd, newPackageName);
+		}
+		return typeDeclaration.toString();
 	}
 }


### PR DESCRIPTION
The datatype instance update in move refactoring  unintentionally removed array declarations