### PR TITLE
Fixed FollowConnection for Blocks with Networks

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/FollowConnectionHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/FollowConnectionHandler.java
@@ -88,11 +88,13 @@ public abstract class FollowConnectionHandler extends AbstractHandler {
 	}
 
 	protected List<IInterfaceElement> getNextFollowPins(final IInterfaceElement pin, final boolean stepMode) {
-		if (stepMode) {
-			return getConnectionOpposites(pin);
+		final List<IInterfaceElement> opposites = getConnectionOpposites(pin);
+		if (!stepMode) {
+			// before jump, we take 1 step to not fulfill the ending-condition early
+			final List<IInterfaceElement> newOpposites = new ArrayList<>();
+			opposites.forEach(ie -> jumpOverConnections(ie, newOpposites));
+			return newOpposites;
 		}
-		final List<IInterfaceElement> opposites = new ArrayList<>();
-		jumpOverConnections(pin, opposites);
 		return opposites;
 	}
 


### PR DESCRIPTION
It was not possible to start following a connection of a TypedSubapp or CFB