### PR TITLE
Remove NO_CHANGE from ConfigurableChange

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/refactoring/AddLibraryDependencyChange.java
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/refactoring/AddLibraryDependencyChange.java
@@ -20,7 +20,6 @@ import org.eclipse.fordiac.ide.library.model.library.Manifest;
 import org.eclipse.fordiac.ide.library.model.library.Required;
 import org.eclipse.fordiac.ide.library.model.util.ManifestHelper;
 import org.eclipse.fordiac.ide.typemanagement.Messages;
-import org.eclipse.fordiac.ide.typemanagement.refactoring.IFordiacPreviewChange.ChangeState;
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.CompositeChange;
 
@@ -43,12 +42,7 @@ public class AddLibraryDependencyChange extends CompositeChange {
 
 		if (dependency != null && ManifestHelper.addDependency(projectManifest, dependency)
 				&& ManifestHelper.saveManifest(projectManifest)) {
-			final DeleteLibraryDependencyChange change = new DeleteLibraryDependencyChange(project,
-					dependency.getSymbolicName());
-			final ChangeState cs = ChangeState.DELETE;
-			change.addState(cs);
-			change.getState().removeIf(state -> !state.equals(cs));
-			return change;
+			return new DeleteLibraryDependencyChange(project, dependency.getSymbolicName());
 		}
 		return null;
 	}

--- a/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/refactoring/DeleteLibraryDependencyChange.java
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/refactoring/DeleteLibraryDependencyChange.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.library.ui.refactoring;
 
-import java.util.EnumSet;
-
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -22,58 +20,32 @@ import org.eclipse.fordiac.ide.library.model.library.Manifest;
 import org.eclipse.fordiac.ide.library.model.library.Required;
 import org.eclipse.fordiac.ide.library.model.util.ManifestHelper;
 import org.eclipse.fordiac.ide.typemanagement.Messages;
-import org.eclipse.fordiac.ide.typemanagement.refactoring.IFordiacPreviewChange;
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.CompositeChange;
 
-public class DeleteLibraryDependencyChange extends CompositeChange implements IFordiacPreviewChange {
+public class DeleteLibraryDependencyChange extends CompositeChange {
 	private final IProject project;
 	private final String symbolicName;
-	private final EnumSet<ChangeState> state = EnumSet.noneOf(ChangeState.class);
 
 	public DeleteLibraryDependencyChange(final IProject project, final String symbolicName) {
 		super(Messages.DeleteLibraryParticipant_Change_Title);
 		this.project = project;
 		this.symbolicName = symbolicName;
-		state.addAll(this.getDefaultSelection());
 	}
 
 	@Override
 	public Change perform(final IProgressMonitor pm) throws CoreException {
-		if (state.contains(ChangeState.DELETE)) {
-			final Manifest projectManifest = ManifestHelper.getContainerManifest(project);
-			if (projectManifest == null || projectManifest.getDependencies() == null) {
-				return null;
-			}
-			final Required dependency = projectManifest.getDependencies().getRequired().stream()
-					.filter(r -> symbolicName.equals(r.getSymbolicName())).findAny().orElse(null);
+		final Manifest projectManifest = ManifestHelper.getContainerManifest(project);
+		if (projectManifest == null || projectManifest.getDependencies() == null) {
+			return null;
+		}
+		final Required dependency = projectManifest.getDependencies().getRequired().stream()
+				.filter(r -> symbolicName.equals(r.getSymbolicName())).findAny().orElse(null);
 
-			if (dependency != null && ManifestHelper.removeDependency(projectManifest, dependency)
-					&& ManifestHelper.saveManifest(projectManifest)) {
-				return new AddLibraryDependencyChange(project, dependency);
-			}
+		if (dependency != null && ManifestHelper.removeDependency(projectManifest, dependency)
+				&& ManifestHelper.saveManifest(projectManifest)) {
+			return new AddLibraryDependencyChange(project, dependency);
 		}
 		return null;
 	}
-
-	@Override
-	public EnumSet<ChangeState> getState() {
-		return state;
-	}
-
-	@Override
-	public EnumSet<ChangeState> getAllowedChoices() {
-		return EnumSet.of(ChangeState.DELETE, ChangeState.NO_CHANGE);
-	}
-
-	@Override
-	public void addState(final ChangeState newState) {
-		state.add(newState);
-	}
-
-	@Override
-	public EnumSet<ChangeState> getDefaultSelection() {
-		return EnumSet.of(ChangeState.DELETE);
-	}
-
 }

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/plugin.properties
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/plugin.properties
@@ -182,4 +182,3 @@ AddLibraryDependency_Change_Title=Adding Library Dependency
 SafeStructDeletionChange_RootNodeChangeText=Changes for occurrence: {0}{1}
 UpdateUntypedSubappPinChange_0=Pin is not part of untyped subapp
 UpdateFBInstances="Update FB instance"
-ConfigurableChange_noChangeErrorMessage0=NO_CHANGE is selected

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/Messages.java
@@ -126,7 +126,6 @@ public final class Messages extends NLS {
 	public static String DeleteFBTypeParticipant_Change_UpdateSubappPins;
 	public static String FBTypeComposedAdapterFactory_FBTypecomposedAdapterFactoryShouldNotBeInsantiated;
 	public static String IFordiacPreviewChange_Reconnect0;
-	public static String ConfigurableChange_noChangeErrorMessage;
 
 	public static String ImportChange_ImportedNamespaceChanged;
 
@@ -192,7 +191,6 @@ public final class Messages extends NLS {
 	public static String PreviewChange_DeleteChoice;
 	public static String PreviewChange_ChangeToAnyStruct;
 	public static String PreviewChange_ReplaceWithMarker;
-	public static String PreviewChange_NoChange;
 
 	public static String DeleteLibraryParticipant_Name;
 	public static String DeleteLibraryParticipant_Change_Title;

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/ConfigurableChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/ConfigurableChange.java
@@ -20,7 +20,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.fordiac.ide.typemanagement.Messages;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 
 public abstract class ConfigurableChange<T extends EObject> extends AbstractCommandChange<T>
@@ -31,29 +30,17 @@ public abstract class ConfigurableChange<T extends EObject> extends AbstractComm
 	@Override
 	public RefactoringStatus isValid(final T element, final IProgressMonitor pm)
 			throws CoreException, OperationCanceledException {
-		final RefactoringStatus status = new RefactoringStatus();
-		if (getState().contains(ChangeState.NO_CHANGE)) {
-			status.addFatalError(Messages.ConfigurableChange_noChangeErrorMessage);
-		}
-		return status;
+		return new RefactoringStatus();
 	}
 
 	protected ConfigurableChange(final String name, final URI elementURI, final Class<T> elementClass) {
 		super(name, elementURI, elementClass);
 		this.state = getDefaultSelection();
-		initEnablement();
 	}
 
 	protected ConfigurableChange(final URI elementURI, final Class<T> elementClass) {
 		super(elementURI, elementClass);
 		this.state = getDefaultSelection();
-		initEnablement();
-	}
-
-	private void initEnablement() {
-		if (getDefaultSelection().contains(ChangeState.NO_CHANGE)) {
-			setEnabled(false);
-		}
 	}
 
 	@Override
@@ -64,10 +51,5 @@ public abstract class ConfigurableChange<T extends EObject> extends AbstractComm
 	@Override
 	public void addState(final ChangeState newState) {
 		state.add(newState);
-	}
-
-	@Override
-	public EnumSet<ChangeState> getDefaultSelection() {
-		return EnumSet.of(ChangeState.NO_CHANGE);
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/ConfigurableModelEdit.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/ConfigurableModelEdit.java
@@ -24,13 +24,6 @@ public abstract class ConfigurableModelEdit<T extends EObject> extends ModelEdit
 	protected ConfigurableModelEdit(final String name, final URI elementURI, final Class<T> elementClass) {
 		super(name, elementURI, elementClass);
 		this.state = getDefaultSelection();
-		initEnablement();
-	}
-
-	private void initEnablement() {
-		if (getDefaultSelection().contains(ChangeState.NO_CHANGE)) {
-			setEnabled(false);
-		}
 	}
 
 	@Override
@@ -41,10 +34,5 @@ public abstract class ConfigurableModelEdit<T extends EObject> extends ModelEdit
 	@Override
 	public void addState(final ChangeState newState) {
 		state.add(newState);
-	}
-
-	@Override
-	public EnumSet<ChangeState> getDefaultSelection() {
-		return EnumSet.of(ChangeState.NO_CHANGE);
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/IFordiacPreviewChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/IFordiacPreviewChange.java
@@ -21,7 +21,7 @@ public interface IFordiacPreviewChange {
 
 	public enum ChangeState {
 		DELETE(Messages.PreviewChange_DeleteChoice), CHANGE_TO_ANY(Messages.PreviewChange_ChangeToAnyStruct),
-		REPLACE_WITH_MARKER(Messages.PreviewChange_ReplaceWithMarker), NO_CHANGE(Messages.PreviewChange_NoChange),
+		REPLACE_WITH_MARKER(Messages.PreviewChange_ReplaceWithMarker),
 		RECONNECT(Messages.IFordiacPreviewChange_Reconnect0);
 
 		private final String descriptor;

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/ReconnectPinChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/ReconnectPinChange.java
@@ -16,9 +16,7 @@ package org.eclipse.fordiac.ide.typemanagement.refactoring;
 import java.util.EnumSet;
 import java.util.Set;
 
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeValueCommand;
@@ -37,7 +35,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.typemanagement.refactoring.IFordiacPreviewChange.ChangeState;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.commands.CompoundCommand;
-import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 
 public class ReconnectPinChange extends ConfigurableChange<FBNetworkElement> {
 
@@ -46,7 +43,7 @@ public class ReconnectPinChange extends ConfigurableChange<FBNetworkElement> {
 
 	public ReconnectPinChange(final URI elementURI, final Class<FBNetworkElement> elementClass, final String newName,
 			final String oldName) {
-		super("Handle connection of : " + oldName, elementURI, elementClass);
+		super("Handle connection of : " + oldName, elementURI, elementClass); //$NON-NLS-1$
 		this.newName = newName;
 		this.oldName = oldName;
 	}
@@ -59,7 +56,7 @@ public class ReconnectPinChange extends ConfigurableChange<FBNetworkElement> {
 
 	@Override
 	public EnumSet<ChangeState> getAllowedChoices() {
-		return EnumSet.of(ChangeState.RECONNECT, ChangeState.NO_CHANGE, ChangeState.DELETE);
+		return EnumSet.of(ChangeState.RECONNECT, ChangeState.DELETE);
 	}
 
 	@Override
@@ -71,13 +68,6 @@ public class ReconnectPinChange extends ConfigurableChange<FBNetworkElement> {
 	public void initializeValidationData(final FBNetworkElement element, final IProgressMonitor pm) {
 		// No special initialization required
 	}
-
-	@Override
-	public RefactoringStatus isValid(final FBNetworkElement element, final IProgressMonitor pm)
-			throws CoreException, OperationCanceledException {
-		return super.isValid(element, pm);
-	}
-
 }
 
 class ReconnectPinByName extends Command {

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/UpdateManipulatorChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/UpdateManipulatorChange.java
@@ -14,7 +14,6 @@
 package org.eclipse.fordiac.ide.typemanagement.refactoring;
 
 import java.text.MessageFormat;
-import java.util.EnumSet;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -27,10 +26,11 @@ import org.eclipse.fordiac.ide.typemanagement.Messages;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 
-public class UpdateManipulatorChange extends ConfigurableChange<StructManipulator> {
+public class UpdateManipulatorChange extends AbstractCommandChange<StructManipulator> {
 
 	public UpdateManipulatorChange(final StructManipulator manipulator) {
 		super(getName(manipulator), EcoreUtil.getURI(manipulator), StructManipulator.class);
+		setEnabled(false); // not enabled by default
 	}
 
 	public static String getName(final StructManipulator manipulator) {
@@ -46,26 +46,15 @@ public class UpdateManipulatorChange extends ConfigurableChange<StructManipulato
 	@Override
 	public RefactoringStatus isValid(final StructManipulator manipulator, final IProgressMonitor pm)
 			throws CoreException, OperationCanceledException {
-		final RefactoringStatus status = super.isValid(manipulator, pm);
+		final RefactoringStatus status = new RefactoringStatus();
 		if (manipulator.eContainer() == null) {
-			status.addError(getName() + " invalid element");
+			status.addError(getName() + " invalid element"); //$NON-NLS-1$
 		}
 		return status;
 	}
 
 	@Override
 	protected Command createCommand(final StructManipulator manipulator) {
-		if (getState().contains(ChangeState.CHANGE_TO_ANY)) {
-			return new ChangeStructCommand(manipulator, IecTypes.GenericTypes.ANY, true);
-		}
-		// only return null if the UI has an incosistency, so returning null will force
-		// an error
-		return null;
+		return new ChangeStructCommand(manipulator, IecTypes.GenericTypes.ANY, true);
 	}
-
-	@Override
-	public EnumSet<ChangeState> getAllowedChoices() {
-		return EnumSet.of(ChangeState.CHANGE_TO_ANY, ChangeState.NO_CHANGE);
-	}
-
 }

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/delete/DeleteUpdateFBTypeInterfaceChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/delete/DeleteUpdateFBTypeInterfaceChange.java
@@ -43,16 +43,17 @@ public class DeleteUpdateFBTypeInterfaceChange extends ConfigurableChange<FBType
 		super(MessageFormat.format(Messages.DeleteFBTypeParticipant_Change_DeleteFBTypeInterface, type.getName(),
 				struct.getName()), EcoreUtil.getURI(type), FBType.class);
 		this.struct = struct;
+		setEnabled(false); // not enabled by default
 	}
 
 	@Override
 	public EnumSet<ChangeState> getAllowedChoices() {
-		return EnumSet.of(ChangeState.CHANGE_TO_ANY, ChangeState.DELETE, ChangeState.NO_CHANGE);
+		return EnumSet.of(ChangeState.CHANGE_TO_ANY, ChangeState.DELETE);
 	}
 
 	@Override
 	public EnumSet<ChangeState> getDefaultSelection() {
-		return EnumSet.of(ChangeState.NO_CHANGE);
+		return EnumSet.of(ChangeState.CHANGE_TO_ANY);
 	}
 
 	@Override
@@ -68,11 +69,11 @@ public class DeleteUpdateFBTypeInterfaceChange extends ConfigurableChange<FBType
 		final List<VarDeclaration> varDeclaration = getVarDeclarationsForStruct(element);
 
 		if (varDeclaration.isEmpty()) {
-			status.addError(struct.getQualifiedName() + " is not part of the interface of " + getName());
+			status.addError(struct.getQualifiedName() + " is not part of the interface of " + getName()); //$NON-NLS-1$
 		}
 
 		if (element.getTypeLibrary() == null || element.getTypeLibrary().getDataTypeLibrary() == null) {
-			status.addError("Type Library is null");
+			status.addError("Type Library is null"); //$NON-NLS-1$
 		}
 
 		return status;

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/delete/DeleteUpdateStructDataTypeMemberVariableChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/delete/DeleteUpdateStructDataTypeMemberVariableChange.java
@@ -38,16 +38,17 @@ public class DeleteUpdateStructDataTypeMemberVariableChange extends Configurable
 				varDeclaration.getName(), varDeclaration.getTypeName(),
 				((INamedElement) varDeclaration.eContainer()).getName()), EcoreUtil.getURI(varDeclaration),
 				VarDeclaration.class);
+		setEnabled(false); // not enabled by default
 	}
 
 	@Override
 	public EnumSet<ChangeState> getAllowedChoices() {
-		return EnumSet.of(ChangeState.DELETE, ChangeState.CHANGE_TO_ANY, ChangeState.NO_CHANGE);
+		return EnumSet.of(ChangeState.DELETE, ChangeState.CHANGE_TO_ANY);
 	}
 
 	@Override
 	public EnumSet<ChangeState> getDefaultSelection() {
-		return EnumSet.of(ChangeState.NO_CHANGE);
+		return EnumSet.of(ChangeState.DELETE);
 	}
 
 	@Override
@@ -61,7 +62,7 @@ public class DeleteUpdateStructDataTypeMemberVariableChange extends Configurable
 		final RefactoringStatus status = super.isValid(element, pm);
 
 		if (!(element.getType() instanceof StructuredType)) {
-			status.addError("This should not happen");
+			status.addError("This should not happen"); //$NON-NLS-1$
 		}
 
 		return status;
@@ -75,10 +76,6 @@ public class DeleteUpdateStructDataTypeMemberVariableChange extends Configurable
 		}
 		if (getState().contains(ChangeState.CHANGE_TO_ANY)) {
 			return ChangeDataTypeCommand.forDataType(varDeclaration, IecTypes.GenericTypes.ANY_STRUCT);
-		}
-
-		if (getState().contains(ChangeState.NO_CHANGE)) {
-			return ChangeDataTypeCommand.forDataType(varDeclaration, varDeclaration.getType());
 		}
 
 		return null;

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/delete/UpdateUntypedSubappPinChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/delete/UpdateUntypedSubappPinChange.java
@@ -36,6 +36,7 @@ public class UpdateUntypedSubappPinChange extends ConfigurableChange<VarDeclarat
 	public UpdateUntypedSubappPinChange(final VarDeclaration varDecl) {
 		super(MessageFormat.format(Messages.DeleteFBTypeParticipant_Change_DeleteSubappPins, varDecl.getName(),
 				getSubappName(varDecl)), EcoreUtil.getURI(varDecl), VarDeclaration.class);
+		setEnabled(false); // not enabled by default
 	}
 
 	private static String getSubappName(final VarDeclaration varDecl) {
@@ -44,12 +45,12 @@ public class UpdateUntypedSubappPinChange extends ConfigurableChange<VarDeclarat
 
 	@Override
 	public EnumSet<ChangeState> getAllowedChoices() {
-		return EnumSet.of(ChangeState.DELETE, ChangeState.CHANGE_TO_ANY, ChangeState.NO_CHANGE);
+		return EnumSet.of(ChangeState.DELETE, ChangeState.CHANGE_TO_ANY);
 	}
 
 	@Override
 	public EnumSet<ChangeState> getDefaultSelection() {
-		return EnumSet.of(ChangeState.NO_CHANGE);
+		return EnumSet.of(ChangeState.DELETE);
 	}
 
 	@Override
@@ -64,9 +65,6 @@ public class UpdateUntypedSubappPinChange extends ConfigurableChange<VarDeclarat
 		}
 		if (getState().contains(ChangeState.CHANGE_TO_ANY)) {
 			return ChangeDataTypeCommand.forDataType(varDecl, IecTypes.GenericTypes.ANY_STRUCT);
-		}
-		if (getState().contains(ChangeState.NO_CHANGE)) {
-			return ChangeDataTypeCommand.forDataType(varDecl, varDecl.getType());
 		}
 		return null;
 	}

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/wizards/ChangeConfigurationViewer.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/wizards/ChangeConfigurationViewer.java
@@ -93,6 +93,9 @@ public class ChangeConfigurationViewer implements IChangePreviewViewer {
 
 		if (choices.keySet().stream().filter(TableItem::getChecked).toList().isEmpty()) {
 			choices.firstEntry().getKey().setChecked(true);
+			final ChangeState cs = choices.firstEntry().getValue();
+			change.addState(cs);
+			change.getState().removeIf(state -> !state.equals(cs));
 		}
 
 	}
@@ -100,11 +103,9 @@ public class ChangeConfigurationViewer implements IChangePreviewViewer {
 	private void initializeChoices(final ChangePreviewViewerInput input) {
 		if (input.getChange() instanceof final IFordiacPreviewChange previewChange) {
 			previewChange.getAllowedChoices().forEach(s -> {
-				if (!s.equals(ChangeState.NO_CHANGE)) { // no change should not be selectable by the User
-					final TableItem ti = new TableItem(table, SWT.NONE);
-					ti.setText(s.toString());
-					choices.put(ti, s);
-				}
+				final TableItem ti = new TableItem(table, SWT.NONE);
+				ti.setText(s.toString());
+				choices.put(ti, s);
 			});
 		}
 


### PR DESCRIPTION
If NO_CHANGE was the standard choice setEnabled(false) will be called in the constructor instead

- DeleteUpdateStructDataTypeMemberVariableChange: not enabled by default, DELETE now standard option
- ReconnectPinChange: no change in behaviour
- UpdateManipulatorChange: not enabled by default, now extends AbstractCommandChange
- DeleteUpdateFBTypeInterfaceChange: not enabled by default, CHANGE_TO_ANY now standard option
- UpdateUntypedSubappPinChange: not enabled by default, DELETE now standard option
- DeleteLibraryDependencyChange: no change in behaviour, now extends AbstractCommandChange