### PR TITLE
Removed dependency updates when type editable changes

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.bulkeditor/src/org/eclipse/fordiac/ide/bulkeditor/editors/BulkEditorTypeEntryAdapter.java
+++ b/plugins/org.eclipse.fordiac.ide.bulkeditor/src/org/eclipse/fordiac/ide/bulkeditor/editors/BulkEditorTypeEntryAdapter.java
@@ -40,9 +40,7 @@ public class BulkEditorTypeEntryAdapter extends AbstractTypeEntryAdapter {
 		}
 
 		// make sure type was reloaded and not just loaded
-		if ((feature.equals(TypeEntry.TYPE_ENTRY_TYPE_FEATURE)
-				|| feature.equals(TypeEntry.TYPE_ENTRY_TYPE_EDITABLE_FEATURE))
-				&& (notification.getOldValue() != null)) {
+		if (feature.equals(TypeEntry.TYPE_ENTRY_TYPE_FEATURE) && (notification.getOldValue() != null)) {
 			if (notification.getNotifier() instanceof final TypeEntry tEntry) {
 				changedFiles.add(tEntry.getFile().getFullPath().toOSString());
 			}

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/TypeEntryAdapter.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/TypeEntryAdapter.java
@@ -100,7 +100,7 @@ public class TypeEntryAdapter extends AbstractTypeEntryAdapter {
 		}
 
 		switch (feature) {
-		case TypeEntry.TYPE_ENTRY_TYPE_FEATURE, TypeEntry.TYPE_ENTRY_TYPE_EDITABLE_FEATURE:
+		case TypeEntry.TYPE_ENTRY_TYPE_FEATURE:
 			// make sure type was reloaded and not just loaded
 			if (notification.getOldValue() != null) {
 				handleFileContentChange();

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
@@ -430,7 +430,6 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 	@Override
 	public void notifyChanged(final Notification notification) {
 		if ((notification.getFeature() == TypeEntry.TYPE_ENTRY_TYPE_FEATURE
-				|| notification.getFeature() == TypeEntry.TYPE_ENTRY_TYPE_EDITABLE_FEATURE
 				|| notification.getFeature() == TypeEntry.TYPE_ENTRY_TYPE_LIBRARY_FEATURE)
 				&& dependencies.get().contains(notification.getNotifier())) {
 


### PR DESCRIPTION
TypeEntries are now not forwarding dependency changes on typeeditable changes and also editors are not reacting to them.