### PR TITLE
Fix potential Null ptr in AbstractTypeEntry ActivationListener

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/AbstractTypeEntryAdapter.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/AbstractTypeEntryAdapter.java
@@ -21,6 +21,7 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IPartListener;
 import org.eclipse.ui.IPartService;
 import org.eclipse.ui.IWindowListener;
+import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
@@ -115,7 +116,12 @@ public abstract class AbstractTypeEntryAdapter extends AdapterImpl {
 
 		@Override
 		public void windowActivated(final IWorkbenchWindow window) {
-			window.getShell().getDisplay().asyncExec(() -> handleActivation(window.getActivePage().getActivePart()));
+			window.getShell().getDisplay().asyncExec(() -> {
+				final IWorkbenchPage activePage = window.getActivePage();
+				if (activePage != null) {
+					handleActivation(activePage.getActivePart());
+				}
+			});
 		}
 
 		@Override


### PR DESCRIPTION
On 4diac IDE shutdown the AbstractTypeEntry's ActivationListener may be triggered and because of the async call getActivePage may return null. This is fixed with this change.