### PR TITLE
Cleaned Device, Resource, and Segment Property Sheet

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/properties/DeviceSection.java
+++ b/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/properties/DeviceSection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 fortiss GmbH, Johannes Kepler University
+ * Copyright (c) 2017, 2025 fortiss GmbH, Johannes Kepler University
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -25,26 +25,15 @@ import org.eclipse.fordiac.ide.model.commands.change.ChangeNameCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.Device;
 import org.eclipse.fordiac.ide.ui.widget.ComboBoxWidgetFactory;
 import org.eclipse.gef.EditPart;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CCombo;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.ui.IWorkbenchPart;
 
 public class DeviceSection extends AbstractInterfaceSection {
 	private static String[] profileNames;
 	private CCombo profile;
-
-	@Override
-	protected CommandStack getCommandStack(final IWorkbenchPart part, final Object input) {
-		final Device helper = getInputType(input);
-		if (null != helper) {
-			return helper.getAutomationSystem().getCommandStack();
-		}
-		return null;
-	}
 
 	@Override
 	protected void performRefresh() {

--- a/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/properties/ResourceSection.java
+++ b/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/properties/ResourceSection.java
@@ -1,6 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 fortiss GmbH
- *               2019 Johannes Kepler University Linz
+ * Copyright (c) 2017, 2025 fortiss GmbH, Johannes Kepler University Linz
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -18,35 +17,25 @@ import org.eclipse.fordiac.ide.model.commands.change.ChangeCommentCommand;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeNameCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.Resource;
 import org.eclipse.gef.EditPart;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.ui.IWorkbenchPart;
 
 public class ResourceSection extends AbstractInterfaceSection {
+
 	@Override
-	protected CommandStack getCommandStack(IWorkbenchPart part, Object input) {
-		Resource helper = getInputType(input);
-		if (null != helper) {
-			return helper.getAutomationSystem().getCommandStack();
+	protected Resource getInputType(final Object input) {
+		final Object inputHelper = (input instanceof final EditPart e) ? e.getModel() : input;
+		if (inputHelper instanceof final Resource res) {
+			return res;
 		}
 		return null;
 	}
 
 	@Override
-	protected Resource getInputType(Object input) {
-		Object inputHelper = (input instanceof EditPart) ? ((EditPart) input).getModel() : input;
-		if (inputHelper instanceof Resource) {
-			return (Resource) inputHelper;
-		}
-		return null;
-	}
-
-	@Override
-	protected void createFBInfoGroup(Composite parent) {
-		Composite composite = getWidgetFactory().createComposite(parent);
+	protected void createFBInfoGroup(final Composite parent) {
+		final Composite composite = getWidgetFactory().createComposite(parent);
 		composite.setLayout(new GridLayout(2, false));
 		composite.setLayoutData(new GridData(SWT.FILL, 0, true, false));
 		getWidgetFactory().createCLabel(composite, "Instance Name:");

--- a/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/properties/SegmentSection.java
+++ b/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/properties/SegmentSection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 Johannes Kepler University
+ * Copyright (c) 2022, 2025 Johannes Kepler University
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -22,14 +22,12 @@ import org.eclipse.fordiac.ide.systemconfiguration.Messages;
 import org.eclipse.fordiac.ide.ui.errormessages.ErrorMessenger;
 import org.eclipse.fordiac.ide.ui.widget.CommandExecutor;
 import org.eclipse.gef.EditPart;
-import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Text;
-import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.views.properties.tabbed.TabbedPropertySheetPage;
 
 public class SegmentSection extends AbstractDoubleColumnSection {
@@ -38,15 +36,6 @@ public class SegmentSection extends AbstractDoubleColumnSection {
 	private Text commentText;
 	private Group commConfigGroup;
 	private Composite commConfigContents;
-
-	@Override
-	protected CommandStack getCommandStack(final IWorkbenchPart part, final Object input) {
-		final Segment type = getInputType(input);
-		if (null != type) {
-			return type.getAutomationSystem().getCommandStack();
-		}
-		return null;
-	}
 
 	@Override
 	protected Segment getInputType(Object input) {


### PR DESCRIPTION
Removed special handling for the command stack. The default case from the base class is better and cleaner. Also it will enable to remove the command stack from the AutomationSystem model.