### PR TITLE
Moved ScrollingDragTracker to PositionableElementEditPart

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractFBNElementEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractFBNElementEditPart.java
@@ -46,7 +46,6 @@ import org.eclipse.fordiac.ide.gef.editparts.InterfaceEditPart;
 import org.eclipse.fordiac.ide.gef.editparts.ZoomScalableFreeformRootEditPart;
 import org.eclipse.fordiac.ide.gef.listeners.DiagramFontChangeListener;
 import org.eclipse.fordiac.ide.gef.policies.DragHighlightEditPolicy;
-import org.eclipse.fordiac.ide.gef.tools.ScrollingDragEditPartsTracker;
 import org.eclipse.fordiac.ide.model.commands.change.UpdateFBTypeCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.Color;
 import org.eclipse.fordiac.ide.model.libraryElement.ColorizableElement;
@@ -64,7 +63,6 @@ import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
 import org.eclipse.fordiac.ide.ui.editors.EditorUtils;
 import org.eclipse.fordiac.ide.ui.preferences.UIPreferenceConstants;
-import org.eclipse.gef.DragTracker;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.GraphicalEditPart;
@@ -625,11 +623,6 @@ public abstract class AbstractFBNElementEditPart extends AbstractPositionableEle
 			}
 		}
 		super.setTransparency(value);
-	}
-
-	@Override
-	public DragTracker getDragTracker(final Request request) {
-		return new ScrollingDragEditPartsTracker(this);
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/AbstractPositionableElementEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/AbstractPositionableElementEditPart.java
@@ -16,10 +16,13 @@ import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.emf.common.notify.Adapter;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.impl.AdapterImpl;
+import org.eclipse.fordiac.ide.gef.tools.ScrollingDragEditPartsTracker;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.libraryElement.Position;
 import org.eclipse.fordiac.ide.model.libraryElement.PositionableElement;
+import org.eclipse.gef.DragTracker;
 import org.eclipse.gef.GraphicalEditPart;
+import org.eclipse.gef.Request;
 
 public abstract class AbstractPositionableElementEditPart extends AbstractViewEditPart {
 
@@ -46,6 +49,11 @@ public abstract class AbstractPositionableElementEditPart extends AbstractViewEd
 			final Rectangle bounds = new Rectangle(position.toScreenPoint(), new Dimension(-1, -1));
 			((GraphicalEditPart) getParent()).setLayoutConstraint(this, getFigure(), bounds);
 		}
+	}
+
+	@Override
+	public DragTracker getDragTracker(final Request request) {
+		return new ScrollingDragEditPartsTracker(this);
 	}
 
 	protected abstract PositionableElement getPositionableElement();


### PR DESCRIPTION
Scrolling when dragging should also be possible for Comments, Groups, and Devices