### PR TITLE
Add buildid Configuration to 4diac IDE Product File

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.product/org.eclipse.fordiac.ide.product
+++ b/plugins/org.eclipse.fordiac.ide.product/org.eclipse.fordiac.ide.product
@@ -110,6 +110,7 @@
       <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+      <property name="eclipse.buildId" value="${project.artifactId}_${unqualifiedVersion}.${buildQualifier}" />
    </configurations>
 
    <preferencesInfo>


### PR DESCRIPTION
With this option the buildid is added to the config.ini file and is as such then available already at startup and most importantly added to the logfile on startup.