### PR TITLE
Provide locale for FB Position export #1573

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/CommonElementExporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/CommonElementExporter.java
@@ -26,7 +26,6 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -183,7 +182,6 @@ public class CommonElementExporter {
 	public static final String LINE_END = "\n"; //$NON-NLS-1$
 	public static final String TAB = "\t"; //$NON-NLS-1$
 	private static final Pattern CDATA_END_PATTERN = Pattern.compile("\\]\\]>"); //$NON-NLS-1$
-	protected static final DecimalFormat positionFormater = new DecimalFormat("#.##"); //$NON-NLS-1$
 
 	private final XMLStreamWriter writer;
 	private final ByteBufferOutputStream outputStream;
@@ -524,8 +522,8 @@ public class CommonElementExporter {
 	}
 
 	protected void addXYAttributes(final double x, final double y) throws XMLStreamException {
-		writer.writeAttribute(LibraryElementTags.X_ATTRIBUTE, positionFormater.format(x));
-		writer.writeAttribute(LibraryElementTags.Y_ATTRIBUTE, positionFormater.format(y));
+		writer.writeAttribute(LibraryElementTags.X_ATTRIBUTE, formatPosOrSizeVal(x));
+		writer.writeAttribute(LibraryElementTags.Y_ATTRIBUTE, formatPosOrSizeVal(y));
 	}
 
 	protected void writeCDataSection(final String cdataText) throws XMLStreamException {
@@ -560,5 +558,10 @@ public class CommonElementExporter {
 			addDependency(libraryElement.getTypeEntry());
 		}
 		return libraryElement;
+	}
+
+	protected static String formatPosOrSizeVal(final double val) {
+		final String stringVal = Double.toString(Math.round(val * 100.0) / 100.0);
+		return (stringVal.endsWith(".0")) ? stringVal.substring(0, stringVal.length() - 2) : stringVal;
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/FBNetworkExporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/FBNetworkExporter.java
@@ -129,8 +129,8 @@ class FBNetworkExporter extends CommonElementExporter {
 
 		addCommentAttribute(comment.getComment());
 		addXYAttributes(comment);
-		getWriter().writeAttribute(LibraryElementTags.WIDTH_ATTRIBUTE, positionFormater.format(comment.getWidth()));
-		getWriter().writeAttribute(LibraryElementTags.HEIGHT_ATTRIBUTE, positionFormater.format(comment.getHeight()));
+		getWriter().writeAttribute(LibraryElementTags.WIDTH_ATTRIBUTE, formatPosOrSizeVal(comment.getWidth()));
+		getWriter().writeAttribute(LibraryElementTags.HEIGHT_ATTRIBUTE, formatPosOrSizeVal(comment.getHeight()));
 
 		if (comment.isInGroup()) {
 			addGroupAttribute(comment.getGroup());
@@ -145,8 +145,8 @@ class FBNetworkExporter extends CommonElementExporter {
 	}
 
 	private void addGroupAttributes(final Group group) throws XMLStreamException {
-		getWriter().writeAttribute(LibraryElementTags.WIDTH_ATTRIBUTE, positionFormater.format(group.getWidth()));
-		getWriter().writeAttribute(LibraryElementTags.HEIGHT_ATTRIBUTE, positionFormater.format(group.getHeight()));
+		getWriter().writeAttribute(LibraryElementTags.WIDTH_ATTRIBUTE, formatPosOrSizeVal(group.getWidth()));
+		getWriter().writeAttribute(LibraryElementTags.HEIGHT_ATTRIBUTE, formatPosOrSizeVal(group.getHeight()));
 		getWriter().writeAttribute(LibraryElementTags.LOCKED_ATTRIBUTE, Boolean.toString(group.isLocked()));
 	}
 
@@ -184,11 +184,11 @@ class FBNetworkExporter extends CommonElementExporter {
 	private void addSubappHeightAndWidthAttributes(final SubApp subApp) throws XMLStreamException {
 		if (subApp.getWidth() != 0) {
 			addAttributeElement(LibraryElementTags.WIDTH_ATTRIBUTE, IecTypes.ElementaryTypes.LREAL,
-					positionFormater.format(subApp.getWidth()), null);
+					formatPosOrSizeVal(subApp.getWidth()), null);
 		}
 		if (subApp.getHeight() != 0) {
 			addAttributeElement(LibraryElementTags.HEIGHT_ATTRIBUTE, IecTypes.ElementaryTypes.LREAL,
-					positionFormater.format(subApp.getHeight()), null);
+					formatPosOrSizeVal(subApp.getHeight()), null);
 		}
 	}
 
@@ -293,13 +293,11 @@ class FBNetworkExporter extends CommonElementExporter {
 		final ConnectionRoutingData routingData = connection.getRoutingData();
 		if (routingData != null && !routingData.is1SegementData()) {
 			// only export connection routing information if not a straight line
-			getWriter().writeAttribute(LibraryElementTags.DX1_ATTRIBUTE, positionFormater.format(routingData.getDx1()));
+			getWriter().writeAttribute(LibraryElementTags.DX1_ATTRIBUTE, formatPosOrSizeVal(routingData.getDx1()));
 			if (routingData.is5SegementData()) {
 				// only export the second two if a five segment connection
-				getWriter().writeAttribute(LibraryElementTags.DX2_ATTRIBUTE,
-						positionFormater.format(routingData.getDx2()));
-				getWriter().writeAttribute(LibraryElementTags.DY_ATTRIBUTE,
-						positionFormater.format(routingData.getDy()));
+				getWriter().writeAttribute(LibraryElementTags.DX2_ATTRIBUTE, formatPosOrSizeVal(routingData.getDx2()));
+				getWriter().writeAttribute(LibraryElementTags.DY_ATTRIBUTE, formatPosOrSizeVal(routingData.getDy()));
 			}
 		}
 	}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/SystemExporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/SystemExporter.java
@@ -138,7 +138,7 @@ public class SystemExporter extends AbstractTypeExporter {
 			addStartElement(LibraryElementTags.SEGMENT_ELEMENT);
 			addNameTypeCommentAttribute(segment, segment.getType());
 			addXYAttributes(segment);
-			getWriter().writeAttribute(LibraryElementTags.DX1_ATTRIBUTE, positionFormater.format(segment.getWidth()));
+			getWriter().writeAttribute(LibraryElementTags.DX1_ATTRIBUTE, formatPosOrSizeVal(segment.getWidth()));
 			addColorAttributeElement(segment);
 			addAttributes(segment.getAttributes());
 			addParamsConfig(segment.getCommunication().getParameters());


### PR DESCRIPTION
The generation of the position text during xml export was not locale independent which lead to wrong XML files.

Fixes: https://github.com/eclipse-4diac/4diac-ide/issues/1573