### PR TITLE
Only set navigation location of type entry adapter on part activation

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.bulkeditor/src/org/eclipse/fordiac/ide/bulkeditor/editors/BulkEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.bulkeditor/src/org/eclipse/fordiac/ide/bulkeditor/editors/BulkEditor.java
@@ -119,7 +119,7 @@ public class BulkEditor extends EditorPart implements CommandExecutor, CommandSt
 	private final Set<TypeEntry> dirtyEntries = new HashSet<>();
 	private BulkEditorSettings settings;
 	private List<URI> selectedSubApps = Collections.emptyList();
-	private final BulkEditorTypeEntryAdapter adapter = new BulkEditorTypeEntryAdapter(this);
+	private BulkEditorTypeEntryAdapter adapter;
 	private final IPartListener2 focusListener = new IPartListener2() {
 		@Override
 		public void partBroughtToTop(final IWorkbenchPartReference partRef) {
@@ -163,6 +163,7 @@ public class BulkEditor extends EditorPart implements CommandExecutor, CommandSt
 
 	@Override
 	public void init(final IEditorSite site, final IEditorInput input) throws PartInitException {
+		adapter = new BulkEditorTypeEntryAdapter(this, site.getWorkbenchWindow().getPartService());
 		registerActions(site);
 		setSite(site);
 		setInput(input);
@@ -780,7 +781,7 @@ public class BulkEditor extends EditorPart implements CommandExecutor, CommandSt
 
 	@Override
 	public void setFocus() {
-		adapter.checkFileReload();
+		// nothing to be done
 	}
 
 	public void reloadType() {
@@ -846,6 +847,7 @@ public class BulkEditor extends EditorPart implements CommandExecutor, CommandSt
 		super.dispose();
 		getSite().getPage().removePartListener(focusListener);
 		copiedElementsMap.keySet().forEach(typeEntry -> typeEntry.eAdapters().remove(adapter));
+		adapter.dispose();
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.bulkeditor/src/org/eclipse/fordiac/ide/bulkeditor/editors/BulkEditorTypeEntryAdapter.java
+++ b/plugins/org.eclipse.fordiac.ide.bulkeditor/src/org/eclipse/fordiac/ide/bulkeditor/editors/BulkEditorTypeEntryAdapter.java
@@ -21,14 +21,13 @@ import org.eclipse.fordiac.ide.model.edit.AbstractTypeEntryAdapter;
 import org.eclipse.fordiac.ide.model.edit.Messages;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.jface.dialogs.MessageDialog;
-import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IPartService;
 
 public class BulkEditorTypeEntryAdapter extends AbstractTypeEntryAdapter {
 	private final Set<String> changedFiles = new HashSet<>();
-	private final BulkEditor editor;
 
-	public BulkEditorTypeEntryAdapter(final BulkEditor editor) {
-		this.editor = editor;
+	public BulkEditorTypeEntryAdapter(final BulkEditor editor, final IPartService partService) {
+		super(editor, partService);
 	}
 
 	@Override
@@ -50,13 +49,13 @@ public class BulkEditorTypeEntryAdapter extends AbstractTypeEntryAdapter {
 
 	@Override
 	protected void reloadEditorType() {
-		editor.reloadType();
+		getEditor().reloadType();
 		changedFiles.clear();
 	}
 
 	@Override
-	protected IEditorPart getEditor() {
-		return editor;
+	protected BulkEditor getEditor() {
+		return (BulkEditor) super.getEditor();
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/AbstractTypeEntryAdapter.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/AbstractTypeEntryAdapter.java
@@ -18,26 +18,57 @@ import org.eclipse.emf.common.notify.impl.AdapterImpl;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IPartListener;
+import org.eclipse.ui.IPartService;
+import org.eclipse.ui.IWindowListener;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
 
 public abstract class AbstractTypeEntryAdapter extends AdapterImpl {
+
+	private final IEditorPart editor;
+	private ActivationListener activationListener;
 	private boolean reloadPending;
 
 	protected abstract void reloadEditorType();
 
-	protected abstract IEditorPart getEditor();
+	public void dispose() {
+		if (activationListener != null) {
+			activationListener.dispose();
+			activationListener = null;
+		}
+	}
 
-	public void checkFileReload() {
+	protected IEditorPart getEditor() {
+		return editor;
+	}
+
+	protected AbstractTypeEntryAdapter(final IEditorPart editor, final IPartService partService) {
+		this.editor = editor;
+		activationListener = new ActivationListener(partService);
+	}
+
+	/**
+	 * This method performs any updates / reloads required when the editor of this
+	 * adapter is activated.
+	 */
+	protected void checkEditorActivated() {
 		if (reloadPending) {
 			performReload();
 		}
 	}
 
 	protected void handleFileContentChange() {
-		if (getEditor().equals(getEditor().getSite().getPage().getActiveEditor())) {
+		if (isActiveEditor()) {
 			performReload();
 		} else {
 			reloadPending = true;
 		}
+	}
+
+	protected boolean isActiveEditor() {
+		return getEditor().equals(getEditor().getSite().getPage().getActiveEditor());
 	}
 
 	protected boolean editorClosed() {
@@ -63,5 +94,79 @@ public abstract class AbstractTypeEntryAdapter extends AdapterImpl {
 				0);
 
 		return dialog.open();
+	}
+
+	class ActivationListener implements IPartListener, IWindowListener {
+
+		private IPartService partService;
+		private boolean ignoreUpdates;
+
+		public ActivationListener(final IPartService partService) {
+			this.partService = partService;
+			partService.addPartListener(this);
+			PlatformUI.getWorkbench().addWindowListener(this);
+		}
+
+		public void dispose() {
+			partService.removePartListener(this);
+			PlatformUI.getWorkbench().removeWindowListener(this);
+			partService = null;
+		}
+
+		@Override
+		public void windowActivated(final IWorkbenchWindow window) {
+			window.getShell().getDisplay().asyncExec(() -> handleActivation(window.getActivePage().getActivePart()));
+		}
+
+		@Override
+		public void partActivated(final IWorkbenchPart part) {
+			handleActivation(part);
+		}
+
+		private void handleActivation(final IWorkbenchPart part) {
+			if (getEditor() == part && !ignoreUpdates) {
+				// some editor activations (e.g., location changes) may result in a recursive
+				// call of this method that can be ignored.
+				ignoreUpdates = true;
+				checkEditorActivated();
+				ignoreUpdates = false;
+			}
+		}
+
+		@Override
+		public void partBroughtToTop(final IWorkbenchPart part) {
+			// nothing to do
+		}
+
+		@Override
+		public void partClosed(final IWorkbenchPart part) {
+			// nothing to do
+		}
+
+		@Override
+		public void partDeactivated(final IWorkbenchPart part) {
+			// nothing to do
+		}
+
+		@Override
+		public void partOpened(final IWorkbenchPart part) {
+			// nothing to do
+		}
+
+		@Override
+		public void windowDeactivated(final IWorkbenchWindow window) {
+			// nothing to do
+		}
+
+		@Override
+		public void windowClosed(final IWorkbenchWindow window) {
+			// nothing to do
+		}
+
+		@Override
+		public void windowOpened(final IWorkbenchWindow window) {
+			// nothing to do
+		}
+
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/TypeEntryAdapter.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/TypeEntryAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Primetals Technologies Austria GmbH
+ * Copyright (c) 2024, 2025 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -47,27 +47,42 @@ import org.eclipse.fordiac.ide.model.typelibrary.SubAppTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.INavigationLocation;
 import org.eclipse.ui.INavigationLocationProvider;
+import org.eclipse.ui.IPartService;
 import org.eclipse.ui.part.FileEditorInput;
 
 public class TypeEntryAdapter extends AbstractTypeEntryAdapter {
 
-	private final ITypeEntryEditor editor;
+	private INavigationLocation location;
 
-	public TypeEntryAdapter(final ITypeEntryEditor editor) {
-		this.editor = editor;
+	public TypeEntryAdapter(final ITypeEntryEditor editor, final IPartService partService) {
+		super(editor, partService);
 	}
 
 	@Override
-	protected IEditorPart getEditor() {
-		return editor;
+	protected ITypeEntryEditor getEditor() {
+		return (ITypeEntryEditor) super.getEditor();
+	}
+
+	@Override
+	protected void checkEditorActivated() {
+		super.checkEditorActivated();
+		performLocationRestore();
+	}
+
+	@Override
+	public void dispose() {
+		super.dispose();
+		if (location != null) {
+			location.dispose();
+			location = null;
+		}
 	}
 
 	@Override
 	protected void reloadEditorType() {
-		editor.reloadType();
+		getEditor().reloadType();
 	}
 
 	@Override
@@ -86,7 +101,7 @@ public class TypeEntryAdapter extends AbstractTypeEntryAdapter {
 		case TypeEntry.TYPE_ENTRY_FILE_FEATURE:
 			Display.getDefault().asyncExec(() -> {
 				if (!editorClosed() && notification.getNewValue() instanceof final IFile newFile) {
-					editor.setInput(new FileEditorInput(newFile));
+					getEditor().setInput(new FileEditorInput(newFile));
 				}
 			});
 			break;
@@ -104,7 +119,7 @@ public class TypeEntryAdapter extends AbstractTypeEntryAdapter {
 	}
 
 	private void handleDependencyUpdate(final TypeEntry typeEntry) {
-		final LibraryElement editedElement = editor.getAdapter(LibraryElement.class);
+		final LibraryElement editedElement = getEditor().getAdapter(LibraryElement.class);
 		if (editedElement != null) {
 			Display.getDefault().asyncExec(() -> {
 				if (editorClosed()) {
@@ -141,7 +156,7 @@ public class TypeEntryAdapter extends AbstractTypeEntryAdapter {
 	private void handleBlockTypeDependencyUpdate(final LibraryElement editedElement, final TypeEntry typeEntry) {
 		final BlockTypeInstanceSearch search = new BlockTypeInstanceSearch(editedElement, typeEntry);
 
-		final INavigationLocation location = getEditorLocation();
+		checkEditorLocation();
 
 		search.performSearch().stream().filter(FBNetworkElement.class::isInstance).map(FBNetworkElement.class::cast)
 				.map(fbnEl -> {
@@ -151,17 +166,17 @@ public class TypeEntryAdapter extends AbstractTypeEntryAdapter {
 					return new UpdateFBTypeCommand(fbnEl, typeEntry);
 				}).forEach(Command::execute);
 
-		if (location != null) {
-			location.restoreLocation();
+		if (isActiveEditor()) {
+			performLocationRestore();
 		}
 	}
 
-	private INavigationLocation getEditorLocation() {
-		if (editor.getAdapter(FBNetwork.class) == null
-				&& editor instanceof final INavigationLocationProvider provider) {
-			return provider.createNavigationLocation();
+	private void checkEditorLocation() {
+		if (location == null && getEditor().getAdapter(FBNetwork.class) == null
+				&& getEditor().getAdapter(FBNetworkElement.class) != null
+				&& getEditor() instanceof final INavigationLocationProvider provider) {
+			location = provider.createNavigationLocation();
 		}
-		return null;
 	}
 
 	private static void handleDataTypeEntryUpdate(final LibraryElement editedElement, final DataTypeEntry dtEntry) {
@@ -184,6 +199,14 @@ public class TypeEntryAdapter extends AbstractTypeEntryAdapter {
 			}
 			return null;
 		}).filter(Objects::nonNull).forEach(Command::execute);
+	}
+
+	private void performLocationRestore() {
+		if (location != null) {
+			location.restoreLocation();
+			location.dispose();
+			location = null;
+		}
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/editors/AutomationSystemEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/editors/AutomationSystemEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 Primetals Technologies Germany GmbH,
+ * Copyright (c) 2020, 2025 Primetals Technologies Germany GmbH,
  *                          Johannes Kepler University Linz,
  *                          Primetals Technologies Austria GmbH
  *
@@ -84,6 +84,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IEditorSite;
 import org.eclipse.ui.IReusableEditor;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.actions.WorkspaceModifyOperation;
@@ -105,7 +106,13 @@ public class AutomationSystemEditor extends AbstractBreadCrumbEditor implements 
 		subEditorCommandStackListener = new EditorTabCommandStackListener(this);
 	}
 
-	private final TypeEntryAdapter adapter = new TypeEntryAdapter(this);
+	private TypeEntryAdapter typeEntryAdapter;
+
+	@Override
+	public void init(final IEditorSite site, final IEditorInput input) throws PartInitException {
+		typeEntryAdapter = new TypeEntryAdapter(this, site.getWorkbenchWindow().getPartService());
+		super.init(site, input);
+	}
 
 	@Override
 	public void createPartControl(final Composite parent) {
@@ -310,7 +317,7 @@ public class AutomationSystemEditor extends AbstractBreadCrumbEditor implements 
 				final TypeEntry newSystemEntry = TypeLibraryManager.INSTANCE.getTypeLibrary(file.getProject())
 						.createTypeEntry(file);
 				newSystemEntry.save(system, monitor);
-				oldSystemEntry.eAdapters().remove(adapter);
+				oldSystemEntry.eAdapters().remove(typeEntryAdapter);
 				oldSystemEntry.setType(null);
 				setInput(new FileEditorInput(file));
 			}
@@ -366,8 +373,9 @@ public class AutomationSystemEditor extends AbstractBreadCrumbEditor implements 
 
 	@Override
 	public void dispose() {
-		if (system != null && system.getTypeEntry() != null && system.getTypeEntry().eAdapters().contains(adapter)) {
-			system.getTypeEntry().eAdapters().remove(adapter);
+		if (system != null && system.getTypeEntry() != null
+				&& system.getTypeEntry().eAdapters().contains(typeEntryAdapter)) {
+			system.getTypeEntry().eAdapters().remove(typeEntryAdapter);
 		}
 
 		// get these values here before calling super dispose
@@ -388,6 +396,7 @@ public class AutomationSystemEditor extends AbstractBreadCrumbEditor implements 
 			((SystemEntry) system.getTypeEntry()).setSystem(null);
 			system = null;
 		}
+		typeEntryAdapter.dispose();
 	}
 
 	@Override
@@ -398,15 +407,15 @@ public class AutomationSystemEditor extends AbstractBreadCrumbEditor implements 
 
 		final SystemEntry typeEntry = (SystemEntry) system.getTypeEntry();
 
-		if (typeEntry.eAdapters().contains(adapter)) {
-			typeEntry.eAdapters().remove(adapter);
+		if (typeEntry.eAdapters().contains(typeEntryAdapter)) {
+			typeEntry.eAdapters().remove(typeEntryAdapter);
 		}
 
 		typeEntry.setSystem(null);
 		system = typeEntry.getSystem();
 		system.setCommandStack(commandStack);
 		getCommandStack().flush();
-		typeEntry.eAdapters().add(adapter);
+		typeEntry.eAdapters().add(typeEntryAdapter);
 		setPartName(system.getName());
 
 		if (!getBreadcrumb().openPath(path, system)) {
@@ -438,8 +447,8 @@ public class AutomationSystemEditor extends AbstractBreadCrumbEditor implements 
 				if (system != null) {
 					getCommandStack().addCommandStackEventListener(this);
 					getCommandStack().addCommandStackEventListener(subEditorCommandStackListener);
-					QualNameChangeListenerManager.INSTANCE.addCommandStackEventListener(getCommandStack());
-					system.getTypeEntry().eAdapters().add(adapter);
+					QualNameChangeListenerManager.addCommandStackEventListener(getCommandStack());
+					system.getTypeEntry().eAdapters().add(typeEntryAdapter);
 				}
 			}
 			setPartName(TypeEntry.getTypeNameFromFile(fileEI.getFile()));
@@ -451,13 +460,6 @@ public class AutomationSystemEditor extends AbstractBreadCrumbEditor implements 
 					.forEach(e -> e.setInput(e.getEditorInput()));
 		}
 		setInputWithNotify(input);
-	}
-
-	@Override
-	public void setFocus() {
-		super.setFocus();
-		// we got focus check if the content needs reload
-		adapter.checkFileReload();
 	}
 
 	private void selectRootModelOfEditor() {

--- a/plugins/org.eclipse.fordiac.ide.typeeditor/src/org/eclipse/fordiac/ide/typeeditor/AbstractTypeEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.typeeditor/src/org/eclipse/fordiac/ide/typeeditor/AbstractTypeEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
+ * Copyright (c) 2008, 2025 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
  * 							Johannes Kepler University, Linz,
  * 							Primetals Technologies Austria GmbH
  *
@@ -95,7 +95,7 @@ public abstract class AbstractTypeEditor extends AbstractCloseAbleFormEditor imp
 
 	private final CommandStack commandStack = new CommandStack();
 	private Collection<ITypeEditorPage> editorPages;
-	private final TypeEntryAdapter adapter = new TypeEntryAdapter(this);
+	private TypeEntryAdapter typeEntryAdapter;
 	private GraphicalAnnotationModel annotationModel;
 	private ValidationJob validationJob;
 	private boolean wasDirtyBeforeExecute = false;
@@ -176,8 +176,8 @@ public abstract class AbstractTypeEditor extends AbstractCloseAbleFormEditor imp
 	@Override
 	public void dispose() {
 		final TypeEntry typeEntry = getTypeEntry();
-		if ((typeEntry != null) && typeEntry.eAdapters().contains(adapter)) {
-			typeEntry.eAdapters().remove(adapter);
+		if ((typeEntry != null) && typeEntry.eAdapters().contains(typeEntryAdapter)) {
+			typeEntry.eAdapters().remove(typeEntryAdapter);
 		}
 		if (validationJob != null) {
 			validationJob.dispose();
@@ -202,6 +202,7 @@ public abstract class AbstractTypeEditor extends AbstractCloseAbleFormEditor imp
 		}
 
 		getCommandStack().removeCommandStackEventListener(this);
+		typeEntryAdapter.dispose();
 	}
 
 	@Override
@@ -283,7 +284,6 @@ public abstract class AbstractTypeEditor extends AbstractCloseAbleFormEditor imp
 		if (adapter == GraphicalAnnotationModel.class) {
 			return adapter.cast(annotationModel);
 		}
-
 		if (isEditorActive()) {
 			// we should only call super if the editor is active otherwise we may get
 			// disposed errors
@@ -362,6 +362,7 @@ public abstract class AbstractTypeEditor extends AbstractCloseAbleFormEditor imp
 
 	@Override
 	public void init(final IEditorSite site, final IEditorInput editorInput) throws PartInitException {
+		typeEntryAdapter = new TypeEntryAdapter(this, site.getWorkbenchWindow().getPartService());
 		getCommandStack().addCommandStackEventListener(this);
 		super.init(site, editorInput);
 		site.getWorkbenchWindow().getSelectionService().addSelectionListener(this);
@@ -394,8 +395,8 @@ public abstract class AbstractTypeEditor extends AbstractCloseAbleFormEditor imp
 		final LibraryElement newFBType = getTypeEntry().copyType();
 		final LibraryElement curType = getType();
 		if (newFBType != curType) {
-			if ((curType != null) && getTypeEntry().eAdapters().contains(adapter)) {
-				getTypeEntry().eAdapters().remove(adapter);
+			if ((curType != null) && getTypeEntry().eAdapters().contains(typeEntryAdapter)) {
+				getTypeEntry().eAdapters().remove(typeEntryAdapter);
 			}
 			final TypeEditorInput typeEI = getTypeEditorInput();
 			if (typeEI != null) {
@@ -408,7 +409,7 @@ public abstract class AbstractTypeEditor extends AbstractCloseAbleFormEditor imp
 						activeEditor.getAdapter(GraphicalViewer.class), editorPage.getSelectableObject()));
 			}
 			getCommandStack().flush();
-			getTypeEntry().eAdapters().add(adapter);
+			getTypeEntry().eAdapters().add(typeEntryAdapter);
 			setPartName(getTypeEntry().getTypeName());
 		}
 	}
@@ -431,12 +432,6 @@ public abstract class AbstractTypeEditor extends AbstractCloseAbleFormEditor imp
 	}
 
 	@Override
-	public void setFocus() {
-		super.setFocus();
-		adapter.checkFileReload();
-	}
-
-	@Override
 	public void setInput(final IEditorInput input) {
 		if (validationJob != null) {
 			validationJob.dispose();
@@ -452,7 +447,7 @@ public abstract class AbstractTypeEditor extends AbstractCloseAbleFormEditor imp
 
 		final TypeEditorInput typeEditorInput = checkEditorInput(input);
 		if (isValidTypeEditorInput(typeEditorInput)) {
-			typeEditorInput.getTypeEntry().eAdapters().add(adapter);
+			typeEditorInput.getTypeEntry().eAdapters().add(typeEntryAdapter);
 			annotationModel = new FordiacMarkerGraphicalAnnotationModel(typeEditorInput.getFile(),
 					typeEditorInput::getContent);
 			validationJob = new ValidationJob(getPartName(), getCommandStack(), annotationModel);


### PR DESCRIPTION
when the type entry adapter needs to update typed subapps to have the correct entry it needs to restore the viewer. This lead to wrong editors getting activated. This change postpones this to the activation of the part.

As part of this change also the reload checks for bulk editor synchronisation are moved to the same infrastructure.