### PR TITLE
Show model edits in refactoring preview

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/STCoreChangeConverter.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/STCoreChangeConverter.java
@@ -231,10 +231,7 @@ public class STCoreChangeConverter extends ChangeConverter {
 	}
 
 	protected static String getSourceElementName(final EObject element) {
-		if (element != null) {
-			return element.eResource().getURI().lastSegment() + ": " + FordiacMarkerHelper.getLocation(element); //$NON-NLS-1$
-		}
-		return ""; //$NON-NLS-1$
+		return FordiacMarkerHelper.getLocation(element);
 	}
 
 	protected String getEditedText(final String original, final TextEdit textEdit) {

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/AbstractCommandChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/AbstractCommandChange.java
@@ -33,6 +33,7 @@ import org.eclipse.fordiac.ide.typemanagement.Messages;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.CompositeChange;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorInput;
@@ -49,9 +50,8 @@ import org.eclipse.ui.part.FileEditorInput;
  *           become out of date. Always use the element parameter passed to the
  *           respective methods.
  */
-public abstract class AbstractCommandChange<T extends EObject> extends Change {
+public abstract class AbstractCommandChange<T extends EObject> extends CompositeChange {
 
-	private final String name;
 	private final URI elementURI;
 	private final Class<T> elementClass;
 	private final TypeEntry typeEntry;
@@ -77,7 +77,7 @@ public abstract class AbstractCommandChange<T extends EObject> extends Change {
 	 * @param elementClass The element class
 	 */
 	protected AbstractCommandChange(final String name, final URI elementURI, final Class<T> elementClass) {
-		this.name = Objects.requireNonNull(name);
+		super(name);
 		this.elementURI = Objects.requireNonNull(elementURI);
 		this.elementClass = Objects.requireNonNull(elementClass);
 		this.typeEntry = TypeLibraryManager.INSTANCE.getTypeEntryForURI(elementURI);
@@ -245,7 +245,18 @@ public abstract class AbstractCommandChange<T extends EObject> extends Change {
 	 *           {@link CommandRedoChange}.
 	 */
 	protected Change createUndoChange(final Command command, final LibraryElement libraryElement) {
-		return new CommandUndoChange<>(name, elementURI, elementClass, command, libraryElement);
+		return new CommandUndoChange<>(getName(), elementURI, elementClass, command, libraryElement);
+	}
+
+	/**
+	 * @throws UnsupportedOperationException adding changes is not supported
+	 * @implNote We need to inherit from {@link CompositeChange} to support showing
+	 *           child nodes in subclasses, but do not actually support adding any
+	 *           changes.
+	 */
+	@Override
+	public final void add(final Change change) throws UnsupportedOperationException {
+		throw new UnsupportedOperationException("Cannot add any changes to this " + getClass().getName()); //$NON-NLS-1$
 	}
 
 	@Override
@@ -267,11 +278,6 @@ public abstract class AbstractCommandChange<T extends EObject> extends Change {
 			return new Object[] { modifiedElement };
 		}
 		return super.getAffectedObjects();
-	}
-
-	@Override
-	public final String getName() {
-		return name;
 	}
 
 	/**

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/ModelEdit.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/ModelEdit.java
@@ -24,9 +24,10 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.typemanagement.Messages;
 import org.eclipse.gef.commands.Command;
+import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 
-public abstract class ModelEdit<T extends EObject> {
+public abstract class ModelEdit<T extends EObject> extends Change {
 	private final String name;
 	private final URI elementURI;
 	private final Class<T> elementClass;
@@ -120,6 +121,7 @@ public abstract class ModelEdit<T extends EObject> {
 	 *
 	 * @return The name (will never be null)
 	 */
+	@Override
 	public String getName() {
 		return name;
 	}
@@ -163,6 +165,26 @@ public abstract class ModelEdit<T extends EObject> {
 				return elementClass.cast(element);
 			}
 		}
+		return null;
+	}
+
+	@Override
+	public final void initializeValidationData(final IProgressMonitor pm) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public final RefactoringStatus isValid(final IProgressMonitor pm) throws CoreException, OperationCanceledException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public final Change perform(final IProgressMonitor pm) throws CoreException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public final Object getModifiedElement() {
 		return null;
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/ModelEditChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/ModelEditChange.java
@@ -42,7 +42,9 @@ public final class ModelEditChange extends AbstractCommandChange<LibraryElement>
 	public void initializeValidationData(final LibraryElement element, final IProgressMonitor pm) {
 		final SubMonitor subMonitor = SubMonitor.convert(pm, edits.size());
 		for (final ModelEdit<?> edit : edits) {
-			edit.initializeValidationData(element, subMonitor.newChild(1));
+			if (edit.isEnabled()) {
+				edit.initializeValidationData(element, subMonitor.newChild(1));
+			}
 		}
 	}
 
@@ -52,7 +54,9 @@ public final class ModelEditChange extends AbstractCommandChange<LibraryElement>
 		final RefactoringStatus result = new RefactoringStatus();
 		final SubMonitor subMonitor = SubMonitor.convert(pm, edits.size());
 		for (final ModelEdit<?> edit : edits) {
-			result.merge(edit.isValid(element, subMonitor.split(1)));
+			if (edit.isEnabled()) {
+				result.merge(edit.isValid(element, subMonitor.split(1)));
+			}
 		}
 		return result;
 	}
@@ -61,7 +65,9 @@ public final class ModelEditChange extends AbstractCommandChange<LibraryElement>
 	protected Command createCommand(final LibraryElement element) throws CoreException {
 		final CompoundCommand result = new CompoundCommand(getName());
 		for (final ModelEdit<?> edit : edits) {
-			result.add(edit.createCommand(element));
+			if (edit.isEnabled()) {
+				result.add(edit.createCommand(element));
+			}
 		}
 		return result;
 	}
@@ -73,6 +79,19 @@ public final class ModelEditChange extends AbstractCommandChange<LibraryElement>
 	 */
 	public List<ModelEdit<?>> getModelEdits() {
 		return Collections.unmodifiableList(edits);
+	}
+
+	@Override
+	public void setEnabled(final boolean enabled) {
+		super.setEnabled(enabled);
+		for (final ModelEdit<?> edit : edits) {
+			edit.setEnabled(enabled);
+		}
+	}
+
+	@Override
+	public Change[] getChildren() {
+		return edits.toArray(Change[]::new);
 	}
 
 	public static CompositeChange fromModelEdits(final String name, final List<? extends ModelEdit<?>> edits) {


### PR DESCRIPTION
The ltk framework only supports showing nodes in the refactoring preview for composite changes or text edits. This inherits the model edit change from composite change and the model edits from change, so the latter may show up in the preview.