### PR TITLE
F_Move: Auto-Set Data Type on Connect/Drop

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/ConfigurableMoveFBEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/ConfigurableMoveFBEditPart.java
@@ -13,12 +13,20 @@
 
 package org.eclipse.fordiac.ide.application.editparts;
 
+import org.eclipse.fordiac.ide.application.policies.ConfigurableMoveFBLayoutEditPolicy;
 import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableMoveFB;
+import org.eclipse.gef.EditPolicy;
 
 public class ConfigurableMoveFBEditPart extends FBEditPart {
 
 	@Override
 	public ConfigurableMoveFB getModel() {
 		return (ConfigurableMoveFB) super.getModel();
+	}
+
+	@Override
+	protected void createEditPolicies() {
+		super.createEditPolicies();
+		installEditPolicy(EditPolicy.LAYOUT_ROLE, new ConfigurableMoveFBLayoutEditPolicy());
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/ConfigurableMoveFBLayoutEditPolicy.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/ConfigurableMoveFBLayoutEditPolicy.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Paul Stemmer - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.application.policies;
+
+import org.eclipse.fordiac.ide.gef.policies.ModifiedNonResizeableEditPolicy;
+import org.eclipse.fordiac.ide.model.commands.change.ChangeStructCommand;
+import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableFB;
+import org.eclipse.fordiac.ide.model.typelibrary.DataTypeEntry;
+import org.eclipse.gef.EditPart;
+import org.eclipse.gef.EditPolicy;
+import org.eclipse.gef.Request;
+import org.eclipse.gef.commands.Command;
+import org.eclipse.gef.editpolicies.LayoutEditPolicy;
+import org.eclipse.gef.requests.CreateRequest;
+
+public class ConfigurableMoveFBLayoutEditPolicy extends LayoutEditPolicy {
+
+	@Override
+	protected EditPolicy createChildEditPolicy(final EditPart child) {
+		return new ModifiedNonResizeableEditPolicy();
+	}
+
+	@Override
+	protected Command getCreateCommand(final CreateRequest request) {
+		if (request != null) {
+			final Object childClass = request.getNewObjectType();
+			if ((getHost().getModel() instanceof final ConfigurableFB cFB)
+					&& (childClass instanceof final DataTypeEntry dataTypeEntry)) {
+				return new ChangeStructCommand(cFB, dataTypeEntry.getType());
+			}
+		}
+		return null;
+	}
+
+	@Override
+	protected Command getMoveChildrenCommand(final Request request) {
+		return null;
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/utilities/FbTypeTemplateTransferDropTargetListener.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/utilities/FbTypeTemplateTransferDropTargetListener.java
@@ -20,6 +20,7 @@ package org.eclipse.fordiac.ide.application.utilities;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.fordiac.ide.model.data.StructuredType;
+import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableFB;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.StructManipulator;
 import org.eclipse.fordiac.ide.model.typelibrary.DataTypeEntry;
@@ -74,7 +75,7 @@ public class FbTypeTemplateTransferDropTargetListener extends TemplateTransferDr
 		} else if (TemplateTransfer.getInstance().getTemplate() instanceof final DataTypeEntry dataTypeEntry
 				&& dataTypeEntry.getType() instanceof StructuredType && null != getTargetEditPart()) {
 			final Object model = getTargetEditPart().getModel();
-			if (model instanceof StructManipulator) {
+			if (model instanceof StructManipulator || model instanceof ConfigurableFB) {
 				getCurrentEvent().detail = DND.DROP_COPY;
 			} else {
 				getCurrentEvent().detail = DND.DROP_NONE;

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeStructCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeStructCommand.java
@@ -23,6 +23,7 @@ import java.text.MessageFormat;
 import org.eclipse.fordiac.ide.model.LibraryElementTags;
 import org.eclipse.fordiac.ide.model.data.DataType;
 import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes;
+import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableFB;
 import org.eclipse.fordiac.ide.model.libraryElement.Demultiplexer;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
@@ -39,6 +40,13 @@ public class ChangeStructCommand extends AbstractUpdateFBNElementCommand {
 	private final TypeEntry newStructTypeEntry;
 	private final String newVisibleChildren;
 	private boolean reloadDatatype = true;
+
+	public ChangeStructCommand(final FBNetworkElement fb, final DataType newStruct) {
+		super(fb);
+		this.newStructTypeEntry = (newStruct != null) ? newStruct.getTypeEntry() : null;
+		this.entry = fb.getTypeEntry();
+		this.newVisibleChildren = null;
+	}
 
 	public ChangeStructCommand(final StructManipulator mux) {
 		this(mux, mux.getDataType(), getOldVisibleChildren(mux));
@@ -83,6 +91,8 @@ public class ChangeStructCommand extends AbstractUpdateFBNElementCommand {
 			copy = LibraryElementFactory.eINSTANCE.createMultiplexer();
 		} else if (srcElement instanceof Demultiplexer) {
 			copy = LibraryElementFactory.eINSTANCE.createDemultiplexer();
+		} else if (srcElement instanceof ConfigurableFB) {
+			copy = LibraryElementFactory.eINSTANCE.createConfigurableMoveFB();
 		}
 		if (copy != null) {
 			copy.setTypeEntry(entry);
@@ -93,10 +103,17 @@ public class ChangeStructCommand extends AbstractUpdateFBNElementCommand {
 	@Override
 	protected void handleConfigurableFB() {
 		if (newStructTypeEntry != null) {
-			getNewMux().setDataType(getDataTypeFromTypeEntry());
+			if (getNewElement() instanceof StructManipulator) {
+				getNewMux().setDataType(getDataTypeFromTypeEntry());
+			} else if (getNewElement() instanceof ConfigurableFB) {
+				getNewMoveFB().setDataType(getDataTypeFromTypeEntry());
+			}
+
 		}
 		if (isDemuxConfiguration()) {
 			getNewMux().loadConfiguration(LibraryElementTags.DEMUX_VISIBLE_CHILDREN, newVisibleChildren);
+		} else if (getNewElement() instanceof ConfigurableFB) {
+			getNewMoveFB().updateConfiguration();
 		} else {
 			getNewMux().updateConfiguration();
 		}
@@ -107,6 +124,10 @@ public class ChangeStructCommand extends AbstractUpdateFBNElementCommand {
 			return demux.isIsConfigured() || newVisibleChildren != null;
 		}
 		return false;
+	}
+
+	public ConfigurableFB getNewMoveFB() {
+		return (ConfigurableFB) newElement;
 	}
 
 	public StructManipulator getNewMux() {

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/AbstractConnectionCreateCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/AbstractConnectionCreateCommand.java
@@ -27,6 +27,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.fordiac.ide.model.ConnectionLayoutTagger;
 import org.eclipse.fordiac.ide.model.commands.ScopedCommand;
 import org.eclipse.fordiac.ide.model.data.StructuredType;
+import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableMoveFB;
 import org.eclipse.fordiac.ide.model.libraryElement.Connection;
 import org.eclipse.fordiac.ide.model.libraryElement.ConnectionRoutingData;
 import org.eclipse.fordiac.ide.model.libraryElement.Demultiplexer;
@@ -297,9 +298,8 @@ public abstract class AbstractConnectionCreateCommand extends Command implements
 			return false;
 		}
 		final FBNetworkElement fbNE = pin.getFBNetworkElement();
-
-		return ((fbNE instanceof Demultiplexer && pin.isIsInput())
-				|| (fbNE instanceof Multiplexer && !pin.isIsInput()));
+		return ((fbNE instanceof Demultiplexer && pin.isIsInput()) || (fbNE instanceof Multiplexer && !pin.isIsInput())
+				|| (fbNE instanceof ConfigurableMoveFB));
 	}
 
 	public static boolean shouldStructDataConnCreationBeUsed(final IInterfaceElement pin,

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/StructDataConnectionCreateCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/StructDataConnectionCreateCommand.java
@@ -15,6 +15,7 @@ package org.eclipse.fordiac.ide.model.commands.create;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeStructCommand;
 import org.eclipse.fordiac.ide.model.data.StructuredType;
 import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes.GenericTypes;
+import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableMoveFB;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.StructManipulator;
@@ -48,23 +49,56 @@ public class StructDataConnectionCreateCommand extends DataConnectionCreateComma
 		final IInterfaceElement source = getSource();
 		final IInterfaceElement target = getDestination();
 
-		if (source.getType() instanceof final StructuredType sourceVar
-				&& target.getType() instanceof final StructuredType targetVar
-				&& !sourceVar.getName().equals(targetVar.getName())) {
-
-			if (isUnconfiguredStructManipulatorDefPin(source)) {
-				changeStructCommand = new ChangeStructCommand((StructManipulator) source.getFBNetworkElement(),
-						targetVar);
+		if (shouldChangeStruct(source, target)) {
+			if (isUnconfiguredStructManipulatorDefPin(source)
+					&& target.getType() instanceof final StructuredType targetVar) {
+				changeStructCommand = (source.getFBNetworkElement() instanceof final ConfigurableMoveFB cmfb)
+						? new ChangeStructCommand(cmfb, targetVar)
+						: new ChangeStructCommand((StructManipulator) source.getFBNetworkElement(), targetVar);
 				changeStructCommand.execute();
-				setSource(changeStructCommand.getNewMux().getInterfaceElement(getSource().getName()));
-			} else if (isUnconfiguredStructManipulatorDefPin(target)) {
-				changeStructCommand = new ChangeStructCommand((StructManipulator) target.getFBNetworkElement(),
-						sourceVar);
+				if (source.getFBNetworkElement() instanceof ConfigurableMoveFB) {
+					setSource(changeStructCommand.getNewElement().getInterfaceElement(getSource().getName()));
+				} else {
+					setSource(changeStructCommand.getNewMux().getInterfaceElement(getSource().getName()));
+				}
+			} else if (isUnconfiguredStructManipulatorDefPin(target)
+					&& source.getType() instanceof final StructuredType sourceVar) {
+				changeStructCommand = (target.getFBNetworkElement() instanceof final ConfigurableMoveFB cmfb)
+						? new ChangeStructCommand(cmfb, sourceVar)
+						: new ChangeStructCommand((StructManipulator) target.getFBNetworkElement(), sourceVar);
 				changeStructCommand.execute();
-				setDestination(changeStructCommand.getNewMux().getInterfaceElement(getDestination().getName()));
+				if (target.getFBNetworkElement() instanceof ConfigurableMoveFB) {
+					setDestination(changeStructCommand.getNewElement().getInterfaceElement(getDestination().getName()));
+				} else {
+					setDestination(changeStructCommand.getNewMux().getInterfaceElement(getDestination().getName()));
+				}
 			}
 		}
 		super.execute();
+	}
+
+	private static boolean shouldChangeStruct(final IInterfaceElement source, final IInterfaceElement target) {
+		final var sourceType = source.getType();
+		final var targetType = target.getType();
+		final var sourceParent = source.eContainer().eContainer();
+		final var targetParent = target.eContainer().eContainer();
+
+		if (sourceType instanceof final StructuredType sourceVar && targetType instanceof final StructuredType targetVar
+				&& !sourceVar.getName().equals(targetVar.getName())) {
+			return true;
+		}
+
+		if (sourceType instanceof StructuredType && targetParent instanceof ConfigurableMoveFB
+				&& !source.getName().equals(target.getName())) {
+			return true;
+		}
+
+		if (targetType instanceof StructuredType && sourceParent instanceof ConfigurableMoveFB
+				&& !target.getName().equals(source.getName())) {
+			return true;
+		}
+
+		return false;
 	}
 
 	@Override
@@ -85,12 +119,13 @@ public class StructDataConnectionCreateCommand extends DataConnectionCreateComma
 
 	private static boolean isStructPin(final IInterfaceElement pin) {
 		return pin instanceof final VarDeclaration varDecl && !varDecl.isArray()
-				&& varDecl.getType() instanceof StructuredType;
+				&& ((varDecl.getType() instanceof StructuredType)
+						|| pin.eContainer().eContainer() instanceof ConfigurableMoveFB);
 	}
 
 	private static boolean isUnconfiguredStructManipulatorDefPin(final IInterfaceElement pin) {
 		return AbstractConnectionCreateCommand.isStructManipulatorDefPin(pin)
-				&& GenericTypes.ANY_STRUCT == pin.getType();
+				&& (GenericTypes.ANY_STRUCT == pin.getType() || GenericTypes.ANY == pin.getType());
 	}
 
 }


### PR DESCRIPTION
Dragging a struct onto a F_MOVE changes the type of the target to the struct in the file.
Dragging a struct or primitive connection from a source/destination to hover a F_MOVE pin will configure the F_MOVE and create a connection.