### PR TITLE
Store evaluator exceptions in result model

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter.edit/plugin.properties
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter.edit/plugin.properties
@@ -77,3 +77,4 @@ _UI_Transaction_duration_feature = Duration
 _UI_EventOccurrence_startTime_feature = Start Time
 _UI_FunctionFBTypeRuntime_type = Function FB Type Runtime
 _UI_FunctionFBTypeRuntime_functionFBType_feature = Function FB Type
+_UI_Transaction_exceptions_feature = Exceptions

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter.edit/src-gen/org/eclipse/fordiac/ide/fb/interpreter/OpSem/provider/TransactionItemProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter.edit/src-gen/org/eclipse/fordiac/ide/fb/interpreter/OpSem/provider/TransactionItemProvider.java
@@ -68,6 +68,7 @@ public class TransactionItemProvider extends ItemProviderAdapter implements IEdi
 
 			addParentEOPropertyDescriptor(object);
 			addDurationPropertyDescriptor(object);
+			addExceptionsPropertyDescriptor(object);
 		}
 		return itemPropertyDescriptors;
 	}
@@ -101,6 +102,22 @@ public class TransactionItemProvider extends ItemProviderAdapter implements IEdi
 								"_UI_Transaction_type"), //$NON-NLS-1$
 						OperationalSemanticsPackage.Literals.TRANSACTION__DURATION, true, false, false,
 						ItemPropertyDescriptor.INTEGRAL_VALUE_IMAGE, null, null));
+	}
+
+	/**
+	 * This adds a property descriptor for the Exceptions feature. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	protected void addExceptionsPropertyDescriptor(Object object) {
+		itemPropertyDescriptors
+				.add(createItemPropertyDescriptor(((ComposeableAdapterFactory) adapterFactory).getRootAdapterFactory(),
+						getResourceLocator(), getString("_UI_Transaction_exceptions_feature"), //$NON-NLS-1$
+						getString("_UI_PropertyDescriptor_description", "_UI_Transaction_exceptions_feature", //$NON-NLS-1$ //$NON-NLS-2$
+								"_UI_Transaction_type"), //$NON-NLS-1$
+						OperationalSemanticsPackage.Literals.TRANSACTION__EXCEPTIONS, false, false, false,
+						ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, null, null));
 	}
 
 	/**
@@ -170,6 +187,7 @@ public class TransactionItemProvider extends ItemProviderAdapter implements IEdi
 
 		switch (notification.getFeatureID(Transaction.class)) {
 		case OperationalSemanticsPackage.TRANSACTION__DURATION:
+		case OperationalSemanticsPackage.TRANSACTION__EXCEPTIONS:
 			fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
 			return;
 		case OperationalSemanticsPackage.TRANSACTION__INPUT_EVENT_OCCURRENCE:

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/model/OperationalSemantics.ecore
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/model/OperationalSemantics.ecore
@@ -94,6 +94,8 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="parentEO" eType="#//EventOccurrence"
         eOpposite="#//EventOccurrence/createdTransactions"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="duration" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Long"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="exceptions" upperBound="-1"
+        eType="#//Exception" changeable="false"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="FBNetworkRuntime" eSuperTypes="#//FBRuntimeAbstract">
     <eOperations name="getModel" lowerBound="1" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//FBNetwork">
@@ -149,4 +151,5 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="condEvent" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="condExpression" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
+  <eClassifiers xsi:type="ecore:EDataType" name="Exception" instanceClassName="java.lang.Exception"/>
 </ecore:EPackage>

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/model/OperationalSemantics.genmodel
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/model/OperationalSemantics.genmodel
@@ -17,6 +17,7 @@
   <testsDirectory xsi:nil="true"/>
   <genPackages prefix="OperationalSemantics" basePackage="org.eclipse.fordiac.ide.fb.interpreter"
       disposableProviderFactory="true" fileExtensions="opsem" ecorePackage="OperationalSemantics.ecore#/">
+    <genDataTypes ecoreDataType="OperationalSemantics.ecore#//Exception"/>
     <genClasses ecoreClass="OperationalSemantics.ecore#//EventOccurrence">
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference OperationalSemantics.ecore#//EventOccurrence/event"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute OperationalSemantics.ecore#//EventOccurrence/active"/>
@@ -66,6 +67,7 @@
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OperationalSemantics.ecore#//Transaction/inputEventOccurrence"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference OperationalSemantics.ecore#//Transaction/parentEO"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute OperationalSemantics.ecore#//Transaction/duration"/>
+      <genFeatures property="Readonly" createChild="false" ecoreFeature="ecore:EAttribute OperationalSemantics.ecore#//Transaction/exceptions"/>
     </genClasses>
     <genClasses ecoreClass="OperationalSemantics.ecore#//FBNetworkRuntime">
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference OperationalSemantics.ecore#//FBNetworkRuntime/fbnetwork"/>

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src-gen/org/eclipse/fordiac/ide/fb/interpreter/OpSem/OperationalSemanticsPackage.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src-gen/org/eclipse/fordiac/ide/fb/interpreter/OpSem/OperationalSemanticsPackage.java
@@ -15,6 +15,7 @@ package org.eclipse.fordiac.ide.fb.interpreter.OpSem;
 
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EDataType;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EReference;
 
@@ -363,13 +364,22 @@ public interface OperationalSemanticsPackage extends EPackage {
 	int TRANSACTION__DURATION = 2;
 
 	/**
+	 * The feature id for the '<em><b>Exceptions</b></em>' attribute list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 * @ordered
+	 */
+	int TRANSACTION__EXCEPTIONS = 3;
+
+	/**
 	 * The number of structural features of the '<em>Transaction</em>' class. <!--
 	 * begin-user-doc --> <!-- end-user-doc -->
 	 *
 	 * @generated
 	 * @ordered
 	 */
-	int TRANSACTION_FEATURE_COUNT = 3;
+	int TRANSACTION_FEATURE_COUNT = 4;
 
 	/**
 	 * The meta object id for the
@@ -457,6 +467,15 @@ public interface OperationalSemanticsPackage extends EPackage {
 	 * @ordered
 	 */
 	int FB_TRANSACTION__DURATION = TRANSACTION__DURATION;
+
+	/**
+	 * The feature id for the '<em><b>Exceptions</b></em>' attribute list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 * @ordered
+	 */
+	int FB_TRANSACTION__EXCEPTIONS = TRANSACTION__EXCEPTIONS;
 
 	/**
 	 * The feature id for the '<em><b>Output Event Occurrences</b></em>' containment
@@ -676,6 +695,16 @@ public interface OperationalSemanticsPackage extends EPackage {
 	 * @ordered
 	 */
 	int TRANSITION_TRACE_FEATURE_COUNT = 4;
+
+	/**
+	 * The meta object id for the '<em>Exception</em>' data type. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @see java.lang.Object
+	 * @see org.eclipse.fordiac.ide.fb.interpreter.OpSem.impl.OperationalSemanticsPackageImpl#getException()
+	 * @generated
+	 */
+	int EXCEPTION = 14;
 
 	/**
 	 * Returns the meta object for class
@@ -982,6 +1011,18 @@ public interface OperationalSemanticsPackage extends EPackage {
 	EAttribute getTransaction_Duration();
 
 	/**
+	 * Returns the meta object for the attribute list
+	 * '{@link org.eclipse.fordiac.ide.fb.interpreter.OpSem.Transaction#getExceptions
+	 * <em>Exceptions</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @return the meta object for the attribute list '<em>Exceptions</em>'.
+	 * @see org.eclipse.fordiac.ide.fb.interpreter.OpSem.Transaction#getExceptions()
+	 * @see #getTransaction()
+	 * @generated
+	 */
+	EAttribute getTransaction_Exceptions();
+
+	/**
 	 * Returns the meta object for class
 	 * '{@link org.eclipse.fordiac.ide.fb.interpreter.OpSem.FBNetworkRuntime <em>FB
 	 * Network Runtime</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -1245,6 +1286,17 @@ public interface OperationalSemanticsPackage extends EPackage {
 	EAttribute getTransitionTrace_CondExpression();
 
 	/**
+	 * Returns the meta object for data type '{@link java.lang.Exception
+	 * <em>Exception</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @return the meta object for data type '<em>Exception</em>'.
+	 * @see java.lang.Exception
+	 * @model instanceClass="java.lang.Exception"
+	 * @generated
+	 */
+	EDataType getException();
+
+	/**
 	 * Returns the factory that creates the instances of the model. <!--
 	 * begin-user-doc --> <!-- end-user-doc -->
 	 *
@@ -1493,6 +1545,14 @@ public interface OperationalSemanticsPackage extends EPackage {
 		EAttribute TRANSACTION__DURATION = eINSTANCE.getTransaction_Duration();
 
 		/**
+		 * The meta object literal for the '<em><b>Exceptions</b></em>' attribute list
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 *
+		 * @generated
+		 */
+		EAttribute TRANSACTION__EXCEPTIONS = eINSTANCE.getTransaction_Exceptions();
+
+		/**
 		 * The meta object literal for the
 		 * '{@link org.eclipse.fordiac.ide.fb.interpreter.OpSem.impl.FBNetworkRuntimeImpl
 		 * <em>FB Network Runtime</em>}' class. <!-- begin-user-doc --> <!--
@@ -1694,6 +1754,16 @@ public interface OperationalSemanticsPackage extends EPackage {
 		 * @generated
 		 */
 		EAttribute TRANSITION_TRACE__COND_EXPRESSION = eINSTANCE.getTransitionTrace_CondExpression();
+
+		/**
+		 * The meta object literal for the '<em>Exception</em>' data type. <!--
+		 * begin-user-doc --> <!-- end-user-doc -->
+		 *
+		 * @see java.lang.Object
+		 * @see org.eclipse.fordiac.ide.fb.interpreter.OpSem.impl.OperationalSemanticsPackageImpl#getException()
+		 * @generated
+		 */
+		EDataType EXCEPTION = eINSTANCE.getException();
 
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src-gen/org/eclipse/fordiac/ide/fb/interpreter/OpSem/Transaction.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src-gen/org/eclipse/fordiac/ide/fb/interpreter/OpSem/Transaction.java
@@ -13,6 +13,7 @@
  */
 package org.eclipse.fordiac.ide.fb.interpreter.OpSem;
 
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 
 /**
@@ -29,6 +30,8 @@ import org.eclipse.emf.ecore.EObject;
  * <em>Parent EO</em>}</li>
  * <li>{@link org.eclipse.fordiac.ide.fb.interpreter.OpSem.Transaction#getDuration
  * <em>Duration</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.fb.interpreter.OpSem.Transaction#getExceptions
+ * <em>Exceptions</em>}</li>
  * </ul>
  *
  * @see org.eclipse.fordiac.ide.fb.interpreter.OpSem.OperationalSemanticsPackage#getTransaction()
@@ -111,5 +114,18 @@ public interface Transaction extends EObject {
 	 * @generated
 	 */
 	void setDuration(long value);
+
+	/**
+	 * Returns the value of the '<em><b>Exceptions</b></em>' attribute list. The
+	 * list contents are of type {@link java.lang.Exception}. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 *
+	 * @return the value of the '<em>Exceptions</em>' attribute list.
+	 * @see org.eclipse.fordiac.ide.fb.interpreter.OpSem.OperationalSemanticsPackage#getTransaction_Exceptions()
+	 * @model dataType="org.eclipse.fordiac.ide.fb.interpreter.OpSem.Exception"
+	 *        changeable="false"
+	 * @generated
+	 */
+	EList<Exception> getExceptions();
 
 } // Transaction

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src-gen/org/eclipse/fordiac/ide/fb/interpreter/OpSem/impl/OperationalSemanticsFactoryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src-gen/org/eclipse/fordiac/ide/fb/interpreter/OpSem/impl/OperationalSemanticsFactoryImpl.java
@@ -16,6 +16,7 @@ package org.eclipse.fordiac.ide.fb.interpreter.OpSem.impl;
 import java.util.Map;
 
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EDataType;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.impl.EFactoryImpl;
@@ -107,6 +108,36 @@ public class OperationalSemanticsFactoryImpl extends EFactoryImpl implements Ope
 			return createTransitionTrace();
 		default:
 			throw new IllegalArgumentException("The class '" + eClass.getName() + "' is not a valid classifier"); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	@Override
+	public Object createFromString(EDataType eDataType, String initialValue) {
+		switch (eDataType.getClassifierID()) {
+		case OperationalSemanticsPackage.EXCEPTION:
+			return createExceptionFromString(eDataType, initialValue);
+		default:
+			throw new IllegalArgumentException("The datatype '" + eDataType.getName() + "' is not a valid classifier"); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	@Override
+	public String convertToString(EDataType eDataType, Object instanceValue) {
+		switch (eDataType.getClassifierID()) {
+		case OperationalSemanticsPackage.EXCEPTION:
+			return convertExceptionToString(eDataType, instanceValue);
+		default:
+			throw new IllegalArgumentException("The datatype '" + eDataType.getName() + "' is not a valid classifier"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 	}
 
@@ -238,6 +269,24 @@ public class OperationalSemanticsFactoryImpl extends EFactoryImpl implements Ope
 	public TransitionTrace createTransitionTrace() {
 		TransitionTraceImpl transitionTrace = new TransitionTraceImpl();
 		return transitionTrace;
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	public Exception createExceptionFromString(EDataType eDataType, String initialValue) {
+		return (Exception) super.createFromString(eDataType, initialValue);
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	public String convertExceptionToString(EDataType eDataType, Object instanceValue) {
+		return super.convertToString(eDataType, instanceValue);
 	}
 
 	/**

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src-gen/org/eclipse/fordiac/ide/fb/interpreter/OpSem/impl/OperationalSemanticsPackageImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src-gen/org/eclipse/fordiac/ide/fb/interpreter/OpSem/impl/OperationalSemanticsPackageImpl.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EDataType;
 import org.eclipse.emf.ecore.EOperation;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EReference;
@@ -143,6 +144,13 @@ public class OperationalSemanticsPackageImpl extends EPackageImpl implements Ope
 	 * @generated
 	 */
 	private EClass transitionTraceEClass = null;
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	private EDataType exceptionEDataType = null;
 
 	/**
 	 * Creates an instance of the model <b>Package</b>, registered with
@@ -475,6 +483,16 @@ public class OperationalSemanticsPackageImpl extends EPackageImpl implements Ope
 	 * @generated
 	 */
 	@Override
+	public EAttribute getTransaction_Exceptions() {
+		return (EAttribute) transactionEClass.getEStructuralFeatures().get(3);
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	@Override
 	public EClass getFBNetworkRuntime() {
 		return fbNetworkRuntimeEClass;
 	}
@@ -695,6 +713,16 @@ public class OperationalSemanticsPackageImpl extends EPackageImpl implements Ope
 	 * @generated
 	 */
 	@Override
+	public EDataType getException() {
+		return exceptionEDataType;
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	@Override
 	public OperationalSemanticsFactory getOperationalSemanticsFactory() {
 		return (OperationalSemanticsFactory) getEFactoryInstance();
 	}
@@ -751,6 +779,7 @@ public class OperationalSemanticsPackageImpl extends EPackageImpl implements Ope
 		createEReference(transactionEClass, TRANSACTION__INPUT_EVENT_OCCURRENCE);
 		createEReference(transactionEClass, TRANSACTION__PARENT_EO);
 		createEAttribute(transactionEClass, TRANSACTION__DURATION);
+		createEAttribute(transactionEClass, TRANSACTION__EXCEPTIONS);
 
 		fbNetworkRuntimeEClass = createEClass(FB_NETWORK_RUNTIME);
 		createEReference(fbNetworkRuntimeEClass, FB_NETWORK_RUNTIME__FBNETWORK);
@@ -780,6 +809,9 @@ public class OperationalSemanticsPackageImpl extends EPackageImpl implements Ope
 		createEAttribute(transitionTraceEClass, TRANSITION_TRACE__DESTINATION_STATE);
 		createEAttribute(transitionTraceEClass, TRANSITION_TRACE__COND_EVENT);
 		createEAttribute(transitionTraceEClass, TRANSITION_TRACE__COND_EXPRESSION);
+
+		// Create data types
+		exceptionEDataType = createEDataType(EXCEPTION);
 	}
 
 	/**
@@ -922,6 +954,9 @@ public class OperationalSemanticsPackageImpl extends EPackageImpl implements Ope
 		initEAttribute(getTransaction_Duration(), theXMLTypePackage.getLong(), "duration", null, 0, 1, //$NON-NLS-1$
 				Transaction.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
 				!IS_DERIVED, IS_ORDERED);
+		initEAttribute(getTransaction_Exceptions(), this.getException(), "exceptions", null, 0, -1, Transaction.class, //$NON-NLS-1$
+				!IS_TRANSIENT, !IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED,
+				IS_ORDERED);
 
 		initEClass(fbNetworkRuntimeEClass, FBNetworkRuntime.class, "FBNetworkRuntime", !IS_ABSTRACT, !IS_INTERFACE, //$NON-NLS-1$
 				IS_GENERATED_INSTANCE_CLASS);
@@ -996,6 +1031,9 @@ public class OperationalSemanticsPackageImpl extends EPackageImpl implements Ope
 		initEAttribute(getTransitionTrace_CondExpression(), ecorePackage.getEString(), "condExpression", null, 0, 1, //$NON-NLS-1$
 				TransitionTrace.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
 				!IS_DERIVED, IS_ORDERED);
+
+		// Initialize data types
+		initEDataType(exceptionEDataType, Exception.class, "Exception", IS_SERIALIZABLE, !IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 
 		// Create resource
 		createResource(eNS_URI);

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src-gen/org/eclipse/fordiac/ide/fb/interpreter/OpSem/impl/TransactionImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src-gen/org/eclipse/fordiac/ide/fb/interpreter/OpSem/impl/TransactionImpl.java
@@ -15,10 +15,12 @@ package org.eclipse.fordiac.ide.fb.interpreter.OpSem.impl;
 
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.impl.MinimalEObjectImpl;
+import org.eclipse.emf.ecore.util.EDataTypeUniqueEList;
 import org.eclipse.fordiac.ide.fb.interpreter.OpSem.EventOccurrence;
 import org.eclipse.fordiac.ide.fb.interpreter.OpSem.OperationalSemanticsPackage;
 import org.eclipse.fordiac.ide.fb.interpreter.OpSem.Transaction;
@@ -36,6 +38,8 @@ import org.eclipse.fordiac.ide.fb.interpreter.OpSem.Transaction;
  * <em>Parent EO</em>}</li>
  * <li>{@link org.eclipse.fordiac.ide.fb.interpreter.OpSem.impl.TransactionImpl#getDuration
  * <em>Duration</em>}</li>
+ * <li>{@link org.eclipse.fordiac.ide.fb.interpreter.OpSem.impl.TransactionImpl#getExceptions
+ * <em>Exceptions</em>}</li>
  * </ul>
  *
  * @generated
@@ -81,6 +85,16 @@ public abstract class TransactionImpl extends MinimalEObjectImpl.Container imple
 	 * @ordered
 	 */
 	protected long duration = DURATION_EDEFAULT;
+
+	/**
+	 * The cached value of the '{@link #getExceptions() <em>Exceptions</em>}'
+	 * attribute list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @see #getExceptions()
+	 * @generated
+	 * @ordered
+	 */
+	protected EList<Exception> exceptions;
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -304,6 +318,20 @@ public abstract class TransactionImpl extends MinimalEObjectImpl.Container imple
 	 * @generated
 	 */
 	@Override
+	public EList<Exception> getExceptions() {
+		if (exceptions == null) {
+			exceptions = new EDataTypeUniqueEList<>(Exception.class, this,
+					OperationalSemanticsPackage.TRANSACTION__EXCEPTIONS);
+		}
+		return exceptions;
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated
+	 */
+	@Override
 	public NotificationChain eInverseAdd(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
 		switch (featureID) {
 		case OperationalSemanticsPackage.TRANSACTION__PARENT_EO:
@@ -355,6 +383,8 @@ public abstract class TransactionImpl extends MinimalEObjectImpl.Container imple
 			return basicGetParentEO();
 		case OperationalSemanticsPackage.TRANSACTION__DURATION:
 			return getDuration();
+		case OperationalSemanticsPackage.TRANSACTION__EXCEPTIONS:
+			return getExceptions();
 		default:
 			return super.eGet(featureID, resolve, coreType);
 		}
@@ -420,6 +450,8 @@ public abstract class TransactionImpl extends MinimalEObjectImpl.Container imple
 			return parentEO != null;
 		case OperationalSemanticsPackage.TRANSACTION__DURATION:
 			return duration != DURATION_EDEFAULT;
+		case OperationalSemanticsPackage.TRANSACTION__EXCEPTIONS:
+			return exceptions != null && !exceptions.isEmpty();
 		default:
 			return super.eIsSet(featureID);
 		}
@@ -439,6 +471,8 @@ public abstract class TransactionImpl extends MinimalEObjectImpl.Container imple
 		StringBuilder result = new StringBuilder(super.toString());
 		result.append(" (duration: "); //$NON-NLS-1$
 		result.append(duration);
+		result.append(", exceptions: "); //$NON-NLS-1$
+		result.append(exceptions);
 		result.append(')');
 		return result.toString();
 	}

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/DefaultRunFBType.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/DefaultRunFBType.java
@@ -42,6 +42,7 @@ import org.eclipse.fordiac.ide.fb.interpreter.OpSem.FBTransaction;
 import org.eclipse.fordiac.ide.fb.interpreter.OpSem.FunctionFBTypeRuntime;
 import org.eclipse.fordiac.ide.fb.interpreter.OpSem.OperationalSemanticsFactory;
 import org.eclipse.fordiac.ide.fb.interpreter.OpSem.SimpleFBTypeRuntime;
+import org.eclipse.fordiac.ide.fb.interpreter.OpSem.Transaction;
 import org.eclipse.fordiac.ide.fb.interpreter.OpSem.TransitionTrace;
 import org.eclipse.fordiac.ide.fb.interpreter.api.EventOccFactory;
 import org.eclipse.fordiac.ide.fb.interpreter.api.IRunFBTypeVisitor;
@@ -83,7 +84,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.Value;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.With;
 import org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementFactoryImpl;
-import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 
 public class DefaultRunFBType implements IRunFBTypeVisitor {
 
@@ -233,6 +233,11 @@ public class DefaultRunFBType implements IRunFBTypeVisitor {
 	private static void executeEvaluator(final Evaluator eval, final List<VarDeclaration> varDecls, final FBType type,
 			final EventOccurrence eventOccurrence, final String name) {
 		setEvaluatorInputState(eval, type.getInterfaceList().getInputVars());
+
+		if (!(eventOccurrence.eContainer() instanceof final Transaction t)) {
+			throw new IllegalArgumentException("Container of EO was not a Transaction"); //$NON-NLS-1$
+		}
+
 		try (final EvaluatorThreadPoolExecutor tpe = new EvaluatorThreadPoolExecutor(name)) {
 			final Clock clock = Clock.fixed(Instant.ofEpochMilli(eventOccurrence.getStartTime()), ZoneOffset.UTC);
 			tpe.setMonotonicClock(clock);
@@ -241,9 +246,9 @@ public class DefaultRunFBType implements IRunFBTypeVisitor {
 					eval.evaluate();
 					getEvaluatorOutputState(eval, varDecls);
 				} catch (final EvaluatorException e) {
-					FordiacLogHelper.logError("Algorithm/Function: " + name, e); //$NON-NLS-1$
+					t.getExceptions().add(e);
 				} catch (final InterruptedException e) {
-					FordiacLogHelper.logError("Algorithm/Function: " + name, e); //$NON-NLS-1$
+					t.getExceptions().add(e);
 					Thread.currentThread().interrupt();
 				}
 			});
@@ -274,11 +279,14 @@ public class DefaultRunFBType implements IRunFBTypeVisitor {
 		}
 	}
 
-	private static boolean processConditionWithEvaluator(final BasicFBType basicFBType,
-			final ECTransition ecTransition) {
+	private static boolean processConditionWithEvaluator(final EventOccurrence eventOccurrence,
+			final BasicFBType basicFBType, final ECTransition ecTransition) {
 
 		if (ecTransition.getConditionExpression().isEmpty()) {
 			throw new IllegalArgumentException("ConditionExpression object cannot be empty"); //$NON-NLS-1$
+		}
+		if (!(eventOccurrence.eContainer() instanceof final Transaction t)) {
+			throw new IllegalArgumentException("Container of EO was not a Transaction"); //$NON-NLS-1$
 		}
 		final List<VarDeclaration> varDecls = new ArrayList<>(basicFBType.getInterfaceList().getInputVars());
 		varDecls.addAll(basicFBType.getInterfaceList().getOutputVars());
@@ -301,20 +309,17 @@ public class DefaultRunFBType implements IRunFBTypeVisitor {
 
 			final Evaluator evaluator = findEvaluator.get().getValue();
 			try {
-				final org.eclipse.fordiac.ide.model.eval.value.Value value = evaluator.evaluate();
+				final var value = evaluator.evaluate();
 				if (value instanceof final BoolValue boolValue) {
 					return boolValue.boolValue();
 				}
 				throw new IllegalStateException("The evaluator does not return a boolean value"); //$NON-NLS-1$
 			} catch (final EvaluatorException e) {
-				FordiacLogHelper.logError("Condition Expression: " + evaluator.getName(), //$NON-NLS-1$
-						e);
+				t.getExceptions().add(e);
 			} catch (final InterruptedException e) {
-				FordiacLogHelper.logError("Condition Expression: " + evaluator.getName(), //$NON-NLS-1$
-						e);
+				t.getExceptions().add(e);
 				Thread.currentThread().interrupt();
 			}
-
 		}
 		return false;
 	}
@@ -357,7 +362,7 @@ public class DefaultRunFBType implements IRunFBTypeVisitor {
 			if (condExpression.isEmpty() || "1".equals(condExpression)) { //$NON-NLS-1$
 				return true;
 			}
-			return processConditionWithEvaluator(basicFBTypeRuntime.getBasicfbtype(), outTransition);
+			return processConditionWithEvaluator(eventOccurrence, basicFBTypeRuntime.getBasicfbtype(), outTransition);
 
 		}
 		return false;


### PR DESCRIPTION
Instead of logging interpreter evaluator exceptions, they now get stored within the transactions of the model.