### PR TITLE
Add model edits to better handle complex refactorings

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/Messages.java
@@ -54,6 +54,7 @@ public final class Messages extends NLS {
 	public static String STCoreQuickfixProvider_RemoveInvalidContinueStatementDescription;
 	public static String STCoreQuickfixProvider_OrganizeImports;
 	public static String STCoreChangeConverter_LinkingErrors;
+	public static String STCoreChangeConverter_ModelChanges;
 	public static String STCoreChangeConverter_ReadOnly;
 	public static String STCoreChangeConverter_SyntaxErrors;
 	public static String STCoreCodeMiningPreferencePage_EnableCodeMinings;

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/messages.properties
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/messages.properties
@@ -47,6 +47,7 @@ STCoreQuickfixProvider_RemoveInvalidContinueStatementLabel=Remove CONTINUE state
 STCoreQuickfixProvider_RemoveInvalidContinueStatementDescription=Removes CONTINUE statement
 STCoreQuickfixProvider_OrganizeImports=Organize imports
 STCoreChangeConverter_LinkingErrors=The file ''{0}'' has unresolved references. Refactoring may not be accurate\!
+STCoreChangeConverter_ModelChanges=Model Changes
 STCoreChangeConverter_ReadOnly=Affected file ''{0}'' is read-only
 STCoreChangeConverter_SyntaxErrors=The file ''{0}'' has syntax errors. Refactoring may not be accurate\!
 STCoreCodeMiningPreferencePage_EnableCodeMinings=Enable code minings

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/STCoreChangeConverter.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/STCoreChangeConverter.java
@@ -13,6 +13,7 @@
 package org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring;
 
 import java.text.MessageFormat;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.log4j.Logger;
@@ -31,10 +32,12 @@ import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.structuredtextcore.resource.LibraryElementXtextResource;
 import org.eclipse.fordiac.ide.structuredtextcore.resource.STCoreResource;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.Messages;
-import org.eclipse.fordiac.ide.typemanagement.refactoring.AttributeValueChange;
-import org.eclipse.fordiac.ide.typemanagement.refactoring.DataTypeChange;
-import org.eclipse.fordiac.ide.typemanagement.refactoring.ImportChange;
-import org.eclipse.fordiac.ide.typemanagement.refactoring.InitialValueChange;
+import org.eclipse.fordiac.ide.typemanagement.refactoring.ModelEdit;
+import org.eclipse.fordiac.ide.typemanagement.refactoring.ModelEditChange;
+import org.eclipse.fordiac.ide.typemanagement.refactoring.edit.AttributeValueEdit;
+import org.eclipse.fordiac.ide.typemanagement.refactoring.edit.DataTypeEdit;
+import org.eclipse.fordiac.ide.typemanagement.refactoring.edit.ImportEdit;
+import org.eclipse.fordiac.ide.typemanagement.refactoring.edit.InitialValueEdit;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
@@ -98,6 +101,8 @@ public class STCoreChangeConverter extends ChangeConverter {
 
 	private final IGlobalServiceProvider globalServiceProvider;
 
+	private final List<ModelEdit<?>> modelEdits = new ArrayList<>();
+
 	protected STCoreChangeConverter(final String name, final Predicate<Change> changeFilter,
 			final RefactoringIssueAcceptor issues, final ResourceURIConverter uriConverter, final IWorkbench workbench,
 			final IGlobalServiceProvider globalServiceProvider) {
@@ -109,12 +114,19 @@ public class STCoreChangeConverter extends ChangeConverter {
 	}
 
 	@Override
+	public Change getChange() {
+		addChange(ModelEditChange.fromModelEdits(Messages.STCoreChangeConverter_ModelChanges, modelEdits));
+		modelEdits.clear();
+		return super.getChange();
+	}
+
+	@Override
 	protected void _handleReplacements(final IEmfResourceChange change) {
 		// ignore pure-EMF changes
 		// those are handled via a separate participant
 		if (change instanceof final ImportedNamespaceChange importedNamespaceChange) {
 			final Import imp = importedNamespaceChange.getImport();
-			addChange(new ImportChange(getSourceElementName(imp), LibraryElementXtextResource.getExternalURI(imp),
+			addModelEdit(new ImportEdit(getSourceElementName(imp), LibraryElementXtextResource.getExternalURI(imp),
 					importedNamespaceChange.getImportedNamespace()));
 		}
 	}
@@ -146,17 +158,17 @@ public class STCoreChangeConverter extends ChangeConverter {
 			final EObject sourceElement = coreResource.getSourceElement();
 			final String sourceElementName = getSourceElementName(sourceElement);
 			if (sourceElement instanceof final Attribute attribute) {
-				addChange(new AttributeValueChange(sourceElementName,
-						LibraryElementXtextResource.getExternalURI(attribute),
-						getEditedText(attribute.getValue(), textEdit)));
+				addModelEdit(
+						new AttributeValueEdit(sourceElementName, LibraryElementXtextResource.getExternalURI(attribute),
+								getEditedText(attribute.getValue(), textEdit)));
 			} else if (sourceElement instanceof final ArraySize arraySize
 					&& arraySize.eContainer() instanceof final VarDeclaration varDeclaration) {
-				addChange(new DataTypeChange(sourceElementName,
-						LibraryElementXtextResource.getExternalURI(varDeclaration),
-						getEditedText(varDeclaration.getFullTypeName(), textEdit)));
+				addModelEdit(
+						new DataTypeEdit(sourceElementName, LibraryElementXtextResource.getExternalURI(varDeclaration),
+								getEditedText(varDeclaration.getFullTypeName(), textEdit)));
 			} else if (sourceElement instanceof final Value value
 					&& value.eContainer() instanceof final VarDeclaration varDeclaration) {
-				addChange(new InitialValueChange(sourceElementName,
+				addModelEdit(new InitialValueEdit(sourceElementName,
 						LibraryElementXtextResource.getExternalURI(varDeclaration),
 						getEditedText(value.getValue(), textEdit)));
 			} else {
@@ -188,6 +200,10 @@ public class STCoreChangeConverter extends ChangeConverter {
 		final TextFileChange textFileChange = new TextFileChange(change.getOldURI().lastSegment(), file);
 		textFileChange.setSaveMode(TextFileChange.FORCE_SAVE);
 		return textFileChange;
+	}
+
+	protected void addModelEdit(final ModelEdit<?> edit) {
+		modelEdits.add(edit);
 	}
 
 	protected IDocumentProvider getDocumentProvider(final URI resourceURI) {

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/META-INF/MANIFEST.MF
@@ -34,6 +34,7 @@ Export-Package: org.eclipse.fordiac.ide.typemanagement,
  org.eclipse.fordiac.ide.typemanagement.navigator,
  org.eclipse.fordiac.ide.typemanagement.preferences,
  org.eclipse.fordiac.ide.typemanagement.refactoring,
+ org.eclipse.fordiac.ide.typemanagement.refactoring.edit,
  org.eclipse.fordiac.ide.typemanagement.refactoring.rename,
  org.eclipse.fordiac.ide.typemanagement.util,
  org.eclipse.fordiac.ide.typemanagement.wizards

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/AbstractCommandChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/AbstractCommandChange.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Martin Erich Jobst
+ * Copyright (c) 2024, 2025 Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -195,8 +195,9 @@ public abstract class AbstractCommandChange<T extends EObject> extends Change {
 	 *
 	 * @param element The element
 	 * @return The command (must not be null)
+	 * @throws CoreException if the command could not be created
 	 */
-	protected abstract Command createCommand(T element);
+	protected abstract Command createCommand(T element) throws CoreException;
 
 	/**
 	 * Acquire the library element for the element URI

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/ModelEdit.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/ModelEdit.java
@@ -1,0 +1,168 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Martin Erich Jobst
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Martin Jobst - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.refactoring;
+
+import java.text.MessageFormat;
+import java.util.Objects;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
+import org.eclipse.fordiac.ide.typemanagement.Messages;
+import org.eclipse.gef.commands.Command;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+
+public abstract class ModelEdit<T extends EObject> {
+	private final String name;
+	private final URI elementURI;
+	private final Class<T> elementClass;
+
+	/**
+	 * Create a model edit
+	 *
+	 * @param name         The edit name
+	 * @param elementURI   The element URI
+	 * @param elementClass The element class
+	 */
+	protected ModelEdit(final String name, final URI elementURI, final Class<T> elementClass) {
+		this.name = Objects.requireNonNull(name);
+		this.elementURI = Objects.requireNonNull(elementURI);
+		this.elementClass = Objects.requireNonNull(elementClass);
+	}
+
+	/**
+	 * Initialize the validation data based on the library element
+	 *
+	 * @param libraryElement The library element
+	 * @param pm             The progress monitor
+	 */
+	public final void initializeValidationData(final LibraryElement libraryElement, final IProgressMonitor pm) {
+		final T element = getElement(libraryElement);
+		if (element != null) {
+			initializeValidationData(element, pm);
+		}
+	}
+
+	/**
+	 * Initialize the validation data based on the element
+	 *
+	 * @param element The element
+	 * @param pm      The progress monitor
+	 */
+	public abstract void initializeValidationData(T element, final IProgressMonitor pm);
+
+	/**
+	 * Check if valid based on the library element
+	 *
+	 * @param libraryElement The library element
+	 * @param pm             The progress monitor
+	 */
+	public final RefactoringStatus isValid(final LibraryElement libraryElement, final IProgressMonitor pm)
+			throws CoreException, OperationCanceledException {
+		final RefactoringStatus status = new RefactoringStatus();
+		final T element = getElement(libraryElement);
+		if (element == null) {
+			status.addFatalError(MessageFormat.format(Messages.AbstractCommandChange_NoSuchElement, elementURI));
+		} else {
+			status.merge(isValid(element, pm));
+		}
+		return status;
+	}
+
+	/**
+	 * Check if valid based on the element
+	 *
+	 * @param element The element
+	 * @param pm      The progress monitor
+	 */
+	public abstract RefactoringStatus isValid(T element, final IProgressMonitor pm)
+			throws CoreException, OperationCanceledException;
+
+	/**
+	 * Create the command based on the library element
+	 *
+	 * @param libraryElement The library element
+	 * @return The command (will not be null)
+	 */
+	public final Command createCommand(final LibraryElement libraryElement) throws CoreException {
+		final T element = getElement(libraryElement);
+		if (element == null) {
+			throw new CoreException(
+					Status.error(MessageFormat.format(Messages.AbstractCommandChange_NoSuchElement, elementURI)));
+		}
+		return Objects.requireNonNull(createCommand(element));
+	}
+
+	/**
+	 * Create the command for the element
+	 *
+	 * @param element The element
+	 * @return The command (must not be null)
+	 */
+	protected abstract Command createCommand(T element);
+
+	/**
+	 * Get the name
+	 *
+	 * @return The name (will never be null)
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * Get the element URI
+	 *
+	 * @return The element URI (will never be null)
+	 */
+	public final URI getElementURI() {
+		return elementURI;
+	}
+
+	/**
+	 * Get the library element URI
+	 *
+	 * @return The library element URI (will never be null)
+	 */
+	public final URI getLibraryElementURI() {
+		return elementURI.trimFragment();
+	}
+
+	/**
+	 * Get the element class
+	 *
+	 * @return The element class (will never be null)
+	 */
+	public final Class<T> getElementClass() {
+		return elementClass;
+	}
+
+	private T getElement(final LibraryElement libraryElement) {
+		if (libraryElement != null && libraryElement.eResource() != null) {
+			final EObject element;
+			if (elementURI.hasFragment()) {
+				element = libraryElement.eResource().getEObject(elementURI.fragment());
+			} else {
+				element = libraryElement;
+			}
+			if (elementClass.isInstance(element)) {
+				return elementClass.cast(element);
+			}
+		}
+		return null;
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/ModelEditChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/ModelEditChange.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Martin Erich Jobst
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Martin Jobst - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.refactoring;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
+import org.eclipse.gef.commands.Command;
+import org.eclipse.gef.commands.CompoundCommand;
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.CompositeChange;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+
+public final class ModelEditChange extends AbstractCommandChange<LibraryElement> {
+
+	private final List<ModelEdit<?>> edits;
+
+	private ModelEditChange(final List<ModelEdit<?>> edits) {
+		super(edits.getFirst().getLibraryElementURI(), LibraryElement.class);
+		this.edits = edits;
+	}
+
+	@Override
+	public void initializeValidationData(final LibraryElement element, final IProgressMonitor pm) {
+		final SubMonitor subMonitor = SubMonitor.convert(pm, edits.size());
+		for (final ModelEdit<?> edit : edits) {
+			edit.initializeValidationData(element, subMonitor.newChild(1));
+		}
+	}
+
+	@Override
+	public RefactoringStatus isValid(final LibraryElement element, final IProgressMonitor pm)
+			throws CoreException, OperationCanceledException {
+		final RefactoringStatus result = new RefactoringStatus();
+		final SubMonitor subMonitor = SubMonitor.convert(pm, edits.size());
+		for (final ModelEdit<?> edit : edits) {
+			result.merge(edit.isValid(element, subMonitor.split(1)));
+		}
+		return result;
+	}
+
+	@Override
+	protected Command createCommand(final LibraryElement element) throws CoreException {
+		final CompoundCommand result = new CompoundCommand(getName());
+		for (final ModelEdit<?> edit : edits) {
+			result.add(edit.createCommand(element));
+		}
+		return result;
+	}
+
+	/**
+	 * Get the model edits
+	 *
+	 * @return The model edits
+	 */
+	public List<ModelEdit<?>> getModelEdits() {
+		return Collections.unmodifiableList(edits);
+	}
+
+	public static CompositeChange fromModelEdits(final String name, final List<? extends ModelEdit<?>> edits) {
+		if (edits.isEmpty()) {
+			return null;
+		}
+		final Map<URI, List<ModelEdit<?>>> groupedEdits = edits.stream()
+				.collect(Collectors.groupingBy(ModelEdit::getLibraryElementURI));
+		final Change[] changes = groupedEdits.values().stream().map(ModelEditChange::new).toArray(Change[]::new);
+		return new CompositeChange(name, changes);
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/edit/AttributeValueEdit.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/edit/AttributeValueEdit.java
@@ -10,7 +10,7 @@
  * Contributors:
  *   Martin Jobst - initial API and implementation and/or initial documentation
  *******************************************************************************/
-package org.eclipse.fordiac.ide.typemanagement.refactoring;
+package org.eclipse.fordiac.ide.typemanagement.refactoring.edit;
 
 import java.util.Objects;
 
@@ -21,15 +21,16 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeAttributeValueCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
 import org.eclipse.fordiac.ide.typemanagement.Messages;
+import org.eclipse.fordiac.ide.typemanagement.refactoring.ModelEdit;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 
-public class AttributeValueChange extends AbstractCommandChange<Attribute> {
+public class AttributeValueEdit extends ModelEdit<Attribute> {
 
 	private final String newValue;
 	private String oldValue;
 
-	public AttributeValueChange(final String name, final URI elementURI, final String newValue) {
+	public AttributeValueEdit(final String name, final URI elementURI, final String newValue) {
 		super(name, elementURI, Attribute.class);
 		this.newValue = newValue;
 	}

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/edit/DataTypeEdit.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/edit/DataTypeEdit.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Martin Erich Jobst
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Martin Jobst - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.refactoring.edit;
+
+import java.util.Objects;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.fordiac.ide.model.commands.change.ChangeDataTypeCommand;
+import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
+import org.eclipse.fordiac.ide.typemanagement.Messages;
+import org.eclipse.fordiac.ide.typemanagement.refactoring.ModelEdit;
+import org.eclipse.gef.commands.Command;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+
+public class DataTypeEdit extends ModelEdit<IInterfaceElement> {
+
+	private final String newTypeDeclaration;
+	private String oldTypeDeclaration;
+
+	public DataTypeEdit(final String name, final URI elementURI, final String newTypeDeclaration) {
+		super(name, elementURI, IInterfaceElement.class);
+		this.newTypeDeclaration = newTypeDeclaration;
+	}
+
+	@Override
+	protected Command createCommand(final IInterfaceElement element) {
+		return ChangeDataTypeCommand.forTypeDeclaration(element, newTypeDeclaration);
+	}
+
+	@Override
+	public void initializeValidationData(final IInterfaceElement element, final IProgressMonitor pm) {
+		oldTypeDeclaration = element.getFullTypeName();
+	}
+
+	@Override
+	public RefactoringStatus isValid(final IInterfaceElement element, final IProgressMonitor pm)
+			throws CoreException, OperationCanceledException {
+		final RefactoringStatus status = new RefactoringStatus();
+		if (!Objects.equals(element.getFullTypeName(), oldTypeDeclaration)) {
+			status.addFatalError(Messages.DataTypeChange_TypeDeclarationChanged);
+		}
+		return status;
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/edit/ImportEdit.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/edit/ImportEdit.java
@@ -10,7 +10,7 @@
  * Contributors:
  *   Martin Jobst - initial API and implementation and/or initial documentation
  *******************************************************************************/
-package org.eclipse.fordiac.ide.typemanagement.refactoring;
+package org.eclipse.fordiac.ide.typemanagement.refactoring.edit;
 
 import java.util.Objects;
 
@@ -23,15 +23,16 @@ import org.eclipse.fordiac.ide.model.commands.delete.DeleteImportCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.CompilerInfo;
 import org.eclipse.fordiac.ide.model.libraryElement.Import;
 import org.eclipse.fordiac.ide.typemanagement.Messages;
+import org.eclipse.fordiac.ide.typemanagement.refactoring.ModelEdit;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 
-public class ImportChange extends AbstractCommandChange<Import> {
+public class ImportEdit extends ModelEdit<Import> {
 
 	private final String newValue;
 	private String oldValue;
 
-	public ImportChange(final String name, final URI elementURI, final String newValue) {
+	public ImportEdit(final String name, final URI elementURI, final String newValue) {
 		super(name, elementURI, Import.class);
 		this.newValue = newValue;
 	}

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/edit/InitialValueEdit.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/edit/InitialValueEdit.java
@@ -10,7 +10,7 @@
  * Contributors:
  *   Martin Jobst - initial API and implementation and/or initial documentation
  *******************************************************************************/
-package org.eclipse.fordiac.ide.typemanagement.refactoring;
+package org.eclipse.fordiac.ide.typemanagement.refactoring.edit;
 
 import java.util.Objects;
 
@@ -21,15 +21,16 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeValueCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.typemanagement.Messages;
+import org.eclipse.fordiac.ide.typemanagement.refactoring.ModelEdit;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 
-public class InitialValueChange extends AbstractCommandChange<VarDeclaration> {
+public class InitialValueEdit extends ModelEdit<VarDeclaration> {
 
 	private final String newValue;
 	private String oldValue;
 
-	public InitialValueChange(final String name, final URI elementURI, final String newValue) {
+	public InitialValueEdit(final String name, final URI elementURI, final String newValue) {
 		super(name, elementURI, VarDeclaration.class);
 		this.newValue = newValue;
 	}


### PR DESCRIPTION
Add model edits that are subsequently grouped by URI to model element changes. This avoids problems with unstable URIs in complex refactorings by ensuring all commands pertaining to a particular library element are first created based on each individual URI and then executed at once. The model edit is intended as a drop-in replacement for the current abstract command change base class.