### PR TITLE
Fix VAR Config column for composite types

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/VarDeclarationColumnAccessor.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/VarDeclarationColumnAccessor.java
@@ -73,7 +73,7 @@ public class VarDeclarationColumnAccessor extends AbstractColumnAccessor<VarDecl
 		};
 	}
 
-	private static boolean getVarConfString(final VarDeclaration rowObject) {
+	private static Boolean getVarConfString(final VarDeclaration rowObject) {
 		return isCompositeFBType(rowObject) ? null : Boolean.valueOf(rowObject.isVarConfig());
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/VarDeclarationColumnAccessor.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/VarDeclarationColumnAccessor.java
@@ -62,7 +62,7 @@ public class VarDeclarationColumnAccessor extends AbstractColumnAccessor<VarDecl
 		case TYPE -> rowObject.getFullTypeName();
 		case COMMENT -> CommentHelper.getInstanceComment(rowObject);
 		case INITIAL_VALUE -> getInitialValue(rowObject);
-		case VAR_CONFIG -> getVarConfString(rowObject);
+		case VAR_CONFIG -> getVarConfValue(rowObject);
 		case VISIBLE -> Boolean.valueOf(rowObject.isVisible());
 		case RETAIN -> getAttributeValueAsString(rowObject);
 		case VISIBLEIN, VISIBLEOUT -> Boolean.valueOf(handleInOutCheck(rowObject, column));
@@ -72,7 +72,7 @@ public class VarDeclarationColumnAccessor extends AbstractColumnAccessor<VarDecl
 		};
 	}
 
-	private static Boolean getVarConfString(final VarDeclaration rowObject) {
+	private static Boolean getVarConfValue(final VarDeclaration rowObject) {
 		return isFBinsideCompositeNetwork(rowObject) ? null : Boolean.valueOf(rowObject.isVarConfig());
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/VarDeclarationColumnAccessor.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/VarDeclarationColumnAccessor.java
@@ -32,8 +32,7 @@ import org.eclipse.fordiac.ide.model.edit.helper.CommentHelper;
 import org.eclipse.fordiac.ide.model.edit.helper.InitialValueHelper;
 import org.eclipse.fordiac.ide.model.errormarker.FordiacMarkerHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
-import org.eclipse.fordiac.ide.model.libraryElement.CFBInstance;
-import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.CompositeFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.MemberVarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
@@ -74,12 +73,19 @@ public class VarDeclarationColumnAccessor extends AbstractColumnAccessor<VarDecl
 	}
 
 	private static Boolean getVarConfString(final VarDeclaration rowObject) {
-		return isCompositeFBType(rowObject) ? null : Boolean.valueOf(rowObject.isVarConfig());
+		return isFBinsideCompositeNetwork(rowObject) ? null : Boolean.valueOf(rowObject.isVarConfig());
 	}
 
-	private static boolean isCompositeFBType(final VarDeclaration rowObject) {
-		final FBNetworkElement fbElement = rowObject.getFBNetworkElement();
-		return fbElement instanceof CFBInstance;
+	private static boolean isFBinsideCompositeNetwork(final VarDeclaration rowObject) {
+		final var fbElement = rowObject.getFBNetworkElement();
+		if (fbElement == null) {
+			return false;
+		}
+		final var fbNetwork = fbElement.getFbNetwork();
+		if (fbNetwork == null) {
+			return false;
+		}
+		return fbNetwork.eContainer() instanceof CompositeFBType;
 	}
 
 	private static boolean handleInOutCheck(final VarDeclaration rowObject, final VarDeclarationTableColumn column) {


### PR DESCRIPTION
Fixes a bug where null was returned for a method that returns a primitive boolean, causing a NPE. Can be replicated by trying to view the instance properties of a composite FB.