### PR TITLE
Avoid editor reload when type is first loaded

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.bulkeditor/src/org/eclipse/fordiac/ide/bulkeditor/editors/BulkEditorTypeEntryAdapter.java
+++ b/plugins/org.eclipse.fordiac.ide.bulkeditor/src/org/eclipse/fordiac/ide/bulkeditor/editors/BulkEditorTypeEntryAdapter.java
@@ -40,7 +40,10 @@ public class BulkEditorTypeEntryAdapter extends AbstractTypeEntryAdapter {
 			feature = string;
 		}
 
-		if (feature.equals(TypeEntry.TYPE_ENTRY_TYPE_FEATURE)) {
+		// make sure type was reloaded and not just loaded
+		if ((feature.equals(TypeEntry.TYPE_ENTRY_TYPE_FEATURE)
+				|| feature.equals(TypeEntry.TYPE_ENTRY_TYPE_EDITABLE_FEATURE))
+				&& (notification.getOldValue() != null)) {
 			if (notification.getNotifier() instanceof final TypeEntry tEntry) {
 				changedFiles.add(tEntry.getFile().getFullPath().toOSString());
 			}

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/TypeEntryAdapter.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/TypeEntryAdapter.java
@@ -80,7 +80,13 @@ public class TypeEntryAdapter extends AbstractTypeEntryAdapter {
 		}
 
 		switch (feature) {
-		case TypeEntry.TYPE_ENTRY_FILE_CONTENT_FEATURE, TypeEntry.TYPE_ENTRY_TYPE_FEATURE:
+		case TypeEntry.TYPE_ENTRY_TYPE_FEATURE, TypeEntry.TYPE_ENTRY_TYPE_EDITABLE_FEATURE:
+			// make sure type was reloaded and not just loaded
+			if (notification.getOldValue() != null) {
+				handleFileContentChange();
+			}
+			break;
+		case TypeEntry.TYPE_ENTRY_FILE_CONTENT_FEATURE:
 			handleFileContentChange();
 			break;
 		case TypeEntry.TYPE_ENTRY_FILE_FEATURE:

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
@@ -428,6 +428,7 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 	@Override
 	public void notifyChanged(final Notification notification) {
 		if ((notification.getFeature() == TypeEntry.TYPE_ENTRY_TYPE_FEATURE
+				|| notification.getFeature() == TypeEntry.TYPE_ENTRY_TYPE_EDITABLE_FEATURE
 				|| notification.getFeature() == TypeEntry.TYPE_ENTRY_TYPE_LIBRARY_FEATURE)
 				&& dependencies.get().contains(notification.getNotifier())) {
 


### PR DESCRIPTION
The type entry no longer has to load the type to provide the type editable for an open editor. This means when the type is later loaded, it could trigger a false reload in the editor. This changes the type entry adapter to check if the type was actually reloaded.