### PR TITLE
Fix null URI for enclosing resource in error type entry

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/TypeEntry.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/TypeEntry.java
@@ -94,6 +94,8 @@ public interface TypeEntry extends Notifier {
 
 	String getFullTypeName();
 
+	String getFileExtension();
+
 	String getComment();
 
 	EClass getTypeEClass();

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
@@ -39,6 +39,7 @@ import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;
 import org.eclipse.emf.common.notify.Notifier;
 import org.eclipse.emf.common.notify.impl.NotificationImpl;
+import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.model.ConcurrentNotifierImpl;
 import org.eclipse.fordiac.ide.model.dataexport.AbstractTypeExporter;
@@ -274,7 +275,8 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 
 	protected void encloseInResource(final LibraryElement newType) {
 		if (newType.eResource() == null) {
-			new FordiacTypeResource(getURI()).getContents().add(newType);
+			new FordiacTypeResource(Objects.requireNonNullElseGet(getURI(),
+					() -> URI.createFileURI(newType.getName() + "." + getFileExtension()))).getContents().add(newType); //$NON-NLS-1$
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AdapterTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AdapterTypeEntryImpl.java
@@ -32,6 +32,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.typelibrary.AdapterTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 
 public class AdapterTypeEntryImpl extends AbstractCheckedTypeEntryImpl<AdapterType> implements AdapterTypeEntry {
 
@@ -52,6 +53,11 @@ public class AdapterTypeEntryImpl extends AbstractCheckedTypeEntryImpl<AdapterTy
 	@Override
 	public EClass getTypeEClass() {
 		return LibraryElementPackage.Literals.ADAPTER_TYPE;
+	}
+
+	@Override
+	public String getFileExtension() {
+		return TypeLibraryTags.ADAPTER_TYPE_FILE_ENDING;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AttributeTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AttributeTypeEntryImpl.java
@@ -20,6 +20,7 @@ import org.eclipse.fordiac.ide.model.dataimport.CommonElementImporter;
 import org.eclipse.fordiac.ide.model.libraryElement.AttributeDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.typelibrary.AttributeTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 
 public class AttributeTypeEntryImpl extends AbstractCheckedTypeEntryImpl<AttributeDeclaration>
 		implements AttributeTypeEntry {
@@ -41,5 +42,10 @@ public class AttributeTypeEntryImpl extends AbstractCheckedTypeEntryImpl<Attribu
 	@Override
 	public EClass getTypeEClass() {
 		return LibraryElementPackage.Literals.ATTRIBUTE_DECLARATION;
+	}
+
+	@Override
+	public String getFileExtension() {
+		return TypeLibraryTags.ATTRIBUTE_TYPE_FILE_ENDING;
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/DataTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/DataTypeEntryImpl.java
@@ -23,6 +23,7 @@ import org.eclipse.fordiac.ide.model.dataexport.DataTypeExporter;
 import org.eclipse.fordiac.ide.model.dataimport.CommonElementImporter;
 import org.eclipse.fordiac.ide.model.dataimport.DataTypeImporter;
 import org.eclipse.fordiac.ide.model.typelibrary.DataTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 
 public class DataTypeEntryImpl extends AbstractCheckedTypeEntryImpl<AnyDerivedType> implements DataTypeEntry {
 
@@ -43,5 +44,10 @@ public class DataTypeEntryImpl extends AbstractCheckedTypeEntryImpl<AnyDerivedTy
 	@Override
 	public EClass getTypeEClass() {
 		return DataPackage.Literals.ANY_DERIVED_TYPE;
+	}
+
+	@Override
+	public String getFileExtension() {
+		return TypeLibraryTags.DATA_TYPE_FILE_ENDING;
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/DeviceTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/DeviceTypeEntryImpl.java
@@ -26,6 +26,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.DeviceType;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.typelibrary.DeviceTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 
 public class DeviceTypeEntryImpl extends AbstractCheckedTypeEntryImpl<DeviceType> implements DeviceTypeEntry {
 
@@ -51,5 +52,10 @@ public class DeviceTypeEntryImpl extends AbstractCheckedTypeEntryImpl<DeviceType
 	@Override
 	public EClass getTypeEClass() {
 		return LibraryElementPackage.Literals.DEVICE_TYPE;
+	}
+
+	@Override
+	public String getFileExtension() {
+		return TypeLibraryTags.DEVICE_TYPE_FILE_ENDING;
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/ErrorDataTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/ErrorDataTypeEntryImpl.java
@@ -22,6 +22,7 @@ import org.eclipse.fordiac.ide.model.dataimport.CommonElementImporter;
 import org.eclipse.fordiac.ide.model.libraryElement.ErrorMarkerDataType;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.typelibrary.ErrorDataTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 
 public class ErrorDataTypeEntryImpl extends AbstractCheckedTypeEntryImpl<ErrorMarkerDataType>
 		implements ErrorDataTypeEntry {
@@ -53,5 +54,10 @@ public class ErrorDataTypeEntryImpl extends AbstractCheckedTypeEntryImpl<ErrorMa
 	@Override
 	public EClass getTypeEClass() {
 		return getType().eClass();
+	}
+
+	@Override
+	public String getFileExtension() {
+		return TypeLibraryTags.DATA_TYPE_FILE_ENDING;
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/FBTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/FBTypeEntryImpl.java
@@ -31,6 +31,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.typelibrary.FBTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 
 public class FBTypeEntryImpl extends AbstractCheckedTypeEntryImpl<FBType> implements FBTypeEntry {
@@ -99,5 +100,10 @@ public class FBTypeEntryImpl extends AbstractCheckedTypeEntryImpl<FBType> implem
 			}
 		}
 		return LibraryElementPackage.Literals.FB_TYPE;
+	}
+
+	@Override
+	public String getFileExtension() {
+		return TypeLibraryTags.FB_TYPE_FILE_ENDING;
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/FunctionFBTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/FunctionFBTypeEntryImpl.java
@@ -20,6 +20,7 @@ import org.eclipse.fordiac.ide.model.dataimport.FCTImporter;
 import org.eclipse.fordiac.ide.model.libraryElement.FunctionFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.typelibrary.FunctionFBTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 
 public class FunctionFBTypeEntryImpl extends AbstractCheckedTypeEntryImpl<FunctionFBType>
 		implements FunctionFBTypeEntry {
@@ -41,5 +42,10 @@ public class FunctionFBTypeEntryImpl extends AbstractCheckedTypeEntryImpl<Functi
 	@Override
 	public EClass getTypeEClass() {
 		return LibraryElementPackage.Literals.FUNCTION_FB_TYPE;
+	}
+
+	@Override
+	public String getFileExtension() {
+		return TypeLibraryTags.FC_TYPE_FILE_ENDING;
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/GlobalConstantsEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/GlobalConstantsEntryImpl.java
@@ -20,6 +20,7 @@ import org.eclipse.fordiac.ide.model.dataimport.GlobalConstantsImporter;
 import org.eclipse.fordiac.ide.model.libraryElement.GlobalConstants;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.typelibrary.GlobalConstantsEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 
 public class GlobalConstantsEntryImpl extends AbstractCheckedTypeEntryImpl<GlobalConstants>
 		implements GlobalConstantsEntry {
@@ -41,5 +42,10 @@ public class GlobalConstantsEntryImpl extends AbstractCheckedTypeEntryImpl<Globa
 	@Override
 	public EClass getTypeEClass() {
 		return LibraryElementPackage.Literals.GLOBAL_CONSTANTS;
+	}
+
+	@Override
+	public String getFileExtension() {
+		return TypeLibraryTags.GLOBAL_CONST_FILE_ENDING;
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/ResourceTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/ResourceTypeEntryImpl.java
@@ -23,6 +23,7 @@ import org.eclipse.fordiac.ide.model.dataimport.RESImporter;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.libraryElement.ResourceType;
 import org.eclipse.fordiac.ide.model.typelibrary.ResourceTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 
 public class ResourceTypeEntryImpl extends AbstractCheckedTypeEntryImpl<ResourceType> implements ResourceTypeEntry {
 
@@ -45,4 +46,8 @@ public class ResourceTypeEntryImpl extends AbstractCheckedTypeEntryImpl<Resource
 		return LibraryElementPackage.Literals.RESOURCE_TYPE;
 	}
 
+	@Override
+	public String getFileExtension() {
+		return TypeLibraryTags.RESOURCE_TYPE_FILE_ENDING;
+	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/SegmentTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/SegmentTypeEntryImpl.java
@@ -26,6 +26,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.libraryElement.SegmentType;
 import org.eclipse.fordiac.ide.model.typelibrary.SegmentTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 
 public class SegmentTypeEntryImpl extends AbstractCheckedTypeEntryImpl<SegmentType> implements SegmentTypeEntry {
 
@@ -51,5 +52,10 @@ public class SegmentTypeEntryImpl extends AbstractCheckedTypeEntryImpl<SegmentTy
 	@Override
 	public EClass getTypeEClass() {
 		return LibraryElementPackage.Literals.SEGMENT_TYPE;
+	}
+
+	@Override
+	public String getFileExtension() {
+		return TypeLibraryTags.SEGMENT_TYPE_FILE_ENDING;
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/SubAppTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/SubAppTypeEntryImpl.java
@@ -23,6 +23,7 @@ import org.eclipse.fordiac.ide.model.dataimport.SubAppTImporter;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.libraryElement.SubAppType;
 import org.eclipse.fordiac.ide.model.typelibrary.SubAppTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 
 public class SubAppTypeEntryImpl extends AbstractCheckedTypeEntryImpl<SubAppType> implements SubAppTypeEntry {
 
@@ -43,5 +44,10 @@ public class SubAppTypeEntryImpl extends AbstractCheckedTypeEntryImpl<SubAppType
 	@Override
 	public EClass getTypeEClass() {
 		return LibraryElementPackage.Literals.SUB_APP_TYPE;
+	}
+
+	@Override
+	public String getFileExtension() {
+		return TypeLibraryTags.SUBAPP_TYPE_FILE_ENDING;
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/SystemEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/SystemEntryImpl.java
@@ -26,6 +26,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.typelibrary.SystemEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 
 public class SystemEntryImpl extends AbstractCheckedTypeEntryImpl<AutomationSystem> implements SystemEntry {
 
@@ -80,6 +81,11 @@ public class SystemEntryImpl extends AbstractCheckedTypeEntryImpl<AutomationSyst
 	@Override
 	public EClass getTypeEClass() {
 		return LibraryElementPackage.Literals.AUTOMATION_SYSTEM;
+	}
+
+	@Override
+	public String getFileExtension() {
+		return TypeLibraryTags.SYSTEM_TYPE_FILE_ENDING;
 	}
 
 	@Override

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/AttributeTypeEntryMock.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/AttributeTypeEntryMock.java
@@ -25,6 +25,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.typelibrary.AttributeTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 
 public class AttributeTypeEntryMock extends BasicNotifierImpl implements AttributeTypeEntry {
 
@@ -141,5 +142,10 @@ public class AttributeTypeEntryMock extends BasicNotifierImpl implements Attribu
 	@Override
 	public EClass getTypeEClass() {
 		return attributeDeclaration.eClass();
+	}
+
+	@Override
+	public String getFileExtension() {
+		return TypeLibraryTags.ATTRIBUTE_TYPE_FILE_ENDING;
 	}
 }

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/DataTypeEntryMock.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/DataTypeEntryMock.java
@@ -26,6 +26,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.typelibrary.DataTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 
 public final class DataTypeEntryMock extends BasicNotifierImpl implements DataTypeEntry {
 
@@ -142,5 +143,10 @@ public final class DataTypeEntryMock extends BasicNotifierImpl implements DataTy
 	@Override
 	public EClass getTypeEClass() {
 		return DataPackage.Literals.ANY_DERIVED_TYPE;
+	}
+
+	@Override
+	public String getFileExtension() {
+		return TypeLibraryTags.DATA_TYPE_FILE_ENDING;
 	}
 }

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/FBTypeEntryMock.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/FBTypeEntryMock.java
@@ -25,6 +25,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.typelibrary.FBTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 
 public class FBTypeEntryMock extends BasicNotifierImpl implements FBTypeEntry {
 
@@ -140,5 +141,10 @@ public class FBTypeEntryMock extends BasicNotifierImpl implements FBTypeEntry {
 	@Override
 	public EClass getTypeEClass() {
 		return fbType.eClass();
+	}
+
+	@Override
+	public String getFileExtension() {
+		return TypeLibraryTags.FB_TYPE_FILE_ENDING;
 	}
 }

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/SubAppTypeEntryMock.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/SubAppTypeEntryMock.java
@@ -26,6 +26,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.SubAppType;
 import org.eclipse.fordiac.ide.model.typelibrary.SubAppTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 
 public final class SubAppTypeEntryMock extends BasicNotifierImpl implements SubAppTypeEntry {
 
@@ -141,5 +142,10 @@ public final class SubAppTypeEntryMock extends BasicNotifierImpl implements SubA
 	@Override
 	public EClass getTypeEClass() {
 		return LibraryElementPackage.Literals.SUB_APP_TYPE;
+	}
+
+	@Override
+	public String getFileExtension() {
+		return TypeLibraryTags.SUBAPP_TYPE_FILE_ENDING;
 	}
 }


### PR DESCRIPTION
The error type entries do not have an associated file, which leads to a null URI when enclosing the error type in a resource. This uses the type name as a fallback when creating the resource. Also add a method to get the file extension for a type entry.