### PR TITLE
Fixed Subapp Color Updated #1494

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/SubAppForFBNetworkEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/SubAppForFBNetworkEditPart.java
@@ -113,7 +113,9 @@ public class SubAppForFBNetworkEditPart extends AbstractFBNElementEditPart imple
 				layoutExpandedInterface();
 			}
 			refreshToolTip();
-			backgroundColorChanged(getFigure());
+			if (notification.getFeature() == LibraryElementPackage.eINSTANCE.getFBNetworkElement_Mapping()) {
+				updateDeviceListener();
+			}
 		}
 
 		private static boolean isUnfoldedAttribute(final Object obj) {


### PR DESCRIPTION
With this change subapps correctly listen to device changes and with that update their color when the device color changes.

Fixes: https://github.com/eclipse-4diac/4diac-ide/issues/1494