### PR TITLE
Fix editor reload during refactoring

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/AbstractTypeEntryAdapter.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/AbstractTypeEntryAdapter.java
@@ -77,7 +77,8 @@ public abstract class AbstractTypeEntryAdapter extends AdapterImpl {
 	}
 
 	private void performReload() {
-		Display.getDefault().asyncExec(() -> {
+		// make sure editor reloads happen synchronously when saving from an UI context
+		Display.getDefault().execute(() -> {
 			if (!editorClosed() && (!getEditor().isDirty() || openFileChangedDialog() == 0)) {
 				reloadEditorType();
 			}

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/AbstractCommandChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/AbstractCommandChange.java
@@ -225,13 +225,16 @@ public abstract class AbstractCommandChange<T extends EObject> extends Change {
 	 * @throws CoreException if there was a problem saving the library element
 	 */
 	private void commit(final LibraryElement libraryElement, final IProgressMonitor pm) throws CoreException {
-		if (typeEntry != null) {
-			typeEntry.save(libraryElement, pm);
-		}
 		if (editor != null) {
 			// if we have an editor mark the save location in the command stack to tell the
 			// editor that it is not dirty anymore
+			// must do that _before_ saving the type entry, so that when the notification
+			// reaches the editor, it is not considered dirty and we do not trigger a reload
+			// dialog
 			Display.getDefault().syncExec(() -> editor.getAdapter(CommandStack.class).markSaveLocation());
+		}
+		if (typeEntry != null) {
+			typeEntry.save(libraryElement, pm);
 		}
 	}
 


### PR DESCRIPTION
When an editor reload happens during refactoring, a race condition could occur when performing the reload asynchronously in the UI thread.

This ensures that editor reloads happen synchronously when already in the UI thread. It also fixes a superfluous reload dialog when the editor was still dirty when saving the type entry.