### PR TITLE
Use empty value instead of placeholder when editing initial values

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/ValueEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/ValueEditPart.java
@@ -376,9 +376,17 @@ public class ValueEditPart extends AbstractGraphicalEditPart implements NodeEdit
 		final IInterfaceElement interfaceElement = getIInterfaceElement();
 		if (interfaceElement instanceof final VarDeclaration varDecl) {
 			return new InitialValueDirectEditManager(this, new FigureCellEditorLocator(getFigure()), varDecl,
-					getFigure().getText());
+					getDirectEditInitialValue());
 		}
 		return new LabelDirectEditManager(this, getFigure());
+	}
+
+	protected String getDirectEditInitialValue() {
+		final String text = getFigure().getText();
+		if (FordiacMessages.ComputingPlaceholderValue.equals(text) || FordiacMessages.ValueTooLarge.equals(text)) {
+			return ""; //$NON-NLS-1$
+		}
+		return text;
 	}
 
 	/** performs the directEdit. */

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/InitialValueCellEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/InitialValueCellEditor.java
@@ -14,6 +14,7 @@ package org.eclipse.fordiac.ide.gef.nat;
 
 import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement;
 import org.eclipse.fordiac.ide.structuredtextalgorithm.ui.editor.embedded.STAlgorithmInitialValueEditedResourceProvider;
+import org.eclipse.fordiac.ide.ui.FordiacMessages;
 import org.eclipse.nebula.widgets.nattable.data.IRowDataProvider;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyledText;
@@ -42,6 +43,15 @@ public class InitialValueCellEditor extends XtextStyledTextCellEditor {
 	@Override
 	protected IEditedResourceProvider createEditedResourceProvider() {
 		return new STAlgorithmInitialValueEditedResourceProvider(getRowObject());
+	}
+
+	@Override
+	public void setEditorValue(final Object value) {
+		if (FordiacMessages.ComputingPlaceholderValue.equals(value) || FordiacMessages.ValueTooLarge.equals(value)) {
+			super.setEditorValue(""); //$NON-NLS-1$
+		} else {
+			super.setEditorValue(value);
+		}
 	}
 
 	protected ITypedElement getRowObject() {


### PR DESCRIPTION
Use empty value instead of `computing` or `too large` placeholder when editing initial values. This avoids having to manually delete the placeholder when editing and also keeps it from being applied on commit.