### PR TITLE
Having resource and workset content as root content breaks Sys Explorer

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/plugin.xml
@@ -229,9 +229,8 @@
          <viewerContentBinding
                viewerId="org.eclipse.fordiac.ide.systemmanagement.ui.systemexplorer">
             <includes>
-      		   <contentExtension isRoot="true" pattern="org.eclipse.ui.navigator.resourceContent"/>
-               <contentExtension isRoot="true"
-               		pattern="org.eclipse.ui.navigator.resources.workingSets" />
+      		   <contentExtension pattern="org.eclipse.ui.navigator.resourceContent"/>
+               <contentExtension pattern="org.eclipse.ui.navigator.resources.workingSets"/>
                <contentExtension pattern="org.eclipse.fordiac.ide.systemmanagement.ui.systemexplorer.automationsystemcontent"/>
                <contentExtension pattern="org.eclipse.fordiac.ide.systemmanagement.ui.systemexplorer.sortOnly"/> 
                <contentExtension pattern="org.eclipse.ui.navigator.resources.filters.startsWithDot"/>


### PR DESCRIPTION
When enabling workingsets as root content projects where shown doubled. The reason was concflicts between resource and workingset content. Removing root from both ensure correct behavior.