### PR TITLE
Use IE as Browser-Engine on Windows #1565

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.product/org.eclipse.fordiac.ide.product
+++ b/plugins/org.eclipse.fordiac.ide.product/org.eclipse.fordiac.ide.product
@@ -30,6 +30,8 @@
       </vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
+      <vmArgsWin>-Dorg.eclipse.swt.browser.DefaultType=IE
+      </vmArgsWin>
    </launcherArgs>
 
    <windowImages i16="/org.eclipse.fordiac.ide/icons/4diac16.png" i32="/org.eclipse.fordiac.ide/icons/4diac32.png" i48="/org.eclipse.fordiac.ide/icons/4diac48.png" i64="/org.eclipse.fordiac.ide/icons/4diac64.png" i128="/org.eclipse.fordiac.ide/icons/4diac128.png" i256="/org.eclipse.fordiac.ide/icons/4diac256.png"/>


### PR DESCRIPTION
As the Edge browser engine has an issue with a missing SWT function we are for now using IE as browser engine for the desription editor.

Workaround: https://github.com/eclipse-4diac/4diac-ide/issues/1565