### PR TITLE
Refactoring unused imports

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/src/org/eclipse/fordiac/ide/globalconstantseditor/ui/GlobalConstantsUiModule.java
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/src/org/eclipse/fordiac/ide/globalconstantseditor/ui/GlobalConstantsUiModule.java
@@ -44,6 +44,7 @@ import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRefactori
 import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreReferenceUpdater;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRegionDiffFormatter;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRelatedEmfResourceUpdater;
+import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRelatedResourcesProvider;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRelatedXtextResourceUpdater;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRenameElementProcessor;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRenameNameValidator;
@@ -72,6 +73,7 @@ import org.eclipse.xtext.ide.serializer.impl.RecordingXtextResourceUpdater;
 import org.eclipse.xtext.ide.serializer.impl.ReferenceUpdater;
 import org.eclipse.xtext.ide.serializer.impl.RegionDiffFormatter;
 import org.eclipse.xtext.ide.serializer.impl.RelatedEmfResourceUpdater;
+import org.eclipse.xtext.ide.serializer.impl.RelatedResourcesProvider;
 import org.eclipse.xtext.ide.serializer.impl.RelatedXtextResourceUpdater;
 import org.eclipse.xtext.ide.serializer.impl.ResourceLifecycleManager;
 import org.eclipse.xtext.resource.containers.IAllContainersState;
@@ -291,6 +293,10 @@ public class GlobalConstantsUiModule extends AbstractGlobalConstantsUiModule {
 
 	public Class<? extends ResourceLifecycleManager> bindResourceLifecycleManager() {
 		return STCoreResourceLifecycleManager.class;
+	}
+
+	public Class<? extends RelatedResourcesProvider> bindRelatedResourcesProvider() {
+		return STCoreRelatedResourcesProvider.class;
 	}
 
 	public Class<? extends PartialSerializer> bindPartialSerializer() {

--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor/src/org/eclipse/fordiac/ide/globalconstantseditor/GlobalConstantsRuntimeModule.java
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor/src/org/eclipse/fordiac/ide/globalconstantseditor/GlobalConstantsRuntimeModule.java
@@ -22,6 +22,7 @@ import org.eclipse.fordiac.ide.structuredtextcore.documentation.STCoreCommentDoc
 import org.eclipse.fordiac.ide.structuredtextcore.naming.STCoreQualifiedNameConverter;
 import org.eclipse.fordiac.ide.structuredtextcore.naming.STCoreQualifiedNameProvider;
 import org.eclipse.fordiac.ide.structuredtextcore.parsetree.reconstr.STCoreCommentAssociater;
+import org.eclipse.fordiac.ide.structuredtextcore.resource.STCoreResourceDescriptionManager;
 import org.eclipse.fordiac.ide.structuredtextcore.resource.STCoreResourceDescriptionStrategy;
 import org.eclipse.fordiac.ide.structuredtextcore.resource.TypeLibraryAllContainersState;
 import org.eclipse.fordiac.ide.structuredtextcore.resource.TypeLibraryResourceDescriptions;
@@ -39,6 +40,7 @@ import org.eclipse.xtext.naming.IQualifiedNameConverter;
 import org.eclipse.xtext.naming.IQualifiedNameProvider;
 import org.eclipse.xtext.parsetree.reconstr.ICommentAssociater;
 import org.eclipse.xtext.resource.IDefaultResourceDescriptionStrategy;
+import org.eclipse.xtext.resource.IResourceDescription;
 import org.eclipse.xtext.resource.IResourceDescriptions;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.resource.containers.IAllContainersState;
@@ -94,6 +96,10 @@ public class GlobalConstantsRuntimeModule extends AbstractGlobalConstantsRuntime
 
 	public Class<? extends IDefaultResourceDescriptionStrategy> bindIDefaultResourceDescriptionStrategy() {
 		return STCoreResourceDescriptionStrategy.class;
+	}
+
+	public Class<? extends IResourceDescription.Manager> bindIResourceDescription$Manager() {
+		return STCoreResourceDescriptionManager.class;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/STAlgorithmUiModule.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/STAlgorithmUiModule.java
@@ -53,6 +53,7 @@ import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRefactori
 import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreReferenceUpdater;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRegionDiffFormatter;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRelatedEmfResourceUpdater;
+import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRelatedResourcesProvider;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRelatedXtextResourceUpdater;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRenameElementProcessor;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRenameNameValidator;
@@ -81,6 +82,7 @@ import org.eclipse.xtext.ide.serializer.impl.RecordingXtextResourceUpdater;
 import org.eclipse.xtext.ide.serializer.impl.ReferenceUpdater;
 import org.eclipse.xtext.ide.serializer.impl.RegionDiffFormatter;
 import org.eclipse.xtext.ide.serializer.impl.RelatedEmfResourceUpdater;
+import org.eclipse.xtext.ide.serializer.impl.RelatedResourcesProvider;
 import org.eclipse.xtext.ide.serializer.impl.RelatedXtextResourceUpdater;
 import org.eclipse.xtext.ide.serializer.impl.ResourceLifecycleManager;
 import org.eclipse.xtext.resource.IContainer;
@@ -334,6 +336,10 @@ public class STAlgorithmUiModule extends AbstractSTAlgorithmUiModule {
 
 	public Class<? extends ResourceLifecycleManager> bindResourceLifecycleManager() {
 		return STCoreResourceLifecycleManager.class;
+	}
+
+	public Class<? extends RelatedResourcesProvider> bindRelatedResourcesProvider() {
+		return STCoreRelatedResourcesProvider.class;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm/src/org/eclipse/fordiac/ide/structuredtextalgorithm/resource/STAlgorithmResourceDescription.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm/src/org/eclipse/fordiac/ide/structuredtextalgorithm/resource/STAlgorithmResourceDescription.java
@@ -12,76 +12,53 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.structuredtextalgorithm.resource;
 
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
-import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.model.datatype.helper.TypeDeclarationParser;
 import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
+import org.eclipse.fordiac.ide.model.libraryElement.Import;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.TypedConfigureableObject;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.structuredtextalgorithm.util.StructuredTextParseUtil;
+import org.eclipse.fordiac.ide.structuredtextcore.resource.STCoreResourceDescription;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STInitializerExpressionSource;
-import org.eclipse.fordiac.ide.structuredtextcore.stcore.STSource;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STTypeDeclaration;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.util.STCoreUtil;
 import org.eclipse.xtext.EcoreUtil2;
-import org.eclipse.xtext.linking.impl.ImportedNamesAdapter;
 import org.eclipse.xtext.naming.IQualifiedNameConverter;
 import org.eclipse.xtext.naming.QualifiedName;
 import org.eclipse.xtext.resource.IDefaultResourceDescriptionStrategy;
-import org.eclipse.xtext.resource.impl.DefaultResourceDescription;
 import org.eclipse.xtext.util.IResourceScopeCache;
 
-public class STAlgorithmResourceDescription extends DefaultResourceDescription {
-
-	private final IQualifiedNameConverter nameConverter;
-
-	private Iterable<QualifiedName> importedNames;
+public class STAlgorithmResourceDescription extends STCoreResourceDescription {
 
 	public STAlgorithmResourceDescription(final Resource resource, final IDefaultResourceDescriptionStrategy strategy,
 			final IResourceScopeCache cache, final IQualifiedNameConverter nameConverter) {
-		super(resource, strategy, cache);
-		this.nameConverter = nameConverter;
+		super(resource, strategy, cache, nameConverter);
 	}
 
 	@Override
-	public Iterable<QualifiedName> getImportedNames() {
-		if (importedNames == null) {
-			importedNames = computeImportedNames();
+	protected void computeImportedNames(final EObject object, final Set<QualifiedName> result) {
+		switch (object) {
+		case final Attribute attribute -> computeImportedNames(attribute, result);
+		case final VarDeclaration varDeclaration -> computeImportedNames(varDeclaration, result);
+		case final TypedConfigureableObject typedConfigureableObject ->
+			computeImportedNames(typedConfigureableObject, result);
+		case final Import imp -> computeImportedNames(imp, result);
+		default -> {
+			// ignore
 		}
-		return importedNames;
-	}
-
-	protected Set<QualifiedName> computeImportedNames() {
-		final Set<QualifiedName> result = new HashSet<>();
-		final TreeIterator<EObject> allContents = EcoreUtil.getAllContents(getResource(), true);
-		while (allContents.hasNext()) {
-			final EObject target = allContents.next();
-			if (target instanceof STSource) {
-				allContents.prune();
-			} else if (target instanceof final Attribute attribute) {
-				computeImportedNames(attribute, result);
-			} else if (target instanceof final VarDeclaration varDeclaration) {
-				computeImportedNames(varDeclaration, result);
-			} else if (target instanceof final TypedConfigureableObject typedConfigureableObject) {
-				computeImportedNames(typedConfigureableObject, result);
-			}
 		}
-		super.getImportedNames().forEach(result::add);
-		return result;
 	}
 
 	protected void computeImportedNames(final Attribute attr, final Set<QualifiedName> result) {
 		final String fullTypeName = PackageNameHelper.getFullTypeName(attr.getType());
 		if (fullTypeName != null && !fullTypeName.isEmpty()) {
-			result.add(nameConverter.toQualifiedName(fullTypeName).toLowerCase());
+			result.add(getNameConverter().toQualifiedName(fullTypeName).toLowerCase());
 		}
 		if (!STCoreUtil.isSimpleAttributeValue(attr, false)) {
 			final STInitializerExpressionSource source = StructuredTextParseUtil.validate(attr.getValue(), getURI(),
@@ -96,7 +73,7 @@ public class STAlgorithmResourceDescription extends DefaultResourceDescription {
 	protected void computeImportedNames(final VarDeclaration decl, final Set<QualifiedName> result) {
 		final String fullTypeName = PackageNameHelper.getFullTypeName(decl.getType());
 		if (fullTypeName != null && !fullTypeName.isEmpty()) {
-			result.add(nameConverter.toQualifiedName(fullTypeName).toLowerCase());
+			result.add(getNameConverter().toQualifiedName(fullTypeName).toLowerCase());
 		}
 		if ((decl.isArray() && !TypeDeclarationParser.isSimpleTypeDeclaration(decl.getArraySize().getValue()))) {
 			final STTypeDeclaration source = StructuredTextParseUtil.validateType(decl, null);
@@ -117,16 +94,7 @@ public class STAlgorithmResourceDescription extends DefaultResourceDescription {
 	protected void computeImportedNames(final TypedConfigureableObject element, final Set<QualifiedName> result) {
 		final String fullTypeName = element.getFullTypeName();
 		if (fullTypeName != null && !fullTypeName.isEmpty()) {
-			result.add(nameConverter.toQualifiedName(fullTypeName).toLowerCase());
+			result.add(getNameConverter().toQualifiedName(fullTypeName).toLowerCase());
 		}
-	}
-
-	protected static Set<QualifiedName> getImportedNames(final Resource resource) {
-		EcoreUtil.resolveAll(resource);
-		final ImportedNamesAdapter adapter = ImportedNamesAdapter.find(resource);
-		if (adapter != null) {
-			return adapter.getImportedNames();
-		}
-		return Collections.emptySet();
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/STCoreUiModule.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/STCoreUiModule.java
@@ -43,6 +43,7 @@ import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRefactori
 import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreReferenceUpdater;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRegionDiffFormatter;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRelatedEmfResourceUpdater;
+import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRelatedResourcesProvider;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRelatedXtextResourceUpdater;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRenameElementProcessor;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRenameNameValidator;
@@ -72,6 +73,7 @@ import org.eclipse.xtext.ide.serializer.impl.RecordingXtextResourceUpdater;
 import org.eclipse.xtext.ide.serializer.impl.ReferenceUpdater;
 import org.eclipse.xtext.ide.serializer.impl.RegionDiffFormatter;
 import org.eclipse.xtext.ide.serializer.impl.RelatedEmfResourceUpdater;
+import org.eclipse.xtext.ide.serializer.impl.RelatedResourcesProvider;
 import org.eclipse.xtext.ide.serializer.impl.RelatedXtextResourceUpdater;
 import org.eclipse.xtext.ide.serializer.impl.ResourceLifecycleManager;
 import org.eclipse.xtext.resource.containers.IAllContainersState;
@@ -294,6 +296,10 @@ public class STCoreUiModule extends AbstractSTCoreUiModule {
 
 	public Class<? extends ResourceLifecycleManager> bindResourceLifecycleManager() {
 		return STCoreResourceLifecycleManager.class;
+	}
+
+	public Class<? extends RelatedResourcesProvider> bindRelatedResourcesProvider() {
+		return STCoreRelatedResourcesProvider.class;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/STCoreImportUpdater.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/STCoreImportUpdater.java
@@ -13,10 +13,13 @@
 package org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring;
 
 import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.model.helpers.ImportHelper;
+import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.Import;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.resource.LibraryElementXtextResource;
@@ -26,6 +29,7 @@ import org.eclipse.xtext.ide.serializer.hooks.IReferenceUpdaterContext;
 import org.eclipse.xtext.ide.serializer.impl.EObjectDescriptionDeltaProvider.Delta;
 import org.eclipse.xtext.ide.serializer.impl.EObjectDescriptionDeltaProvider.Deltas;
 import org.eclipse.xtext.naming.IQualifiedNameConverter;
+import org.eclipse.xtext.naming.IQualifiedNameProvider;
 import org.eclipse.xtext.naming.QualifiedName;
 import org.eclipse.xtext.resource.IEObjectDescription;
 
@@ -37,28 +41,41 @@ public class STCoreImportUpdater {
 	@Inject
 	private IQualifiedNameConverter nameConverter;
 
+	@Inject
+	private IQualifiedNameProvider nameProvider;
+
 	public void updateImports(final IReferenceUpdaterContext context) {
 		if (context.getResource().getParseResult().getRootASTElement() instanceof final STSource source) {
-			updateImports(context.getEObjectDescriptionDeltas(), source, Import::setImportedNamespace);
+			updateImports(context.getEObjectDescriptionDeltas(), source, STCoreImportUpdater::updateImport);
 		}
 		if (context.getResource() instanceof final LibraryElementXtextResource libResource) {
 			updateImports(context.getEObjectDescriptionDeltas(), libResource.getInternalLibraryElement(),
-					Import::setImportedNamespace);
+					STCoreImportUpdater::updateImport);
 		}
+	}
+
+	protected static void updateImport(final Import imp, final String importedNamespace) {
+		if (importedNamespace == null || importedNamespace.isBlank()) {
+			EcoreUtil.remove(imp);
+		}
+		imp.setImportedNamespace(importedNamespace);
 	}
 
 	public void updateImports(final Deltas deltas, final STSource source,
 			final BiConsumer<? super Import, String> updater) {
+		final QualifiedName packageName = getPackageName(source);
 		source.eContents().stream().filter(STImport.class::isInstance).map(STImport.class::cast)
-				.forEach(imp -> updateImport(deltas, imp, updater));
+				.forEach(imp -> updateImport(deltas, packageName, imp, updater));
 	}
 
 	public void updateImports(final Deltas deltas, final LibraryElement libraryElement,
 			final BiConsumer<? super Import, String> updater) {
-		ImportHelper.getImports(libraryElement).stream().forEach(imp -> updateImport(deltas, imp, updater));
+		final QualifiedName packageName = getPackageName(libraryElement);
+		List.copyOf(ImportHelper.getImports(libraryElement))
+				.forEach(imp -> updateImport(deltas, packageName, imp, updater));
 	}
 
-	protected void updateImport(final Deltas deltas, final Import imp,
+	protected void updateImport(final Deltas deltas, final QualifiedName packageName, final Import imp,
 			final BiConsumer<? super Import, String> updater) {
 		final QualifiedName imported = nameConverter.toQualifiedName(imp.getImportedNamespace());
 		if (isWildcardImport(imported)) {
@@ -67,8 +84,9 @@ public class STCoreImportUpdater {
 		// find matching delta
 		final Optional<Delta> delta = findDelta(deltas, imported);
 		// find longest qualified name and set as imported namespace
-		delta.flatMap(STCoreImportUpdater::findLongestQualifiedName).map(nameConverter::toString)
-				.ifPresent(s -> updater.accept(imp, s));
+		// or remove import
+		updater.accept(imp, delta.flatMap(STCoreImportUpdater::findLongestQualifiedName)
+				.filter(name -> !matchesPackageName(name, packageName)).map(nameConverter::toString).orElse(null));
 	}
 
 	protected static Optional<Delta> findDelta(final Deltas deltas, final QualifiedName imported) {
@@ -82,6 +100,10 @@ public class STCoreImportUpdater {
 				.anyMatch(desc -> desc.getQualifiedName().equals(imported));
 	}
 
+	protected static boolean matchesPackageName(final QualifiedName imported, final QualifiedName packageName) {
+		return imported.skipLast(1).equalsIgnoreCase(packageName);
+	}
+
 	protected static boolean isWildcardImport(final QualifiedName imported) {
 		return ImportHelper.WILDCARD_IMPORT.equals(imported.getLastSegment());
 	}
@@ -89,5 +111,21 @@ public class STCoreImportUpdater {
 	protected static Optional<QualifiedName> findLongestQualifiedName(final Delta delta) {
 		return delta.getDescriptions().stream().map(IEObjectDescription::getQualifiedName)
 				.max(Comparator.comparingInt(QualifiedName::getSegmentCount));
+	}
+
+	protected QualifiedName getPackageName(final STSource source) {
+		final QualifiedName packageName = nameProvider.getFullyQualifiedName(source);
+		if (packageName == null || packageName.isEmpty()) {
+			return QualifiedName.EMPTY;
+		}
+		return packageName.skipLast(1);
+	}
+
+	protected QualifiedName getPackageName(final LibraryElement libraryElement) {
+		final String packageName = PackageNameHelper.getPackageName(libraryElement);
+		if (packageName.isBlank()) {
+			return QualifiedName.EMPTY;
+		}
+		return nameConverter.toQualifiedName(packageName);
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/STCoreReferenceUpdater.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/STCoreReferenceUpdater.java
@@ -12,10 +12,13 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring;
 
+import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRelatedResourcesProvider.STCoreRelatedResource;
 import org.eclipse.xtext.formatting2.regionaccess.ISemanticRegion;
 import org.eclipse.xtext.formatting2.regionaccess.ITextRegionDiffBuilder;
 import org.eclipse.xtext.ide.serializer.hooks.IReferenceUpdaterContext;
 import org.eclipse.xtext.ide.serializer.hooks.IUpdatableReference;
+import org.eclipse.xtext.ide.serializer.impl.EObjectDescriptionDeltaProvider.Delta;
+import org.eclipse.xtext.ide.serializer.impl.EObjectDescriptionDeltaProvider.Deltas;
 import org.eclipse.xtext.ide.serializer.impl.ReferenceUpdater;
 import org.eclipse.xtext.ide.serializer.impl.RelatedResourcesProvider.RelatedResource;
 import org.eclipse.xtext.naming.IQualifiedNameConverter;
@@ -41,9 +44,25 @@ public class STCoreReferenceUpdater extends ReferenceUpdater {
 	private IScopeProvider scopeProvider;
 
 	@Override
-	protected void updateExternalReferences(final IReferenceUpdaterContext context,
-			final RelatedResource relatedResource) {
-		super.updateExternalReferences(context, relatedResource);
+	public boolean isAffected(final Deltas deltas, final RelatedResource resource) {
+		if (resource instanceof final STCoreRelatedResource coreRelatedResource) {
+			final Iterable<QualifiedName> importedNames = coreRelatedResource.getImportedNames();
+			for (final Delta delta : deltas.getDeltas()) {
+				for (final IEObjectDescription desc : delta.getSnapshot().getDescriptions()) {
+					for (final QualifiedName name : importedNames) {
+						if (name.equalsIgnoreCase(desc.getQualifiedName())) {
+							return true;
+						}
+					}
+				}
+			}
+		}
+		return super.isAffected(deltas, resource);
+	}
+
+	@Override
+	public void update(final IReferenceUpdaterContext context) {
+		super.update(context);
 		context.modifyModel(() -> importUpdater.updateImports(context));
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/STCoreRelatedResourcesProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/STCoreRelatedResourcesProvider.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Martin Erich Jobst
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Martin Jobst - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.SequencedSet;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.xtext.ide.serializer.hooks.IEObjectSnapshot;
+import org.eclipse.xtext.ide.serializer.hooks.IResourceSnapshot;
+import org.eclipse.xtext.ide.serializer.impl.RelatedResourcesProvider;
+import org.eclipse.xtext.naming.QualifiedName;
+import org.eclipse.xtext.resource.IEObjectDescription;
+import org.eclipse.xtext.resource.IResourceDescription;
+import org.eclipse.xtext.resource.IResourceDescriptions;
+import org.eclipse.xtext.resource.IResourceDescriptionsProvider;
+
+import com.google.inject.Inject;
+
+@SuppressWarnings("restriction")
+public class STCoreRelatedResourcesProvider extends RelatedResourcesProvider {
+
+	@Inject
+	private IResourceDescriptionsProvider resourceDescriptionsProvider;
+
+	@Override
+	public List<RelatedResource> getRelatedResources(final Collection<IResourceSnapshot> snapshots) {
+		final Map<URI, RelatedResource> result = super.getRelatedResources(snapshots).stream().collect(
+				Collectors.toMap(RelatedResource::getUri, Function.identity(), (a, b) -> a, LinkedHashMap::new));
+		for (final ResourceSet resourceSet : getDistinctResourceSets(snapshots)) {
+			final IResourceDescriptions resourceDescriptions = resourceDescriptionsProvider
+					.getResourceDescriptions(resourceSet);
+			for (final IResourceDescription description : resourceDescriptions.getAllResourceDescriptions()) {
+				if (!result.containsKey(description.getURI()) && containsImportedName(description, snapshots)) {
+					result.put(description.getURI(),
+							new STCoreRelatedResource(description.getURI(), description.getImportedNames()));
+				}
+			}
+		}
+		return result.values().stream().toList();
+	}
+
+	protected static SequencedSet<ResourceSet> getDistinctResourceSets(final Collection<IResourceSnapshot> snapshots) {
+		return snapshots.stream().map(IResourceSnapshot::getResource).map(Resource::getResourceSet)
+				.collect(Collectors.toCollection(LinkedHashSet::new));
+	}
+
+	protected static boolean containsImportedName(final IResourceDescription resourceDescription,
+			final Collection<IResourceSnapshot> snapshots) {
+		final Iterable<QualifiedName> importedNames = resourceDescription.getImportedNames();
+		for (final IResourceSnapshot res : snapshots) {
+			for (final IEObjectSnapshot obj : res.getObjects().values()) {
+				for (final IEObjectDescription desc : obj.getDescriptions()) {
+					for (final QualifiedName name : importedNames) {
+						if (name.equalsIgnoreCase(desc.getQualifiedName())) {
+							return true;
+						}
+					}
+				}
+			}
+		}
+		return false;
+	}
+
+	public class STCoreRelatedResource extends RelatedResource {
+
+		private final Iterable<QualifiedName> importedNames;
+
+		public STCoreRelatedResource(final URI uri, final Iterable<QualifiedName> importedNames) {
+			super(uri);
+			this.importedNames = importedNames;
+		}
+
+		public Iterable<QualifiedName> getImportedNames() {
+			return importedNames;
+		}
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/resource/STCoreResourceDescription.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/resource/STCoreResourceDescription.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Martin Erich Jobst
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Martin Jobst - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.structuredtextcore.resource;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.emf.common.util.TreeIterator;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.fordiac.ide.model.helpers.ImportHelper;
+import org.eclipse.fordiac.ide.model.libraryElement.Import;
+import org.eclipse.xtext.linking.impl.ImportedNamesAdapter;
+import org.eclipse.xtext.naming.IQualifiedNameConverter;
+import org.eclipse.xtext.naming.QualifiedName;
+import org.eclipse.xtext.resource.IDefaultResourceDescriptionStrategy;
+import org.eclipse.xtext.resource.impl.DefaultResourceDescription;
+import org.eclipse.xtext.util.IResourceScopeCache;
+
+public class STCoreResourceDescription extends DefaultResourceDescription {
+	private final IQualifiedNameConverter nameConverter;
+
+	private Iterable<QualifiedName> importedNames;
+
+	public STCoreResourceDescription(final Resource resource, final IDefaultResourceDescriptionStrategy strategy,
+			final IResourceScopeCache cache, final IQualifiedNameConverter nameConverter) {
+		super(resource, strategy, cache);
+		this.nameConverter = nameConverter;
+	}
+
+	@Override
+	public Iterable<QualifiedName> getImportedNames() {
+		if (importedNames == null) {
+			importedNames = computeImportedNames();
+		}
+		return importedNames;
+	}
+
+	protected Set<QualifiedName> computeImportedNames() {
+		final Set<QualifiedName> result = new HashSet<>();
+		final TreeIterator<EObject> allContents = EcoreUtil.getAllContents(getResource(), true);
+		while (allContents.hasNext()) {
+			computeImportedNames(allContents.next(), result);
+		}
+		super.getImportedNames().forEach(result::add);
+		return result;
+	}
+
+	protected void computeImportedNames(final EObject object, final Set<QualifiedName> result) {
+		if (object instanceof final Import imp) {
+			computeImportedNames(imp, result);
+		}
+	}
+
+	protected void computeImportedNames(final Import imp, final Set<QualifiedName> result) {
+		final QualifiedName imported = nameConverter.toQualifiedName(imp.getImportedNamespace());
+		if (!ImportHelper.WILDCARD_IMPORT.equals(imported.getLastSegment())) {
+			result.add(imported.toLowerCase());
+		}
+	}
+
+	protected static Set<QualifiedName> getImportedNames(final Resource resource) {
+		EcoreUtil.resolveAll(resource);
+		final ImportedNamesAdapter adapter = ImportedNamesAdapter.find(resource);
+		if (adapter != null) {
+			return adapter.getImportedNames();
+		}
+		return Collections.emptySet();
+	}
+
+	protected IQualifiedNameConverter getNameConverter() {
+		return nameConverter;
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/resource/STCoreResourceDescriptionManager.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/resource/STCoreResourceDescriptionManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Martin Erich Jobst
+ * Copyright (c) 2025 Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -10,18 +10,28 @@
  * Contributors:
  *   Martin Jobst - initial API and implementation and/or initial documentation
  *******************************************************************************/
-package org.eclipse.fordiac.ide.structuredtextalgorithm.resource;
+package org.eclipse.fordiac.ide.structuredtextcore.resource;
 
 import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.fordiac.ide.structuredtextcore.resource.STCoreResourceDescriptionManager;
+import org.eclipse.xtext.naming.IQualifiedNameConverter;
 import org.eclipse.xtext.resource.IDefaultResourceDescriptionStrategy;
 import org.eclipse.xtext.resource.IResourceDescription;
+import org.eclipse.xtext.resource.impl.DefaultResourceDescriptionManager;
 
-public class STAlgorithmResourceDescriptionManager extends STCoreResourceDescriptionManager {
+import com.google.inject.Inject;
+
+public class STCoreResourceDescriptionManager extends DefaultResourceDescriptionManager {
+
+	@Inject
+	private IQualifiedNameConverter nameConverter;
 
 	@Override
 	protected IResourceDescription internalGetResourceDescription(final Resource resource,
 			final IDefaultResourceDescriptionStrategy strategy) {
-		return new STAlgorithmResourceDescription(resource, strategy, getCache(), getNameConverter());
+		return new STCoreResourceDescription(resource, strategy, getCache(), nameConverter);
+	}
+
+	public IQualifiedNameConverter getNameConverter() {
+		return nameConverter;
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/ui/STFunctionUiModule.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/ui/STFunctionUiModule.java
@@ -45,6 +45,7 @@ import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRefactori
 import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreReferenceUpdater;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRegionDiffFormatter;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRelatedEmfResourceUpdater;
+import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRelatedResourcesProvider;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRelatedXtextResourceUpdater;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRenameElementProcessor;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRenameNameValidator;
@@ -80,6 +81,7 @@ import org.eclipse.xtext.ide.serializer.impl.RecordingXtextResourceUpdater;
 import org.eclipse.xtext.ide.serializer.impl.ReferenceUpdater;
 import org.eclipse.xtext.ide.serializer.impl.RegionDiffFormatter;
 import org.eclipse.xtext.ide.serializer.impl.RelatedEmfResourceUpdater;
+import org.eclipse.xtext.ide.serializer.impl.RelatedResourcesProvider;
 import org.eclipse.xtext.ide.serializer.impl.RelatedXtextResourceUpdater;
 import org.eclipse.xtext.ide.serializer.impl.ResourceLifecycleManager;
 import org.eclipse.xtext.resource.containers.IAllContainersState;
@@ -312,6 +314,10 @@ public class STFunctionUiModule extends AbstractSTFunctionUiModule {
 
 	public Class<? extends ResourceLifecycleManager> bindResourceLifecycleManager() {
 		return STCoreResourceLifecycleManager.class;
+	}
+
+	public Class<? extends RelatedResourcesProvider> bindRelatedResourcesProvider() {
+		return STCoreRelatedResourcesProvider.class;
 	}
 
 	public Class<? extends PartialSerializer> bindPartialSerializer() {

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/STFunctionRuntimeModule.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/STFunctionRuntimeModule.java
@@ -21,6 +21,7 @@ import org.eclipse.fordiac.ide.structuredtextcore.converter.STCoreValueConverter
 import org.eclipse.fordiac.ide.structuredtextcore.documentation.STCoreCommentDocumentationProvider;
 import org.eclipse.fordiac.ide.structuredtextcore.naming.STCoreQualifiedNameConverter;
 import org.eclipse.fordiac.ide.structuredtextcore.parsetree.reconstr.STCoreCommentAssociater;
+import org.eclipse.fordiac.ide.structuredtextcore.resource.STCoreResourceDescriptionManager;
 import org.eclipse.fordiac.ide.structuredtextcore.resource.STCoreResourceDescriptionStrategy;
 import org.eclipse.fordiac.ide.structuredtextcore.resource.TypeLibraryAllContainersState;
 import org.eclipse.fordiac.ide.structuredtextcore.resource.TypeLibraryResourceDescriptions;
@@ -45,6 +46,7 @@ import org.eclipse.xtext.naming.IQualifiedNameConverter;
 import org.eclipse.xtext.naming.IQualifiedNameProvider;
 import org.eclipse.xtext.parsetree.reconstr.ICommentAssociater;
 import org.eclipse.xtext.resource.IDefaultResourceDescriptionStrategy;
+import org.eclipse.xtext.resource.IResourceDescription;
 import org.eclipse.xtext.resource.IResourceDescriptions;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.resource.containers.IAllContainersState;
@@ -99,6 +101,10 @@ public class STFunctionRuntimeModule extends AbstractSTFunctionRuntimeModule {
 
 	public Class<? extends IDefaultResourceDescriptionStrategy> bindIDefaultResourceDescriptionStrategy() {
 		return STCoreResourceDescriptionStrategy.class;
+	}
+
+	public Class<? extends IResourceDescription.Manager> bindIResourceDescription$Manager() {
+		return STCoreResourceDescriptionManager.class;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/ImportChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/ImportChange.java
@@ -19,6 +19,8 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeImportNamespaceCommand;
+import org.eclipse.fordiac.ide.model.commands.delete.DeleteImportCommand;
+import org.eclipse.fordiac.ide.model.libraryElement.CompilerInfo;
 import org.eclipse.fordiac.ide.model.libraryElement.Import;
 import org.eclipse.fordiac.ide.typemanagement.Messages;
 import org.eclipse.gef.commands.Command;
@@ -36,6 +38,9 @@ public class ImportChange extends AbstractCommandChange<Import> {
 
 	@Override
 	protected Command createCommand(final Import element) {
+		if (newValue == null || newValue.isBlank()) {
+			return new DeleteImportCommand((CompilerInfo) element.eContainer(), element);
+		}
 		return new ChangeImportNamespaceCommand(element, newValue);
 	}
 


### PR DESCRIPTION
This both [considers unused imports for related resources when refactoring](https://github.com/eclipse-4diac/4diac-ide/commit/5bb1bad62a67c382877d17e9f38f8d47374cffaf) and also [removes unused imports when moving a type to the same package](https://github.com/eclipse-4diac/4diac-ide/commit/4a1ed03de12b40c226cd7eb17f3a004a1ed8fef9).