### PR TITLE
Fixed Exception for resizing Dynamic NatTable with 0 rows

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.bulkeditor/src/org/eclipse/fordiac/ide/bulkeditor/editors/BulkEditorNatTable.java
+++ b/plugins/org.eclipse.fordiac.ide.bulkeditor/src/org/eclipse/fordiac/ide/bulkeditor/editors/BulkEditorNatTable.java
@@ -124,8 +124,8 @@ public class BulkEditorNatTable {
 			attributeProvider.setInput(list);
 			attributeSorterModel.setSortingList(list);
 
-			if (this.dynamicTable) {
-				final var dataLayer = NatTableWidgetFactory.getDataLayer(natTable);
+			final var dataLayer = NatTableWidgetFactory.getDataLayer(natTable);
+			if (this.dynamicTable && dataLayer.getRowCount() > 0) {
 				dataLayer.doCommand(new AutoResizeColumnsCommand(natTable,
 						IntStream.range(0, dataLayer.getColumnCount()).toArray()));
 				for (int colPos = 0; colPos < dataLayer.getColumnCount(); colPos++) {


### PR DESCRIPTION
When searching for an AttributeDeclaration in BulkEditor simple-mode, not finding any would lead to an exception