### PR TITLE
Null check for copying/pasting was added.

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/PasteCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/PasteCommand.java
@@ -157,7 +157,7 @@ public class PasteCommand extends Command implements ScopedCommand {
 			}
 		}
 		final EObject destContainer = EcoreUtil.getRootContainer(dstFBNetwork);
-		if (destContainer instanceof final LibraryElement le) {
+		if (destContainer instanceof final LibraryElement le && le.getCompilerInfo() != null) {
 			final List<String> importNames = le.getCompilerInfo().getImports().stream()
 					.map(Import::getImportedNamespace).toList();
 


### PR DESCRIPTION
This way at least a quick fix can be performed and no exception occurs when copying across projects.