### PR TITLE
Use library element as element type in model, evaluator, and ST parser

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/DeploymentDebugWatchUtils.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/DeploymentDebugWatchUtils.java
@@ -25,6 +25,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.Device;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.Resource;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
@@ -135,7 +136,7 @@ public final class DeploymentDebugWatchUtils {
 		};
 	}
 
-	public static INamedElement evaluateWatchType(final VarDeclaration varDeclaration) {
+	public static LibraryElement evaluateWatchType(final VarDeclaration varDeclaration) {
 		if (varDeclaration.isInOutVar() && varDeclaration.isArray()
 				&& TypeDeclarationParser.isVariableArrayBounds(varDeclaration.getArraySize().getValue())) {
 			// use type of defining InOut declaration for arrays with variable length

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/VarDeclarationSupport.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/VarDeclarationSupport.xtend
@@ -16,7 +16,6 @@ import java.util.Map
 import org.eclipse.fordiac.ide.export.ExportException
 import org.eclipse.fordiac.ide.export.forte_ng.ForteNgExportFilter
 import org.eclipse.fordiac.ide.model.eval.variable.VariableOperations
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STInitializerExpressionSource
@@ -30,7 +29,7 @@ import static extension org.eclipse.xtext.EcoreUtil2.*
 class VarDeclarationSupport extends StructuredTextSupport {
 	final VarDeclaration varDeclaration
 
-	INamedElement resultType
+	LibraryElement resultType
 	STInitializerExpressionSource parseResult
 
 	override prepare() {

--- a/plugins/org.eclipse.fordiac.ide.model.eval.st/src/org/eclipse/fordiac/ide/model/eval/st/AttributeEvaluator.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval.st/src/org/eclipse/fordiac/ide/model/eval/st/AttributeEvaluator.java
@@ -32,7 +32,6 @@ import org.eclipse.fordiac.ide.model.eval.variable.VariableEvaluator;
 import org.eclipse.fordiac.ide.model.eval.variable.VariableOperations;
 import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextalgorithm.util.StructuredTextParseUtil;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STInitializerExpressionSource;
@@ -105,7 +104,7 @@ public class AttributeEvaluator extends StructuredTextEvaluator implements Varia
 	}
 
 	@Override
-	public INamedElement evaluateResultType() throws EvaluatorException, InterruptedException {
+	public LibraryElement evaluateResultType() throws EvaluatorException, InterruptedException {
 		return attribute.getType() instanceof final AnyType resultType ? resultType : ElementaryTypes.WSTRING;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.model.eval.st/src/org/eclipse/fordiac/ide/model/eval/st/ConstantExpressionEvaluator.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval.st/src/org/eclipse/fordiac/ide/model/eval/st/ConstantExpressionEvaluator.java
@@ -18,7 +18,7 @@ import java.util.Set;
 import org.eclipse.fordiac.ide.model.eval.EvaluatorException;
 import org.eclipse.fordiac.ide.model.eval.value.Value;
 import org.eclipse.fordiac.ide.model.eval.variable.Variable;
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpression;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STInitializerExpression;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STVarDeclaration;
@@ -40,7 +40,7 @@ public final class ConstantExpressionEvaluator extends StructuredTextEvaluator {
 		return INSTANCE.evaluateInitializerExpression(variable, expression);
 	}
 
-	public static INamedElement evaluateResultType(final STVarDeclaration varDeclaration)
+	public static LibraryElement evaluateResultType(final STVarDeclaration varDeclaration)
 			throws EvaluatorException, InterruptedException {
 		return INSTANCE.evaluateType(varDeclaration);
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.eval.st/src/org/eclipse/fordiac/ide/model/eval/st/DirectlyDerivedTypeEvaluator.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval.st/src/org/eclipse/fordiac/ide/model/eval/st/DirectlyDerivedTypeEvaluator.java
@@ -28,7 +28,6 @@ import org.eclipse.fordiac.ide.model.eval.variable.Variable;
 import org.eclipse.fordiac.ide.model.eval.variable.VariableEvaluator;
 import org.eclipse.fordiac.ide.model.eval.variable.VariableOperations;
 import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextalgorithm.util.StructuredTextParseUtil;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STInitializerExpressionSource;
@@ -100,7 +99,7 @@ public class DirectlyDerivedTypeEvaluator extends StructuredTextEvaluator implem
 	}
 
 	@Override
-	public INamedElement evaluateResultType() throws EvaluatorException, InterruptedException {
+	public LibraryElement evaluateResultType() throws EvaluatorException, InterruptedException {
 		return directlyDerivedType.getBaseType();
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.model.eval.st/src/org/eclipse/fordiac/ide/model/eval/st/StructuredTextEvaluator.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval.st/src/org/eclipse/fordiac/ide/model/eval/st/StructuredTextEvaluator.java
@@ -69,6 +69,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.GlobalConstants;
 import org.eclipse.fordiac.ide.model.libraryElement.ICallable;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STArrayAccessExpression;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STArrayInitElement;
@@ -215,7 +216,7 @@ public abstract class StructuredTextEvaluator extends AbstractEvaluator {
 		};
 	}
 
-	protected INamedElement evaluateType(final STVarDeclaration declaration)
+	protected LibraryElement evaluateType(final STVarDeclaration declaration)
 			throws EvaluatorException, InterruptedException {
 		final DataType type = switch (declaration.getType()) {
 		case final AnyStringType anyStringType when declaration.getMaxLength() != null -> STCoreUtil.newStringType(

--- a/plugins/org.eclipse.fordiac.ide.model.eval.st/src/org/eclipse/fordiac/ide/model/eval/st/VarDeclarationEvaluator.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval.st/src/org/eclipse/fordiac/ide/model/eval/st/VarDeclarationEvaluator.java
@@ -32,7 +32,6 @@ import org.eclipse.fordiac.ide.model.eval.variable.Variable;
 import org.eclipse.fordiac.ide.model.eval.variable.VariableEvaluator;
 import org.eclipse.fordiac.ide.model.eval.variable.VariableOperations;
 import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.structuredtextalgorithm.util.StructuredTextParseUtil;
@@ -44,7 +43,7 @@ import org.eclipse.xtext.EcoreUtil2;
 
 public class VarDeclarationEvaluator extends StructuredTextEvaluator implements VariableEvaluator {
 	private final VarDeclaration varDeclaration;
-	private INamedElement resultType;
+	private LibraryElement resultType;
 	private STTypeDeclaration parseResultType;
 	private STInitializerExpressionSource parseResult;
 
@@ -135,7 +134,7 @@ public class VarDeclarationEvaluator extends StructuredTextEvaluator implements 
 	}
 
 	@Override
-	public INamedElement evaluateResultType() throws EvaluatorException, InterruptedException {
+	public LibraryElement evaluateResultType() throws EvaluatorException, InterruptedException {
 		if (resultType == null) {
 			prepareResultType();
 			if (parseResultType != null) {
@@ -156,7 +155,7 @@ public class VarDeclarationEvaluator extends StructuredTextEvaluator implements 
 		return true;
 	}
 
-	protected INamedElement evaluateTypeDeclaration(final STTypeDeclaration declaration)
+	protected LibraryElement evaluateTypeDeclaration(final STTypeDeclaration declaration)
 			throws EvaluatorException, InterruptedException {
 		final DataType type = switch (declaration.getType()) {
 		case final AnyStringType anyStringType when declaration.getMaxLength() != null -> STCoreUtil.newStringType(

--- a/plugins/org.eclipse.fordiac.ide.model.eval.st/src/org/eclipse/fordiac/ide/model/eval/st/variable/STVariableOperations.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval.st/src/org/eclipse/fordiac/ide/model/eval/st/variable/STVariableOperations.java
@@ -17,7 +17,7 @@ import org.eclipse.fordiac.ide.model.eval.st.ConstantExpressionEvaluator;
 import org.eclipse.fordiac.ide.model.eval.value.Value;
 import org.eclipse.fordiac.ide.model.eval.variable.Variable;
 import org.eclipse.fordiac.ide.model.eval.variable.VariableOperations;
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STVarDeclaration;
 
 @SuppressWarnings("java:S1452")
@@ -39,7 +39,7 @@ public final class STVariableOperations {
 		return VariableOperations.newVariable(varDeclaration.getName(), evaluateResultType(varDeclaration), value);
 	}
 
-	public static INamedElement evaluateResultType(final STVarDeclaration varDeclaration) throws EvaluatorException {
+	public static LibraryElement evaluateResultType(final STVarDeclaration varDeclaration) throws EvaluatorException {
 		try {
 			return ConstantExpressionEvaluator.evaluateResultType(varDeclaration);
 		} catch (final InterruptedException e) {

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/EvaluatorCache.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/EvaluatorCache.java
@@ -17,8 +17,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.fordiac.ide.model.eval.value.Value;
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 public final class EvaluatorCache implements AutoCloseable {
 
@@ -27,7 +27,7 @@ public final class EvaluatorCache implements AutoCloseable {
 	private final AtomicInteger stackDepth = new AtomicInteger(0);
 
 	private final Map<ITypedElement, Value> cachedInitialValues = new ConcurrentHashMap<>();
-	private final Map<ITypedElement, INamedElement> cachedResultType = new ConcurrentHashMap<>();
+	private final Map<ITypedElement, LibraryElement> cachedResultType = new ConcurrentHashMap<>();
 
 	private EvaluatorCache() {
 	}
@@ -63,16 +63,16 @@ public final class EvaluatorCache implements AutoCloseable {
 		return value;
 	}
 
-	public <K extends ITypedElement> INamedElement computeResultTypeIfAbsent(final K key,
-			final CacheFunction<? super K, ? extends INamedElement> comp)
+	public <K extends ITypedElement> LibraryElement computeResultTypeIfAbsent(final K key,
+			final CacheFunction<? super K, ? extends LibraryElement> comp)
 			throws EvaluatorException, InterruptedException {
 		// cannot use computeIfAbsent due to recursive update
 		// use optimistic computation and putIfAbsent instead
-		final INamedElement type = cachedResultType.get(key);
+		final LibraryElement type = cachedResultType.get(key);
 		if (type == null) {
-			final INamedElement newType = comp.apply(key);
+			final LibraryElement newType = comp.apply(key);
 			if (newType != null) {
-				final INamedElement oldType = cachedResultType.putIfAbsent(key, newType);
+				final LibraryElement oldType = cachedResultType.putIfAbsent(key, newType);
 				if (oldType != null) {
 					return oldType; // concurrent update -> discard computed value and return current value
 				}

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/value/StructValue.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/value/StructValue.java
@@ -24,7 +24,7 @@ import org.eclipse.fordiac.ide.model.data.StructuredType;
 import org.eclipse.fordiac.ide.model.eval.EvaluatorInitializerException;
 import org.eclipse.fordiac.ide.model.eval.variable.Variable;
 import org.eclipse.fordiac.ide.model.eval.variable.VariableOperations;
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 
 @SuppressWarnings("java:S1452")
@@ -60,7 +60,7 @@ public final class StructValue implements AnyDerivedValue, Iterable<Value> {
 
 	protected static Variable<?> initializeMember(final VarDeclaration variable, final Object value) {
 		try {
-			final INamedElement type = VariableOperations.evaluateResultType(variable);
+			final LibraryElement type = VariableOperations.evaluateResultType(variable);
 			return VariableOperations.newVariable(variable.getName(), type, ValueOperations.wrapValue(value, type));
 		} catch (final Exception e) {
 			throw new EvaluatorInitializerException(variable, e);

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/value/Value.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/value/Value.java
@@ -12,7 +12,7 @@
  */
 package org.eclipse.fordiac.ide.model.eval.value;
 
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 public interface Value {
 	/**
@@ -20,7 +20,7 @@ public interface Value {
 	 *
 	 * @return The type
 	 */
-	INamedElement getType();
+	LibraryElement getType();
 
 	/**
 	 * Returns a string representation of the value, with optional pretty

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/value/ValueOperations.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/value/ValueOperations.java
@@ -106,7 +106,6 @@ import org.eclipse.fordiac.ide.model.eval.variable.ArrayVariable;
 import org.eclipse.fordiac.ide.model.eval.variable.StructVariable;
 import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.typelibrary.DataTypeLibrary;
 import org.eclipse.fordiac.ide.model.value.TypedValue;
@@ -1013,7 +1012,7 @@ public final class ValueOperations {
 		return 0xffffffffffffffffL >>> (64 - type.getBitSize());
 	}
 
-	public static Value defaultValue(final INamedElement type) {
+	public static Value defaultValue(final LibraryElement type) {
 		return switch (type) { // NOSONAR
 		case null -> null;
 		case final LrealType unused -> LRealValue.DEFAULT;
@@ -1065,7 +1064,7 @@ public final class ValueOperations {
 		};
 	}
 
-	public static Value castValue(final Value value, final INamedElement type) {
+	public static Value castValue(final Value value, final LibraryElement type) {
 		if (value == null) {
 			return null;
 		}
@@ -1086,7 +1085,7 @@ public final class ValueOperations {
 		};
 	}
 
-	private static Value castValue(final BoolValue value, final INamedElement type) {
+	private static Value castValue(final BoolValue value, final LibraryElement type) {
 		return switch (type) {
 		case final LwordType unused -> toLWordValue(value.longValue());
 		case final DwordType unused -> toDWordValue(value.intValue());
@@ -1097,7 +1096,7 @@ public final class ValueOperations {
 		};
 	}
 
-	private static Value castValue(final AnyMagnitudeValue value, final INamedElement type) {
+	private static Value castValue(final AnyMagnitudeValue value, final LibraryElement type) {
 		return switch (type) {
 		case final LrealType unused -> toLRealValue(value);
 		case final RealType unused -> toRealValue(value);
@@ -1120,7 +1119,7 @@ public final class ValueOperations {
 		};
 	}
 
-	private static Value castValue(final AnyBitValue value, final INamedElement type) {
+	private static Value castValue(final AnyBitValue value, final LibraryElement type) {
 		return switch (type) {
 		case final LrealType unused -> toLRealValue(value.longValue());
 		case final RealType unused -> toRealValue(value.longValue());
@@ -1142,7 +1141,7 @@ public final class ValueOperations {
 		};
 	}
 
-	private static Value castValue(final AnyCharsValue value, final INamedElement type) {
+	private static Value castValue(final AnyCharsValue value, final LibraryElement type) {
 		return switch (type) {
 		case final WstringType wstringType ->
 			wstringType.isSetMaxLength() ? toWStringValue(value, wstringType.getMaxLength()) : toWStringValue(value);
@@ -1155,7 +1154,7 @@ public final class ValueOperations {
 		};
 	}
 
-	private static Value castValue(final AnyDateValue value, final INamedElement type) {
+	private static Value castValue(final AnyDateValue value, final LibraryElement type) {
 		return switch (type) {
 		case final LdtType unused -> toLDateAndTimeValue(value);
 		case final DateAndTimeType unused -> toDateAndTimeValue(value);
@@ -1168,14 +1167,14 @@ public final class ValueOperations {
 		};
 	}
 
-	private static Value castValue(final AnyDerivedValue value, final INamedElement type) {
+	private static Value castValue(final AnyDerivedValue value, final LibraryElement type) {
 		return switch (type) {
 		case final DataType dataType when dataType.isAssignableFrom(value.getType()) -> value;
 		case null, default -> throw createCastException(value, type);
 		};
 	}
 
-	public static Value wrapValue(final Object value, final INamedElement type) {
+	public static Value wrapValue(final Object value, final LibraryElement type) {
 		if (value == null) {
 			return defaultValue(type);
 		}
@@ -1383,11 +1382,11 @@ public final class ValueOperations {
 		};
 	}
 
-	public static Value parseValue(final String value, final INamedElement type) {
+	public static Value parseValue(final String value, final LibraryElement type) {
 		return parseValue(value, type, null);
 	}
 
-	public static Value parseValue(final String value, final INamedElement type, final DataTypeLibrary typeLibrary) {
+	public static Value parseValue(final String value, final LibraryElement type, final DataTypeLibrary typeLibrary) {
 		if (value == null || value.isEmpty()) {
 			return defaultValue(type);
 		}
@@ -1397,7 +1396,7 @@ public final class ValueOperations {
 		throw createUnsupportedTypeException(type);
 	}
 
-	public static Class<? extends Value> valueType(final INamedElement type) {
+	public static Class<? extends Value> valueType(final LibraryElement type) {
 		return switch (type) { // NOSONAR
 		case final LrealType unused -> LRealValue.class;
 		case final RealType unused -> RealValue.class;
@@ -1555,12 +1554,12 @@ public final class ValueOperations {
 				MessageFormat.format(Messages.ValueOperations_UnsupportedType, typeName(value)));
 	}
 
-	private static RuntimeException createUnsupportedTypeException(final INamedElement type) {
+	private static RuntimeException createUnsupportedTypeException(final LibraryElement type) {
 		return new UnsupportedOperationException(
 				MessageFormat.format(Messages.ValueOperations_UnsupportedType, typeName(type)));
 	}
 
-	private static RuntimeException createCastException(final Value value, final INamedElement type) {
+	private static RuntimeException createCastException(final Value value, final LibraryElement type) {
 		return new ClassCastException(
 				MessageFormat.format(Messages.ValueOperations_UnsupportedCast, value, typeName(value), typeName(type)));
 	}
@@ -1569,12 +1568,8 @@ public final class ValueOperations {
 		return value != null ? typeName(value.getType()) : null;
 	}
 
-	private static String typeName(final INamedElement type) {
-		return switch (type) {
-		case null -> null;
-		case final LibraryElement libraryElement -> PackageNameHelper.getFullTypeName(libraryElement);
-		default -> type.getName();
-		};
+	private static String typeName(final LibraryElement type) {
+		return PackageNameHelper.getFullTypeName(type);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/AbstractVariable.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/AbstractVariable.java
@@ -19,16 +19,16 @@ import org.eclipse.fordiac.ide.model.data.EnumeratedType;
 import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes;
 import org.eclipse.fordiac.ide.model.eval.value.Value;
 import org.eclipse.fordiac.ide.model.eval.value.ValueOperations;
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
 import org.eclipse.fordiac.ide.model.value.TypedValue;
 import org.eclipse.fordiac.ide.model.value.TypedValueConverter;
 
 public abstract class AbstractVariable<T extends Value> implements Variable<T> {
 	private final String name;
-	private final INamedElement type;
+	private final LibraryElement type;
 
-	protected AbstractVariable(final String name, final INamedElement type) {
+	protected AbstractVariable(final String name, final LibraryElement type) {
 		this.name = name;
 		this.type = type;
 	}
@@ -54,7 +54,7 @@ public abstract class AbstractVariable<T extends Value> implements Variable<T> {
 	}
 
 	@Override
-	public INamedElement getType() {
+	public LibraryElement getType() {
 		return type;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/Variable.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/Variable.java
@@ -15,7 +15,7 @@ package org.eclipse.fordiac.ide.model.eval.variable;
 import java.util.stream.Stream;
 
 import org.eclipse.fordiac.ide.model.eval.value.Value;
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
 import org.eclipse.fordiac.ide.model.value.TypedValue;
 
@@ -32,7 +32,7 @@ public interface Variable<T extends Value> {
 	 *
 	 * @return The type
 	 */
-	INamedElement getType();
+	LibraryElement getType();
 
 	/**
 	 * Get the current value of the variable

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/VariableEvaluator.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/VariableEvaluator.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 import org.eclipse.fordiac.ide.model.eval.Evaluator;
 import org.eclipse.fordiac.ide.model.eval.EvaluatorException;
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 public interface VariableEvaluator extends Evaluator {
 	/**
@@ -48,7 +48,7 @@ public interface VariableEvaluator extends Evaluator {
 	 * @throws EvaluatorException   if an exception occurred during evaluation
 	 * @throws InterruptedException if the evaluation was interrupted
 	 */
-	INamedElement evaluateResultType() throws EvaluatorException, InterruptedException;
+	LibraryElement evaluateResultType() throws EvaluatorException, InterruptedException;
 
 	/**
 	 * Validate the result type

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/VariableOperations.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/VariableOperations.java
@@ -49,15 +49,15 @@ import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
 import org.eclipse.fordiac.ide.model.libraryElement.FB;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.value.TypedValueConverter;
 
 @SuppressWarnings("java:S1452")
 public final class VariableOperations {
-	public static Variable<?> newVariable(final String name, final INamedElement type) {
+	public static Variable<?> newVariable(final String name, final LibraryElement type) {
 		return switch (type) {
 		case final AnyType anyType when GenericTypes.isAnyType(anyType) -> new GenericVariable(name, anyType);
 		case final ArrayType arrayType -> new ArrayVariable(name, arrayType);
@@ -72,7 +72,7 @@ public final class VariableOperations {
 		};
 	}
 
-	public static Variable<?> newVariable(final String name, final INamedElement type, final String value) {
+	public static Variable<?> newVariable(final String name, final LibraryElement type, final String value) {
 		return switch (type) {
 		case final AnyType anyType when GenericTypes.isAnyType(anyType) -> new GenericVariable(name, anyType, value);
 		case final ArrayType arrayType -> new ArrayVariable(name, arrayType, value);
@@ -88,7 +88,7 @@ public final class VariableOperations {
 		};
 	}
 
-	public static Variable<?> newVariable(final String name, final INamedElement type, final Value value) {
+	public static Variable<?> newVariable(final String name, final LibraryElement type, final Value value) {
 		return switch (type) {
 		case final AnyType anyType when GenericTypes.isAnyType(anyType) -> new GenericVariable(name, anyType, value);
 		case final ArrayType arrayType -> new ArrayVariable(name, arrayType, value);
@@ -226,7 +226,7 @@ public final class VariableOperations {
 		return newVariable(withValue(type, initialValue));
 	}
 
-	public static INamedElement evaluateResultType(final VarDeclaration decl) throws EvaluatorException {
+	public static LibraryElement evaluateResultType(final VarDeclaration decl) throws EvaluatorException {
 		if (decl.isArray()) {
 			try (EvaluatorCache cache = EvaluatorCache.open()) {
 				return cache.computeResultTypeIfAbsent(decl, VariableOperations::doEvaluateResultType);
@@ -237,7 +237,7 @@ public final class VariableOperations {
 		return decl.getType();
 	}
 
-	private static INamedElement doEvaluateResultType(final VarDeclaration varDeclaration)
+	private static LibraryElement doEvaluateResultType(final VarDeclaration varDeclaration)
 			throws EvaluatorException, InterruptedException {
 		if (TypeDeclarationParser.isSimpleTypeDeclaration(varDeclaration.getArraySize().getValue())) {
 			return TypeDeclarationParser.parseSimpleTypeDeclaration(varDeclaration.getType(),

--- a/plugins/org.eclipse.fordiac.ide.model/model/fordiac.genmodel
+++ b/plugins/org.eclipse.fordiac.ide.model/model/fordiac.genmodel
@@ -629,7 +629,7 @@
     </genClasses>
     <genClasses image="false" ecoreClass="lib.ecore#//ITypedElement">
       <genOperations ecoreOperation="lib.ecore#//ITypedElement/getType"/>
-      <genOperations ecoreOperation="lib.ecore#//ITypedElement/getTypeName" body="org.eclipse.fordiac.ide.model.libraryElement.INamedElement type = getType();&#xA;if(type != null){&#xA;&#x9;return type.getName();&#xA;}&#xA;return null;"/>
+      <genOperations ecoreOperation="lib.ecore#//ITypedElement/getTypeName" body="org.eclipse.fordiac.ide.model.libraryElement.LibraryElement type = getType();&#xA;if(type != null){&#xA;&#x9;return type.getName();&#xA;}&#xA;return null;"/>
       <genOperations ecoreOperation="lib.ecore#//ITypedElement/getFullTypeName" body="return getTypeName();"/>
       <genOperations ecoreOperation="lib.ecore#//ITypedElement/validateType" body="return org.eclipse.fordiac.ide.model.libraryElement.impl.TypedElementAnnotations.validateType(this, diagnostics, context);">
         <genParameters ecoreParameter="lib.ecore#//ITypedElement/validateType/diagnostics"/>

--- a/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
+++ b/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
@@ -1720,10 +1720,10 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ITypedElement" abstract="true" interface="true"
       eSuperTypes="#//INamedElement">
-    <eOperations name="getType" eType="#//INamedElement"/>
+    <eOperations name="getType" eType="#//LibraryElement"/>
     <eOperations name="getTypeName" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
-        <details key="body" value="org.eclipse.fordiac.ide.model.libraryElement.INamedElement type = getType();&#xA;if(type != null){&#xA;&#x9;return type.getName();&#xA;}&#xA;return null;"/>
+        <details key="body" value="org.eclipse.fordiac.ide.model.libraryElement.LibraryElement type = getType();&#xA;if(type != null){&#xA;&#x9;return type.getName();&#xA;}&#xA;return null;"/>
       </eAnnotations>
     </eOperations>
     <eOperations name="getFullTypeName" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString">

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/ITypedElement.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/ITypedElement.java
@@ -37,7 +37,7 @@ public interface ITypedElement extends INamedElement {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getType();
+	LibraryElement getType();
 
 	/**
 	 * <!-- begin-user-doc -->

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/AdapterDeclarationImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/AdapterDeclarationImpl.java
@@ -513,7 +513,7 @@ public class AdapterDeclarationImpl extends EObjectImpl implements AdapterDeclar
 	 */
 	@Override
 	public String getTypeName() {
-		org.eclipse.fordiac.ide.model.libraryElement.INamedElement type = getType();
+		org.eclipse.fordiac.ide.model.libraryElement.LibraryElement type = getType();
 		if(type != null){
 			return type.getName();
 		}

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/AttributeDeclarationImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/AttributeDeclarationImpl.java
@@ -678,7 +678,7 @@ public class AttributeDeclarationImpl extends EObjectImpl implements AttributeDe
 	 */
 	@Override
 	public String getTypeName() {
-		org.eclipse.fordiac.ide.model.libraryElement.INamedElement type = getType();
+		org.eclipse.fordiac.ide.model.libraryElement.LibraryElement type = getType();
 		if(type != null){
 			return type.getName();
 		}

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/AttributeImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/AttributeImpl.java
@@ -335,7 +335,7 @@ public class AttributeImpl extends EObjectImpl implements Attribute {
 	 */
 	@Override
 	public String getTypeName() {
-		org.eclipse.fordiac.ide.model.libraryElement.INamedElement type = getType();
+		org.eclipse.fordiac.ide.model.libraryElement.LibraryElement type = getType();
 		if(type != null){
 			return type.getName();
 		}

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/ErrorMarkerInterfaceImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/ErrorMarkerInterfaceImpl.java
@@ -384,7 +384,7 @@ public class ErrorMarkerInterfaceImpl extends EObjectImpl implements ErrorMarker
 	 */
 	@Override
 	public String getTypeName() {
-		org.eclipse.fordiac.ide.model.libraryElement.INamedElement type = getType();
+		org.eclipse.fordiac.ide.model.libraryElement.LibraryElement type = getType();
 		if(type != null){
 			return type.getName();
 		}

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/EventImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/EventImpl.java
@@ -460,7 +460,7 @@ public class EventImpl extends EObjectImpl implements Event {
 	 */
 	@Override
 	public String getTypeName() {
-		org.eclipse.fordiac.ide.model.libraryElement.INamedElement type = getType();
+		org.eclipse.fordiac.ide.model.libraryElement.LibraryElement type = getType();
 		if(type != null){
 			return type.getName();
 		}

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
@@ -5175,7 +5175,7 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 
 		initEClass(iTypedElementEClass, ITypedElement.class, "ITypedElement", IS_ABSTRACT, IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 
-		addEOperation(iTypedElementEClass, this.getINamedElement(), "getType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(iTypedElementEClass, this.getLibraryElement(), "getType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		addEOperation(iTypedElementEClass, ecorePackage.getEString(), "getTypeName", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/VarDeclarationImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/VarDeclarationImpl.java
@@ -718,7 +718,7 @@ public class VarDeclarationImpl extends EObjectImpl implements VarDeclaration {
 	 */
 	@Override
 	public String getTypeName() {
-		org.eclipse.fordiac.ide.model.libraryElement.INamedElement type = getType();
+		org.eclipse.fordiac.ide.model.libraryElement.LibraryElement type = getType();
 		if(type != null){
 			return type.getName();
 		}

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/builder/STAlgorithmInitialValueBuilderParticipant.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/builder/STAlgorithmInitialValueBuilderParticipant.java
@@ -39,7 +39,6 @@ import org.eclipse.fordiac.ide.model.helpers.ImportHelper;
 import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
 import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType;
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.Import;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
@@ -212,7 +211,7 @@ public class STAlgorithmInitialValueBuilderParticipant implements IXtextBuilderP
 		final List<Issue> issues = new ArrayList<>();
 		// do not parse value if blank or variable has invalid type
 		if (!value.isBlank() && varDeclaration.getType() instanceof AnyType) {
-			final INamedElement featureType = STCoreUtil.getFeatureType(varDeclaration);
+			final LibraryElement featureType = STCoreUtil.getFeatureType(varDeclaration);
 			try {
 				new TypedValueConverter((DataType) featureType, true).toValue(value);
 			} catch (final Exception e) {

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/editor/embedded/STAlgorithmConditionEditedResourceProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/editor/embedded/STAlgorithmConditionEditedResourceProvider.java
@@ -15,7 +15,6 @@ package org.eclipse.fordiac.ide.structuredtextalgorithm.ui.editor.embedded;
 import java.util.Collection;
 
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextalgorithm.resource.STAlgorithmResource;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STResource;
@@ -23,11 +22,11 @@ import org.eclipse.xtext.ParserRule;
 
 public class STAlgorithmConditionEditedResourceProvider extends STAlgorithmEditedResourceProvider {
 
-	private final INamedElement expectedType;
+	private final LibraryElement expectedType;
 	private final Collection<? extends EObject> additionalContent;
 
 	public STAlgorithmConditionEditedResourceProvider(final LibraryElement libraryElement,
-			final Collection<? extends EObject> additionalContent, final INamedElement expectedType) {
+			final Collection<? extends EObject> additionalContent, final LibraryElement expectedType) {
 		super(libraryElement);
 		this.expectedType = expectedType;
 		this.additionalContent = additionalContent;

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/editor/embedded/STAlgorithmEmbeddedEditorUtil.xtend
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/editor/embedded/STAlgorithmEmbeddedEditorUtil.xtend
@@ -46,7 +46,7 @@ final class STAlgorithmEmbeddedEditorUtil {
 	}
 
 	def static void updateEditor(EmbeddedEditor editor, URI uri, LibraryElement type,
-		Collection<? extends EObject> additionalContent, INamedElement expectedType) {
+		Collection<? extends EObject> additionalContent, LibraryElement expectedType) {
 		editor.updateEditor(uri, type, additionalContent, #{STResource.OPTION_EXPECTED_TYPE -> expectedType})
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/editor/embedded/STAlgorithmInitialValueEditedResourceProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/editor/embedded/STAlgorithmInitialValueEditedResourceProvider.java
@@ -13,7 +13,6 @@
 package org.eclipse.fordiac.ide.structuredtextalgorithm.ui.editor.embedded;
 
 import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextalgorithm.resource.STAlgorithmResource;
@@ -33,7 +32,7 @@ public class STAlgorithmInitialValueEditedResourceProvider extends STAlgorithmEd
 	@Override
 	public STAlgorithmResource createResource() {
 		final STAlgorithmResource resource = super.createResource();
-		final INamedElement featureType = STCoreUtil.getFeatureType(element);
+		final LibraryElement featureType = STCoreUtil.getFeatureType(element);
 		resource.getDefaultLoadOptions().put(STResource.OPTION_EXPECTED_TYPE, featureType);
 		return resource;
 	}

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm/src/org/eclipse/fordiac/ide/structuredtextalgorithm/util/STAlgorithmParseUtil.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm/src/org/eclipse/fordiac/ide/structuredtextalgorithm/util/STAlgorithmParseUtil.java
@@ -24,7 +24,6 @@ import java.util.function.UnaryOperator;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType;
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.STAlgorithm;
 import org.eclipse.fordiac.ide.model.libraryElement.STMethod;
@@ -105,14 +104,14 @@ public final class STAlgorithmParseUtil {
 		};
 	}
 
-	public static IParseResult parseExpression(final String expression, final INamedElement expectedType,
+	public static IParseResult parseExpression(final String expression, final LibraryElement expectedType,
 			final EObject context) {
 		return parse(expression, getGrammarAccess().getSTExpressionSourceRule(),
 				context.eResource() != null ? context.eResource().getURI() : null, expectedType,
 				EcoreUtil2.getContainerOfType(context, LibraryElement.class), null, null);
 	}
 
-	public static IParseResult parseInitializerExpression(final String expression, final INamedElement expectedType,
+	public static IParseResult parseInitializerExpression(final String expression, final LibraryElement expectedType,
 			final EObject context) {
 		return parse(expression, getGrammarAccess().getSTInitializerExpressionSourceRule(),
 				context.eResource() != null ? context.eResource().getURI() : null, expectedType,
@@ -126,7 +125,7 @@ public final class STAlgorithmParseUtil {
 	}
 
 	public static IParseResult parse(final String text, final ParserRule entryPoint, final URI uri,
-			final INamedElement expectedType, final LibraryElement type,
+			final LibraryElement expectedType, final LibraryElement type,
 			final Collection<? extends EObject> additionalContent, final List<Issue> issues) {
 		final XtextResourceSet resourceSet = SERVICE_PROVIDER_FBT.get(XtextResourceSet.class);
 		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().putAll(EXTENSION_TO_FACTORY_MAP);
@@ -134,7 +133,7 @@ public final class STAlgorithmParseUtil {
 				issues, Objects.requireNonNullElse(uri, SYNTHETIC_URI_FBT), getLoadOptions(expectedType));
 	}
 
-	private static Map<String, Object> getLoadOptions(final INamedElement expectedType) {
+	private static Map<String, Object> getLoadOptions(final LibraryElement expectedType) {
 		if (expectedType != null) {
 			final Map<String, Object> loadOptions = new HashMap<>(DEFAULT_LOAD_OPTIONS);
 			loadOptions.put(STResource.OPTION_EXPECTED_TYPE, expectedType);

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm/src/org/eclipse/fordiac/ide/structuredtextalgorithm/util/StructuredTextParseUtil.xtend
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm/src/org/eclipse/fordiac/ide/structuredtextalgorithm/util/StructuredTextParseUtil.xtend
@@ -19,7 +19,6 @@ import org.eclipse.emf.common.util.URI
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.resource.ResourceSet
 import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement
 import org.eclipse.fordiac.ide.model.libraryElement.STAlgorithm
 import org.eclipse.fordiac.ide.model.libraryElement.STMethod
@@ -103,7 +102,7 @@ class StructuredTextParseUtil {
 			rootASTElement as STAlgorithmSource
 	}
 
-	def static STInitializerExpressionSource validate(String expression, URI uri, INamedElement expectedType,
+	def static STInitializerExpressionSource validate(String expression, URI uri, LibraryElement expectedType,
 		LibraryElement type, Collection<? extends EObject> additionalContent, List<Issue> issues) {
 		val parser = SERVICE_PROVIDER_FBT.get(IParser) as STAlgorithmParser
 		expression.parse(parser.grammarAccess.STInitializerExpressionSourceRule, uri, expectedType, type,
@@ -118,12 +117,12 @@ class StructuredTextParseUtil {
 			typeVariable.getContainerOfType(LibraryElement), null, issues).rootASTElement as STTypeDeclaration
 	}
 
-	def static STExpressionSource parse(String expression, INamedElement expectedType, LibraryElement type,
+	def static STExpressionSource parse(String expression, LibraryElement expectedType, LibraryElement type,
 		List<String> errors, List<String> warnings, List<String> infos) {
 		expression.parse(expectedType, type, null, errors, warnings, infos)
 	}
 
-	def static STExpressionSource parse(String expression, INamedElement expectedType, LibraryElement type,
+	def static STExpressionSource parse(String expression, LibraryElement expectedType, LibraryElement type,
 		Collection<? extends EObject> additionalContent, List<String> errors, List<String> warnings,
 		List<String> infos) {
 		val parser = SERVICE_PROVIDER_FBT.get(IParser) as STAlgorithmParser
@@ -131,7 +130,7 @@ class StructuredTextParseUtil {
 			additionalContent, errors, warnings, infos)?.rootASTElement as STExpressionSource
 	}
 
-	def static STInitializerExpressionSource parse(String expression, URI uri, INamedElement expectedType,
+	def static STInitializerExpressionSource parse(String expression, URI uri, LibraryElement expectedType,
 		LibraryElement type, Collection<? extends EObject> additionalContent, List<String> errors,
 		List<String> warnings, List<String> infos) {
 		val parser = SERVICE_PROVIDER_FBT.get(IParser) as STAlgorithmParser
@@ -154,7 +153,7 @@ class StructuredTextParseUtil {
 		text.parse(entryPoint, type?.eResource?.URI, null, name, type, null, errors, warnings, infos)
 	}
 
-	def private static IParseResult parse(String text, ParserRule entryPoint, URI uri, INamedElement expectedType,
+	def private static IParseResult parse(String text, ParserRule entryPoint, URI uri, LibraryElement expectedType,
 		LibraryElement type, Collection<? extends EObject> additionalContent, List<String> errors,
 		List<String> warnings, List<String> infos) {
 		val issues = newArrayList
@@ -162,7 +161,7 @@ class StructuredTextParseUtil {
 			issues)
 	}
 
-	def private static IParseResult parse(String text, ParserRule entryPoint, URI uri, INamedElement expectedType,
+	def private static IParseResult parse(String text, ParserRule entryPoint, URI uri, LibraryElement expectedType,
 		String name, LibraryElement type, Collection<? extends EObject> additionalContent, List<String> errors,
 		List<String> warnings, List<String> infos) {
 		val issues = newArrayList
@@ -170,7 +169,7 @@ class StructuredTextParseUtil {
 		name.postProcess(errors, warnings, infos, issues, parseResult)
 	}
 
-	def private static IParseResult parse(String text, ParserRule entryPoint, URI uri, INamedElement expectedType,
+	def private static IParseResult parse(String text, ParserRule entryPoint, URI uri, LibraryElement expectedType,
 		LibraryElement type, Collection<? extends EObject> additionalContent, List<Issue> issues) {
 		val resourceSet = SERVICE_PROVIDER_FBT.get(ResourceSet) as XtextResourceSet
 		resourceSet.resourceFactoryRegistry.extensionToFactoryMap.put("fbt", SERVICE_PROVIDER_FBT.get(IResourceFactory))

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/model/STCore.ecore
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/model/STCore.ecore
@@ -22,24 +22,24 @@
   <eClassifiers xsi:type="ecore:EClass" name="STVarInOutDeclarationBlock" eSuperTypes="#//STVarDeclarationBlock"/>
   <eClassifiers xsi:type="ecore:EClass" name="STVarTempDeclarationBlock" eSuperTypes="#//STVarDeclarationBlock"/>
   <eClassifiers xsi:type="ecore:EClass" name="STInitializerExpression">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return null;"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return null;"/>
       </eAnnotations>
     </eOperations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="STElementaryInitializerExpression" eSuperTypes="#//STInitializerExpression">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);"/>
       </eAnnotations>
@@ -48,12 +48,12 @@
         containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="STArrayInitializerExpression" eSuperTypes="#//STInitializerExpression">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);"/>
       </eAnnotations>
@@ -63,16 +63,16 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="STArrayInitElement" abstract="true"
       interface="true">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement"/>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement"/>
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement"/>
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="STSingleArrayInitElement" eSuperTypes="#//STArrayInitElement">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);"/>
       </eAnnotations>
@@ -81,12 +81,12 @@
         containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="STRepeatArrayInitElement" eSuperTypes="#//STArrayInitElement">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);"/>
       </eAnnotations>
@@ -112,12 +112,12 @@
         containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="STCallArgument">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return null;"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return null;"/>
       </eAnnotations>
@@ -126,24 +126,24 @@
         containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="STCallUnnamedArgument" eSuperTypes="#//STCallArgument">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);"/>
       </eAnnotations>
     </eOperations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="STCallNamedInputArgument" eSuperTypes="#//STCallArgument">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);"/>
       </eAnnotations>
@@ -151,12 +151,12 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="parameter" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="STCallNamedOutputArgument" eSuperTypes="#//STCallArgument">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);"/>
       </eAnnotations>
@@ -225,12 +225,12 @@
         containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="STExpression" eSuperTypes="#//STStatement">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return null;"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return null;"/>
       </eAnnotations>
@@ -268,12 +268,12 @@
     <eLiterals name="L" value="4" literal="%L"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="STNumericLiteral" eSuperTypes="#//STExpression">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);"/>
       </eAnnotations>
@@ -282,12 +282,12 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EJavaObject"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="STDateLiteral" eSuperTypes="#//STExpression">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);"/>
       </eAnnotations>
@@ -296,12 +296,12 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="#//STDate"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="STTimeLiteral" eSuperTypes="#//STExpression">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);"/>
       </eAnnotations>
@@ -310,12 +310,12 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="#//STTime"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="STTimeOfDayLiteral" eSuperTypes="#//STExpression">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);"/>
       </eAnnotations>
@@ -324,12 +324,12 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="#//STTimeOfDay"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="STDateAndTimeLiteral" eSuperTypes="#//STExpression">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);"/>
       </eAnnotations>
@@ -338,12 +338,12 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="#//STDateAndTime"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="STStringLiteral" eSuperTypes="#//STExpression">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);"/>
       </eAnnotations>
@@ -352,12 +352,12 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="#//STString"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="STEnumLiteral" eSuperTypes="#//STExpression">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);"/>
       </eAnnotations>
@@ -399,12 +399,12 @@
   <eClassifiers xsi:type="ecore:EClass" name="STExit" eSuperTypes="#//STStatement"/>
   <eClassifiers xsi:type="ecore:EClass" name="STNop" eSuperTypes="#//STStatement"/>
   <eClassifiers xsi:type="ecore:EClass" name="STBinaryExpression" eSuperTypes="#//STExpression">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);"/>
       </eAnnotations>
@@ -416,12 +416,12 @@
         containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="STUnaryExpression" eSuperTypes="#//STExpression">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);"/>
       </eAnnotations>
@@ -431,12 +431,12 @@
         containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="STMemberAccessExpression" eSuperTypes="#//STExpression">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);"/>
       </eAnnotations>
@@ -447,12 +447,12 @@
         containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="STArrayAccessExpression" eSuperTypes="#//STExpression">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);"/>
       </eAnnotations>
@@ -463,12 +463,12 @@
         eType="#//STExpression" containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="STFeatureExpression" eSuperTypes="#//STExpression">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);"/>
       </eAnnotations>
@@ -506,12 +506,12 @@
         eType="#//STCallArgument" containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="STBuiltinFeatureExpression" eSuperTypes="#//STExpression">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);"/>
       </eAnnotations>
@@ -552,12 +552,12 @@
     <eLiterals name="THIS"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="STMultibitPartialExpression" eSuperTypes="#//STExpression">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);"/>
       </eAnnotations>
@@ -615,12 +615,12 @@
     <eLiterals name="INNER" value="3"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="STStructInitializerExpression" eSuperTypes="#//STInitializerExpression">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);"/>
       </eAnnotations>
@@ -639,12 +639,12 @@
         eType="#//STStructInitElement" containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="STStructInitElement">
-    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);"/>
       </eAnnotations>
     </eOperations>
-    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement">
+    <eOperations name="getDeclaredResultType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);"/>
       </eAnnotations>

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STArrayAccessExpression.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STArrayAccessExpression.java
@@ -19,6 +19,7 @@ package org.eclipse.fordiac.ide.structuredtextcore.stcore;
 import org.eclipse.emf.common.util.EList;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -78,7 +79,7 @@ public interface STArrayAccessExpression extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -86,6 +87,6 @@ public interface STArrayAccessExpression extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 
 } // STArrayAccessExpression

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STArrayInitElement.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STArrayInitElement.java
@@ -20,6 +20,7 @@ import org.eclipse.emf.common.util.EList;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -38,7 +39,7 @@ public interface STArrayInitElement extends EObject {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -46,6 +47,6 @@ public interface STArrayInitElement extends EObject {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 
 } // STArrayInitElement

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STArrayInitializerExpression.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STArrayInitializerExpression.java
@@ -18,6 +18,7 @@ package org.eclipse.fordiac.ide.structuredtextcore.stcore;
 
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -54,7 +55,7 @@ public interface STArrayInitializerExpression extends STInitializerExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -62,6 +63,6 @@ public interface STArrayInitializerExpression extends STInitializerExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 
 } // STArrayInitializerExpression

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STBinaryExpression.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STBinaryExpression.java
@@ -17,6 +17,7 @@
 package org.eclipse.fordiac.ide.structuredtextcore.stcore;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -112,7 +113,7 @@ public interface STBinaryExpression extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -120,6 +121,6 @@ public interface STBinaryExpression extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 
 } // STBinaryExpression

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STBuiltinFeatureExpression.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STBuiltinFeatureExpression.java
@@ -22,6 +22,7 @@ import org.eclipse.emf.common.util.EList;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -107,7 +108,7 @@ public interface STBuiltinFeatureExpression extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -115,7 +116,7 @@ public interface STBuiltinFeatureExpression extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 
 	/**
 	 * <!-- begin-user-doc -->

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STCallArgument.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STCallArgument.java
@@ -18,6 +18,7 @@ package org.eclipse.fordiac.ide.structuredtextcore.stcore;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -65,7 +66,7 @@ public interface STCallArgument extends EObject {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -73,5 +74,5 @@ public interface STCallArgument extends EObject {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 } // STCallArgument

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STCallNamedInputArgument.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STCallNamedInputArgument.java
@@ -17,6 +17,7 @@
 package org.eclipse.fordiac.ide.structuredtextcore.stcore;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -63,7 +64,7 @@ public interface STCallNamedInputArgument extends STCallArgument {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -71,6 +72,6 @@ public interface STCallNamedInputArgument extends STCallArgument {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 
 } // STCallNamedInputArgument

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STCallNamedOutputArgument.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STCallNamedOutputArgument.java
@@ -17,6 +17,7 @@
 package org.eclipse.fordiac.ide.structuredtextcore.stcore;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -86,7 +87,7 @@ public interface STCallNamedOutputArgument extends STCallArgument {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -94,6 +95,6 @@ public interface STCallNamedOutputArgument extends STCallArgument {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 
 } // STCallNamedOutputArgument

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STCallUnnamedArgument.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STCallUnnamedArgument.java
@@ -17,6 +17,7 @@
 package org.eclipse.fordiac.ide.structuredtextcore.stcore;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 
 /**
@@ -36,7 +37,7 @@ public interface STCallUnnamedArgument extends STCallArgument {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -44,6 +45,6 @@ public interface STCallUnnamedArgument extends STCallArgument {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 
 } // STCallUnnamedArgument

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STDateAndTimeLiteral.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STDateAndTimeLiteral.java
@@ -21,6 +21,7 @@ import java.time.LocalDateTime;
 import org.eclipse.fordiac.ide.model.data.DataType;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -90,7 +91,7 @@ public interface STDateAndTimeLiteral extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -98,6 +99,6 @@ public interface STDateAndTimeLiteral extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 
 } // STDateAndTimeLiteral

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STDateLiteral.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STDateLiteral.java
@@ -21,6 +21,7 @@ import java.time.LocalDate;
 import org.eclipse.fordiac.ide.model.data.DataType;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -90,7 +91,7 @@ public interface STDateLiteral extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -98,6 +99,6 @@ public interface STDateLiteral extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 
 } // STDateLiteral

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STElementaryInitializerExpression.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STElementaryInitializerExpression.java
@@ -17,6 +17,7 @@
 package org.eclipse.fordiac.ide.structuredtextcore.stcore;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 
 /**
@@ -64,7 +65,7 @@ public interface STElementaryInitializerExpression extends STInitializerExpressi
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -72,6 +73,6 @@ public interface STElementaryInitializerExpression extends STInitializerExpressi
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 
 } // STElementaryInitializerExpression

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STEnumLiteral.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STEnumLiteral.java
@@ -19,6 +19,7 @@ package org.eclipse.fordiac.ide.structuredtextcore.stcore;
 import org.eclipse.fordiac.ide.model.data.EnumeratedValue;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -65,7 +66,7 @@ public interface STEnumLiteral extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -73,6 +74,6 @@ public interface STEnumLiteral extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 
 } // STEnumLiteral

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STExpression.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STExpression.java
@@ -19,6 +19,7 @@ package org.eclipse.fordiac.ide.structuredtextcore.stcore;
 import org.eclipse.emf.ecore.EObject;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -37,7 +38,7 @@ public interface STExpression extends STStatement {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -45,6 +46,6 @@ public interface STExpression extends STStatement {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 
 } // STExpression

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STFeatureExpression.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STFeatureExpression.java
@@ -21,6 +21,7 @@ import org.eclipse.emf.common.util.EList;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -103,7 +104,7 @@ public interface STFeatureExpression extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -111,7 +112,7 @@ public interface STFeatureExpression extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 
 	/**
 	 * <!-- begin-user-doc -->

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STInitializerExpression.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STInitializerExpression.java
@@ -18,6 +18,7 @@ package org.eclipse.fordiac.ide.structuredtextcore.stcore;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -37,7 +38,7 @@ public interface STInitializerExpression extends EObject {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -45,5 +46,5 @@ public interface STInitializerExpression extends EObject {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 } // STInitializerExpression

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STMemberAccessExpression.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STMemberAccessExpression.java
@@ -17,6 +17,7 @@
 package org.eclipse.fordiac.ide.structuredtextcore.stcore;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -86,7 +87,7 @@ public interface STMemberAccessExpression extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -94,6 +95,6 @@ public interface STMemberAccessExpression extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 
 } // STMemberAccessExpression

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STMultibitPartialExpression.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STMultibitPartialExpression.java
@@ -19,6 +19,7 @@ package org.eclipse.fordiac.ide.structuredtextcore.stcore;
 import java.math.BigInteger;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -114,7 +115,7 @@ public interface STMultibitPartialExpression extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -122,6 +123,6 @@ public interface STMultibitPartialExpression extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 
 } // STMultibitPartialExpression

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STNumericLiteral.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STNumericLiteral.java
@@ -21,6 +21,7 @@ import java.math.BigDecimal;
 import org.eclipse.fordiac.ide.model.data.DataType;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -90,7 +91,7 @@ public interface STNumericLiteral extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -98,6 +99,6 @@ public interface STNumericLiteral extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 
 } // STNumericLiteral

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STRepeatArrayInitElement.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STRepeatArrayInitElement.java
@@ -20,6 +20,7 @@ import java.math.BigInteger;
 import org.eclipse.emf.common.util.EList;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -79,7 +80,7 @@ public interface STRepeatArrayInitElement extends STArrayInitElement {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -87,6 +88,6 @@ public interface STRepeatArrayInitElement extends STArrayInitElement {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 
 } // STRepeatArrayInitElement

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STSingleArrayInitElement.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STSingleArrayInitElement.java
@@ -17,6 +17,7 @@
 package org.eclipse.fordiac.ide.structuredtextcore.stcore;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -63,7 +64,7 @@ public interface STSingleArrayInitElement extends STArrayInitElement {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -71,6 +72,6 @@ public interface STSingleArrayInitElement extends STArrayInitElement {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 
 } // STSingleArrayInitElement

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STStringLiteral.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STStringLiteral.java
@@ -19,6 +19,7 @@ package org.eclipse.fordiac.ide.structuredtextcore.stcore;
 import org.eclipse.fordiac.ide.model.data.DataType;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -88,7 +89,7 @@ public interface STStringLiteral extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -96,6 +97,6 @@ public interface STStringLiteral extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 
 } // STStringLiteral

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STStructInitElement.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STStructInitElement.java
@@ -19,6 +19,7 @@ package org.eclipse.fordiac.ide.structuredtextcore.stcore;
 import org.eclipse.emf.ecore.EObject;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -88,7 +89,7 @@ public interface STStructInitElement extends EObject {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -96,6 +97,6 @@ public interface STStructInitElement extends EObject {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 
 } // STStructInitElement

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STStructInitializerExpression.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STStructInitializerExpression.java
@@ -21,6 +21,7 @@ import org.eclipse.emf.common.util.EList;
 
 import org.eclipse.fordiac.ide.model.data.StructuredType;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -80,7 +81,7 @@ public interface STStructInitializerExpression extends STInitializerExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -88,7 +89,7 @@ public interface STStructInitializerExpression extends STInitializerExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 
 	/**
 	 * <!-- begin-user-doc -->

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STTimeLiteral.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STTimeLiteral.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import org.eclipse.fordiac.ide.model.data.DataType;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -90,7 +91,7 @@ public interface STTimeLiteral extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -98,6 +99,6 @@ public interface STTimeLiteral extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 
 } // STTimeLiteral

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STTimeOfDayLiteral.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STTimeOfDayLiteral.java
@@ -21,6 +21,7 @@ import java.time.LocalTime;
 import org.eclipse.fordiac.ide.model.data.DataType;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -90,7 +91,7 @@ public interface STTimeOfDayLiteral extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -98,6 +99,6 @@ public interface STTimeOfDayLiteral extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 
 } // STTimeOfDayLiteral

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STUnaryExpression.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STUnaryExpression.java
@@ -17,6 +17,7 @@
 package org.eclipse.fordiac.ide.structuredtextcore.stcore;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 /**
  * <!-- begin-user-doc -->
@@ -89,7 +90,7 @@ public interface STUnaryExpression extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getResultType();
+	LibraryElement getResultType();
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -97,6 +98,6 @@ public interface STUnaryExpression extends STExpression {
 	 * @model kind="operation"
 	 * @generated
 	 */
-	INamedElement getDeclaredResultType();
+	LibraryElement getDeclaredResultType();
 
 } // STUnaryExpression

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STArrayAccessExpressionImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STArrayAccessExpressionImpl.java
@@ -33,6 +33,7 @@ import org.eclipse.emf.ecore.util.InternalEList;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STArrayAccessExpression;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpression;
@@ -155,7 +156,7 @@ public class STArrayAccessExpressionImpl extends STExpressionImpl implements STA
 	 * @generated
 	 */
 	@Override
-	public INamedElement getResultType() {
+	public LibraryElement getResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);
 	}
 
@@ -165,7 +166,7 @@ public class STArrayAccessExpressionImpl extends STExpressionImpl implements STA
 	 * @generated
 	 */
 	@Override
-	public INamedElement getDeclaredResultType() {
+	public LibraryElement getDeclaredResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STArrayInitializerExpressionImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STArrayInitializerExpressionImpl.java
@@ -29,6 +29,7 @@ import org.eclipse.emf.ecore.util.EObjectContainmentEList;
 import org.eclipse.emf.ecore.util.InternalEList;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STArrayInitElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STArrayInitializerExpression;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
@@ -95,7 +96,7 @@ public class STArrayInitializerExpressionImpl extends STInitializerExpressionImp
 	 * @generated
 	 */
 	@Override
-	public INamedElement getResultType() {
+	public LibraryElement getResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);
 	}
 
@@ -105,7 +106,7 @@ public class STArrayInitializerExpressionImpl extends STInitializerExpressionImp
 	 * @generated
 	 */
 	@Override
-	public INamedElement getDeclaredResultType() {
+	public LibraryElement getDeclaredResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STBinaryExpressionImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STBinaryExpressionImpl.java
@@ -26,6 +26,7 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STBinaryExpression;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STBinaryOperator;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
@@ -225,7 +226,7 @@ public class STBinaryExpressionImpl extends STExpressionImpl implements STBinary
 	 * @generated
 	 */
 	@Override
-	public INamedElement getResultType() {
+	public LibraryElement getResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);
 	}
 
@@ -235,7 +236,7 @@ public class STBinaryExpressionImpl extends STExpressionImpl implements STBinary
 	 * @generated
 	 */
 	@Override
-	public INamedElement getDeclaredResultType() {
+	public LibraryElement getDeclaredResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STBuiltinFeatureExpressionImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STBuiltinFeatureExpressionImpl.java
@@ -35,6 +35,7 @@ import org.eclipse.emf.ecore.util.InternalEList;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 
 import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STBuiltinFeature;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STBuiltinFeatureExpression;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCallArgument;
@@ -191,7 +192,7 @@ public class STBuiltinFeatureExpressionImpl extends STExpressionImpl implements 
 	 * @generated
 	 */
 	@Override
-	public INamedElement getResultType() {
+	public LibraryElement getResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);
 	}
 
@@ -201,7 +202,7 @@ public class STBuiltinFeatureExpressionImpl extends STExpressionImpl implements 
 	 * @generated
 	 */
 	@Override
-	public INamedElement getDeclaredResultType() {
+	public LibraryElement getDeclaredResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STCallArgumentImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STCallArgumentImpl.java
@@ -25,6 +25,7 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.impl.MinimalEObjectImpl;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCallArgument;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpression;
@@ -123,7 +124,7 @@ public class STCallArgumentImpl extends MinimalEObjectImpl.Container implements 
 	 * @generated
 	 */
 	@Override
-	public INamedElement getResultType() {
+	public LibraryElement getResultType() {
 		return null;
 	}
 
@@ -133,7 +134,7 @@ public class STCallArgumentImpl extends MinimalEObjectImpl.Container implements 
 	 * @generated
 	 */
 	@Override
-	public INamedElement getDeclaredResultType() {
+	public LibraryElement getDeclaredResultType() {
 		return null;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STCallNamedInputArgumentImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STCallNamedInputArgumentImpl.java
@@ -26,6 +26,7 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCallNamedInputArgument;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpression;
@@ -119,7 +120,7 @@ public class STCallNamedInputArgumentImpl extends STCallArgumentImpl implements 
 	 * @generated
 	 */
 	@Override
-	public INamedElement getResultType() {
+	public LibraryElement getResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);
 	}
 
@@ -129,7 +130,7 @@ public class STCallNamedInputArgumentImpl extends STCallArgumentImpl implements 
 	 * @generated
 	 */
 	@Override
-	public INamedElement getDeclaredResultType() {
+	public LibraryElement getDeclaredResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STCallNamedOutputArgumentImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STCallNamedOutputArgumentImpl.java
@@ -26,6 +26,7 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCallNamedOutputArgument;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpression;
@@ -163,7 +164,7 @@ public class STCallNamedOutputArgumentImpl extends STCallArgumentImpl implements
 	 * @generated
 	 */
 	@Override
-	public INamedElement getResultType() {
+	public LibraryElement getResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);
 	}
 
@@ -173,7 +174,7 @@ public class STCallNamedOutputArgumentImpl extends STCallArgumentImpl implements
 	 * @generated
 	 */
 	@Override
-	public INamedElement getDeclaredResultType() {
+	public LibraryElement getDeclaredResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STCallUnnamedArgumentImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STCallUnnamedArgumentImpl.java
@@ -25,6 +25,7 @@ import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCallUnnamedArgument;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpression;
@@ -62,7 +63,7 @@ public class STCallUnnamedArgumentImpl extends STCallArgumentImpl implements STC
 	 * @generated
 	 */
 	@Override
-	public INamedElement getResultType() {
+	public LibraryElement getResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);
 	}
 
@@ -72,7 +73,7 @@ public class STCallUnnamedArgumentImpl extends STCallArgumentImpl implements STC
 	 * @generated
 	 */
 	@Override
-	public INamedElement getDeclaredResultType() {
+	public LibraryElement getDeclaredResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STCorePackageImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STCorePackageImpl.java
@@ -2754,44 +2754,44 @@ public class STCorePackageImpl extends EPackageImpl implements STCorePackage {
 
 		initEClass(stInitializerExpressionEClass, STInitializerExpression.class, "STInitializerExpression", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 
-		addEOperation(stInitializerExpressionEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stInitializerExpressionEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stInitializerExpressionEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stInitializerExpressionEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(stElementaryInitializerExpressionEClass, STElementaryInitializerExpression.class, "STElementaryInitializerExpression", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getSTElementaryInitializerExpression_Value(), this.getSTExpression(), null, "value", null, 0, 1, STElementaryInitializerExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stElementaryInitializerExpressionEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stElementaryInitializerExpressionEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stElementaryInitializerExpressionEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stElementaryInitializerExpressionEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(stArrayInitializerExpressionEClass, STArrayInitializerExpression.class, "STArrayInitializerExpression", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getSTArrayInitializerExpression_Values(), this.getSTArrayInitElement(), null, "values", null, 0, -1, STArrayInitializerExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stArrayInitializerExpressionEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stArrayInitializerExpressionEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stArrayInitializerExpressionEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stArrayInitializerExpressionEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(stArrayInitElementEClass, STArrayInitElement.class, "STArrayInitElement", IS_ABSTRACT, IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 
-		addEOperation(stArrayInitElementEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stArrayInitElementEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stArrayInitElementEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stArrayInitElementEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(stSingleArrayInitElementEClass, STSingleArrayInitElement.class, "STSingleArrayInitElement", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getSTSingleArrayInitElement_InitExpression(), this.getSTInitializerExpression(), null, "initExpression", null, 0, 1, STSingleArrayInitElement.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stSingleArrayInitElementEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stSingleArrayInitElementEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stSingleArrayInitElementEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stSingleArrayInitElementEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(stRepeatArrayInitElementEClass, STRepeatArrayInitElement.class, "STRepeatArrayInitElement", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEAttribute(getSTRepeatArrayInitElement_Repetitions(), ecorePackage.getEBigInteger(), "repetitions", null, 0, 1, STRepeatArrayInitElement.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEReference(getSTRepeatArrayInitElement_InitExpressions(), this.getSTInitializerExpression(), null, "initExpressions", null, 0, -1, STRepeatArrayInitElement.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stRepeatArrayInitElementEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stRepeatArrayInitElementEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stRepeatArrayInitElementEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stRepeatArrayInitElementEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(stPragmaEClass, STPragma.class, "STPragma", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getSTPragma_Attributes(), this.getSTAttribute(), null, "attributes", null, 0, -1, STPragma.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
@@ -2809,30 +2809,30 @@ public class STCorePackageImpl extends EPackageImpl implements STCorePackage {
 		initEClass(stCallArgumentEClass, STCallArgument.class, "STCallArgument", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getSTCallArgument_Argument(), this.getSTExpression(), null, "argument", null, 0, 1, STCallArgument.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stCallArgumentEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stCallArgumentEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stCallArgumentEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stCallArgumentEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(stCallUnnamedArgumentEClass, STCallUnnamedArgument.class, "STCallUnnamedArgument", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 
-		addEOperation(stCallUnnamedArgumentEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stCallUnnamedArgumentEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stCallUnnamedArgumentEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stCallUnnamedArgumentEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(stCallNamedInputArgumentEClass, STCallNamedInputArgument.class, "STCallNamedInputArgument", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getSTCallNamedInputArgument_Parameter(), theLibraryElementPackage.getINamedElement(), null, "parameter", null, 0, 1, STCallNamedInputArgument.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stCallNamedInputArgumentEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stCallNamedInputArgumentEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stCallNamedInputArgumentEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stCallNamedInputArgumentEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(stCallNamedOutputArgumentEClass, STCallNamedOutputArgument.class, "STCallNamedOutputArgument", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEAttribute(getSTCallNamedOutputArgument_Not(), ecorePackage.getEBoolean(), "not", null, 0, 1, STCallNamedOutputArgument.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEReference(getSTCallNamedOutputArgument_Parameter(), theLibraryElementPackage.getINamedElement(), null, "parameter", null, 0, 1, STCallNamedOutputArgument.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stCallNamedOutputArgumentEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stCallNamedOutputArgumentEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stCallNamedOutputArgumentEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stCallNamedOutputArgumentEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(stIfStatementEClass, STIfStatement.class, "STIfStatement", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getSTIfStatement_Condition(), this.getSTExpression(), null, "condition", null, 0, 1, STIfStatement.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
@@ -2874,64 +2874,64 @@ public class STCorePackageImpl extends EPackageImpl implements STCorePackage {
 
 		initEClass(stExpressionEClass, STExpression.class, "STExpression", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 
-		addEOperation(stExpressionEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stExpressionEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stExpressionEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stExpressionEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(stNumericLiteralEClass, STNumericLiteral.class, "STNumericLiteral", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getSTNumericLiteral_Type(), theDataPackage.getDataType(), null, "type", null, 0, 1, STNumericLiteral.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEAttribute(getSTNumericLiteral_Value(), ecorePackage.getEJavaObject(), "value", null, 0, 1, STNumericLiteral.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stNumericLiteralEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stNumericLiteralEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stNumericLiteralEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stNumericLiteralEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(stDateLiteralEClass, STDateLiteral.class, "STDateLiteral", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getSTDateLiteral_Type(), theDataPackage.getDataType(), null, "type", null, 0, 1, STDateLiteral.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEAttribute(getSTDateLiteral_Value(), this.getSTDate(), "value", null, 0, 1, STDateLiteral.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stDateLiteralEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stDateLiteralEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stDateLiteralEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stDateLiteralEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(stTimeLiteralEClass, STTimeLiteral.class, "STTimeLiteral", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getSTTimeLiteral_Type(), theDataPackage.getDataType(), null, "type", null, 0, 1, STTimeLiteral.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEAttribute(getSTTimeLiteral_Value(), this.getSTTime(), "value", null, 0, 1, STTimeLiteral.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stTimeLiteralEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stTimeLiteralEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stTimeLiteralEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stTimeLiteralEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(stTimeOfDayLiteralEClass, STTimeOfDayLiteral.class, "STTimeOfDayLiteral", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getSTTimeOfDayLiteral_Type(), theDataPackage.getDataType(), null, "type", null, 0, 1, STTimeOfDayLiteral.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEAttribute(getSTTimeOfDayLiteral_Value(), this.getSTTimeOfDay(), "value", null, 0, 1, STTimeOfDayLiteral.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stTimeOfDayLiteralEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stTimeOfDayLiteralEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stTimeOfDayLiteralEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stTimeOfDayLiteralEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(stDateAndTimeLiteralEClass, STDateAndTimeLiteral.class, "STDateAndTimeLiteral", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getSTDateAndTimeLiteral_Type(), theDataPackage.getDataType(), null, "type", null, 0, 1, STDateAndTimeLiteral.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEAttribute(getSTDateAndTimeLiteral_Value(), this.getSTDateAndTime(), "value", null, 0, 1, STDateAndTimeLiteral.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stDateAndTimeLiteralEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stDateAndTimeLiteralEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stDateAndTimeLiteralEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stDateAndTimeLiteralEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(stStringLiteralEClass, STStringLiteral.class, "STStringLiteral", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getSTStringLiteral_Type(), theDataPackage.getDataType(), null, "type", null, 0, 1, STStringLiteral.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEAttribute(getSTStringLiteral_Value(), this.getSTString(), "value", null, 0, 1, STStringLiteral.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stStringLiteralEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stStringLiteralEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stStringLiteralEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stStringLiteralEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(stEnumLiteralEClass, STEnumLiteral.class, "STEnumLiteral", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getSTEnumLiteral_Value(), theDataPackage.getEnumeratedValue(), null, "value", null, 0, 1, STEnumLiteral.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stEnumLiteralEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stEnumLiteralEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stEnumLiteralEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stEnumLiteralEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(stVarDeclarationEClass, STVarDeclaration.class, "STVarDeclaration", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getSTVarDeclaration_LocatedAt(), theLibraryElementPackage.getINamedElement(), null, "locatedAt", null, 0, 1, STVarDeclaration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
@@ -2965,42 +2965,42 @@ public class STCorePackageImpl extends EPackageImpl implements STCorePackage {
 		initEAttribute(getSTBinaryExpression_Op(), this.getSTBinaryOperator(), "op", null, 0, 1, STBinaryExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEReference(getSTBinaryExpression_Right(), this.getSTExpression(), null, "right", null, 0, 1, STBinaryExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stBinaryExpressionEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stBinaryExpressionEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stBinaryExpressionEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stBinaryExpressionEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(stUnaryExpressionEClass, STUnaryExpression.class, "STUnaryExpression", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEAttribute(getSTUnaryExpression_Op(), this.getSTUnaryOperator(), "op", null, 0, 1, STUnaryExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEReference(getSTUnaryExpression_Expression(), this.getSTExpression(), null, "expression", null, 0, 1, STUnaryExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stUnaryExpressionEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stUnaryExpressionEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stUnaryExpressionEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stUnaryExpressionEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(stMemberAccessExpressionEClass, STMemberAccessExpression.class, "STMemberAccessExpression", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getSTMemberAccessExpression_Receiver(), this.getSTExpression(), null, "receiver", null, 0, 1, STMemberAccessExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEReference(getSTMemberAccessExpression_Member(), this.getSTExpression(), null, "member", null, 0, 1, STMemberAccessExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stMemberAccessExpressionEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stMemberAccessExpressionEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stMemberAccessExpressionEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stMemberAccessExpressionEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(stArrayAccessExpressionEClass, STArrayAccessExpression.class, "STArrayAccessExpression", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getSTArrayAccessExpression_Receiver(), this.getSTExpression(), null, "receiver", null, 0, 1, STArrayAccessExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEReference(getSTArrayAccessExpression_Index(), this.getSTExpression(), null, "index", null, 0, -1, STArrayAccessExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stArrayAccessExpressionEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stArrayAccessExpressionEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stArrayAccessExpressionEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stArrayAccessExpressionEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(stFeatureExpressionEClass, STFeatureExpression.class, "STFeatureExpression", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getSTFeatureExpression_Feature(), theLibraryElementPackage.getINamedElement(), null, "feature", null, 0, 1, STFeatureExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEAttribute(getSTFeatureExpression_Call(), ecorePackage.getEBoolean(), "call", null, 0, 1, STFeatureExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEReference(getSTFeatureExpression_Parameters(), this.getSTCallArgument(), null, "parameters", null, 0, -1, STFeatureExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stFeatureExpressionEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stFeatureExpressionEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stFeatureExpressionEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stFeatureExpressionEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		EOperation op = addEOperation(stFeatureExpressionEClass, null, "getMappedInputArguments", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 		EGenericType g1 = createEGenericType(ecorePackage.getEMap());
@@ -3031,9 +3031,9 @@ public class STCorePackageImpl extends EPackageImpl implements STCorePackage {
 		initEAttribute(getSTBuiltinFeatureExpression_Call(), ecorePackage.getEBoolean(), "call", null, 0, 1, STBuiltinFeatureExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEReference(getSTBuiltinFeatureExpression_Parameters(), this.getSTCallArgument(), null, "parameters", null, 0, -1, STBuiltinFeatureExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stBuiltinFeatureExpressionEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stBuiltinFeatureExpressionEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stBuiltinFeatureExpressionEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stBuiltinFeatureExpressionEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		op = addEOperation(stBuiltinFeatureExpressionEClass, null, "getMappedInputArguments", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 		g1 = createEGenericType(ecorePackage.getEMap());
@@ -3064,9 +3064,9 @@ public class STCorePackageImpl extends EPackageImpl implements STCorePackage {
 		initEAttribute(getSTMultibitPartialExpression_Index(), ecorePackage.getEBigInteger(), "index", null, 0, 1, STMultibitPartialExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEReference(getSTMultibitPartialExpression_Expression(), this.getSTExpression(), null, "expression", null, 0, 1, STMultibitPartialExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stMultibitPartialExpressionEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stMultibitPartialExpressionEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stMultibitPartialExpressionEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stMultibitPartialExpressionEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(stStandardFunctionEClass, STStandardFunction.class, "STStandardFunction", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEAttribute(getSTStandardFunction_ReturnValueComment(), ecorePackage.getEString(), "returnValueComment", null, 0, 1, STStandardFunction.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
@@ -3088,9 +3088,9 @@ public class STCorePackageImpl extends EPackageImpl implements STCorePackage {
 		initEReference(getSTStructInitializerExpression_Type(), theDataPackage.getStructuredType(), null, "type", null, 0, 1, STStructInitializerExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEReference(getSTStructInitializerExpression_Values(), this.getSTStructInitElement(), null, "values", null, 0, -1, STStructInitializerExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stStructInitializerExpressionEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stStructInitializerExpressionEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stStructInitializerExpressionEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stStructInitializerExpressionEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		op = addEOperation(stStructInitializerExpressionEClass, null, "getMappedStructInitElements", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 		g1 = createEGenericType(ecorePackage.getEMap());
@@ -3104,9 +3104,9 @@ public class STCorePackageImpl extends EPackageImpl implements STCorePackage {
 		initEReference(getSTStructInitElement_Variable(), theLibraryElementPackage.getINamedElement(), null, "variable", null, 0, 1, STStructInitElement.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEReference(getSTStructInitElement_Value(), this.getSTInitializerExpression(), null, "value", null, 0, 1, STStructInitElement.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stStructInitElementEClass, theLibraryElementPackage.getINamedElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stStructInitElementEClass, theLibraryElementPackage.getLibraryElement(), "getResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(stStructInitElementEClass, theLibraryElementPackage.getINamedElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(stStructInitElementEClass, theLibraryElementPackage.getLibraryElement(), "getDeclaredResultType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(stExpressionSourceEClass, STExpressionSource.class, "STExpressionSource", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getSTExpressionSource_Expression(), this.getSTExpression(), null, "expression", null, 0, 1, STExpressionSource.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STDateAndTimeLiteralImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STDateAndTimeLiteralImpl.java
@@ -29,6 +29,7 @@ import org.eclipse.fordiac.ide.model.data.DataType;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STDateAndTimeLiteral;
 
@@ -165,7 +166,7 @@ public class STDateAndTimeLiteralImpl extends STExpressionImpl implements STDate
 	 * @generated
 	 */
 	@Override
-	public INamedElement getResultType() {
+	public LibraryElement getResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);
 	}
 
@@ -175,7 +176,7 @@ public class STDateAndTimeLiteralImpl extends STExpressionImpl implements STDate
 	 * @generated
 	 */
 	@Override
-	public INamedElement getDeclaredResultType() {
+	public LibraryElement getDeclaredResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STDateLiteralImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STDateLiteralImpl.java
@@ -29,6 +29,7 @@ import org.eclipse.fordiac.ide.model.data.DataType;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STDateLiteral;
 
@@ -165,7 +166,7 @@ public class STDateLiteralImpl extends STExpressionImpl implements STDateLiteral
 	 * @generated
 	 */
 	@Override
-	public INamedElement getResultType() {
+	public LibraryElement getResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);
 	}
 
@@ -175,7 +176,7 @@ public class STDateLiteralImpl extends STExpressionImpl implements STDateLiteral
 	 * @generated
 	 */
 	@Override
-	public INamedElement getDeclaredResultType() {
+	public LibraryElement getDeclaredResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STElementaryInitializerExpressionImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STElementaryInitializerExpressionImpl.java
@@ -25,6 +25,7 @@ import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STElementaryInitializerExpression;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpression;
@@ -123,7 +124,7 @@ public class STElementaryInitializerExpressionImpl extends STInitializerExpressi
 	 * @generated
 	 */
 	@Override
-	public INamedElement getResultType() {
+	public LibraryElement getResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);
 	}
 
@@ -133,7 +134,7 @@ public class STElementaryInitializerExpressionImpl extends STInitializerExpressi
 	 * @generated
 	 */
 	@Override
-	public INamedElement getDeclaredResultType() {
+	public LibraryElement getDeclaredResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STEnumLiteralImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STEnumLiteralImpl.java
@@ -27,6 +27,7 @@ import org.eclipse.fordiac.ide.model.data.EnumeratedValue;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STEnumLiteral;
 
@@ -119,7 +120,7 @@ public class STEnumLiteralImpl extends STExpressionImpl implements STEnumLiteral
 	 * @generated
 	 */
 	@Override
-	public INamedElement getResultType() {
+	public LibraryElement getResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);
 	}
 
@@ -129,7 +130,7 @@ public class STEnumLiteralImpl extends STExpressionImpl implements STEnumLiteral
 	 * @generated
 	 */
 	@Override
-	public INamedElement getDeclaredResultType() {
+	public LibraryElement getDeclaredResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STExpressionImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STExpressionImpl.java
@@ -22,6 +22,7 @@ import org.eclipse.emf.ecore.impl.MinimalEObjectImpl;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpression;
 
@@ -58,7 +59,7 @@ public class STExpressionImpl extends STStatementImpl implements STExpression {
 	 * @generated
 	 */
 	@Override
-	public INamedElement getResultType() {
+	public LibraryElement getResultType() {
 		return null;
 	}
 
@@ -68,7 +69,7 @@ public class STExpressionImpl extends STStatementImpl implements STExpression {
 	 * @generated
 	 */
 	@Override
-	public INamedElement getDeclaredResultType() {
+	public LibraryElement getDeclaredResultType() {
 		return null;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STFeatureExpressionImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STFeatureExpressionImpl.java
@@ -35,6 +35,7 @@ import org.eclipse.emf.ecore.util.InternalEList;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 
 import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCallArgument;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpression;
@@ -197,7 +198,7 @@ public class STFeatureExpressionImpl extends STExpressionImpl implements STFeatu
 	 * @generated
 	 */
 	@Override
-	public INamedElement getResultType() {
+	public LibraryElement getResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);
 	}
 
@@ -207,7 +208,7 @@ public class STFeatureExpressionImpl extends STExpressionImpl implements STFeatu
 	 * @generated
 	 */
 	@Override
-	public INamedElement getDeclaredResultType() {
+	public LibraryElement getDeclaredResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STInitializerExpressionImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STInitializerExpressionImpl.java
@@ -21,6 +21,7 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.impl.MinimalEObjectImpl;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STInitializerExpression;
 
@@ -57,7 +58,7 @@ public class STInitializerExpressionImpl extends MinimalEObjectImpl.Container im
 	 * @generated
 	 */
 	@Override
-	public INamedElement getResultType() {
+	public LibraryElement getResultType() {
 		return null;
 	}
 
@@ -67,7 +68,7 @@ public class STInitializerExpressionImpl extends MinimalEObjectImpl.Container im
 	 * @generated
 	 */
 	@Override
-	public INamedElement getDeclaredResultType() {
+	public LibraryElement getDeclaredResultType() {
 		return null;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STMemberAccessExpressionImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STMemberAccessExpressionImpl.java
@@ -26,6 +26,7 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpression;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STMemberAccessExpression;
@@ -180,7 +181,7 @@ public class STMemberAccessExpressionImpl extends STExpressionImpl implements ST
 	 * @generated
 	 */
 	@Override
-	public INamedElement getResultType() {
+	public LibraryElement getResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);
 	}
 
@@ -190,7 +191,7 @@ public class STMemberAccessExpressionImpl extends STExpressionImpl implements ST
 	 * @generated
 	 */
 	@Override
-	public INamedElement getDeclaredResultType() {
+	public LibraryElement getDeclaredResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STMultibitPartialExpressionImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STMultibitPartialExpressionImpl.java
@@ -28,6 +28,7 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpression;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STMultiBitAccessSpecifier;
@@ -215,7 +216,7 @@ public class STMultibitPartialExpressionImpl extends STExpressionImpl implements
 	 * @generated
 	 */
 	@Override
-	public INamedElement getResultType() {
+	public LibraryElement getResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);
 	}
 
@@ -225,7 +226,7 @@ public class STMultibitPartialExpressionImpl extends STExpressionImpl implements
 	 * @generated
 	 */
 	@Override
-	public INamedElement getDeclaredResultType() {
+	public LibraryElement getDeclaredResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STNumericLiteralImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STNumericLiteralImpl.java
@@ -29,6 +29,7 @@ import org.eclipse.fordiac.ide.model.data.DataType;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STNumericLiteral;
 
@@ -165,7 +166,7 @@ public class STNumericLiteralImpl extends STExpressionImpl implements STNumericL
 	 * @generated
 	 */
 	@Override
-	public INamedElement getResultType() {
+	public LibraryElement getResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);
 	}
 
@@ -175,7 +176,7 @@ public class STNumericLiteralImpl extends STExpressionImpl implements STNumericL
 	 * @generated
 	 */
 	@Override
-	public INamedElement getDeclaredResultType() {
+	public LibraryElement getDeclaredResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STRepeatArrayInitElementImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STRepeatArrayInitElementImpl.java
@@ -35,6 +35,7 @@ import org.eclipse.emf.ecore.util.InternalEList;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STInitializerExpression;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STRepeatArrayInitElement;
@@ -145,7 +146,7 @@ public class STRepeatArrayInitElementImpl extends MinimalEObjectImpl.Container i
 	 * @generated
 	 */
 	@Override
-	public INamedElement getResultType() {
+	public LibraryElement getResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);
 	}
 
@@ -155,7 +156,7 @@ public class STRepeatArrayInitElementImpl extends MinimalEObjectImpl.Container i
 	 * @generated
 	 */
 	@Override
-	public INamedElement getDeclaredResultType() {
+	public LibraryElement getDeclaredResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STSingleArrayInitElementImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STSingleArrayInitElementImpl.java
@@ -27,6 +27,7 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.impl.MinimalEObjectImpl;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STInitializerExpression;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STSingleArrayInitElement;
@@ -125,7 +126,7 @@ public class STSingleArrayInitElementImpl extends MinimalEObjectImpl.Container i
 	 * @generated
 	 */
 	@Override
-	public INamedElement getResultType() {
+	public LibraryElement getResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);
 	}
 
@@ -135,7 +136,7 @@ public class STSingleArrayInitElementImpl extends MinimalEObjectImpl.Container i
 	 * @generated
 	 */
 	@Override
-	public INamedElement getDeclaredResultType() {
+	public LibraryElement getDeclaredResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STStringLiteralImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STStringLiteralImpl.java
@@ -27,6 +27,7 @@ import org.eclipse.fordiac.ide.model.data.DataType;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STString;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STStringLiteral;
@@ -164,7 +165,7 @@ public class STStringLiteralImpl extends STExpressionImpl implements STStringLit
 	 * @generated
 	 */
 	@Override
-	public INamedElement getResultType() {
+	public LibraryElement getResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);
 	}
 
@@ -174,7 +175,7 @@ public class STStringLiteralImpl extends STExpressionImpl implements STStringLit
 	 * @generated
 	 */
 	@Override
-	public INamedElement getDeclaredResultType() {
+	public LibraryElement getDeclaredResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STStructInitElementImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STStructInitElementImpl.java
@@ -27,6 +27,7 @@ import org.eclipse.emf.ecore.impl.MinimalEObjectImpl;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STInitializerExpression;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STStructInitElement;
@@ -176,7 +177,7 @@ public class STStructInitElementImpl extends MinimalEObjectImpl.Container implem
 	 * @generated
 	 */
 	@Override
-	public INamedElement getResultType() {
+	public LibraryElement getResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);
 	}
 
@@ -186,7 +187,7 @@ public class STStructInitElementImpl extends MinimalEObjectImpl.Container implem
 	 * @generated
 	 */
 	@Override
-	public INamedElement getDeclaredResultType() {
+	public LibraryElement getDeclaredResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STStructInitializerExpressionImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STStructInitializerExpressionImpl.java
@@ -34,6 +34,7 @@ import org.eclipse.emf.ecore.util.InternalEList;
 import org.eclipse.fordiac.ide.model.data.StructuredType;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STInitializerExpression;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STStructInitElement;
@@ -151,7 +152,7 @@ public class STStructInitializerExpressionImpl extends STInitializerExpressionIm
 	 * @generated
 	 */
 	@Override
-	public INamedElement getResultType() {
+	public LibraryElement getResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);
 	}
 
@@ -161,7 +162,7 @@ public class STStructInitializerExpressionImpl extends STInitializerExpressionIm
 	 * @generated
 	 */
 	@Override
-	public INamedElement getDeclaredResultType() {
+	public LibraryElement getDeclaredResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STTimeLiteralImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STTimeLiteralImpl.java
@@ -29,6 +29,7 @@ import org.eclipse.fordiac.ide.model.data.DataType;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STTimeLiteral;
 
@@ -165,7 +166,7 @@ public class STTimeLiteralImpl extends STExpressionImpl implements STTimeLiteral
 	 * @generated
 	 */
 	@Override
-	public INamedElement getResultType() {
+	public LibraryElement getResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);
 	}
 
@@ -175,7 +176,7 @@ public class STTimeLiteralImpl extends STExpressionImpl implements STTimeLiteral
 	 * @generated
 	 */
 	@Override
-	public INamedElement getDeclaredResultType() {
+	public LibraryElement getDeclaredResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STTimeOfDayLiteralImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STTimeOfDayLiteralImpl.java
@@ -29,6 +29,7 @@ import org.eclipse.fordiac.ide.model.data.DataType;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STTimeOfDayLiteral;
 
@@ -165,7 +166,7 @@ public class STTimeOfDayLiteralImpl extends STExpressionImpl implements STTimeOf
 	 * @generated
 	 */
 	@Override
-	public INamedElement getResultType() {
+	public LibraryElement getResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);
 	}
 
@@ -175,7 +176,7 @@ public class STTimeOfDayLiteralImpl extends STExpressionImpl implements STTimeOf
 	 * @generated
 	 */
 	@Override
-	public INamedElement getDeclaredResultType() {
+	public LibraryElement getDeclaredResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STUnaryExpressionImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STUnaryExpressionImpl.java
@@ -26,6 +26,7 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpression;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STUnaryExpression;
@@ -169,7 +170,7 @@ public class STUnaryExpressionImpl extends STExpressionImpl implements STUnaryEx
 	 * @generated
 	 */
 	@Override
-	public INamedElement getResultType() {
+	public LibraryElement getResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getResultType(this);
 	}
 
@@ -179,7 +180,7 @@ public class STUnaryExpressionImpl extends STExpressionImpl implements STUnaryEx
 	 * @generated
 	 */
 	@Override
-	public INamedElement getDeclaredResultType() {
+	public LibraryElement getDeclaredResultType() {
 		return org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.ExpressionAnnotations.getDeclaredResultType(this);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STVarDeclarationImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STVarDeclarationImpl.java
@@ -493,7 +493,7 @@ public class STVarDeclarationImpl extends MinimalEObjectImpl.Container implement
 	 */
 	@Override
 	public String getTypeName() {
-		org.eclipse.fordiac.ide.model.libraryElement.INamedElement type = getType();
+		org.eclipse.fordiac.ide.model.libraryElement.LibraryElement type = getType();
 		if(type != null){
 			return type.getName();
 		}

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/STResource.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/STResource.java
@@ -12,17 +12,17 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.structuredtextcore.stcore;
 
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 public interface STResource {
 
 	String OPTION_EXPECTED_TYPE = STResource.class.getName() + ".EXPECTED_TYPE"; //$NON-NLS-1$
 
-	INamedElement getExpectedType();
+	LibraryElement getExpectedType();
 
-	void setExpectedType(INamedElement expectedType);
+	void setExpectedType(LibraryElement expectedType);
 
-	INamedElement getExpectedType(STExpression expression);
+	LibraryElement getExpectedType(STExpression expression);
 
-	INamedElement getExpectedType(STInitializerExpression expression);
+	LibraryElement getExpectedType(STInitializerExpression expression);
 }

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/ExpressionAnnotations.xtend
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/ExpressionAnnotations.xtend
@@ -34,6 +34,8 @@ import org.eclipse.fordiac.ide.model.libraryElement.FB
 import org.eclipse.fordiac.ide.model.libraryElement.FBType
 import org.eclipse.fordiac.ide.model.libraryElement.ICallable
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement
+import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STArrayAccessExpression
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STArrayInitializerExpression
@@ -66,18 +68,17 @@ import org.eclipse.fordiac.ide.structuredtextcore.stcore.STVarDeclaration
 import static extension org.eclipse.emf.ecore.util.EcoreUtil.copy
 import static extension org.eclipse.fordiac.ide.model.eval.function.Functions.*
 import static extension org.eclipse.fordiac.ide.structuredtextcore.stcore.util.STCoreUtil.*
-import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement
 
 final package class ExpressionAnnotations {
 
 	private new() {
 	}
 
-	def package static INamedElement getResultType(STBinaryExpression expr) { getResultType(expr, false) }
+	def package static LibraryElement getResultType(STBinaryExpression expr) { getResultType(expr, false) }
 
-	def package static INamedElement getDeclaredResultType(STBinaryExpression expr) { getResultType(expr, true) }
+	def package static LibraryElement getDeclaredResultType(STBinaryExpression expr) { getResultType(expr, true) }
 
-	def package static INamedElement getResultType(STBinaryExpression expr, boolean declared) {
+	def package static LibraryElement getResultType(STBinaryExpression expr, boolean declared) {
 		if (expr.op.comparison)
 			ElementaryTypes.BOOL // always return BOOL for comparison
 		else {
@@ -118,23 +119,23 @@ final package class ExpressionAnnotations {
 		}
 	}
 
-	def package static INamedElement getResultType(STUnaryExpression expr) { expr.expression?.resultType }
+	def package static LibraryElement getResultType(STUnaryExpression expr) { expr.expression?.resultType }
 
-	def package static INamedElement getDeclaredResultType(STUnaryExpression expr) {
+	def package static LibraryElement getDeclaredResultType(STUnaryExpression expr) {
 		expr.expression?.declaredResultType
 	}
 
-	def package static INamedElement getResultType(STMemberAccessExpression expr) { expr.member?.resultType }
+	def package static LibraryElement getResultType(STMemberAccessExpression expr) { expr.member?.resultType }
 
-	def package static INamedElement getDeclaredResultType(STMemberAccessExpression expr) {
+	def package static LibraryElement getDeclaredResultType(STMemberAccessExpression expr) {
 		expr.member?.declaredResultType
 	}
 
-	def package static INamedElement getResultType(STArrayAccessExpression expr) { getResultType(expr, false) }
+	def package static LibraryElement getResultType(STArrayAccessExpression expr) { getResultType(expr, false) }
 
-	def package static INamedElement getDeclaredResultType(STArrayAccessExpression expr) { getResultType(expr, true) }
+	def package static LibraryElement getDeclaredResultType(STArrayAccessExpression expr) { getResultType(expr, true) }
 
-	def package static INamedElement getResultType(STArrayAccessExpression expr, boolean declared) {
+	def package static LibraryElement getResultType(STArrayAccessExpression expr, boolean declared) {
 		val receiverType = declared ? expr.receiver?.declaredResultType : expr.receiver?.resultType
 		switch (receiverType) {
 			ArrayType:
@@ -149,7 +150,7 @@ final package class ExpressionAnnotations {
 		}
 	}
 
-	def package static INamedElement getResultType(STFeatureExpression expr) {
+	def package static LibraryElement getResultType(STFeatureExpression expr) {
 		switch (feature : expr.feature) {
 			STStandardFunction:
 				feature.javaMethod.inferReturnTypeFromDataTypes([switch (type: expr.expectedType) { DataType: type }], [
@@ -160,7 +161,7 @@ final package class ExpressionAnnotations {
 		}
 	}
 
-	def package static INamedElement getDeclaredResultType(STFeatureExpression expr) {
+	def package static LibraryElement getDeclaredResultType(STFeatureExpression expr) {
 		// mirror changes here in callaSTCoreScopeProvider.isApplicableForFeatureReference(IEObjectDescription)
 		switch (feature : expr.feature) {
 			VarDeclaration,
@@ -181,18 +182,18 @@ final package class ExpressionAnnotations {
 		}
 	}
 
-	def package static INamedElement getResultType(STBuiltinFeatureExpression expr) { getDeclaredResultType(expr) }
+	def package static LibraryElement getResultType(STBuiltinFeatureExpression expr) { getDeclaredResultType(expr) }
 
-	def package static INamedElement getDeclaredResultType(STBuiltinFeatureExpression expr) {
+	def package static LibraryElement getDeclaredResultType(STBuiltinFeatureExpression expr) {
 		switch (expr.feature) {
 			case THIS:
 				if(expr.call) null else expr.eResource?.contents?.filter(FBType)?.head
 		}
 	}
 
-	def package static INamedElement getResultType(STMultibitPartialExpression expr) { getDeclaredResultType(expr) }
+	def package static LibraryElement getResultType(STMultibitPartialExpression expr) { getDeclaredResultType(expr) }
 
-	def package static INamedElement getDeclaredResultType(STMultibitPartialExpression expr) {
+	def package static LibraryElement getDeclaredResultType(STMultibitPartialExpression expr) {
 		switch (expr.specifier) {
 			case null,
 			case X: ElementaryTypes.BOOL
@@ -203,7 +204,7 @@ final package class ExpressionAnnotations {
 		}
 	}
 
-	def package static INamedElement getResultType(STNumericLiteral expr) {
+	def package static LibraryElement getResultType(STNumericLiteral expr) {
 		expr.type ?: switch (result : expr.expectedType) {
 			DataType case result.isNumericValueValid(expr.value):
 				result
@@ -228,9 +229,9 @@ final package class ExpressionAnnotations {
 		} ?: getValueType(expr)
 	}
 
-	def package static INamedElement getDeclaredResultType(STNumericLiteral expr) { expr.type ?: getValueType(expr) }
+	def package static LibraryElement getDeclaredResultType(STNumericLiteral expr) { expr.type ?: getValueType(expr) }
 
-	def package static INamedElement getValueType(STNumericLiteral expr) {
+	def package static LibraryElement getValueType(STNumericLiteral expr) {
 		switch (it : expr.value) {
 			Boolean: ElementaryTypes.BOOL
 			BigDecimal: ElementaryTypes.LREAL
@@ -243,32 +244,32 @@ final package class ExpressionAnnotations {
 		}
 	}
 
-	def package static INamedElement getResultType(STDateLiteral expr) { getDeclaredResultType(expr) }
+	def package static LibraryElement getResultType(STDateLiteral expr) { getDeclaredResultType(expr) }
 
-	def package static INamedElement getDeclaredResultType(STDateLiteral expr) { expr.type }
+	def package static LibraryElement getDeclaredResultType(STDateLiteral expr) { expr.type }
 
-	def package static INamedElement getResultType(STTimeLiteral expr) { getDeclaredResultType(expr) }
+	def package static LibraryElement getResultType(STTimeLiteral expr) { getDeclaredResultType(expr) }
 
-	def package static INamedElement getDeclaredResultType(STTimeLiteral expr) { expr.type }
+	def package static LibraryElement getDeclaredResultType(STTimeLiteral expr) { expr.type }
 
-	def package static INamedElement getResultType(STTimeOfDayLiteral expr) { getDeclaredResultType(expr) }
+	def package static LibraryElement getResultType(STTimeOfDayLiteral expr) { getDeclaredResultType(expr) }
 
-	def package static INamedElement getDeclaredResultType(STTimeOfDayLiteral expr) { expr.type }
+	def package static LibraryElement getDeclaredResultType(STTimeOfDayLiteral expr) { expr.type }
 
-	def package static INamedElement getResultType(STDateAndTimeLiteral expr) { getDeclaredResultType(expr) }
+	def package static LibraryElement getResultType(STDateAndTimeLiteral expr) { getDeclaredResultType(expr) }
 
-	def package static INamedElement getDeclaredResultType(STDateAndTimeLiteral expr) { expr.type }
+	def package static LibraryElement getDeclaredResultType(STDateAndTimeLiteral expr) { expr.type }
 
-	def package static INamedElement getResultType(STStringLiteral expr) {
+	def package static LibraryElement getResultType(STStringLiteral expr) {
 		expr.type ?: switch (result : expr.expectedType) {
 			DataType case result.isStringValueValid(expr.value): result
 			default: null
 		} ?: getValueType(expr)
 	}
 
-	def package static INamedElement getDeclaredResultType(STStringLiteral expr) { expr.type ?: getValueType(expr) }
+	def package static LibraryElement getDeclaredResultType(STStringLiteral expr) { expr.type ?: getValueType(expr) }
 
-	def package static INamedElement getValueType(STStringLiteral expr) {
+	def package static LibraryElement getValueType(STStringLiteral expr) {
 		if (expr.value.length == 1) {
 			if(expr.value.wide) ElementaryTypes.WCHAR else ElementaryTypes.CHAR
 		} else {
@@ -276,69 +277,69 @@ final package class ExpressionAnnotations {
 		}
 	}
 
-	def package static INamedElement getResultType(STEnumLiteral expr) { getDeclaredResultType(expr) }
+	def package static LibraryElement getResultType(STEnumLiteral expr) { getDeclaredResultType(expr) }
 
-	def package static INamedElement getDeclaredResultType(STEnumLiteral expr) { expr.value?.type }
+	def package static LibraryElement getDeclaredResultType(STEnumLiteral expr) { expr.value?.type }
 
-	def package static INamedElement getResultType(STCallUnnamedArgument arg) { arg.argument?.resultType }
+	def package static LibraryElement getResultType(STCallUnnamedArgument arg) { arg.argument?.resultType }
 
-	def package static INamedElement getDeclaredResultType(STCallUnnamedArgument arg) {
+	def package static LibraryElement getDeclaredResultType(STCallUnnamedArgument arg) {
 		arg.argument?.declaredResultType
 	}
 
-	def package static INamedElement getResultType(STCallNamedInputArgument arg) { arg.argument?.resultType }
+	def package static LibraryElement getResultType(STCallNamedInputArgument arg) { arg.argument?.resultType }
 
-	def package static INamedElement getDeclaredResultType(STCallNamedInputArgument arg) {
+	def package static LibraryElement getDeclaredResultType(STCallNamedInputArgument arg) {
 		arg.argument?.declaredResultType
 	}
 
-	def package static INamedElement getResultType(STCallNamedOutputArgument arg) { arg.argument?.resultType }
+	def package static LibraryElement getResultType(STCallNamedOutputArgument arg) { arg.argument?.resultType }
 
-	def package static INamedElement getDeclaredResultType(STCallNamedOutputArgument arg) {
+	def package static LibraryElement getDeclaredResultType(STCallNamedOutputArgument arg) {
 		arg.argument?.declaredResultType
 	}
 
-	def package static INamedElement getResultType(STElementaryInitializerExpression expr) { expr.value?.resultType }
+	def package static LibraryElement getResultType(STElementaryInitializerExpression expr) { expr.value?.resultType }
 
-	def package static INamedElement getDeclaredResultType(STElementaryInitializerExpression expr) {
+	def package static LibraryElement getDeclaredResultType(STElementaryInitializerExpression expr) {
 		expr.value?.declaredResultType
 	}
 
-	def package static INamedElement getResultType(STArrayInitializerExpression expr) {
+	def package static LibraryElement getResultType(STArrayInitializerExpression expr) {
 		expr.expectedType ?:
 			expr.values.map[resultType].reduce[first, second|first.commonSupertype(second)].addDimension(expr)
 	}
 
-	def package static INamedElement getDeclaredResultType(STArrayInitializerExpression expr) {
+	def package static LibraryElement getDeclaredResultType(STArrayInitializerExpression expr) {
 		expr.expectedType ?:
 			expr.values.map[declaredResultType].reduce[first, second|first.commonSupertype(second)].addDimension(expr)
 	}
 
-	def package static INamedElement getResultType(STSingleArrayInitElement expr) {
+	def package static LibraryElement getResultType(STSingleArrayInitElement expr) {
 		expr.initExpression.resultType
 	}
 
-	def package static INamedElement getDeclaredResultType(STSingleArrayInitElement expr) {
+	def package static LibraryElement getDeclaredResultType(STSingleArrayInitElement expr) {
 		expr.initExpression.declaredResultType
 	}
 
-	def package static INamedElement getResultType(STRepeatArrayInitElement expr) {
+	def package static LibraryElement getResultType(STRepeatArrayInitElement expr) {
 		expr.initExpressions.map[resultType].reduce[first, second|first.commonSupertype(second)]
 	}
 
-	def package static INamedElement getDeclaredResultType(STRepeatArrayInitElement expr) {
+	def package static LibraryElement getDeclaredResultType(STRepeatArrayInitElement expr) {
 		expr.initExpressions.map[declaredResultType].reduce[first, second|first.commonSupertype(second)]
 	}
 
-	def package static INamedElement getResultType(STStructInitializerExpression expr) {
+	def package static LibraryElement getResultType(STStructInitializerExpression expr) {
 		getDeclaredResultType(expr) ?: expr.expectedType
 	}
 
-	def package static INamedElement getDeclaredResultType(STStructInitializerExpression expr) { expr.type }
+	def package static LibraryElement getDeclaredResultType(STStructInitializerExpression expr) { expr.type }
 
-	def package static INamedElement getResultType(STStructInitElement expr) { getDeclaredResultType(expr) }
+	def package static LibraryElement getResultType(STStructInitElement expr) { getDeclaredResultType(expr) }
 
-	def package static INamedElement getDeclaredResultType(STStructInitElement expr) { expr.variable.featureType }
+	def package static LibraryElement getDeclaredResultType(STStructInitElement expr) { expr.variable.featureType }
 
 	def package static Map<ITypedElement, STCallArgument> getMappedInputArguments(STFeatureExpression expr) {
 		expr.feature.computeMappedInputArguments(expr.parameters)
@@ -445,7 +446,7 @@ final package class ExpressionAnnotations {
 			emptyMap
 	}
 
-	def package static INamedElement addDimension(INamedElement type, STArrayInitializerExpression expr) {
+	def package static LibraryElement addDimension(INamedElement type, STArrayInitializerExpression expr) {
 		try {
 			val size = expr.values.map [
 				switch (it) {
@@ -462,7 +463,7 @@ final package class ExpressionAnnotations {
 		}
 	}
 
-	def package static INamedElement commonSupertype(INamedElement first, INamedElement second) {
+	def package static LibraryElement commonSupertype(LibraryElement first, LibraryElement second) {
 		if (first == second)
 			first
 		else if (first instanceof DataType) {

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STVarDeclarationAnnotations.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STVarDeclarationAnnotations.java
@@ -12,14 +12,14 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.structuredtextcore.stcore.impl;
 
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STVarDeclaration;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.util.STCoreUtil;
 
 final class STVarDeclarationAnnotations {
 
 	static String getFullTypeName(final STVarDeclaration varDeclaration) {
-		final INamedElement featureType = STCoreUtil.getFeatureType(varDeclaration);
+		final LibraryElement featureType = STCoreUtil.getFeatureType(varDeclaration);
 		if (featureType != null) {
 			return featureType.getName();
 		}

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/util/STCoreUtil.xtend
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/util/STCoreUtil.xtend
@@ -72,6 +72,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.Attribute
 import org.eclipse.fordiac.ide.model.libraryElement.ICallable
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement
 import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration
 import org.eclipse.fordiac.ide.model.value.TypedValueConverter
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STArrayAccessExpression
@@ -175,7 +176,7 @@ final class STCoreUtil {
 		operator == STBinaryOperator.RANGE
 	}
 
-	def static boolean isApplicableTo(STUnaryOperator operator, INamedElement type) {
+	def static boolean isApplicableTo(STUnaryOperator operator, LibraryElement type) {
 		switch (operator) {
 			case type.anyType: false
 			case PLUS,
@@ -184,7 +185,7 @@ final class STCoreUtil {
 		}
 	}
 
-	def static boolean isApplicableTo(STBinaryOperator operator, INamedElement first, INamedElement second) {
+	def static boolean isApplicableTo(STBinaryOperator operator, LibraryElement first, LibraryElement second) {
 		switch (operator) {
 			case first.anyType || second.anyType:
 				false
@@ -322,7 +323,7 @@ final class STCoreUtil {
 		value.signum >= 0 && value <= upper
 	}
 
-	def static INamedElement getExpectedType(STExpression expression) {
+	def static LibraryElement getExpectedType(STExpression expression) {
 		val resource = expression.eResource
 		if (resource instanceof STResource)
 			resource.getExpectedType(expression)
@@ -330,7 +331,7 @@ final class STCoreUtil {
 			expression.computeExpectedType
 	}
 
-	def static INamedElement getExpectedType(STInitializerExpression expression) {
+	def static LibraryElement getExpectedType(STInitializerExpression expression) {
 		val resource = expression.eResource
 		if (resource instanceof STResource)
 			resource.getExpectedType(expression)
@@ -338,7 +339,7 @@ final class STCoreUtil {
 			expression.computeExpectedType
 	}
 
-	def static INamedElement computeExpectedType(STExpression expression) {
+	def static LibraryElement computeExpectedType(STExpression expression) {
 		switch (it : expression.eContainer) {
 			STUnaryExpression case op.arithmetic:
 				expectedType.equivalentAnyNumType
@@ -375,7 +376,7 @@ final class STCoreUtil {
 		}
 	}
 
-	def static INamedElement computeExpectedType(STInitializerExpression expression) {
+	def static LibraryElement computeExpectedType(STInitializerExpression expression) {
 		switch (it : expression.eContainer) {
 			STAttribute:
 				declaration.featureType
@@ -394,7 +395,7 @@ final class STCoreUtil {
 		}
 	}
 
-	def private static INamedElement computeExpectedType(STArrayInitElement initElement) {
+	def private static LibraryElement computeExpectedType(STArrayInitElement initElement) {
 		switch (it : initElement.eContainer) {
 			STArrayInitializerExpression:
 				switch (type : expectedType) {
@@ -407,7 +408,7 @@ final class STCoreUtil {
 		}
 	}
 
-	def private static INamedElement computeExpectedType(STCallArgument argument) {
+	def private static LibraryElement computeExpectedType(STCallArgument argument) {
 		val featureExpression = argument.eContainer
 		if (featureExpression instanceof STFeatureExpression) {
 			val feature = featureExpression.feature
@@ -492,7 +493,7 @@ final class STCoreUtil {
 		].filterNull.toList
 	}
 
-	def static getFeatureType(INamedElement feature) {
+	def static LibraryElement getFeatureType(INamedElement feature) {
 		switch (feature) {
 			VarDeclaration:
 				if (feature.array)
@@ -599,7 +600,7 @@ final class STCoreUtil {
 			other
 	}
 
-	def static AnyNumType getEquivalentAnyNumType(INamedElement type) {
+	def static AnyNumType getEquivalentAnyNumType(LibraryElement type) {
 		switch (type) {
 			BoolType: ElementaryTypes.SINT
 			ByteType: ElementaryTypes.USINT
@@ -610,7 +611,7 @@ final class STCoreUtil {
 		}
 	}
 
-	def static AnyUnsignedType getEquivalentAnyUnsignedType(INamedElement type) {
+	def static AnyUnsignedType getEquivalentAnyUnsignedType(LibraryElement type) {
 		switch (type) {
 			SintType: ElementaryTypes.USINT
 			IntType: ElementaryTypes.UINT
@@ -620,7 +621,7 @@ final class STCoreUtil {
 		}
 	}
 
-	def static AnyBitType getEquivalentAnyBitType(INamedElement type) {
+	def static AnyBitType getEquivalentAnyBitType(LibraryElement type) {
 		switch (type) {
 			SintType,
 			UsintType: ElementaryTypes.BYTE
@@ -634,7 +635,7 @@ final class STCoreUtil {
 		}
 	}
 
-	def static getEquivalentAnyLDateType(INamedElement type) {
+	def static getEquivalentAnyLDateType(LibraryElement type) {
 		switch (type) {
 			DateType: ElementaryTypes.LDATE
 			TimeOfDayType: ElementaryTypes.LTOD
@@ -643,23 +644,23 @@ final class STCoreUtil {
 		}
 	}
 
-	def static boolean isInstanceofAnySimpleDateType(INamedElement type) {
+	def static boolean isInstanceofAnySimpleDateType(LibraryElement type) {
 		return type instanceof DateType || type instanceof LdateType
 	}
 
-	def static boolean isInstanceofAnyTimeOfDayType(INamedElement type) {
+	def static boolean isInstanceofAnyTimeOfDayType(LibraryElement type) {
 		return type instanceof TimeOfDayType || type instanceof LtodType
 	}
 
-	def static boolean isInstanceofAnyDateAndTimeType(INamedElement type) {
+	def static boolean isInstanceofAnyDateAndTimeType(LibraryElement type) {
 		return type instanceof DateAndTimeType || type instanceof LdtType
 	}
 
-	def static boolean isInstanceofAnySDateType(INamedElement type) {
+	def static boolean isInstanceofAnySDateType(LibraryElement type) {
 		return type instanceof DateType || type instanceof TimeOfDayType || type instanceof DateAndTimeType
 	}
 
-	def static boolean isInstanceofAnyLDateType(INamedElement type) {
+	def static boolean isInstanceofAnyLDateType(LibraryElement type) {
 		return type instanceof LdateType || type instanceof LtodType || type instanceof LdtType
 	}
 
@@ -676,7 +677,7 @@ final class STCoreUtil {
 			null
 	}
 
-	def static hasCommonSupertype(INamedElement type1, INamedElement type2) {
+	def static hasCommonSupertype(LibraryElement type1, LibraryElement type2) {
 		if (type1 == type2)
 			true
 		else if (type1 instanceof DataType)

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/quickfix/STCoreQuickfixProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/quickfix/STCoreQuickfixProvider.java
@@ -51,6 +51,7 @@ import org.eclipse.fordiac.ide.model.helpers.ImportHelper;
 import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.ICallable;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.structuredtextcore.resource.LibraryElementXtextResource;
 import org.eclipse.fordiac.ide.structuredtextcore.scoping.STStandardFunctionProvider;
@@ -552,7 +553,7 @@ public class STCoreQuickfixProvider extends DefaultQuickfixProvider {
 		if (element instanceof final STFeatureExpression expression) {
 			final ICallable callable = EcoreUtil2.getContainerOfType(expression, ICallable.class);
 			final String name = getFeatureText(expression);
-			final INamedElement type = getExpectedFeatureType(expression);
+			final LibraryElement type = getExpectedFeatureType(expression);
 			if (callable != null && IdentifierVerifier.verifyIdentifier(name).isEmpty()
 					&& type instanceof final DataType dataType) {
 				createMissingVariable(callable, name, dataType, kind);
@@ -595,14 +596,14 @@ public class STCoreQuickfixProvider extends DefaultQuickfixProvider {
 				.stream().map(INode::getText).map(String::trim).collect(Collectors.joining());
 	}
 
-	protected static INamedElement getExpectedFeatureType(final STFeatureExpression element) {
-		final INamedElement expectedType = STCoreUtil.getExpectedType(element);
+	protected static LibraryElement getExpectedFeatureType(final STFeatureExpression element) {
+		final LibraryElement expectedType = STCoreUtil.getExpectedType(element);
 		if (expectedType != null) {
 			return expectedType;
 		}
 		if (element.eContainer() instanceof final STAssignment assignment && assignment.getLeft() == element
 				&& assignment.getRight() != null) {
-			final INamedElement resultType = assignment.getRight().getResultType();
+			final LibraryElement resultType = assignment.getRight().getResultType();
 			if (resultType != null) {
 				return resultType;
 			}

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/ExtractCallableRefactoring.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/ExtractCallableRefactoring.java
@@ -41,7 +41,7 @@ import org.eclipse.fordiac.ide.model.IdentifierVerifier;
 import org.eclipse.fordiac.ide.model.NamedElementComparator;
 import org.eclipse.fordiac.ide.model.data.AnyElementaryType;
 import org.eclipse.fordiac.ide.model.libraryElement.ICallable;
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STContinue;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STExit;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpression;
@@ -108,7 +108,7 @@ public class ExtractCallableRefactoring extends Refactoring {
 	private String callableName = "CALLABLE"; //$NON-NLS-1$
 	private AccessMode referencedReturnVariable = AccessMode.NONE;
 	private Map<STVarDeclaration, AccessMode> referencedLocalVariables = Collections.emptyMap();
-	private Optional<INamedElement> returnType = Optional.empty();
+	private Optional<LibraryElement> returnType = Optional.empty();
 	private List<STVarDeclaration> inputParameters = Collections.emptyList();
 	private List<STVarDeclaration> outputParameters = Collections.emptyList();
 	private List<STVarDeclaration> inoutParameters = Collections.emptyList();
@@ -459,7 +459,7 @@ public class ExtractCallableRefactoring extends Refactoring {
 				&& EcoreUtil2.getContainerOfType(expression.getFeature(), ICallable.class) == callable.orElse(null);
 	}
 
-	protected Optional<INamedElement> calculateReturnType() {
+	protected Optional<LibraryElement> calculateReturnType() {
 		if (referencedReturnVariable != AccessMode.NONE) {
 			return callable.map(ICallable::getReturnType);
 		}
@@ -549,11 +549,11 @@ public class ExtractCallableRefactoring extends Refactoring {
 		return referencedLocalVariables;
 	}
 
-	public Optional<INamedElement> getReturnType() {
+	public Optional<LibraryElement> getReturnType() {
 		return returnType;
 	}
 
-	public void setReturnType(final Optional<INamedElement> returnType) {
+	public void setReturnType(final Optional<LibraryElement> returnType) {
 		this.returnType = returnType;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/STCoreResourceLifecycleManager.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/STCoreResourceLifecycleManager.java
@@ -21,7 +21,7 @@ import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.model.data.AnyDerivedType;
 import org.eclipse.fordiac.ide.model.data.ArrayType;
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STResource;
 import org.eclipse.xtext.ide.serializer.impl.RelatedResourcesProvider.RelatedResource;
@@ -50,7 +50,7 @@ public class STCoreResourceLifecycleManager extends ResourceLifecycleManager {
 		}
 	}
 
-	protected static <T extends INamedElement> void updateType(final T type, final Consumer<? super T> consumer,
+	protected static <T extends LibraryElement> void updateType(final T type, final Consumer<? super T> consumer,
 			final ResourceSet resourceSet) {
 		if (type instanceof AnyDerivedType) {
 			final Class<? extends T> clazz = getClass(type);

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/resource/STCoreResource.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/resource/STCoreResource.java
@@ -26,7 +26,6 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.model.libraryElement.ArraySize;
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.Value;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
@@ -65,13 +64,13 @@ public class STCoreResource extends LibraryElementXtextResource implements STRes
 	@Inject
 	private STCoreGrammarAccess grammarAccess;
 
-	private INamedElement expectedType;
+	private LibraryElement expectedType;
 
 	@Override
 	protected void doLoad(final InputStream inputStream, final Map<?, ?> options) throws IOException {
 		final Map<?, ?> actualOptions = Objects.requireNonNullElse(options, getDefaultLoadOptions());
 		if (isLoadPlainST(actualOptions, inputStream)) {
-			setExpectedType((INamedElement) actualOptions.get(OPTION_EXPECTED_TYPE));
+			setExpectedType((LibraryElement) actualOptions.get(OPTION_EXPECTED_TYPE));
 			super.doLoad(inputStream, actualOptions);
 			if (getLibraryElement() == null) {
 				final TypeEntry typeEntry = TypeLibraryManager.INSTANCE.getTypeEntryForURI(uri);
@@ -299,23 +298,23 @@ public class STCoreResource extends LibraryElementXtextResource implements STRes
 	}
 
 	@Override
-	public INamedElement getExpectedType() {
+	public LibraryElement getExpectedType() {
 		return expectedType;
 	}
 
 	@Override
-	public void setExpectedType(final INamedElement expectedType) {
+	public void setExpectedType(final LibraryElement expectedType) {
 		this.expectedType = expectedType;
 	}
 
 	@Override
-	public INamedElement getExpectedType(final STExpression expression) {
+	public LibraryElement getExpectedType(final STExpression expression) {
 		return getCache().get(Tuples.create(EXPECTED_TYPE_CACHE_KEY, expression), this,
 				() -> STCoreUtil.computeExpectedType(expression));
 	}
 
 	@Override
-	public INamedElement getExpectedType(final STInitializerExpression expression) {
+	public LibraryElement getExpectedType(final STInitializerExpression expression) {
 		return getCache().get(Tuples.create(EXPECTED_TYPE_CACHE_KEY, expression), this,
 				() -> STCoreUtil.computeExpectedType(expression));
 	}

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/resource/STCoreResourceDescriptionStrategy.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/resource/STCoreResourceDescriptionStrategy.java
@@ -175,7 +175,7 @@ public class STCoreResourceDescriptionStrategy extends DefaultResourceDescriptio
 		return ""; //$NON-NLS-1$
 	}
 
-	protected static String getCallableParameterTypeDefaultValue(final INamedElement type) {
+	protected static String getCallableParameterTypeDefaultValue(final LibraryElement type) {
 		if (type instanceof AnyDerivedType) {
 			return "VAR"; //$NON-NLS-1$
 		}
@@ -225,7 +225,7 @@ public class STCoreResourceDescriptionStrategy extends DefaultResourceDescriptio
 			builder.append(s);
 		}
 
-		public SignatureHashBuilder appendType(final INamedElement type) {
+		public SignatureHashBuilder appendType(final LibraryElement type) {
 			if (type != null) {
 				append(EcoreUtil.getURI(type).toString());
 			}

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/scoping/STCoreLinkingDiagnosticMessageProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/scoping/STCoreLinkingDiagnosticMessageProvider.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 import org.eclipse.fordiac.ide.model.data.StructuredType;
 import org.eclipse.fordiac.ide.model.libraryElement.ICallable;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.Messages;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCallArgument;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
@@ -41,7 +42,7 @@ public class STCoreLinkingDiagnosticMessageProvider extends LinkingDiagnosticMes
 		if (context.getReference() == STCorePackage.Literals.ST_FEATURE_EXPRESSION__FEATURE) {
 			final var receiverType = getReceiverType(context);
 			if (context.getContext() instanceof final STFeatureExpression expression && expression.isCall()) {
-				final List<INamedElement> argumentTypes = expression.getParameters().stream()
+				final List<LibraryElement> argumentTypes = expression.getParameters().stream()
 						.map(STCallArgument::getDeclaredResultType).toList();
 				return createCallableDiagnosticMessage(context, argumentTypes, receiverType);
 			}
@@ -67,7 +68,7 @@ public class STCoreLinkingDiagnosticMessageProvider extends LinkingDiagnosticMes
 		return super.getUnresolvedProxyMessage(context);
 	}
 
-	protected static INamedElement getReceiverType(final ILinkingDiagnosticContext context) {
+	protected static LibraryElement getReceiverType(final ILinkingDiagnosticContext context) {
 		final var receiver = STCoreScopeProvider.getReceiver(context.getContext());
 		// if there is a receiver, which is not the same EObject as the context
 		if (receiver != null && receiver != context.getContext()) {
@@ -83,7 +84,7 @@ public class STCoreLinkingDiagnosticMessageProvider extends LinkingDiagnosticMes
 	}
 
 	protected static DiagnosticMessage createVariableDiagnosticMessage(final ILinkingDiagnosticContext context,
-			final INamedElement type) {
+			final LibraryElement type) {
 		if (type != null && !type.eIsProxy()) {
 			return new DiagnosticMessage(
 					MessageFormat.format(Messages.STCoreLinkingDiagnosticMessageProvider_UndefinedVariableForType,
@@ -96,7 +97,7 @@ public class STCoreLinkingDiagnosticMessageProvider extends LinkingDiagnosticMes
 	}
 
 	protected static DiagnosticMessage createCallableDiagnosticMessage(final ILinkingDiagnosticContext context,
-			final List<INamedElement> argumentTypes, final INamedElement type) {
+			final List<LibraryElement> argumentTypes, final LibraryElement type) {
 		final String argumentTypesString = argumentTypes.stream()
 				.map(t -> t != null ? t.getName() : Messages.STCoreLinkingDiagnosticMessageProvider_UnknownType)
 				.collect(Collectors.joining(", ")); //$NON-NLS-1$

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/util/STAbstractCorePartitioner.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/util/STAbstractCorePartitioner.java
@@ -140,7 +140,7 @@ public abstract class STAbstractCorePartitioner<E extends INamedElement> impleme
 				.map(INode::getText).collect(Collectors.joining()).trim();
 	}
 
-	protected static DataType resolveDataType(final INamedElement type, final EObject context,
+	protected static DataType resolveDataType(final LibraryElement type, final EObject context,
 			final DataType defaultType) {
 		if (type != null && type.eIsProxy()) {
 			final String linkName = extractLinkName(type, context);

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/validation/STCoreValidator.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/validation/STCoreValidator.java
@@ -277,7 +277,7 @@ public class STCoreValidator extends AbstractSTCoreValidator {
 
 	@Check
 	public void checkArrayAccessExpression(final STArrayAccessExpression accessExpression) {
-		final INamedElement receiverType = accessExpression.getReceiver().getResultType();
+		final LibraryElement receiverType = accessExpression.getReceiver().getResultType();
 		switch (receiverType) {
 		case final ArrayType arrayType -> checkArrayAccessIndices(accessExpression, arrayType);
 		case final AnyStringType stringType -> checkStringAccessIndices(accessExpression, stringType);
@@ -290,7 +290,7 @@ public class STCoreValidator extends AbstractSTCoreValidator {
 			final ArrayType receiverType) {
 		IntStream.range(0, accessExpression.getIndex().size()).forEachOrdered(index -> {
 			final STExpression indexExpression = accessExpression.getIndex().get(index);
-			final INamedElement resultType = indexExpression.getResultType();
+			final LibraryElement resultType = indexExpression.getResultType();
 			checkTypeCompatibility(GenericTypes.ANY_INT, resultType,
 					STCorePackage.Literals.ST_ARRAY_ACCESS_EXPRESSION__INDEX, index);
 			if (index < receiverType.getSubranges().size()) {
@@ -325,7 +325,7 @@ public class STCoreValidator extends AbstractSTCoreValidator {
 			final AnyStringType receiverType) {
 		IntStream.range(0, accessExpression.getIndex().size()).forEachOrdered(index -> {
 			final STExpression indexExpression = accessExpression.getIndex().get(index);
-			final INamedElement resultType = indexExpression.getResultType();
+			final LibraryElement resultType = indexExpression.getResultType();
 			checkTypeCompatibility(GenericTypes.ANY_INT, resultType,
 					STCorePackage.Literals.ST_ARRAY_ACCESS_EXPRESSION__INDEX, index);
 			if (index < 1) {
@@ -425,10 +425,10 @@ public class STCoreValidator extends AbstractSTCoreValidator {
 				&& CONVERSION_FUNCTION_PATTERN.matcher(feature.getName()).matches()
 				&& standardFunction.getInputParameters().size() == 1 && featureExpression.getParameters().size() == 1) {
 			final STCallArgument argument = featureExpression.getParameters().get(0);
-			final INamedElement argumentType = argument.getResultType();
-			final INamedElement expectedArgumentType = STCoreUtil.getExpectedType(argument.getArgument());
-			final INamedElement returnType = featureExpression.getResultType();
-			final INamedElement expectedReturnType = STCoreUtil.getExpectedType(featureExpression);
+			final LibraryElement argumentType = argument.getResultType();
+			final LibraryElement expectedArgumentType = STCoreUtil.getExpectedType(argument.getArgument());
+			final LibraryElement returnType = featureExpression.getResultType();
+			final LibraryElement expectedReturnType = STCoreUtil.getExpectedType(featureExpression);
 
 			if (argumentType instanceof final DataType argumentDataType
 					&& expectedArgumentType instanceof final DataType expectedArgumentDataType
@@ -672,7 +672,7 @@ public class STCoreValidator extends AbstractSTCoreValidator {
 		final var type = stmt.getStatement().getSelector().getResultType();
 		IntStream.range(0, stmt.getConditions().size()).forEachOrdered(index -> {
 			final STExpression condition = stmt.getConditions().get(index);
-			final INamedElement resultType = condition.getResultType();
+			final LibraryElement resultType = condition.getResultType();
 			if (!STCoreUtil.hasCommonSupertype(type, resultType)) {
 				error(MessageFormat.format(Messages.STCoreValidator_NonComparableTypes, resultType.getName(),
 						type.getName()), STCorePackage.Literals.ST_CASE_CASES__CONDITIONS, index, NON_COMPARABLE_TYPES,
@@ -980,23 +980,23 @@ public class STCoreValidator extends AbstractSTCoreValidator {
 		}
 	}
 
-	protected void checkTypeCompatibility(final INamedElement destination, final INamedElement source,
+	protected void checkTypeCompatibility(final LibraryElement destination, final LibraryElement source,
 			final EStructuralFeature feature) {
 		checkTypeCompatibility(destination, source, feature, false);
 	}
 
-	protected void checkTypeCompatibility(final INamedElement destination, final INamedElement source,
+	protected void checkTypeCompatibility(final LibraryElement destination, final LibraryElement source,
 			final EStructuralFeature feature, final int index) {
 		checkTypeCompatibility(destination, source, feature, index, false);
 	}
 
-	protected void checkTypeCompatibility(final INamedElement destination, final INamedElement source,
+	protected void checkTypeCompatibility(final LibraryElement destination, final LibraryElement source,
 			final EStructuralFeature feature, final boolean allowAnyAssignment) {
 		checkTypeCompatibility(destination, source, feature, ValidationMessageAcceptor.INSIGNIFICANT_INDEX,
 				allowAnyAssignment);
 	}
 
-	protected void checkTypeCompatibility(final INamedElement destination, final INamedElement source,
+	protected void checkTypeCompatibility(final LibraryElement destination, final LibraryElement source,
 			final EStructuralFeature feature, final int index, final boolean allowAnyAssignment) {
 		if (destination instanceof final DataType destinationDataType
 				&& source instanceof final DataType sourceDataType) {
@@ -1018,7 +1018,7 @@ public class STCoreValidator extends AbstractSTCoreValidator {
 		}
 	}
 
-	protected void checkTypeStrictCompatibility(final INamedElement destination, final INamedElement source,
+	protected void checkTypeStrictCompatibility(final LibraryElement destination, final LibraryElement source,
 			final EStructuralFeature feature, final int index) {
 		if (destination instanceof final DataType destinationDataType
 				&& source instanceof final DataType sourceDataType) {

--- a/tests/org.eclipse.fordiac.ide.test.model.eval/src/org/eclipse/fordiac/ide/test/model/eval/variable/VariableOperationTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model.eval/src/org/eclipse/fordiac/ide/test/model/eval/variable/VariableOperationTest.java
@@ -53,7 +53,7 @@ import org.eclipse.fordiac.ide.model.helpers.ArraySizeHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
 import org.eclipse.fordiac.ide.model.libraryElement.AttributeDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.FB;
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.SimpleFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.test.model.eval.AbstractEvaluatorTest;
@@ -138,7 +138,7 @@ class VariableOperationTest extends AbstractEvaluatorTest {
 				assertThrows(EvaluatorInitializerException.class,
 						() -> VariableOperations.newVariable("Test", directlyDerivedType4)).getMessage());
 		assertVariableEquals("Test", new FBValue(type), VariableOperations.newVariable("Test", type));
-		assertThrows(NullPointerException.class, () -> VariableOperations.newVariable("Test", (INamedElement) null));
+		assertThrows(NullPointerException.class, () -> VariableOperations.newVariable("Test", (LibraryElement) null));
 		assertThrows(UnsupportedOperationException.class,
 				() -> VariableOperations.newVariable("Test", HelperTypes.CDATA));
 	}
@@ -158,7 +158,7 @@ class VariableOperationTest extends AbstractEvaluatorTest {
 		assertVariableEquals("Test", toDIntValue(42),
 				VariableOperations.newVariable("Test", directlyDerivedType1, "42"));
 		assertThrows(NullPointerException.class,
-				() -> VariableOperations.newVariable("Test", (INamedElement) null, ""));
+				() -> VariableOperations.newVariable("Test", (LibraryElement) null, ""));
 		assertThrows(UnsupportedOperationException.class,
 				() -> VariableOperations.newVariable("Test", HelperTypes.CDATA, ""));
 	}
@@ -184,7 +184,7 @@ class VariableOperationTest extends AbstractEvaluatorTest {
 				VariableOperations.newVariable("Test", type, new FBValue(type,
 						Map.of("DI1", toDIntValue(17), "DI2", toDIntValue(4), "DI3", toDIntValue(21)))));
 		assertThrows(NullPointerException.class,
-				() -> VariableOperations.newVariable("Test", (INamedElement) null, toDIntValue(0)));
+				() -> VariableOperations.newVariable("Test", (LibraryElement) null, toDIntValue(0)));
 		assertThrows(UnsupportedOperationException.class,
 				() -> VariableOperations.newVariable("Test", HelperTypes.CDATA, toDIntValue(0)));
 	}


### PR DESCRIPTION
This uses library element instead of the generic named element as the element type in the model, evaluator, and ST parser, improving both readability and type safety.