### PR TITLE
Fix save actions during reload in ST editor

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.st/src/org/eclipse/fordiac/ide/fbtypeeditor/st/StructuredTextFBTypeEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.st/src/org/eclipse/fordiac/ide/fbtypeeditor/st/StructuredTextFBTypeEditor.java
@@ -16,6 +16,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.fordiac.ide.fbtypeeditor.editors.FBTypeXtextEditor;
 import org.eclipse.fordiac.ide.structuredtextcore.resource.LibraryElementXtextResource;
+import org.eclipse.fordiac.ide.structuredtextcore.ui.cleanup.STCoreSaveActionsEditor;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.document.LibraryElementXtextDocument;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.document.LibraryElementXtextDocumentUpdater;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.STCoreEditorPreferences;
@@ -28,7 +29,7 @@ import org.eclipse.xtext.util.ITextRegion;
 
 import com.google.inject.Inject;
 
-public class StructuredTextFBTypeEditor extends FBTypeXtextEditor {
+public class StructuredTextFBTypeEditor extends FBTypeXtextEditor implements STCoreSaveActionsEditor {
 
 	@Inject
 	private STCoreMapper algorithmMapper;
@@ -102,5 +103,26 @@ public class StructuredTextFBTypeEditor extends FBTypeXtextEditor {
 	@Override
 	public String getEditorId() {
 		return getLanguageName();
+	}
+
+	private boolean saveActionsDisabled;
+
+	@Override
+	public void doRevertToSaved() {
+		setSaveActionsDisabled(true);
+		try {
+			super.doRevertToSaved();
+		} finally {
+			setSaveActionsDisabled(false);
+		}
+	}
+
+	@Override
+	public boolean isSaveActionsDisabled() {
+		return saveActionsDisabled;
+	}
+
+	public void setSaveActionsDisabled(final boolean saveActionsDisabled) {
+		this.saveActionsDisabled = saveActionsDisabled;
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/src/org/eclipse/fordiac/ide/globalconstantseditor/ui/GlobalConstantsUiModule.java
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/src/org/eclipse/fordiac/ide/globalconstantseditor/ui/GlobalConstantsUiModule.java
@@ -28,6 +28,7 @@ import org.eclipse.fordiac.ide.structuredtextcore.ui.contentassist.STCoreProposa
 import org.eclipse.fordiac.ide.structuredtextcore.ui.document.STCoreDocumentPartitioner;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.document.STCoreDocumentProvider;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.STCoreSourceViewer.STCoreSourceViewerFactory;
+import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.STCoreXtextEditor;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.formatting.STCoreWhitespaceInformationProvider;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.occurrences.STCoreOccurrenceComputer;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.preferences.STCoreSubLanguagePreferenceStoreAccess;
@@ -196,6 +197,10 @@ public class GlobalConstantsUiModule extends AbstractGlobalConstantsUiModule {
 
 	public Class<? extends XtextQuickAssistProcessor> bindXtextQuickAssistProcessor() {
 		return STCoreQuickAssistProcessor.class;
+	}
+
+	public Class<? extends XtextEditor> bindXtextEditor() {
+		return STCoreXtextEditor.class;
 	}
 
 	public Class<? extends XtextSourceViewer.Factory> bindXtextSourceViewer$Factory() {

--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/src/org/eclipse/fordiac/ide/globalconstantseditor/ui/editor/GlobalConstantsEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/src/org/eclipse/fordiac/ide/globalconstantseditor/ui/editor/GlobalConstantsEditor.java
@@ -15,6 +15,7 @@ package org.eclipse.fordiac.ide.globalconstantseditor.ui.editor;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.fordiac.ide.globalconstantseditor.ui.properties.GlobalConstantsPropertySheetPage;
+import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.STCoreXtextEditor;
 import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.gef.commands.CommandStackEvent;
 import org.eclipse.gef.commands.CommandStackEventListener;
@@ -27,9 +28,8 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IEditorSite;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.views.properties.tabbed.ITabbedPropertySheetPageContributor;
-import org.eclipse.xtext.ui.editor.XtextEditor;
 
-public class GlobalConstantsEditor extends XtextEditor
+public class GlobalConstantsEditor extends STCoreXtextEditor
 		implements CommandStackEventListener, ITabbedPropertySheetPageContributor {
 
 	private final CommandStack commandStack = new CommandStack();

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/STAlgorithmUiModule.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/STAlgorithmUiModule.java
@@ -35,6 +35,7 @@ import org.eclipse.fordiac.ide.structuredtextcore.ui.document.STCoreDocumentPart
 import org.eclipse.fordiac.ide.structuredtextcore.ui.document.STCoreDocumentProvider;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.STCoreSourceViewer.STCoreSourceViewerFactory;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.STCoreURIEditorOpener;
+import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.STCoreXtextEditor;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.formatting.STCoreWhitespaceInformationProvider;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.occurrences.STCoreOccurrenceComputer;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.preferences.STCoreSubLanguagePreferenceStoreAccess;
@@ -238,6 +239,10 @@ public class STAlgorithmUiModule extends AbstractSTAlgorithmUiModule {
 
 	public Class<? extends XtextQuickAssistProcessor> bindXtextQuickAssistProcessor() {
 		return STCoreQuickAssistProcessor.class;
+	}
+
+	public Class<? extends XtextEditor> bindXtextEditor() {
+		return STCoreXtextEditor.class;
 	}
 
 	public Class<? extends XtextSourceViewer.Factory> bindXtextSourceViewer$Factory() {

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/STCoreUiModule.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/STCoreUiModule.java
@@ -28,6 +28,7 @@ import org.eclipse.fordiac.ide.structuredtextcore.ui.contentassist.STCoreProposa
 import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.STCoreEditorPreferences;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.STCoreSourceViewer.STCoreSourceViewerFactory;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.STCoreURIEditorOpener;
+import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.STCoreXtextEditor;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.formatting.STCoreWhitespaceInformationProvider;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.occurrences.STCoreOccurrenceComputer;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.quickfix.STCoreQuickAssistProcessor;
@@ -185,6 +186,10 @@ public class STCoreUiModule extends AbstractSTCoreUiModule {
 
 	public Class<? extends XtextQuickAssistProcessor> bindXtextQuickAssistProcessor() {
 		return STCoreQuickAssistProcessor.class;
+	}
+
+	public Class<? extends XtextEditor> bindXtextEditor() {
+		return STCoreXtextEditor.class;
 	}
 
 	public Class<? extends XtextSourceViewer.Factory> bindXtextSourceViewer$Factory() {

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/cleanup/STCoreCleanupEditorCallback.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/cleanup/STCoreCleanupEditorCallback.java
@@ -38,7 +38,9 @@ public class STCoreCleanupEditorCallback extends IXtextEditorCallback.NullImpl {
 
 	@Override
 	public void afterSave(final XtextEditor editor) {
-		if (!running && preferences.isEnableSaveActions(getProject(editor))) {
+		if (!running && preferences.isEnableSaveActions(getProject(editor))
+				&& editor instanceof final STCoreSaveActionsEditor stCoreXtextEditor
+				&& !stCoreXtextEditor.isSaveActionsDisabled()) {
 			try {
 				running = true;
 				performSaveActions(editor);

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/cleanup/STCoreSaveActionsEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/cleanup/STCoreSaveActionsEditor.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Martin Erich Jobst
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Martin Jobst - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.structuredtextcore.ui.cleanup;
+
+public interface STCoreSaveActionsEditor {
+
+	/**
+	 * Checks if save actions should currectly be disabled.
+	 *
+	 * @return true if disabled, false otherwise
+	 */
+	boolean isSaveActionsDisabled();
+}

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/editor/STCoreXtextEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/editor/STCoreXtextEditor.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Martin Erich Jobst
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Martin Jobst - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.structuredtextcore.ui.editor;
+
+import org.eclipse.fordiac.ide.structuredtextcore.ui.cleanup.STCoreSaveActionsEditor;
+import org.eclipse.xtext.ui.editor.XtextEditor;
+
+public class STCoreXtextEditor extends XtextEditor implements STCoreSaveActionsEditor {
+
+	private boolean saveActionsDisabled;
+
+	@Override
+	public void doRevertToSaved() {
+		setSaveActionsDisabled(true);
+		try {
+			super.doRevertToSaved();
+		} finally {
+			setSaveActionsDisabled(false);
+		}
+	}
+
+	@Override
+	public boolean isSaveActionsDisabled() {
+		return saveActionsDisabled;
+	}
+
+	public void setSaveActionsDisabled(final boolean saveActionsDisabled) {
+		this.saveActionsDisabled = saveActionsDisabled;
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/ui/STFunctionUiModule.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/ui/STFunctionUiModule.java
@@ -27,6 +27,7 @@ import org.eclipse.fordiac.ide.structuredtextcore.ui.document.STCoreDocumentPart
 import org.eclipse.fordiac.ide.structuredtextcore.ui.document.STCoreDocumentProvider;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.STCoreSourceViewer.STCoreSourceViewerFactory;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.STCoreURIEditorOpener;
+import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.STCoreXtextEditor;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.formatting.STCoreWhitespaceInformationProvider;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.occurrences.STCoreOccurrenceComputer;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.preferences.STCoreSubLanguagePreferenceStoreAccess;
@@ -210,6 +211,10 @@ public class STFunctionUiModule extends AbstractSTFunctionUiModule {
 
 	public Class<? extends XtextQuickAssistProcessor> bindXtextQuickAssistProcessor() {
 		return STCoreQuickAssistProcessor.class;
+	}
+
+	public Class<? extends XtextEditor> bindXtextEditor() {
+		return STCoreXtextEditor.class;
 	}
 
 	public Class<? extends XtextSourceViewer.Factory> bindXtextSourceViewer$Factory() {


### PR DESCRIPTION
The Xtext editor also calls the after-save callback when performing a revert, which resulted in the save actions also running during a reload. This sets a flag to disable save actions during a revert/reload.