### PR TITLE
Fix code folding in algorithms and methods

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/STAlgorithmUiModule.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/STAlgorithmUiModule.java
@@ -21,6 +21,7 @@ import org.eclipse.fordiac.ide.structuredtextalgorithm.ui.document.STAlgorithmDo
 import org.eclipse.fordiac.ide.structuredtextalgorithm.ui.document.STAlgorithmDocumentPartitioner;
 import org.eclipse.fordiac.ide.structuredtextalgorithm.ui.document.STAlgorithmDocumentUpdaterChangeAdapterFilter;
 import org.eclipse.fordiac.ide.structuredtextalgorithm.ui.editor.embedded.STAlgorithmEmbeddedEditorActions;
+import org.eclipse.fordiac.ide.structuredtextalgorithm.ui.editor.folding.STAlgorithmFoldingRegionProvider;
 import org.eclipse.fordiac.ide.structuredtextalgorithm.ui.editor.hyperlinking.STAlgorithmHyperlinkHelper;
 import org.eclipse.fordiac.ide.structuredtextalgorithm.ui.refactoring.ExtractMethodRefactoring;
 import org.eclipse.fordiac.ide.structuredtextalgorithm.ui.refactoring.STAlgorithmLinkedPositionGroupCalculator;
@@ -98,6 +99,7 @@ import org.eclipse.xtext.ui.editor.contentassist.IContentProposalPriorities;
 import org.eclipse.xtext.ui.editor.contentassist.PrefixMatcher;
 import org.eclipse.xtext.ui.editor.contentassist.XtextContentAssistProcessor;
 import org.eclipse.xtext.ui.editor.embedded.EmbeddedEditorActions;
+import org.eclipse.xtext.ui.editor.folding.IFoldingRegionProvider;
 import org.eclipse.xtext.ui.editor.hover.IEObjectHoverProvider;
 import org.eclipse.xtext.ui.editor.hover.html.IEObjectHoverDocumentationProvider;
 import org.eclipse.xtext.ui.editor.hyperlinking.IHyperlinkHelper;
@@ -213,6 +215,10 @@ public class STAlgorithmUiModule extends AbstractSTAlgorithmUiModule {
 
 	public Class<? extends IHyperlinkHelper> bindIHyperlinkHelper() {
 		return STAlgorithmHyperlinkHelper.class;
+	}
+
+	public Class<? extends IFoldingRegionProvider> bindIFoldingRegionProvider() {
+		return STAlgorithmFoldingRegionProvider.class;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/editor/folding/STAlgorithmFoldingRegionProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/editor/folding/STAlgorithmFoldingRegionProvider.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Martin Erich Jobst
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Martin Jobst - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.structuredtextalgorithm.ui.editor.folding;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.fordiac.ide.structuredtextalgorithm.stalgorithm.STAlgorithmBody;
+import org.eclipse.fordiac.ide.structuredtextalgorithm.stalgorithm.STMethodBody;
+import org.eclipse.xtext.ui.editor.folding.DefaultFoldingRegionProvider;
+
+public class STAlgorithmFoldingRegionProvider extends DefaultFoldingRegionProvider {
+
+	@Override
+	protected boolean isHandled(final EObject eObject) {
+		return super.isHandled(eObject) && !(eObject instanceof STAlgorithmBody || eObject instanceof STMethodBody);
+	}
+}


### PR DESCRIPTION
The algorithm and method body AST elements resulted in an overlapping folding region between the respective contents and the body itself. This excludes the body from folding, which correctly leaves the algorithm or method itself and its respective contents.