### PR TITLE
Fix ignore unrelated imports during move refactoring

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/STCoreImportUpdater.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/STCoreImportUpdater.java
@@ -83,6 +83,9 @@ public class STCoreImportUpdater {
 		}
 		// find matching delta
 		final Optional<Delta> delta = findDelta(deltas, imported);
+		if (delta.isEmpty()) {
+			return; // no delta for import
+		}
 		// find longest qualified name and set as imported namespace
 		// or remove import
 		updater.accept(imp, delta.flatMap(STCoreImportUpdater::findLongestQualifiedName)


### PR DESCRIPTION
The move refactoring also removed any unrelated imports and not just unused ones. This makes sure to skip unrelated imports for which no delta exists.