### PR TITLE
Combine trivial parameterized tests

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.tests/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/tests/STFunctionValidatorPartialAccessTest.xtend
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.tests/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/tests/STFunctionValidatorPartialAccessTest.xtend
@@ -42,17 +42,18 @@ class STFunctionValidatorPartialAccessTest {
 		new DataTypeLibrary
 	}
 
-	@ParameterizedTest(name="Check valid index {0}")
-	@MethodSource("generateValidByteIndices")
-	def void testValidBytePartialAccess(String input) {
-		'''
-			FUNCTION partialTest
-			VAR
-			x : BYTE;
-			END_VAR
-			x.«input» := 1;
-			END_FUNCTION
-		'''.parse.assertNoErrors
+	@Test
+	def void testValidBytePartialAccess() {
+		generateValidByteIndices.forEach [ input |
+			'''
+				FUNCTION partialTest
+				VAR
+				x : BYTE;
+				END_VAR
+				x.«input» := 1;
+				END_FUNCTION
+			'''.parse.assertNoErrors
+		]
 	}
 
 	def static generateValidByteIndices() {
@@ -61,17 +62,18 @@ class STFunctionValidatorPartialAccessTest {
 		return shortBitAccess + longBitAccess
 	}
 
-	@ParameterizedTest(name="Check valid index {0}")
-	@MethodSource("generateValidWordIndices")
-	def void testValidWordPartialAccess(String input) {
-		'''
-			FUNCTION partialTest
-			VAR
-			x : WORD;
-			END_VAR
-			x.«input» := true;
-			END_FUNCTION
-		'''.parse.assertNoErrors
+	@Test
+	def void testValidWordPartialAccess() {
+		generateValidWordIndices.forEach [ input |
+			'''
+				FUNCTION partialTest
+				VAR
+				x : WORD;
+				END_VAR
+				x.«input» := true;
+				END_FUNCTION
+			'''.parse.assertNoErrors
+		]
 	}
 
 	def static generateValidWordIndices() {
@@ -81,17 +83,18 @@ class STFunctionValidatorPartialAccessTest {
 		return shortBitAccess + longBitAccess + byteAccess
 	}
 
-	@ParameterizedTest(name="Check valid index {0}")
-	@MethodSource("generateValidDWordIndices")
-	def void testValidDWordPartialAccess(String input) {
-		'''
-			FUNCTION partialTest
-			VAR
-			x : DWORD;
-			END_VAR
-			x.«input» := true;
-			END_FUNCTION
-		'''.parse.assertNoErrors
+	@Test
+	def void testValidDWordPartialAccess() {
+		generateValidDWordIndices.forEach [ input |
+			'''
+				FUNCTION partialTest
+				VAR
+				x : DWORD;
+				END_VAR
+				x.«input» := true;
+				END_FUNCTION
+			'''.parse.assertNoErrors
+		]
 	}
 
 	def static generateValidDWordIndices() {
@@ -102,17 +105,18 @@ class STFunctionValidatorPartialAccessTest {
 		return shortBitAccess + longBitAccess + byteAccess + wordAccess
 	}
 
-	@ParameterizedTest(name="Check valid index {0}")
-	@MethodSource("generateValidLWordIndices")
-	def void testValidLWordPartialAccess(String input) {
-		'''
-			FUNCTION partialTest
-			VAR
-			x : LWORD;
-			END_VAR
-			x.«input» := true;
-			END_FUNCTION
-		'''.parse.assertNoErrors
+	@Test
+	def void testValidLWordPartialAccess() {
+		generateValidLWordIndices.forEach [ input |
+			'''
+				FUNCTION partialTest
+				VAR
+				x : LWORD;
+				END_VAR
+				x.«input» := true;
+				END_FUNCTION
+			'''.parse.assertNoErrors
+		]
 	}
 
 	def static generateValidLWordIndices() {
@@ -124,47 +128,50 @@ class STFunctionValidatorPartialAccessTest {
 		return shortBitAccess + longBitAccess + byteAccess + wordAccess + dwordAccess
 	}
 
-	@ParameterizedTest
-	@MethodSource("generateTypeNonAnyBitTypeNames")
-	def void testNonAnyBitTypesCannotPerformPartialAccess(String input) {
-		'''
-			FUNCTION partialTest
-			VAR
-			x : «input»;
-			END_VAR
-			x.1 := true;
-			END_FUNCTION
-		'''.parse.assertError(STCorePackage.eINSTANCE.STMultibitPartialExpression,
-			STCoreValidator.BIT_ACCESS_INVALID_FOR_TYPE,
-			"Partial access invalid for type " + input + ", which is not of ANY_BIT")
+	@Test
+	def void testNonAnyBitTypesCannotPerformPartialAccess() {
+		generateTypeNonAnyBitTypeNames.forEach [ input |
+			'''
+				FUNCTION partialTest
+				VAR
+				x : «input»;
+				END_VAR
+				x.1 := true;
+				END_FUNCTION
+			'''.parse.assertError(STCorePackage.eINSTANCE.STMultibitPartialExpression,
+				STCoreValidator.BIT_ACCESS_INVALID_FOR_TYPE,
+				"Partial access invalid for type " + input + ", which is not of ANY_BIT")
+		]
 	}
 
 	def static generateTypeNonAnyBitTypeNames() {
 		return DataTypeLibrary.nonUserDefinedDataTypes.filter[!(it instanceof AnyBitType)].map[it.name]
 	}
 
-	@ParameterizedTest(name="Check invalid index {0}")
-	@MethodSource("generateInvalidByteIndices")
-	def void testInvalidBytePartialAccess(String input) {
-		var exprString = "";
-		try {
-			Integer.parseInt(input)
-			exprString = "%X" + input
-		} catch (NumberFormatException e) {
-			exprString = input
-		}
-		'''
-			FUNCTION partialTest
-			VAR
-			x : BYTE;
-			END_VAR
-			x.«input» := 1;
-			END_FUNCTION
-		'''.parse.assertError(
-			STCorePackage.eINSTANCE.STMultibitPartialExpression,
-			STCoreValidator.BIT_ACCESS_INDEX_OUT_OF_RANGE,
-			"Partial access index " + exprString + " of out range"
-		)
+	@Test
+	def void testInvalidBytePartialAccess() {
+		generateInvalidByteIndices.forEach [ input |
+			var exprString = "";
+			try {
+				Integer.parseInt(input)
+				exprString = "%X" + input
+			} catch (NumberFormatException e) {
+				exprString = input
+			}
+
+			'''
+				FUNCTION partialTest
+				VAR
+				x : BYTE;
+				END_VAR
+				x.«input» := 1;
+				END_FUNCTION
+			'''.parse.assertError(
+				STCorePackage.eINSTANCE.STMultibitPartialExpression,
+				STCoreValidator.BIT_ACCESS_INDEX_OUT_OF_RANGE,
+				"Partial access index " + exprString + " of out range"
+			)
+		]
 	}
 
 	def static generateInvalidByteIndices() {
@@ -174,28 +181,30 @@ class STFunctionValidatorPartialAccessTest {
 		return shortBitAccess + longBitAccess + byteAccess
 	}
 
-	@ParameterizedTest(name="Check invalid index {0}")
-	@MethodSource("generateInvalidWordIndices")
-	def void testInvalidWordPartialAccess(String input) {
-		var exprString = "";
-		try {
-			Integer.parseInt(input)
-			exprString = "%X" + input
-		} catch (NumberFormatException e) {
-			exprString = input
-		}
-		'''
-			FUNCTION partialTest
-			VAR
-			x : WORD;
-			END_VAR
-			x.«input» := 1;
-			END_FUNCTION
-		'''.parse.assertError(
-			STCorePackage.eINSTANCE.STMultibitPartialExpression,
-			STCoreValidator.BIT_ACCESS_INDEX_OUT_OF_RANGE,
-			"Partial access index " + exprString + " of out range"
-		)
+	@Test
+	def void testInvalidWordPartialAccess() {
+		generateInvalidWordIndices.forEach [ input |
+			var exprString = "";
+			try {
+				Integer.parseInt(input)
+				exprString = "%X" + input
+			} catch (NumberFormatException e) {
+				exprString = input
+			}
+
+			'''
+				FUNCTION partialTest
+				VAR
+				x : WORD;
+				END_VAR
+				x.«input» := 1;
+				END_FUNCTION
+			'''.parse.assertError(
+				STCorePackage.eINSTANCE.STMultibitPartialExpression,
+				STCoreValidator.BIT_ACCESS_INDEX_OUT_OF_RANGE,
+				"Partial access index " + exprString + " of out range"
+			)
+		]
 	}
 
 	def static generateInvalidWordIndices() {
@@ -206,28 +215,30 @@ class STFunctionValidatorPartialAccessTest {
 		return shortBitAccess + longBitAccess + byteAccess + wordAccess
 	}
 
-	@ParameterizedTest(name="Check invalid index {0}")
-	@MethodSource("generateInvalidDWordIndices")
-	def void testInvalidDWordPartialAccess(String input) {
-		var exprString = "";
-		try {
-			Integer.parseInt(input)
-			exprString = "%X" + input
-		} catch (NumberFormatException e) {
-			exprString = input
-		}
-		'''
-			FUNCTION partialTest
-			VAR
-			x : DWORD;
-			END_VAR
-			x.«input» := 1;
-			END_FUNCTION
-		'''.parse.assertError(
-			STCorePackage.eINSTANCE.STMultibitPartialExpression,
-			STCoreValidator.BIT_ACCESS_INDEX_OUT_OF_RANGE,
-			"Partial access index " + exprString + " of out range"
-		)
+	@Test
+	def void testInvalidDWordPartialAccess() {
+		generateInvalidDWordIndices.forEach [ input |
+			var exprString = "";
+			try {
+				Integer.parseInt(input)
+				exprString = "%X" + input
+			} catch (NumberFormatException e) {
+				exprString = input
+			}
+
+			'''
+				FUNCTION partialTest
+				VAR
+				x : DWORD;
+				END_VAR
+				x.«input» := 1;
+				END_FUNCTION
+			'''.parse.assertError(
+				STCorePackage.eINSTANCE.STMultibitPartialExpression,
+				STCoreValidator.BIT_ACCESS_INDEX_OUT_OF_RANGE,
+				"Partial access index " + exprString + " of out range"
+			)
+		]
 	}
 
 	def static generateInvalidDWordIndices() {
@@ -239,28 +250,30 @@ class STFunctionValidatorPartialAccessTest {
 		return shortBitAccess + longBitAccess + byteAccess + wordAccess + dwordAccess
 	}
 
-	@ParameterizedTest(name="Check invalid index {0}")
-	@MethodSource("generateInvalidLWordIndices")
-	def void testInvalidLWordPartialAccess(String input) {
-		var exprString = "";
-		try {
-			Integer.parseInt(input)
-			exprString = "%X" + input
-		} catch (NumberFormatException e) {
-			exprString = input
-		}
-		'''
-			FUNCTION partialTest
-			VAR
-			x : LWORD;
-			END_VAR
-			x.«input» := 1;
-			END_FUNCTION
-		'''.parse.assertError(
-			STCorePackage.eINSTANCE.STMultibitPartialExpression,
-			STCoreValidator.BIT_ACCESS_INDEX_OUT_OF_RANGE,
-			"Partial access index " + exprString + " of out range"
-		)
+	@Test
+	def void testInvalidLWordPartialAccess() {
+		generateInvalidLWordIndices.forEach [ input |
+			var exprString = "";
+			try {
+				Integer.parseInt(input)
+				exprString = "%X" + input
+			} catch (NumberFormatException e) {
+				exprString = input
+			}
+
+			'''
+				FUNCTION partialTest
+				VAR
+				x : LWORD;
+				END_VAR
+				x.«input» := 1;
+				END_FUNCTION
+			'''.parse.assertError(
+				STCorePackage.eINSTANCE.STMultibitPartialExpression,
+				STCoreValidator.BIT_ACCESS_INDEX_OUT_OF_RANGE,
+				"Partial access index " + exprString + " of out range"
+			)
+		]
 	}
 
 	def static generateInvalidLWordIndices() {
@@ -273,18 +286,19 @@ class STFunctionValidatorPartialAccessTest {
 		return shortBitAccess + longBitAccess + byteAccess + wordAccess + dwordAccess + lwordAccess
 	}
 
-	@ParameterizedTest(name="Check invalid access on non Variable expression with index {0}")
-	@MethodSource("generateValidLWordIndices")
-	def void testInvalidPartialAccessOnNonVariable(String input) {
-		'''
-			FUNCTION partialTest
-			VAR
-			x : LWORD;
-			END_VAR
-			x := (x OR x).«input»;
-			END_FUNCTION
-		'''.parse.assertError(STCorePackage.eINSTANCE.STMultibitPartialExpression,
-			STCoreValidator.BIT_ACCESS_INVALID_RECEIVER, "Receiving expression invalid for partial access")
+	@Test
+	def void testInvalidPartialAccessOnNonVariable() {
+		generateValidLWordIndices.forEach [ input |
+			'''
+				FUNCTION partialTest
+				VAR
+				x : LWORD;
+				END_VAR
+				x := (x OR x).«input»;
+				END_FUNCTION
+			'''.parse.assertError(STCorePackage.eINSTANCE.STMultibitPartialExpression,
+				STCoreValidator.BIT_ACCESS_INVALID_RECEIVER, "Receiving expression invalid for partial access")
+		]
 	}
 
 	@Test
@@ -300,38 +314,41 @@ class STFunctionValidatorPartialAccessTest {
 		'''.parse.assertNoErrors
 	}
 
-	@ParameterizedTest(name="Check valid access expression of type {0}")
-	@MethodSource("generateValidAccessExpressionTypes")
-	def void testValidPartialAccessExpressions(String input) {
-		'''
-			FUNCTION partialTest
-			VAR
-			accessor : «input»;
-			accessed : LWORD;
-			END_VAR
-			accessed.(accessor);
-			END_FUNCTION
-		'''.parse.assertNoErrors
+	@Test
+	def void testValidPartialAccessExpressions() {
+		generateValidAccessExpressionTypes.forEach [ input |
+			'''
+				FUNCTION partialTest
+				VAR
+				accessor : «input»;
+				accessed : LWORD;
+				END_VAR
+				accessed.(accessor);
+				END_FUNCTION
+			'''.parse.assertNoErrors
+		]
 	}
 
 	def static generateValidAccessExpressionTypes() {
 		return DataTypeLibrary.nonUserDefinedDataTypes.filter[it instanceof AnyIntType].map[it.name]
 	}
-	
-	@ParameterizedTest(name="Check valid access expression of type {0}")
-	@MethodSource("generateInvalidAccessExpressionTypes")
-	def void testInvalidPartialAccessExpressions(String input) {
-		'''
-			FUNCTION partialTest
-			VAR
-			accessor : «input»;
-			accessed : LWORD;
-			END_VAR
-			accessed.(accessor);
-			END_FUNCTION
-		'''.parse.assertError(STCorePackage.eINSTANCE.STMultibitPartialExpression,
-			STCoreValidator.BIT_ACCESS_EXPRESSION_NOT_OF_TYPE_ANY_INT, "Partial bit access expression is not resulting in an ANY_INT, but in " + input)
-		
+
+	@Test
+	def void testInvalidPartialAccessExpressions() {
+		generateInvalidAccessExpressionTypes.forEach [ input |
+			'''
+				FUNCTION partialTest
+				VAR
+				accessor : «input»;
+				accessed : LWORD;
+				END_VAR
+				accessed.(accessor);
+				END_FUNCTION
+			'''.parse.assertError(STCorePackage.eINSTANCE.STMultibitPartialExpression,
+				STCoreValidator.BIT_ACCESS_EXPRESSION_NOT_OF_TYPE_ANY_INT,
+				"Partial bit access expression is not resulting in an ANY_INT, but in " + input)
+
+		]
 	}
 
 	def static generateInvalidAccessExpressionTypes() {

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.tests/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/tests/STFunctionValidatorTest.xtend
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.tests/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/tests/STFunctionValidatorTest.xtend
@@ -771,7 +771,7 @@ class STFunctionValidatorTest {
 				CONST3 : INT := 0;
 				CONST4 : INT := 0;
 			END_VAR
-
+			
 			IF TEMP1 THEN
 				TEMP1 := TRUE;
 			ELSIF TEMP2 THEN
@@ -1202,111 +1202,82 @@ class STFunctionValidatorTest {
 			STCoreValidator.STANDARD_FUNCTION_WITH_FORMAL_ARGUMENTS)
 	}
 
-	@ParameterizedTest(name="{index}: {0} with {1}")
-	@MethodSource("typeUnaryOperatorArgumentsCartesianProvider")
-	def void testUnaryOperatorNotApplicableErrorValidator(String operatorName, String typeName) {
-		val operator = STUnaryOperator.getByName(operatorName)
-		val type = ElementaryTypes.getTypeByName(typeName)
-		val result = '''
-		FUNCTION hubert
-		VAR
-		    var1 : «type.name»;
-		END_VAR
-		var1 := «operator.literal» var1;
-		END_FUNCTION'''.parse
-		if (STCoreUtil.isApplicableTo(operator, type))
-			result.assertNoErrors
-		else
-			result.assertError(STCorePackage.eINSTANCE.STUnaryExpression, STCoreValidator.OPERATOR_NOT_APPLICABLE)
-	}
-
-	@ParameterizedTest(name="{index}: {0} with {1} and {2}")
-	@MethodSource("typeBinaryOperatorArgumentsCartesianProvider")
-	def void testBinaryOperatorNotApplicableErrorValidator(String operatorName, String leftTypeName,
-		String rightTypeName) {
-		val operator = STBinaryOperator.getByName(operatorName)
-		val leftType = ElementaryTypes.getTypeByName(leftTypeName)
-		val rightType = ElementaryTypes.getTypeByName(rightTypeName)
-		val result = '''
-		FUNCTION hubert
-		VAR
-		    var1 : «leftType.name»;
-		    var2 : «rightType.name»;
-		    var3 : BOOL;
-		END_VAR
-		var3 := (var1 «operator.literal» var2) = (var1 «operator.literal» var2);
-		END_FUNCTION'''.parse
-		if (STCoreUtil.isApplicableTo(operator, leftType, rightType))
-			result.assertNoErrors
-		else
-			result.assertError(STCorePackage.eINSTANCE.STBinaryExpression, STCoreValidator.OPERATOR_NOT_APPLICABLE)
-	}
-
-	@ParameterizedTest(name="{index}: {0} with {1}")
-	@MethodSource("typeUnaryOperatorApplicableArgumentsCartesianProvider")
-	def void testUnaryOperatorResultType(String operatorName, String typeName) {
-		val operator = STUnaryOperator.getByName(operatorName)
-		val type = ElementaryTypes.getTypeByName(typeName)
-		val result = '''
-		FUNCTION hubert
-		VAR
-		    var1 : «type.name»;
-		END_VAR
-		«operator.literal» var1;
-		END_FUNCTION'''.parse
-		val expression = result.functions.head.code.head as STUnaryExpression
-		assertNotNull(expression.resultType, "invalid result type from applicable operator")
-	}
-
-	@ParameterizedTest(name="{index}: {0} with {1} and {2}")
-	@MethodSource("typeBinaryOperatorApplicableArgumentsCartesianProvider")
-	def void testBinaryOperatorResultType(String operatorName, String leftTypeName, String rightTypeName) {
-		val operator = STBinaryOperator.getByName(operatorName)
-		val leftType = ElementaryTypes.getTypeByName(leftTypeName)
-		val rightType = ElementaryTypes.getTypeByName(rightTypeName)
-		val result = '''
-		FUNCTION hubert
-		VAR
-		    var1 : «leftType.name»;
-		    var2 : «rightType.name»;
-		END_VAR
-		var1 «operator.literal» var2;
-		END_FUNCTION'''.parse
-		val expression = result.functions.head.code.head as STBinaryExpression
-		assertNotNull(expression.resultType, "invalid result type from applicable operator")
-	}
-
-	def static Stream<Arguments> typeUnaryOperatorArgumentsCartesianProvider() {
-		DataTypeLibrary.nonUserDefinedDataTypes.stream.flatMap [ type |
-			STUnaryOperator.VALUES.stream.map [ op |
-				arguments(op.getName, type.name)
+	@Test
+	def void testUnaryOperatorNotApplicableErrorValidator() {
+		DataTypeLibrary.nonUserDefinedDataTypes.forEach [ type |
+			STUnaryOperator.VALUES.forEach [ operator |
+				val result = '''
+				FUNCTION hubert
+				VAR
+				    var1 : «type.name»;
+				END_VAR
+				var1 := «operator.literal» var1;
+				END_FUNCTION'''.parse
+				if (STCoreUtil.isApplicableTo(operator, type))
+					result.assertNoErrors
+				else
+					result.assertError(STCorePackage.eINSTANCE.STUnaryExpression,
+						STCoreValidator.OPERATOR_NOT_APPLICABLE)
 			]
 		]
 	}
 
-	def static Stream<Arguments> typeBinaryOperatorArgumentsCartesianProvider() {
-		DataTypeLibrary.nonUserDefinedDataTypes.stream.flatMap [ first |
-			DataTypeLibrary.nonUserDefinedDataTypes.stream.flatMap [ second |
-				STBinaryOperator.VALUES.stream.map [ op |
-					arguments(op.getName, first.name, second.name)
+	@Test
+	def void testBinaryOperatorNotApplicableErrorValidator() {
+		DataTypeLibrary.nonUserDefinedDataTypes.forEach [ leftType |
+			DataTypeLibrary.nonUserDefinedDataTypes.forEach [ rightType |
+				STBinaryOperator.VALUES.forEach [ operator |
+					val result = '''
+					FUNCTION hubert
+					VAR
+					    var1 : «leftType.name»;
+					    var2 : «rightType.name»;
+					    var3 : BOOL;
+					END_VAR
+					var3 := (var1 «operator.literal» var2) = (var1 «operator.literal» var2);
+					END_FUNCTION'''.parse
+					if (STCoreUtil.isApplicableTo(operator, leftType, rightType))
+						result.assertNoErrors
+					else
+						result.assertError(STCorePackage.eINSTANCE.STBinaryExpression,
+							STCoreValidator.OPERATOR_NOT_APPLICABLE)
 				]
 			]
 		]
 	}
 
-	def static Stream<Arguments> typeUnaryOperatorApplicableArgumentsCartesianProvider() {
-		DataTypeLibrary.nonUserDefinedDataTypes.stream.flatMap [ type |
-			STUnaryOperator.VALUES.stream.filter[op|STCoreUtil.isApplicableTo(op, type)].map [ op |
-				arguments(op.getName, type.name)
+	@Test
+	def void testUnaryOperatorResultType() {
+		DataTypeLibrary.nonUserDefinedDataTypes.forEach [ type |
+			STUnaryOperator.VALUES.filter[op|STCoreUtil.isApplicableTo(op, type)].forEach [ operator |
+				val result = '''
+				FUNCTION hubert
+				VAR
+				    var1 : «type.name»;
+				END_VAR
+				«operator.literal» var1;
+				END_FUNCTION'''.parse
+				val expression = result.functions.head.code.head as STUnaryExpression
+				assertNotNull(expression.resultType, "invalid result type from applicable operator")
 			]
 		]
 	}
 
-	def static Stream<Arguments> typeBinaryOperatorApplicableArgumentsCartesianProvider() {
-		DataTypeLibrary.nonUserDefinedDataTypes.stream.flatMap [ first |
-			DataTypeLibrary.nonUserDefinedDataTypes.stream.flatMap [ second |
-				STBinaryOperator.VALUES.stream.filter[op|STCoreUtil.isApplicableTo(op, first, second)].map [ op |
-					arguments(op.getName, first.name, second.name)
+	@Test
+	def void testBinaryOperatorResultType() {
+		DataTypeLibrary.nonUserDefinedDataTypes.forEach [ leftType |
+			DataTypeLibrary.nonUserDefinedDataTypes.forEach [ rightType |
+				STBinaryOperator.VALUES.filter[op|STCoreUtil.isApplicableTo(op, leftType, rightType)].forEach [ operator |
+					val result = '''
+					FUNCTION hubert
+					VAR
+					    var1 : «leftType.name»;
+					    var2 : «rightType.name»;
+					END_VAR
+					var1 «operator.literal» var2;
+					END_FUNCTION'''.parse
+					val expression = result.functions.head.code.head as STBinaryExpression
+					assertNotNull(expression.resultType, "invalid result type from applicable operator")
 				]
 			]
 		]

--- a/tests/org.eclipse.fordiac.ide.test.model.eval/src/org/eclipse/fordiac/ide/test/model/eval/value/ValueOperationsTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model.eval/src/org/eclipse/fordiac/ide/test/model/eval/value/ValueOperationsTest.java
@@ -43,7 +43,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Collection;
 import java.util.Map;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -69,7 +68,6 @@ import org.eclipse.fordiac.ide.model.data.LtodType;
 import org.eclipse.fordiac.ide.model.data.StructuredType;
 import org.eclipse.fordiac.ide.model.data.TimeOfDayType;
 import org.eclipse.fordiac.ide.model.data.TimeType;
-import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes.ElementaryTypes;
 import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes.GenericTypes;
 import org.eclipse.fordiac.ide.model.eval.value.LTimeValue;
 import org.eclipse.fordiac.ide.model.eval.value.TimeValue;
@@ -77,9 +75,6 @@ import org.eclipse.fordiac.ide.model.eval.value.Value;
 import org.eclipse.fordiac.ide.model.eval.value.ValueOperations;
 import org.eclipse.fordiac.ide.model.typelibrary.DataTypeLibrary;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
 @SuppressWarnings({ "static-method", "nls" })
 class ValueOperationsTest {
@@ -109,415 +104,399 @@ class ValueOperationsTest {
 		assertThrows(UnsupportedOperationException.class, () -> parseValue("0", null));
 	}
 
-	@ParameterizedTest(name = "{index}: {0}")
-	@MethodSource("typeArgumentsProvider")
-	void testAbs(final String typeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		final Value defaultValue = defaultValue(type);
-		if (type instanceof AnyMagnitudeType) {
-			assertEquals(defaultValue, abs(defaultValue));
-		} else {
-			assertThrows(UnsupportedOperationException.class, () -> abs(defaultValue));
-		}
-	}
-
-	@ParameterizedTest(name = "{index}: {0}")
-	@MethodSource("typeArgumentsProvider")
-	void testNegate(final String typeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		final Value defaultValue = defaultValue(type);
-		if (type instanceof AnyMagnitudeType) {
-			assertEquals(defaultValue, negate(defaultValue));
-		} else {
-			assertThrows(UnsupportedOperationException.class, () -> negate(defaultValue));
-		}
-	}
-
-	@ParameterizedTest(name = "{index}: {0}")
-	@MethodSource("typeArgumentsProvider")
-	void testBitwiseNot(final String typeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		final Value defaultValue = defaultValue(type);
-		if (type instanceof AnyBitType) {
-			assertNotEquals(defaultValue, bitwiseNot(defaultValue));
-		} else {
-			assertThrows(UnsupportedOperationException.class, () -> bitwiseNot(defaultValue));
-		}
-	}
-
-	@ParameterizedTest(name = "{index}: {0}")
-	@MethodSource("typeArgumentsProvider")
-	void testReverseBytes(final String typeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		final Value defaultValue = defaultValue(type);
-		assertEquals(defaultValue, reverseBytes(defaultValue));
-	}
-
-	@ParameterizedTest(name = "{index}: {0}")
-	@MethodSource("typeArgumentsProvider")
-	void testAdd(final String typeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		final Value defaultValue = defaultValue(type);
-		if (type instanceof AnyMagnitudeType) {
-			assertEquals(defaultValue, add(defaultValue, defaultValue));
-		} else if (type instanceof TimeOfDayType || type instanceof LtodType || type instanceof DateAndTimeType
-				|| type instanceof LdtType) {
-			assertEquals(defaultValue, add(defaultValue, TimeValue.DEFAULT));
-		} else {
-			assertThrows(UnsupportedOperationException.class, () -> add(defaultValue, defaultValue));
-		}
-	}
-
-	@ParameterizedTest(name = "{index}: {0}")
-	@MethodSource("typeArgumentsProvider")
-	void testSubtract(final String typeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		final Value defaultValue = defaultValue(type);
-		if (type instanceof AnyMagnitudeType) {
-			assertEquals(defaultValue, subtract(defaultValue, defaultValue));
-		} else if (type instanceof TimeOfDayType || type instanceof DateAndTimeType) {
-			assertEquals(defaultValue, subtract(defaultValue, TimeValue.DEFAULT));
-			assertEquals(TimeValue.DEFAULT, subtract(defaultValue, defaultValue));
-		} else if (type instanceof LtodType || type instanceof LdtType) {
-			assertEquals(defaultValue, subtract(defaultValue, TimeValue.DEFAULT));
-			assertEquals(LTimeValue.DEFAULT, subtract(defaultValue, defaultValue));
-		} else if (type instanceof DateType) {
-			assertEquals(TimeValue.DEFAULT, subtract(defaultValue, defaultValue));
-		} else if (type instanceof LdateType) {
-			assertEquals(LTimeValue.DEFAULT, subtract(defaultValue, defaultValue));
-		} else {
-			assertThrows(UnsupportedOperationException.class, () -> subtract(defaultValue, defaultValue));
-		}
-	}
-
-	@ParameterizedTest(name = "{index}: {0}")
-	@MethodSource("typeArgumentsProvider")
-	void testMultiply(final String typeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		final Value defaultValue = defaultValue(type);
-		if (type instanceof AnyMagnitudeType) {
-			assertEquals(defaultValue, multiply(defaultValue, defaultValue));
-		} else {
-			assertThrows(UnsupportedOperationException.class, () -> multiply(defaultValue, defaultValue));
-		}
-	}
-
-	@ParameterizedTest(name = "{index}: {0}")
-	@MethodSource("typeArgumentsProvider")
-	void testMultiplyTime(final String typeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		final Value defaultValue = defaultValue(type);
-		if (type instanceof AnyNumType) {
-			assertEquals(TimeValue.DEFAULT, multiply(TimeValue.DEFAULT, defaultValue));
-			assertEquals(LTimeValue.DEFAULT, multiply(LTimeValue.DEFAULT, defaultValue));
-		}
-	}
-
-	@ParameterizedTest(name = "{index}: {0}")
-	@MethodSource("typeArgumentsProvider")
-	void testDivide(final String typeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		final Value defaultValue = defaultValue(type);
-		if (type instanceof AnyRealType) {
-			assertNotEquals(defaultValue, divideBy(defaultValue, defaultValue));
-		} else if (type instanceof AnyIntType || type instanceof AnyDurationType) {
-			assertEquals(defaultValue, divideBy(defaultValue, wrapValue(Integer.valueOf(1), type)));
-			assertThrows(ArithmeticException.class, () -> divideBy(defaultValue, defaultValue));
-		} else {
-			assertThrows(UnsupportedOperationException.class, () -> divideBy(defaultValue, defaultValue));
-		}
-	}
-
-	@ParameterizedTest(name = "{index}: {0}")
-	@MethodSource("typeArgumentsProvider")
-	void testDivideTime(final String typeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		final Value defaultValue = defaultValue(type);
-		if (type instanceof AnyNumType) {
-			assertEquals(TimeValue.DEFAULT, divideBy(TimeValue.DEFAULT, wrapValue(Integer.valueOf(1), type)));
-			assertEquals(LTimeValue.DEFAULT, divideBy(LTimeValue.DEFAULT, wrapValue(Integer.valueOf(1), type)));
-			assertThrows(ArithmeticException.class, () -> divideBy(TimeValue.DEFAULT, defaultValue));
-			assertThrows(ArithmeticException.class, () -> divideBy(TimeValue.DEFAULT, defaultValue));
-		}
-	}
-
-	@ParameterizedTest(name = "{index}: {0}")
-	@MethodSource("typeArgumentsProvider")
-	void testRemainder(final String typeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		final Value defaultValue = defaultValue(type);
-		if (type instanceof AnyIntType) {
-			assertEquals(defaultValue, remainderBy(defaultValue, wrapValue(Integer.valueOf(1), type)));
-			assertEquals(defaultValue, ValueOperations.remainderBy(defaultValue, defaultValue));
-		} else {
-			assertThrows(UnsupportedOperationException.class, () -> remainderBy(defaultValue, defaultValue));
-		}
-	}
-
-	@ParameterizedTest(name = "{index}: {0}")
-	@MethodSource("typeArgumentsProvider")
-	void testPower(final String typeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		final Value defaultValue = defaultValue(type);
-		if (type instanceof AnyRealType) {
-			assertEquals(wrapValue(Integer.valueOf(1), type), power(defaultValue, defaultValue));
-		} else {
-			assertThrows(UnsupportedOperationException.class, () -> power(defaultValue, defaultValue));
-		}
-	}
-
-	@ParameterizedTest(name = "{index}: {0}")
-	@MethodSource("typeArgumentsProvider")
-	void testAnd(final String typeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		final Value defaultValue = defaultValue(type);
-		if (type instanceof AnyBitType) {
-			assertEquals(defaultValue, bitwiseAnd(defaultValue, defaultValue));
-		} else {
-			assertThrows(UnsupportedOperationException.class, () -> bitwiseAnd(defaultValue, defaultValue));
-		}
-	}
-
-	@ParameterizedTest(name = "{index}: {0}")
-	@MethodSource("typeArgumentsProvider")
-	void testOr(final String typeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		final Value defaultValue = defaultValue(type);
-		if (type instanceof AnyBitType) {
-			assertEquals(defaultValue, bitwiseOr(defaultValue, defaultValue));
-		} else {
-			assertThrows(UnsupportedOperationException.class, () -> bitwiseOr(defaultValue, defaultValue));
-		}
-	}
-
-	@ParameterizedTest(name = "{index}: {0}")
-	@MethodSource("typeArgumentsProvider")
-	void testXor(final String typeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		final Value defaultValue = defaultValue(type);
-		if (type instanceof AnyBitType) {
-			assertEquals(defaultValue, bitwiseXor(defaultValue, defaultValue));
-		} else {
-			assertThrows(UnsupportedOperationException.class, () -> bitwiseXor(defaultValue, defaultValue));
-		}
-	}
-
-	@ParameterizedTest(name = "{index}: {0}")
-	@MethodSource("typeArgumentsProvider")
-	void testEquals(final String typeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		final Value defaultValue = defaultValue(type);
-		assertEquals(Boolean.valueOf(true), Boolean.valueOf(ValueOperations.equals(defaultValue, defaultValue)));
-	}
-
-	@ParameterizedTest(name = "{index}: {0}")
-	@MethodSource("typeArgumentsProvider")
-	void testLessThan(final String typeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		final Value defaultValue = defaultValue(type);
-		assertFalse(lessThan(defaultValue, defaultValue));
-	}
-
-	@ParameterizedTest(name = "{index}: {0}")
-	@MethodSource("typeArgumentsProvider")
-	void testLessEquals(final String typeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		final Value defaultValue = defaultValue(type);
-		assertTrue(lessEquals(defaultValue, defaultValue));
-	}
-
-	@ParameterizedTest(name = "{index}: {0}")
-	@MethodSource("typeArgumentsProvider")
-	void testGreaterThan(final String typeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		final Value defaultValue = defaultValue(type);
-		assertFalse(greaterThan(defaultValue, defaultValue));
-	}
-
-	@ParameterizedTest(name = "{index}: {0}")
-	@MethodSource("typeArgumentsProvider")
-	void testGreaterEquals(final String typeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		final Value defaultValue = defaultValue(type);
-		assertTrue(greaterEquals(defaultValue, defaultValue));
-	}
-
-	@ParameterizedTest(name = "{index}: {0}")
-	@MethodSource("typeArgumentsProvider")
-	void testCompareTo(final String typeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		final Value defaultValue = defaultValue(type);
-		assertEquals(0, compareTo(defaultValue, defaultValue));
-	}
-
-	@ParameterizedTest(name = "{index}: {0} partial {1}")
-	@MethodSource("typeArgumentsCartesianProvider")
-	void testPartial(final String typeName, final String partialTypeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		final DataType partialType = ValueOperationsTest.getTypeByName(partialTypeName);
-		final Value defaultValue = defaultValue(type);
-		final Value defaultPartialValue = defaultValue(partialType);
-		if (type instanceof final AnyBitType bitType && partialType instanceof final AnyBitType partialBitType
-				&& type != partialType && type.isAssignableFrom(partialType)) {
-			IntStream.range(0, bitType.getBitSize() / partialBitType.getBitSize()).forEach(index -> {
-				assertEquals(defaultValue(partialType), ValueOperations.partial(defaultValue, partialType, index));
-				assertEquals(
-						wrapValue(Integer.valueOf((0xffffffff >>> (32 - partialBitType.getBitSize()))), partialType),
-						partial(wrapValue(Long.valueOf(0xffffffffffffffffL), type), partialType, index));
-				assertEquals(defaultValue, partial(defaultValue, partialType, index, defaultValue(partialType)));
-				assertEquals(wrapValue(Long.valueOf((0x1L << (index * partialBitType.getBitSize()))), type),
-						partial(defaultValue, partialType, index, wrapValue(Integer.valueOf(1), partialType)));
-
-			});
-		} else {
-			assertThrows(UnsupportedOperationException.class, () -> partial(defaultValue, partialType, 0));
-			assertThrows(UnsupportedOperationException.class,
-					() -> partial(defaultValue, partialType, 0, defaultPartialValue));
-		}
-	}
-
-	@ParameterizedTest(name = "{index}: {0} as {1}")
-	@MethodSource("typeArgumentsCartesianProvider")
-	void testCastValue(final String typeName, final String castTypeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		final DataType castType = ValueOperationsTest.getTypeByName(castTypeName);
-		final Value defaultValue = defaultValue(type);
-		final Value defaultCastValue = defaultValue(castType);
-		switch (type) {
-		case final BoolType unused -> {
-			if (castType instanceof AnyBitType) {
-				assertEquals(defaultCastValue, castValue(defaultValue, castType));
+	@Test
+	void testAbs() {
+		for (final DataType type : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+			final Value defaultValue = defaultValue(type);
+			if (type instanceof AnyMagnitudeType) {
+				assertEquals(defaultValue, abs(defaultValue));
 			} else {
-				assertThrows(ClassCastException.class, () -> castValue(defaultValue, castType));
+				assertThrows(UnsupportedOperationException.class, () -> abs(defaultValue));
 			}
 		}
-		case final AnyMagnitudeType unused -> {
-			if (castType instanceof AnyMagnitudeType
-					|| (castType instanceof AnyBitType && !(castType instanceof BoolType))) {
-				assertEquals(defaultCastValue, castValue(defaultValue, castType));
+	}
+
+	@Test
+	void testNegate() {
+		for (final DataType type : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+			final Value defaultValue = defaultValue(type);
+			if (type instanceof AnyMagnitudeType) {
+				assertEquals(defaultValue, negate(defaultValue));
 			} else {
-				assertThrows(ClassCastException.class, () -> castValue(defaultValue, castType));
+				assertThrows(UnsupportedOperationException.class, () -> negate(defaultValue));
 			}
 		}
-		case final AnyBitType unused -> {
-			if (castType instanceof AnyNumType || castType instanceof AnyBitType) {
-				assertEquals(defaultCastValue, castValue(defaultValue, castType));
+	}
+
+	@Test
+	void testBitwiseNot() {
+		for (final DataType type : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+			final Value defaultValue = defaultValue(type);
+			if (type instanceof AnyBitType) {
+				assertNotEquals(defaultValue, bitwiseNot(defaultValue));
 			} else {
-				assertThrows(ClassCastException.class, () -> castValue(defaultValue, castType));
+				assertThrows(UnsupportedOperationException.class, () -> bitwiseNot(defaultValue));
 			}
 		}
-		case final AnyCharType unused -> {
-			if (castType instanceof AnyCharType) {
-				assertEquals(defaultCastValue, castValue(defaultValue, castType));
-			} else if (castType instanceof AnyStringType) {
-				assertEquals(wrapValue(" ", castType), castValue(defaultValue, castType));
+	}
+
+	@Test
+	void testReverseBytes() {
+		for (final DataType type : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+			final Value defaultValue = defaultValue(type);
+			assertEquals(defaultValue, reverseBytes(defaultValue));
+		}
+	}
+
+	@Test
+	void testAdd() {
+		for (final DataType type : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+			final Value defaultValue = defaultValue(type);
+			if (type instanceof AnyMagnitudeType) {
+				assertEquals(defaultValue, add(defaultValue, defaultValue));
+			} else if (type instanceof TimeOfDayType || type instanceof LtodType || type instanceof DateAndTimeType
+					|| type instanceof LdtType) {
+				assertEquals(defaultValue, add(defaultValue, TimeValue.DEFAULT));
 			} else {
-				assertThrows(ClassCastException.class, () -> castValue(defaultValue, castType));
+				assertThrows(UnsupportedOperationException.class, () -> add(defaultValue, defaultValue));
 			}
 		}
-		case final AnyStringType unused -> {
-			if (castType instanceof AnyStringType) {
-				assertEquals(defaultCastValue, castValue(defaultValue, castType));
-			} else if ((castType instanceof AnyCharType)) {
-				assertEquals(wrapValue("\u0000", castType), castValue(defaultValue, castType));
+	}
+
+	@Test
+	void testSubtract() {
+		for (final DataType type : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+			final Value defaultValue = defaultValue(type);
+			if (type instanceof AnyMagnitudeType) {
+				assertEquals(defaultValue, subtract(defaultValue, defaultValue));
+			} else if (type instanceof TimeOfDayType || type instanceof DateAndTimeType) {
+				assertEquals(defaultValue, subtract(defaultValue, TimeValue.DEFAULT));
+				assertEquals(TimeValue.DEFAULT, subtract(defaultValue, defaultValue));
+			} else if (type instanceof LtodType || type instanceof LdtType) {
+				assertEquals(defaultValue, subtract(defaultValue, TimeValue.DEFAULT));
+				assertEquals(LTimeValue.DEFAULT, subtract(defaultValue, defaultValue));
+			} else if (type instanceof DateType) {
+				assertEquals(TimeValue.DEFAULT, subtract(defaultValue, defaultValue));
+			} else if (type instanceof LdateType) {
+				assertEquals(LTimeValue.DEFAULT, subtract(defaultValue, defaultValue));
 			} else {
-				assertThrows(ClassCastException.class, () -> castValue(defaultValue, castType));
+				assertThrows(UnsupportedOperationException.class, () -> subtract(defaultValue, defaultValue));
 			}
 		}
-		case final AnyDateType unused -> {
-			if (castType instanceof AnyDateType) {
-				assertEquals(defaultCastValue, castValue(defaultValue, castType));
+	}
+
+	@Test
+	void testMultiply() {
+		for (final DataType type : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+			final Value defaultValue = defaultValue(type);
+			if (type instanceof AnyMagnitudeType) {
+				assertEquals(defaultValue, multiply(defaultValue, defaultValue));
 			} else {
-				assertThrows(ClassCastException.class, () -> castValue(defaultValue, castType));
+				assertThrows(UnsupportedOperationException.class, () -> multiply(defaultValue, defaultValue));
 			}
 		}
-		default -> assertThrows(UnsupportedOperationException.class, () -> castValue(defaultValue, castType));
-		}
-		assertNull(castValue(null, castType));
 	}
 
-	@ParameterizedTest(name = "{index}: {0} as {1}")
-	@MethodSource("typeArgumentsElementaryAndGenericsCartesianProvider")
-	void testCastValueWithGenerics(final String typeName, final String castTypeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		final DataType castType = ValueOperationsTest.getTypeByName(castTypeName);
-		final Value defaultValue = defaultValue(type);
-		if (castType.isAssignableFrom(type)) {
-			assertTrue(castType.isAssignableFrom((DataType) castValue(defaultValue, castType).getType()));
-		} else {
-			assertThrows(ClassCastException.class, () -> castValue(defaultValue, castType));
-		}
-		assertNull(castValue(null, castType));
-	}
-
-	@ParameterizedTest(name = "{index}: {0}")
-	@MethodSource("typeArgumentsWithGenericsProvider")
-	void testWrapValue(final String typeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		final Value defaultValue = defaultValue(type);
-		if (type instanceof AnyCharType) {
-			assertEquals(defaultValue, wrapValue("\u0000", type));
-		} else if (type instanceof AnyCharsType) {
-			assertEquals(defaultValue, wrapValue("", type));
-		} else if (type instanceof StructuredType) {
-			assertEquals(defaultValue, wrapValue(Map.of(), type));
-		} else {
-			assertEquals(defaultValue, wrapValue(Integer.valueOf(0), type));
+	@Test
+	void testMultiplyTime() {
+		for (final DataType type : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+			final Value defaultValue = defaultValue(type);
+			if (type instanceof AnyNumType) {
+				assertEquals(TimeValue.DEFAULT, multiply(TimeValue.DEFAULT, defaultValue));
+				assertEquals(LTimeValue.DEFAULT, multiply(LTimeValue.DEFAULT, defaultValue));
+			}
 		}
 	}
 
-	@ParameterizedTest(name = "{index}: {0}")
-	@MethodSource("typeArgumentsProvider")
-	void testParseValue(final String typeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		final Value defaultValue = defaultValue(type);
-		switch (type) {
-		case final AnyNumType unused -> assertEquals(defaultValue, parseValue("0", type));
-		case final AnyBitType unused -> assertEquals(defaultValue, parseValue("0", type));
-		case final TimeType unused -> assertEquals(defaultValue, parseValue("T#0s", type));
-		case final LtimeType unused -> assertEquals(defaultValue, parseValue("LT#0s", type));
-		case final AnyCharsType unused -> assertEquals(defaultValue, parseValue("", type));
-		case final DateType unused -> assertEquals(defaultValue, parseValue("D#1970-01-01", type));
-		case final LdateType unused -> assertEquals(defaultValue, parseValue("LD#1970-01-01", type));
-		case final TimeOfDayType unused -> assertEquals(defaultValue, parseValue("TOD#00:00:00", type));
-		case final LtodType unused -> assertEquals(defaultValue, parseValue("LTOD#00:00:00", type));
-		case final DateAndTimeType unused -> assertEquals(defaultValue, parseValue("DT#1970-01-01-00:00:00", type));
-		case final LdtType unused -> assertEquals(defaultValue, parseValue("LDT#1970-01-01-00:00:00", type));
-		default -> assertThrows(UnsupportedOperationException.class, () -> parseValue("0", type));
+	@Test
+	void testDivide() {
+		for (final DataType type : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+			final Value defaultValue = defaultValue(type);
+			if (type instanceof AnyRealType) {
+				assertNotEquals(defaultValue, divideBy(defaultValue, defaultValue));
+			} else if (type instanceof AnyIntType || type instanceof AnyDurationType) {
+				assertEquals(defaultValue, divideBy(defaultValue, wrapValue(Integer.valueOf(1), type)));
+				assertThrows(ArithmeticException.class, () -> divideBy(defaultValue, defaultValue));
+			} else {
+				assertThrows(UnsupportedOperationException.class, () -> divideBy(defaultValue, defaultValue));
+			}
 		}
 	}
 
-	@ParameterizedTest(name = "{index}: {0}")
-	@MethodSource("typeArgumentsWithGenericsProvider")
-	void testResultType(final String typeName) {
-		final DataType type = ValueOperationsTest.getTypeByName(typeName);
-		assertEquals(type, resultType(type, type));
+	@Test
+	void testDivideTime() {
+		for (final DataType type : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+			final Value defaultValue = defaultValue(type);
+			if (type instanceof AnyNumType) {
+				assertEquals(TimeValue.DEFAULT, divideBy(TimeValue.DEFAULT, wrapValue(Integer.valueOf(1), type)));
+				assertEquals(LTimeValue.DEFAULT, divideBy(LTimeValue.DEFAULT, wrapValue(Integer.valueOf(1), type)));
+				assertThrows(ArithmeticException.class, () -> divideBy(TimeValue.DEFAULT, defaultValue));
+				assertThrows(ArithmeticException.class, () -> divideBy(TimeValue.DEFAULT, defaultValue));
+			}
+		}
 	}
 
-	static DataType getTypeByName(final String typeName) {
-		return Stream.of(ElementaryTypes.getAllElementaryType(), GenericTypes.getAllGenericTypes())
-				.flatMap(Collection::stream).filter(type -> typeName.equals(type.getName())).findFirst().orElseThrow();
+	@Test
+	void testRemainder() {
+		for (final DataType type : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+			final Value defaultValue = defaultValue(type);
+			if (type instanceof AnyIntType) {
+				assertEquals(defaultValue, remainderBy(defaultValue, wrapValue(Integer.valueOf(1), type)));
+				assertEquals(defaultValue, ValueOperations.remainderBy(defaultValue, defaultValue));
+			} else {
+				assertThrows(UnsupportedOperationException.class, () -> remainderBy(defaultValue, defaultValue));
+			}
+		}
 	}
 
-	static Stream<String> typeArgumentsProvider() {
-		return DataTypeLibrary.getNonUserDefinedDataTypes().stream().map(DataType::getName);
+	@Test
+	void testPower() {
+		for (final DataType type : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+			final Value defaultValue = defaultValue(type);
+			if (type instanceof AnyRealType) {
+				assertEquals(wrapValue(Integer.valueOf(1), type), power(defaultValue, defaultValue));
+			} else {
+				assertThrows(UnsupportedOperationException.class, () -> power(defaultValue, defaultValue));
+			}
+		}
 	}
 
-	static Stream<String> typeArgumentsGenericProvider() {
-		return GenericTypes.getAllGenericTypes().stream().map(DataType::getName);
+	@Test
+	void testAnd() {
+		for (final DataType type : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+			final Value defaultValue = defaultValue(type);
+			if (type instanceof AnyBitType) {
+				assertEquals(defaultValue, bitwiseAnd(defaultValue, defaultValue));
+			} else {
+				assertThrows(UnsupportedOperationException.class, () -> bitwiseAnd(defaultValue, defaultValue));
+			}
+		}
 	}
 
-	static Stream<String> typeArgumentsWithGenericsProvider() {
-		return Stream.concat(typeArgumentsProvider(), typeArgumentsGenericProvider());
+	@Test
+	void testOr() {
+		for (final DataType type : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+			final Value defaultValue = defaultValue(type);
+			if (type instanceof AnyBitType) {
+				assertEquals(defaultValue, bitwiseOr(defaultValue, defaultValue));
+			} else {
+				assertThrows(UnsupportedOperationException.class, () -> bitwiseOr(defaultValue, defaultValue));
+			}
+		}
 	}
 
-	static Stream<Arguments> typeArgumentsCartesianProvider() {
-		return typeArgumentsProvider()
-				.flatMap(first -> typeArgumentsProvider().map(second -> Arguments.arguments(first, second)));
+	@Test
+	void testXor() {
+		for (final DataType type : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+			final Value defaultValue = defaultValue(type);
+			if (type instanceof AnyBitType) {
+				assertEquals(defaultValue, bitwiseXor(defaultValue, defaultValue));
+			} else {
+				assertThrows(UnsupportedOperationException.class, () -> bitwiseXor(defaultValue, defaultValue));
+			}
+		}
 	}
 
-	static Stream<Arguments> typeArgumentsElementaryAndGenericsCartesianProvider() {
-		return typeArgumentsProvider()
-				.flatMap(first -> typeArgumentsGenericProvider().map(second -> Arguments.arguments(first, second)));
+	@Test
+	void testEquals() {
+		for (final DataType type : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+			final Value defaultValue = defaultValue(type);
+			assertEquals(Boolean.valueOf(true), Boolean.valueOf(ValueOperations.equals(defaultValue, defaultValue)));
+		}
+	}
+
+	@Test
+	void testLessThan() {
+		for (final DataType type : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+			final Value defaultValue = defaultValue(type);
+			assertFalse(lessThan(defaultValue, defaultValue));
+		}
+	}
+
+	@Test
+	void testLessEquals() {
+		for (final DataType type : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+			final Value defaultValue = defaultValue(type);
+			assertTrue(lessEquals(defaultValue, defaultValue));
+		}
+	}
+
+	@Test
+	void testGreaterThan() {
+		for (final DataType type : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+			final Value defaultValue = defaultValue(type);
+			assertFalse(greaterThan(defaultValue, defaultValue));
+		}
+	}
+
+	@Test
+	void testGreaterEquals() {
+		for (final DataType type : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+			final Value defaultValue = defaultValue(type);
+			assertTrue(greaterEquals(defaultValue, defaultValue));
+		}
+	}
+
+	@Test
+	void testCompareTo() {
+		for (final DataType type : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+			final Value defaultValue = defaultValue(type);
+			assertEquals(0, compareTo(defaultValue, defaultValue));
+		}
+	}
+
+	@Test
+	void testPartial() {
+		for (final DataType type : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+			for (final DataType partialType : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+				final Value defaultValue = defaultValue(type);
+				final Value defaultPartialValue = defaultValue(partialType);
+				if (type instanceof final AnyBitType bitType && partialType instanceof final AnyBitType partialBitType
+						&& type != partialType && type.isAssignableFrom(partialType)) {
+					IntStream.range(0, bitType.getBitSize() / partialBitType.getBitSize()).forEach(index -> {
+						assertEquals(defaultValue(partialType),
+								ValueOperations.partial(defaultValue, partialType, index));
+						assertEquals(
+								wrapValue(Integer.valueOf((0xffffffff >>> (32 - partialBitType.getBitSize()))),
+										partialType),
+								partial(wrapValue(Long.valueOf(0xffffffffffffffffL), type), partialType, index));
+						assertEquals(defaultValue,
+								partial(defaultValue, partialType, index, defaultValue(partialType)));
+						assertEquals(wrapValue(Long.valueOf((0x1L << (index * partialBitType.getBitSize()))), type),
+								partial(defaultValue, partialType, index, wrapValue(Integer.valueOf(1), partialType)));
+
+					});
+				} else {
+					assertThrows(UnsupportedOperationException.class, () -> partial(defaultValue, partialType, 0));
+					assertThrows(UnsupportedOperationException.class,
+							() -> partial(defaultValue, partialType, 0, defaultPartialValue));
+				}
+			}
+		}
+	}
+
+	@Test
+	void testCastValue() {
+		for (final DataType type : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+			for (final DataType castType : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+				final Value defaultValue = defaultValue(type);
+				final Value defaultCastValue = defaultValue(castType);
+				switch (type) {
+				case final BoolType unused -> {
+					if (castType instanceof AnyBitType) {
+						assertEquals(defaultCastValue, castValue(defaultValue, castType));
+					} else {
+						assertThrows(ClassCastException.class, () -> castValue(defaultValue, castType));
+					}
+				}
+				case final AnyMagnitudeType unused -> {
+					if (castType instanceof AnyMagnitudeType
+							|| (castType instanceof AnyBitType && !(castType instanceof BoolType))) {
+						assertEquals(defaultCastValue, castValue(defaultValue, castType));
+					} else {
+						assertThrows(ClassCastException.class, () -> castValue(defaultValue, castType));
+					}
+				}
+				case final AnyBitType unused -> {
+					if (castType instanceof AnyNumType || castType instanceof AnyBitType) {
+						assertEquals(defaultCastValue, castValue(defaultValue, castType));
+					} else {
+						assertThrows(ClassCastException.class, () -> castValue(defaultValue, castType));
+					}
+				}
+				case final AnyCharType unused -> {
+					if (castType instanceof AnyCharType) {
+						assertEquals(defaultCastValue, castValue(defaultValue, castType));
+					} else if (castType instanceof AnyStringType) {
+						assertEquals(wrapValue(" ", castType), castValue(defaultValue, castType));
+					} else {
+						assertThrows(ClassCastException.class, () -> castValue(defaultValue, castType));
+					}
+				}
+				case final AnyStringType unused -> {
+					if (castType instanceof AnyStringType) {
+						assertEquals(defaultCastValue, castValue(defaultValue, castType));
+					} else if ((castType instanceof AnyCharType)) {
+						assertEquals(wrapValue("\u0000", castType), castValue(defaultValue, castType));
+					} else {
+						assertThrows(ClassCastException.class, () -> castValue(defaultValue, castType));
+					}
+				}
+				case final AnyDateType unused -> {
+					if (castType instanceof AnyDateType) {
+						assertEquals(defaultCastValue, castValue(defaultValue, castType));
+					} else {
+						assertThrows(ClassCastException.class, () -> castValue(defaultValue, castType));
+					}
+				}
+				default -> assertThrows(UnsupportedOperationException.class, () -> castValue(defaultValue, castType));
+				}
+				assertNull(castValue(null, castType));
+			}
+		}
+	}
+
+	@Test
+	void testCastValueWithGenerics() {
+		for (final DataType type : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+			for (final DataType castType : GenericTypes.getAllGenericTypes()) {
+				final Value defaultValue = defaultValue(type);
+				if (castType.isAssignableFrom(type)) {
+					assertTrue(castType.isAssignableFrom((DataType) castValue(defaultValue, castType).getType()));
+				} else {
+					assertThrows(ClassCastException.class, () -> castValue(defaultValue, castType));
+				}
+				assertNull(castValue(null, castType));
+			}
+		}
+	}
+
+	@Test
+	void testWrapValue() {
+		for (final DataType type : typesWithGenerics()) {
+			final Value defaultValue = defaultValue(type);
+			if (type instanceof AnyCharType) {
+				assertEquals(defaultValue, wrapValue("\u0000", type));
+			} else if (type instanceof AnyCharsType) {
+				assertEquals(defaultValue, wrapValue("", type));
+			} else if (type instanceof StructuredType) {
+				assertEquals(defaultValue, wrapValue(Map.of(), type));
+			} else {
+				assertEquals(defaultValue, wrapValue(Integer.valueOf(0), type));
+			}
+		}
+	}
+
+	@Test
+	void testParseValue() {
+		for (final DataType type : DataTypeLibrary.getNonUserDefinedDataTypes()) {
+			final Value defaultValue = defaultValue(type);
+			switch (type) {
+			case final AnyNumType unused -> assertEquals(defaultValue, parseValue("0", type));
+			case final AnyBitType unused -> assertEquals(defaultValue, parseValue("0", type));
+			case final TimeType unused -> assertEquals(defaultValue, parseValue("T#0s", type));
+			case final LtimeType unused -> assertEquals(defaultValue, parseValue("LT#0s", type));
+			case final AnyCharsType unused -> assertEquals(defaultValue, parseValue("", type));
+			case final DateType unused -> assertEquals(defaultValue, parseValue("D#1970-01-01", type));
+			case final LdateType unused -> assertEquals(defaultValue, parseValue("LD#1970-01-01", type));
+			case final TimeOfDayType unused -> assertEquals(defaultValue, parseValue("TOD#00:00:00", type));
+			case final LtodType unused -> assertEquals(defaultValue, parseValue("LTOD#00:00:00", type));
+			case final DateAndTimeType unused -> assertEquals(defaultValue, parseValue("DT#1970-01-01-00:00:00", type));
+			case final LdtType unused -> assertEquals(defaultValue, parseValue("LDT#1970-01-01-00:00:00", type));
+			default -> assertThrows(UnsupportedOperationException.class, () -> parseValue("0", type));
+			}
+		}
+	}
+
+	@Test
+	void testResultType() {
+		for (final DataType type : typesWithGenerics()) {
+			assertEquals(type, resultType(type, type));
+		}
+	}
+
+	static Iterable<DataType> typesWithGenerics() {
+		return Stream.concat(DataTypeLibrary.getNonUserDefinedDataTypes().stream(),
+				GenericTypes.getAllGenericTypes().stream()).toList();
 	}
 }

--- a/tests/org.eclipse.fordiac.ide.test.model.eval/src/org/eclipse/fordiac/ide/test/model/eval/value/ValueTest.xtend
+++ b/tests/org.eclipse.fordiac.ide.test.model.eval/src/org/eclipse/fordiac/ide/test/model/eval/value/ValueTest.xtend
@@ -13,7 +13,6 @@
 package org.eclipse.fordiac.ide.test.model.eval.value
 
 import java.time.LocalDate
-import java.util.stream.Stream
 import org.eclipse.fordiac.ide.globalconstantseditor.GlobalConstantsStandaloneSetup
 import org.eclipse.fordiac.ide.model.data.AnyCharType
 import org.eclipse.fordiac.ide.model.data.AnyStringType
@@ -27,8 +26,6 @@ import org.eclipse.fordiac.ide.structuredtextalgorithm.STAlgorithmStandaloneSetu
 import org.eclipse.fordiac.ide.structuredtextfunctioneditor.STFunctionStandaloneSetup
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.MethodSource
 
 import static org.eclipse.fordiac.ide.model.eval.variable.ArrayVariable.*
 
@@ -45,47 +42,47 @@ class ValueTest {
 		StructuredTextEvaluatorFactory.register
 	}
 
-	@ParameterizedTest(name="{index}: {0}")
-	@MethodSource("typeArgumentsProvider")
-	def void testValueEquals(String typeName) {
-		val type = ElementaryTypes.getTypeByName(typeName)
-		assertTrue(type.defaultValue.equals(type.defaultValue))
-		assertFalse(type.defaultValue.equals(null))
-		switch (type) {
-			AnyCharType,
-			AnyStringType: assertFalse(type.defaultValue.equals("a".wrapValue(type)))
-			default: assertFalse(type.defaultValue.equals(1.wrapValue(type)))
-		}
+	@Test
+	def void testValueEquals() {
+		DataTypeLibrary.nonUserDefinedDataTypes.forEach [ type |
+			assertTrue(type.defaultValue.equals(type.defaultValue))
+			assertFalse(type.defaultValue.equals(null))
+			switch (type) {
+				AnyCharType,
+				AnyStringType: assertFalse(type.defaultValue.equals("a".wrapValue(type)))
+				default: assertFalse(type.defaultValue.equals(1.wrapValue(type)))
+			}
+		]
 	}
 
-	@ParameterizedTest(name="{index}: {0}")
-	@MethodSource("typeArgumentsProvider")
-	def void testValueHashCode(String typeName) {
-		val type = ElementaryTypes.getTypeByName(typeName)
-		type.defaultValue.hashCode.assertEquals(type.defaultValue.hashCode)
-		switch (type) {
-			AnyCharType,
-			AnyStringType: type.defaultValue.hashCode.assertNotEquals("a".wrapValue(type).hashCode)
-			default: type.defaultValue.hashCode.assertNotEquals(1.wrapValue(type).hashCode)
-		}
+	@Test
+	def void testValueHashCode() {
+		DataTypeLibrary.nonUserDefinedDataTypes.forEach [ type |
+			type.defaultValue.hashCode.assertEquals(type.defaultValue.hashCode)
+			switch (type) {
+				AnyCharType,
+				AnyStringType: type.defaultValue.hashCode.assertNotEquals("a".wrapValue(type).hashCode)
+				default: type.defaultValue.hashCode.assertNotEquals(1.wrapValue(type).hashCode)
+			}
+		]
 	}
 
-	@ParameterizedTest(name="{index}: {0}")
-	@MethodSource("typeArgumentsProvider")
-	def void testValueStringConversion(String typeName) {
-		val type = ElementaryTypes.getTypeByName(typeName)
-		type.defaultValue.assertEquals(type.defaultValue.toString.parseValue(type))
-		switch (type) {
-			AnyCharType,
-			AnyStringType:
-				"a".wrapValue(type).assertEquals("a".wrapValue(type).toString.parseValue(type))
-			DateType,
-			LdateType:
-				LocalDate.of(1970, 01, 02).wrapValue(type).assertEquals(
-					LocalDate.of(1970, 01, 02).wrapValue(type).toString.parseValue(type))
-			default:
-				1.wrapValue(type).assertEquals(1.wrapValue(type).toString.parseValue(type))
-		}
+	@Test
+	def void testValueStringConversion() {
+		DataTypeLibrary.nonUserDefinedDataTypes.forEach [ type |
+			type.defaultValue.assertEquals(type.defaultValue.toString.parseValue(type))
+			switch (type) {
+				AnyCharType,
+				AnyStringType:
+					"a".wrapValue(type).assertEquals("a".wrapValue(type).toString.parseValue(type))
+				DateType,
+				LdateType:
+					LocalDate.of(1970, 01, 02).wrapValue(type).assertEquals(
+						LocalDate.of(1970, 01, 02).wrapValue(type).toString.parseValue(type))
+				default:
+					1.wrapValue(type).assertEquals(1.wrapValue(type).toString.parseValue(type))
+			}
+		]
 	}
 
 	@Test
@@ -103,9 +100,5 @@ class ValueTest {
 		assertIterableEquals((0 .. 255).map[1.toDIntValue], largeArray.value)
 		largeDistinctArray.value = "[17(4)]"
 		assertIterableEquals((0 .. 255).map[(it < 17 ? 4 : 0).toDIntValue], largeDistinctArray.value)
-	}
-
-	def static Stream<String> typeArgumentsProvider() {
-		DataTypeLibrary.nonUserDefinedDataTypes.stream.map[name]
 	}
 }


### PR DESCRIPTION
There are several trivial parameterized tests that produce significant output during builds. This combines those tests into a non-parameterized version to reduce build output and improve build times.