### PR TITLE
Added Interface-only Parsing to Interface providing TypeEntries

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/ElementEditPartFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/ElementEditPartFactory.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023  Profactor GmbH, fortiss GmbH, Johannes Kepler University,
- * 							 Primetals Technologies Germany GmbH
+ * Copyright (c) 2008, 2025 Profactor GmbH, fortiss GmbH, Johannes Kepler University,
+ * 							Primetals Technologies Germany GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -115,15 +115,7 @@ public class ElementEditPartFactory extends Abstract4diacEditPartFactory {
 			return new ConfigurableMoveFBEditPart();
 		}
 		if (element instanceof final FB fb) {
-			if (null != fb.getType() && null != fb.getType().getName()) {
-				if (fb.getType().getName().contentEquals(LibraryElementTags.TYPENAME_MUX)) {
-					return new MultiplexerEditPart();
-				}
-				if (fb.getType().getName().contentEquals(LibraryElementTags.TYPENAME_DEMUX)) {
-					return new DemultiplexerEditPart();
-				}
-			}
-			return new FBEditPart();
+			return getPartForFBInstances(fb);
 		}
 		if (element instanceof SubApp) {
 			return new SubAppForFBNetworkEditPart();
@@ -136,6 +128,19 @@ public class ElementEditPartFactory extends Abstract4diacEditPartFactory {
 		}
 
 		throw createEditpartCreationException(element);
+	}
+
+	protected static EditPart getPartForFBInstances(final FB fb) {
+		if (fb.getTypeEntry() != null && fb.getTypeEntry().getTypeName() != null) {
+			final String typeName = fb.getTypeEntry().getTypeName();
+			if (typeName.contentEquals(LibraryElementTags.TYPENAME_MUX)) {
+				return new MultiplexerEditPart();
+			}
+			if (typeName.contentEquals(LibraryElementTags.TYPENAME_DEMUX)) {
+				return new DemultiplexerEditPart();
+			}
+		}
+		return new FBEditPart();
 	}
 
 	@SuppressWarnings("static-method") // not static to allow subclasses to provide own elements

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/ErrorMarkerFBNEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/ErrorMarkerFBNEditPart.java
@@ -18,7 +18,6 @@ import org.eclipse.draw2d.IFigure;
 import org.eclipse.fordiac.ide.application.Messages;
 import org.eclipse.fordiac.ide.application.figures.ErrorMarkerFBNeworkElementFigure;
 import org.eclipse.fordiac.ide.model.libraryElement.ErrorMarkerFBNElement;
-import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.ui.editors.AdvancedScrollingGraphicalViewer;
 
 public class ErrorMarkerFBNEditPart extends AbstractFBNElementEditPart {
@@ -42,13 +41,11 @@ public class ErrorMarkerFBNEditPart extends AbstractFBNElementEditPart {
 		final StringBuilder errorText = new StringBuilder();
 
 		if (getModel().getTypeEntry() != null) {
-			final FBType type = (FBType) getModel().getTypeEntry().getType();
-			if (type != null) {
-				errorText.append(MessageFormat.format(Messages.ErrorMarkerFBNEditPart_OldType, type.getName()));
-			}
+			errorText.append(MessageFormat.format(Messages.ErrorMarkerFBNEditPart_OldType,
+					getModel().getTypeEntry().getTypeName()));
 		}
 
-		if (errorText.length() == 0) {
+		if (errorText.isEmpty()) {
 			errorText.append(Messages.ErrorMarkerFBNEditPart_ErrorMarker);
 		}
 

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/UpdateFBTypeHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/UpdateFBTypeHandler.java
@@ -76,7 +76,7 @@ public class UpdateFBTypeHandler extends AbstractHandler {
 				if (element instanceof final EditPart ep) {
 					element = ep.getModel();
 				}
-				if ((element instanceof final FBNetworkElement fb) && (null != fb.getType())) {
+				if ((element instanceof final FBNetworkElement fb) && (fb.getTypeEntry() != null)) {
 					selectedNetworkElements.add(fb);
 				}
 			}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/InfoPropertySection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/InfoPropertySection.java
@@ -236,7 +236,7 @@ public class InfoPropertySection extends AbstractSection {
 	private HashMap<String, Integer> countFBInstances(final Iterable<FBNetworkElement> networkElements,
 			final HashMap<String, Integer> fbs) {
 		for (final FBNetworkElement fe : networkElements) {
-			if (null != fe.getType()) {
+			if (fe.getTypeEntry() != null) {
 				fbs.merge(fe.getTypeName(), 1, Integer::sum);
 			}
 			if (fe instanceof final UntypedSubApp sa) {

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/InterfaceElementSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/InterfaceElementSection.java
@@ -44,7 +44,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.CompositeFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.ErrorMarkerInterface;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
-import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.libraryElement.MemberVarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.ui.widgets.OpenStructMenu;
@@ -246,10 +245,10 @@ public class InterfaceElementSection extends AbstractDoubleColumnSection {
 	protected void refreshTypeInitialValue() {
 		if (getType() instanceof final VarDeclaration varDeclaration && varDeclaration.isIsInput()
 				&& varDeclaration.getFBNetworkElement() != null) {
-			final InterfaceList typeInterface = varDeclaration.getFBNetworkElement().getTypeInterface();
-			if (typeInterface != null) {
+			final VarDeclaration typeVar = varDeclaration.findInTypeInterface();
+			if (typeVar != null) {
 				parameterText.setText(FordiacMessages.ComputingPlaceholderValue);
-				refreshJob.setInterfaceElement(typeInterface.getInterfaceElement(varDeclaration.getName()));
+				refreshJob.setInterfaceElement(typeVar);
 				refreshJob.refresh();
 			}
 		} else {

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/InterfaceElementSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/InterfaceElementSection.java
@@ -46,6 +46,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.MemberVarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 import org.eclipse.fordiac.ide.model.ui.widgets.OpenStructMenu;
 import org.eclipse.fordiac.ide.ui.FordiacMessages;
 import org.eclipse.fordiac.ide.ui.preferences.PreferenceStoreProvider;
@@ -244,11 +245,10 @@ public class InterfaceElementSection extends AbstractDoubleColumnSection {
 
 	protected void refreshTypeInitialValue() {
 		if (getType() instanceof final VarDeclaration varDeclaration && varDeclaration.isIsInput()
-				&& varDeclaration.getFBNetworkElement() != null
-				&& varDeclaration.getFBNetworkElement().getType() != null) {
+				&& varDeclaration.getFBNetworkElement() != null && varDeclaration.getFBNetworkElement()
+						.getTypeEntry() instanceof final InterfaceTypeEntry ifTypeEntry) {
 			parameterText.setText(FordiacMessages.ComputingPlaceholderValue);
-			refreshJob.setInterfaceElement(varDeclaration.getFBNetworkElement().getType().getInterfaceList()
-					.getInterfaceElement(varDeclaration.getName()));
+			refreshJob.setInterfaceElement(ifTypeEntry.getInterface().getInterfaceElement(varDeclaration.getName()));
 			refreshJob.refresh();
 		} else {
 			parameterText.setText("");//$NON-NLS-1$

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/InterfaceElementSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/InterfaceElementSection.java
@@ -44,9 +44,9 @@ import org.eclipse.fordiac.ide.model.libraryElement.CompositeFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.ErrorMarkerInterface;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
+import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.libraryElement.MemberVarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
-import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 import org.eclipse.fordiac.ide.model.ui.widgets.OpenStructMenu;
 import org.eclipse.fordiac.ide.ui.FordiacMessages;
 import org.eclipse.fordiac.ide.ui.preferences.PreferenceStoreProvider;
@@ -245,11 +245,13 @@ public class InterfaceElementSection extends AbstractDoubleColumnSection {
 
 	protected void refreshTypeInitialValue() {
 		if (getType() instanceof final VarDeclaration varDeclaration && varDeclaration.isIsInput()
-				&& varDeclaration.getFBNetworkElement() != null && varDeclaration.getFBNetworkElement()
-						.getTypeEntry() instanceof final InterfaceTypeEntry ifTypeEntry) {
-			parameterText.setText(FordiacMessages.ComputingPlaceholderValue);
-			refreshJob.setInterfaceElement(ifTypeEntry.getInterface().getInterfaceElement(varDeclaration.getName()));
-			refreshJob.refresh();
+				&& varDeclaration.getFBNetworkElement() != null) {
+			final InterfaceList typeInterface = varDeclaration.getFBNetworkElement().getTypeInterface();
+			if (typeInterface != null) {
+				parameterText.setText(FordiacMessages.ComputingPlaceholderValue);
+				refreshJob.setInterfaceElement(typeInterface.getInterfaceElement(varDeclaration.getName()));
+				refreshJob.refresh();
+			}
 		} else {
 			parameterText.setText("");//$NON-NLS-1$
 		}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/ShowInterfaceAdapterSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/ShowInterfaceAdapterSection.java
@@ -22,6 +22,7 @@ import org.eclipse.fordiac.ide.model.commands.delete.DeleteInterfaceCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
+import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 import org.eclipse.gef.EditPart;
 
 public class ShowInterfaceAdapterSection extends AbstractEditInterfaceAdapterSection {
@@ -79,7 +80,7 @@ public class ShowInterfaceAdapterSection extends AbstractEditInterfaceAdapterSec
 
 	@Override
 	protected InterfaceList getInterface() {
-		return getType().getType().getInterfaceList();
+		return ((InterfaceTypeEntry) getType().getTypeEntry()).getInterface();
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/ShowInterfaceAdapterSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/ShowInterfaceAdapterSection.java
@@ -22,7 +22,6 @@ import org.eclipse.fordiac.ide.model.commands.delete.DeleteInterfaceCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
-import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 import org.eclipse.gef.EditPart;
 
 public class ShowInterfaceAdapterSection extends AbstractEditInterfaceAdapterSection {
@@ -80,7 +79,7 @@ public class ShowInterfaceAdapterSection extends AbstractEditInterfaceAdapterSec
 
 	@Override
 	protected InterfaceList getInterface() {
-		return ((InterfaceTypeEntry) getType().getTypeEntry()).getInterface();
+		return getType().getTypeInterface();
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/ShowInterfaceDataSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/ShowInterfaceDataSection.java
@@ -24,6 +24,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.libraryElement.StructManipulator;
+import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 
 public class ShowInterfaceDataSection extends AbstractEditInterfaceDataSection {
 	@Override
@@ -79,7 +80,7 @@ public class ShowInterfaceDataSection extends AbstractEditInterfaceDataSection {
 
 	@Override
 	protected InterfaceList getInterface() {
-		return getType().getType().getInterfaceList();
+		return ((InterfaceTypeEntry) getType().getTypeEntry()).getInterface();
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/ShowInterfaceDataSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/ShowInterfaceDataSection.java
@@ -24,7 +24,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.libraryElement.StructManipulator;
-import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 
 public class ShowInterfaceDataSection extends AbstractEditInterfaceDataSection {
 	@Override
@@ -80,7 +79,7 @@ public class ShowInterfaceDataSection extends AbstractEditInterfaceDataSection {
 
 	@Override
 	protected InterfaceList getInterface() {
-		return ((InterfaceTypeEntry) getType().getTypeEntry()).getInterface();
+		return getType().getTypeInterface();
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/ShowInterfaceEventSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/ShowInterfaceEventSection.java
@@ -20,7 +20,6 @@ import org.eclipse.fordiac.ide.model.commands.delete.DeleteInterfaceCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
-import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 
 public class ShowInterfaceEventSection extends AbstractEditInterfaceEventSection {
 	@Override
@@ -67,7 +66,7 @@ public class ShowInterfaceEventSection extends AbstractEditInterfaceEventSection
 
 	@Override
 	protected InterfaceList getInterface() {
-		return ((InterfaceTypeEntry) getType().getTypeEntry()).getInterface();
+		return getType().getTypeInterface();
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/ShowInterfaceEventSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/ShowInterfaceEventSection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Primetals Technologies Germany GmbH
+ * Copyright (c) 2020, 2025 Primetals Technologies Germany GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -20,6 +20,7 @@ import org.eclipse.fordiac.ide.model.commands.delete.DeleteInterfaceCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
+import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 
 public class ShowInterfaceEventSection extends AbstractEditInterfaceEventSection {
 	@Override
@@ -66,7 +67,7 @@ public class ShowInterfaceEventSection extends AbstractEditInterfaceEventSection
 
 	@Override
 	protected InterfaceList getInterface() {
-		return getType().getType().getInterfaceList();
+		return ((InterfaceTypeEntry) getType().getTypeEntry()).getInterface();
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/TypedInterfacePinFilter.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/TypedInterfacePinFilter.java
@@ -44,7 +44,7 @@ public class TypedInterfacePinFilter implements IFilter {
 	private static boolean isPinOfTypedElement(final Object element) {
 		if (element instanceof final IInterfaceElement ie) {
 			final FBNetworkElement fbEl = ie.getFBNetworkElement();
-			return ((fbEl != null) && ((fbEl.getType() != null) || isIndirectlyTyped(fbEl)));
+			return ((fbEl != null) && ((fbEl.getTypeEntry() != null) || isIndirectlyTyped(fbEl)));
 		}
 		return false;
 	}

--- a/plugins/org.eclipse.fordiac.ide.deployment/src/org/eclipse/fordiac/ide/deployment/util/DeploymentHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src/org/eclipse/fordiac/ide/deployment/util/DeploymentHelper.java
@@ -83,7 +83,7 @@ public final class DeploymentHelper {
 	}
 
 	private static boolean equalsTypeValue(final Value value, final VarDeclaration variable) {
-		final VarDeclaration typeVariable = VariableOperations.getTypeVariable(variable);
+		final VarDeclaration typeVariable = variable.findInTypeInterface();
 		if (typeVariable == null) {
 			return false;
 		}

--- a/plugins/org.eclipse.fordiac.ide.elk/src/org/eclipse/fordiac/ide/elk/handlers/SystemLayoutHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.elk/src/org/eclipse/fordiac/ide/elk/handlers/SystemLayoutHandler.java
@@ -348,7 +348,7 @@ public class SystemLayoutHandler extends AbstractHandler {
 
 	private static EObject getBreadCrumbRefElement(final EObject sel) {
 		EObject refElement = sel;
-		if ((sel instanceof final FBNetworkElement fbnEl && fbnEl.getType() != null) || (sel instanceof Group)) {
+		if ((sel instanceof final FBNetworkElement fbnEl && fbnEl.getTypeEntry() != null) || (sel instanceof Group)) {
 			refElement = sel.eContainer().eContainer();
 		}
 		// For unfolded subapps find the next parent that is not expanded as refElement

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.network/src/org/eclipse/fordiac/ide/fbtypeeditor/network/viewer/AbstractFbNetworkInstanceViewer.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.network/src/org/eclipse/fordiac/ide/fbtypeeditor/network/viewer/AbstractFbNetworkInstanceViewer.java
@@ -56,7 +56,7 @@ public abstract class AbstractFbNetworkInstanceViewer extends DiagramEditor {
 			super.notifyChanged(msg);
 			final Object feature = msg.getFeature();
 			if (((LibraryElementPackage.eINSTANCE.getTypedConfigureableObject_TypeEntry().equals(feature))
-					&& (fbNetworkElement.getType() == null)) || isSubAppToggledToCollapsed(msg)) {
+					&& (fbNetworkElement.getTypeEntry() == null)) || isSubAppToggledToCollapsed(msg)) {
 				// the subapp/cfb was detached from the type or subapp is being collapsed
 				closeEditor();
 			}

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/figures/ToolTipFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/figures/ToolTipFigure.java
@@ -24,7 +24,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.Device;
 import org.eclipse.fordiac.ide.model.libraryElement.Event;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement;
-import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.libraryElement.MemberVarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.With;
@@ -120,21 +119,14 @@ public class ToolTipFigure extends Figure {
 	}
 
 	private static VarDeclaration getTypevariable(final VarDeclaration variable) {
-		if (variable.eContainer() instanceof final Device dev) {
-			if (null != dev.getType()) {
-				for (final VarDeclaration typeVar : dev.getType().getVarDeclaration()) {
-					if (typeVar.getName().equals(variable.getName())) {
-						return typeVar;
-					}
+		if ((variable.eContainer() instanceof final Device dev) && (dev.getType() != null)) {
+			for (final VarDeclaration typeVar : dev.getType().getVarDeclaration()) {
+				if (typeVar.getName().equals(variable.getName())) {
+					return typeVar;
 				}
 			}
-		} else if (variable.getFBNetworkElement() != null) {
-			final InterfaceList typeInterface = variable.getFBNetworkElement().getTypeInterface();
-			if (typeInterface != null) {
-				return typeInterface.getVariable(variable.getName());
-			}
 		}
-		return null;
+		return variable.findInTypeInterface();
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/figures/ToolTipFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/figures/ToolTipFigure.java
@@ -24,10 +24,10 @@ import org.eclipse.fordiac.ide.model.libraryElement.Device;
 import org.eclipse.fordiac.ide.model.libraryElement.Event;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.libraryElement.MemberVarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.With;
-import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 import org.eclipse.fordiac.ide.ui.FordiacMessages;
 
 /**
@@ -128,10 +128,11 @@ public class ToolTipFigure extends Figure {
 					}
 				}
 			}
-		} else if ((variable.getFBNetworkElement() != null)
-				&& (variable.getFBNetworkElement().getTypeEntry() instanceof final InterfaceTypeEntry ifTypeEntry
-						&& ifTypeEntry.getInterface() != null)) {
-			return ifTypeEntry.getInterface().getVariable(variable.getName());
+		} else if (variable.getFBNetworkElement() != null) {
+			final InterfaceList typeInterface = variable.getFBNetworkElement().getTypeInterface();
+			if (typeInterface != null) {
+				return typeInterface.getVariable(variable.getName());
+			}
 		}
 		return null;
 	}

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/figures/ToolTipFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/figures/ToolTipFigure.java
@@ -27,6 +27,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.MemberVarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.With;
+import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 import org.eclipse.fordiac.ide.ui.FordiacMessages;
 
 /**
@@ -127,8 +128,10 @@ public class ToolTipFigure extends Figure {
 					}
 				}
 			}
-		} else if (null != variable.getFBNetworkElement() && null != variable.getFBNetworkElement().getType()) {
-			return variable.getFBNetworkElement().getType().getInterfaceList().getVariable(variable.getName());
+		} else if ((variable.getFBNetworkElement() != null)
+				&& (variable.getFBNetworkElement().getTypeEntry() instanceof final InterfaceTypeEntry ifTypeEntry
+						&& ifTypeEntry.getInterface() != null)) {
+			return ifTypeEntry.getInterface().getVariable(variable.getName());
 		}
 		return null;
 	}

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/filters/FilterProperties.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/filters/FilterProperties.java
@@ -27,8 +27,7 @@ public class FilterProperties {
 	}
 
 	public static boolean isSubappPin(final Object o) {
-		if (o instanceof IInterfaceElement) {
-			final IInterfaceElement pin = (IInterfaceElement) o;
+		if (o instanceof final IInterfaceElement pin) {
 			final FBNetworkElement fbEl = pin.getFBNetworkElement();
 			return isSubapp(fbEl);
 		}
@@ -59,7 +58,7 @@ public class FilterProperties {
 	}
 
 	private static boolean isTyped(final FBNetworkElement fbNetworkElement) {
-		return fbNetworkElement.getType() != null || fbNetworkElement.isContainedInTypedInstance();
+		return fbNetworkElement.getTypeEntry() != null || fbNetworkElement.isContainedInTypedInstance();
 	}
 
 	public static boolean isUntypedSubappPin(final Object o) {

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractUpdateFBNElementCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractUpdateFBNElementCommand.java
@@ -58,7 +58,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.TypedSubApp;
 import org.eclipse.fordiac.ide.model.libraryElement.Value;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.impl.ConfigurableFBManagement;
-import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.commands.CompoundCommand;
@@ -134,11 +133,11 @@ public abstract class AbstractUpdateFBNElementCommand extends Command implements
 		// set Visible attribute after reconnect, to not hide connected In/Outputs
 		// transfer attributes from type first (for new vars), then override them from
 		// old instance
-		if (newElement.getTypeEntry() instanceof final InterfaceTypeEntry ifTypeEntry) {
-			final InterfaceList interfaceList = ifTypeEntry.getInterface();
-			transferVisibleAndVarConfigAttributes(interfaceList.getInputVars());
-			transferVisibleAndVarConfigAttributes(interfaceList.getOutputVars());
-			transferVisibleAndVarConfigAttributes(interfaceList.getInOutVars());
+		final InterfaceList typeInterface = newElement.getTypeInterface();
+		if (typeInterface != null) {
+			transferVisibleAndVarConfigAttributes(typeInterface.getInputVars());
+			transferVisibleAndVarConfigAttributes(typeInterface.getOutputVars());
+			transferVisibleAndVarConfigAttributes(typeInterface.getInOutVars());
 		}
 
 		transferVisibleAndVarConfigAttributes(oldElement.getInterface().getInputVars());
@@ -224,8 +223,9 @@ public abstract class AbstractUpdateFBNElementCommand extends Command implements
 	}
 
 	protected void setInterface() {
-		if (newElement.getType() != null) {
-			newElement.setInterface(((InterfaceTypeEntry) newElement.getTypeEntry()).getInterface().copy());
+		final InterfaceList typeInterface = newElement.getTypeInterface();
+		if (typeInterface != null) {
+			newElement.setInterface(typeInterface.copy());
 		} else {
 			newElement.setInterface(LibraryElementFactory.eINSTANCE.createInterfaceList());
 		}

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractUpdateFBNElementCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractUpdateFBNElementCommand.java
@@ -58,6 +58,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.TypedSubApp;
 import org.eclipse.fordiac.ide.model.libraryElement.Value;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.impl.ConfigurableFBManagement;
+import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.commands.CompoundCommand;
@@ -133,12 +134,13 @@ public abstract class AbstractUpdateFBNElementCommand extends Command implements
 		// set Visible attribute after reconnect, to not hide connected In/Outputs
 		// transfer attributes from type first (for new vars), then override them from
 		// old instance
-		if (newElement.getType() != null) {
-			transferVisibleAndVarConfigAttributes(newElement.getType().getInterfaceList().getInputVars());
-			transferVisibleAndVarConfigAttributes(newElement.getType().getInterfaceList().getOutputVars());
-			transferVisibleAndVarConfigAttributes(newElement.getType().getInterfaceList().getInOutVars());
-
+		if (newElement.getTypeEntry() instanceof final InterfaceTypeEntry ifTypeEntry) {
+			final InterfaceList interfaceList = ifTypeEntry.getInterface();
+			transferVisibleAndVarConfigAttributes(interfaceList.getInputVars());
+			transferVisibleAndVarConfigAttributes(interfaceList.getOutputVars());
+			transferVisibleAndVarConfigAttributes(interfaceList.getInOutVars());
 		}
+
 		transferVisibleAndVarConfigAttributes(oldElement.getInterface().getInputVars());
 		transferVisibleAndVarConfigAttributes(oldElement.getInterface().getOutputVars());
 		transferVisibleAndVarConfigAttributes(oldElement.getInterface().getInOutVars());
@@ -223,7 +225,7 @@ public abstract class AbstractUpdateFBNElementCommand extends Command implements
 
 	protected void setInterface() {
 		if (newElement.getType() != null) {
-			newElement.setInterface(newElement.getType().getInterfaceList().copy());
+			newElement.setInterface(((InterfaceTypeEntry) newElement.getTypeEntry()).getInterface().copy());
 		} else {
 			newElement.setInterface(LibraryElementFactory.eINSTANCE.createInterfaceList());
 		}

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeFbTypeCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeFbTypeCommand.java
@@ -68,7 +68,7 @@ public class ChangeFbTypeCommand extends Command implements ScopedCommand {
 
 	private void setFBType(final FBTypeEntry entry) {
 		fb.setTypeEntry(entry);
-		fb.setInterface(entry.getType().getInterfaceList().copy());
+		fb.setInterface(entry.getInterface().copy());
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeFbTypeCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeFbTypeCommand.java
@@ -61,7 +61,7 @@ public class ChangeFbTypeCommand extends Command implements ScopedCommand {
 
 	@Override
 	public void execute() {
-		oldEntry = (FBTypeEntry) fb.getType().getTypeEntry();
+		oldEntry = (FBTypeEntry) fb.getTypeEntry();
 		setFBType(newType);
 		additionalCommands.execute();
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/UntypeSubAppCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/UntypeSubAppCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Johannes Kepler University Linz
+ * Copyright (c) 2019, 2025 Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,6 +18,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
 import org.eclipse.fordiac.ide.model.libraryElement.TypedSubApp;
 import org.eclipse.fordiac.ide.model.libraryElement.UntypedSubApp;
+import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 
 public class UntypeSubAppCommand extends AbstractUpdateFBNElementCommand {
 
@@ -46,6 +47,6 @@ public class UntypeSubAppCommand extends AbstractUpdateFBNElementCommand {
 
 	@Override
 	protected void setInterface() {
-		newElement.setInterface(oldElement.getType().getInterfaceList().copy());
+		newElement.setInterface(((InterfaceTypeEntry) oldElement.getTypeEntry()).getInterface().copy());
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/UntypeSubAppCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/UntypeSubAppCommand.java
@@ -27,7 +27,7 @@ public class UntypeSubAppCommand extends AbstractUpdateFBNElementCommand {
 
 	@Override
 	public boolean canExecute() {
-		return super.canExecute() && oldElement instanceof final TypedSubApp subapp && subapp.getType() != null;
+		return super.canExecute() && oldElement instanceof final TypedSubApp subapp && subapp.getTypeEntry() != null;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/UntypeSubAppCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/UntypeSubAppCommand.java
@@ -18,7 +18,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
 import org.eclipse.fordiac.ide.model.libraryElement.TypedSubApp;
 import org.eclipse.fordiac.ide.model.libraryElement.UntypedSubApp;
-import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 
 public class UntypeSubAppCommand extends AbstractUpdateFBNElementCommand {
 
@@ -47,6 +46,6 @@ public class UntypeSubAppCommand extends AbstractUpdateFBNElementCommand {
 
 	@Override
 	protected void setInterface() {
-		newElement.setInterface(((InterfaceTypeEntry) oldElement.getTypeEntry()).getInterface().copy());
+		newElement.setInterface(oldElement.getTypeInterface().copy());
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/UpdateInternalFBCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/UpdateInternalFBCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Primetals Technologies Germany GmbH
+ * Copyright (c) 2023, 205 Primetals Technologies Germany GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -28,6 +28,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.typelibrary.AdapterTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.gef.commands.Command;
 
@@ -64,7 +65,7 @@ public class UpdateInternalFBCommand extends Command implements ScopedCommand {
 
 	protected void createNewFB() {
 		newElement = createCopiedFBEntry(oldElement);
-		newElement.setInterface(newElement.getType().getInterfaceList().copy());
+		newElement.setInterface(((InterfaceTypeEntry) newElement.getTypeEntry()).getInterface().copy());
 		newElement.setName(oldElement.getName());
 		createValues();
 		transferInstanceComments();

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/UpdateInternalFBCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/UpdateInternalFBCommand.java
@@ -28,7 +28,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.typelibrary.AdapterTypeEntry;
-import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.gef.commands.Command;
 
@@ -65,7 +64,7 @@ public class UpdateInternalFBCommand extends Command implements ScopedCommand {
 
 	protected void createNewFB() {
 		newElement = createCopiedFBEntry(oldElement);
-		newElement.setInterface(((InterfaceTypeEntry) newElement.getTypeEntry()).getInterface().copy());
+		newElement.setInterface(newElement.getTypeInterface().copy());
 		newElement.setName(oldElement.getName());
 		createValues();
 		transferInstanceComments();

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/AbstractCreateFBNetworkElementCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/AbstractCreateFBNetworkElementCommand.java
@@ -1,7 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2016 fortiss GmbH
- * 				 2019 Johannes Keppler University Linz
- * 				 2021 Primetals Technologies Austria GmbH
+ * Copyright (c) 2016, 2025 fortiss GmbH, Johannes Keppler University Linz,
+ *                          Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -10,8 +9,8 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *   Alois Zoitl - initial API and implementation and/or initial documentation
- *   Alois Zoitl - removed editor check from canUndo
+ *   Alois Zoitl      - initial API and implementation and/or initial documentation
+ *                    - removed editor check from canUndo
  *   Daniel Lindhuber - added recursive type handling
  *******************************************************************************/
 package org.eclipse.fordiac.ide.model.commands.create;
@@ -66,9 +65,7 @@ public abstract class AbstractCreateFBNetworkElementCommand extends Command
 	@Override
 	public void execute() {
 		element.setInterface(createInterfaceList());
-		if (element.getType() != null) {
-			transferAttributes(element);
-		}
+		transferAttributes(element);
 		element.setPosition(position);
 		insertFBNetworkElement();
 		checkName();

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/CreateInternalFBCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/CreateInternalFBCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Primetals Technologies Germany GmbH
+ * Copyright (c) 2021, 2025 Primetals Technologies Germany GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -32,7 +32,7 @@ public class CreateInternalFBCommand extends CreationCommand implements ScopedCo
 	private final BaseFBType baseFbType;
 
 	/** Command information */
-	private FBTypeEntry fbType;
+	private FBTypeEntry fbTypeEntry;
 	private final String name;
 	private final int index;
 
@@ -46,11 +46,11 @@ public class CreateInternalFBCommand extends CreationCommand implements ScopedCo
 	}
 
 	public CreateInternalFBCommand(final BaseFBType baseFbType, final int index, final String name,
-			final FBTypeEntry fbType) {
+			final FBTypeEntry fbTypeEntry) {
 		this.baseFbType = Objects.requireNonNull(baseFbType);
-		this.fbType = fbType;
-		if (null == fbType) {
-			this.fbType = baseFbType.getTypeLibrary().getFbTypes().iterator().next();
+		this.fbTypeEntry = fbTypeEntry;
+		if (null == fbTypeEntry) {
+			this.fbTypeEntry = baseFbType.getTypeLibrary().getFbTypes().iterator().next();
 		}
 		this.name = (null != name) ? name : DEFAULT_INTERNAL_FB_NAME;
 		this.index = index;
@@ -62,16 +62,15 @@ public class CreateInternalFBCommand extends CreationCommand implements ScopedCo
 	}
 
 	private EList<FB> getInteralFBList() {
-		final BaseFBType type = baseFbType;
-		return type.getInternalFbs();
+		return baseFbType.getInternalFbs();
 	}
 
 	@Override
 	public void execute() {
 		internalFB = LibraryElementFactory.eINSTANCE.createFB();
-		internalFB.setTypeEntry(fbType);
+		internalFB.setTypeEntry(fbTypeEntry);
 		internalFB.setComment(""); //$NON-NLS-1$
-		internalFB.setInterface(fbType.getType().getInterfaceList().copy());
+		internalFB.setInterface(fbTypeEntry.getInterface().copy());
 		getInteralFBList().add(index, internalFB);
 		internalFB.setName(NameRepository.createUniqueName(internalFB, name));
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/CreateStructFromInterfaceElementsCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/CreateStructFromInterfaceElementsCommand.java
@@ -76,7 +76,7 @@ public class CreateStructFromInterfaceElementsCommand extends Command {
 		}
 		// FBNElement must be untyped subapp
 		final InterfaceList il = getInterfaceList();
-		if (il.getFBNetworkElement().getType() != null) { // cannot edit instance of typed elements
+		if (il.getFBNetworkElement().getTypeEntry() != null) { // cannot edit instance of typed elements
 			return false;
 		}
 

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/CreateSubAppInstanceCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/CreateSubAppInstanceCommand.java
@@ -47,7 +47,13 @@ public class CreateSubAppInstanceCommand extends AbstractCreateFBNetworkElementC
 
 	@Override
 	protected InterfaceList createInterfaceList() {
-		return typeEntry.getType().getInterfaceList().copy();
+		InterfaceList interfaceList = typeEntry.getInterface();
+		if (interfaceList == null) {
+			interfaceList = LibraryElementFactory.eINSTANCE.createInterfaceList();
+		} else {
+			interfaceList = interfaceList.copy();
+		}
+		return interfaceList;
 	}
 
 	public TypedSubApp getSubApp() {

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/FBCreateCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/FBCreateCommand.java
@@ -20,6 +20,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.FB;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.Position;
 import org.eclipse.fordiac.ide.model.typelibrary.FBTypeEntry;
 
@@ -80,7 +81,13 @@ public class FBCreateCommand extends AbstractCreateFBNetworkElementCommand {
 
 	@Override
 	protected InterfaceList createInterfaceList() {
-		return typeEntry.getType().getInterfaceList().copy();
+		InterfaceList interfaceList = typeEntry.getInterface();
+		if (interfaceList == null) {
+			interfaceList = LibraryElementFactory.eINSTANCE.createInterfaceList();
+		} else {
+			interfaceList = interfaceList.copy();
+		}
+		return interfaceList;
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/helper/CommentHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/helper/CommentHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Martin Erich Jobst
+ * Copyright (c) 2023, 2025 Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,6 +18,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.StructManipulator;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 
 public final class CommentHelper {
 
@@ -46,8 +47,10 @@ public final class CommentHelper {
 					return structMember.getComment();
 				}
 			}
-			if (fbn != null && fbn.getType() != null) {
-				final IInterfaceElement typeElement = fbn.getType().getInterfaceList()
+
+			if ((fbn != null) && (fbn.getTypeEntry() instanceof final InterfaceTypeEntry ifTypeEntry
+					&& ifTypeEntry.getInterface() != null)) {
+				final IInterfaceElement typeElement = ifTypeEntry.getInterface()
 						.getInterfaceElement(interfaceElement.getName());
 				if (typeElement != null && typeElement.getComment() != null) {
 					return typeElement.getComment();

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/helper/CommentHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/helper/CommentHelper.java
@@ -16,7 +16,6 @@ import org.eclipse.fordiac.ide.model.data.StructuredType;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
-import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.libraryElement.StructManipulator;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 
@@ -48,15 +47,11 @@ public final class CommentHelper {
 				}
 			}
 
-			if (fbn != null) {
-				final InterfaceList typeInterface = fbn.getTypeInterface();
-				if (typeInterface != null) {
-					final IInterfaceElement typeElement = typeInterface.getInterfaceElement(interfaceElement.getName());
-					if (typeElement != null && typeElement.getComment() != null) {
-						return typeElement.getComment();
-					}
-				}
+			final IInterfaceElement typeElement = interfaceElement.findInTypeInterface();
+			if (typeElement != null && typeElement.getComment() != null) {
+				return typeElement.getComment();
 			}
+
 		}
 		return ""; //$NON-NLS-1$
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/helper/CommentHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/helper/CommentHelper.java
@@ -16,9 +16,9 @@ import org.eclipse.fordiac.ide.model.data.StructuredType;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.libraryElement.StructManipulator;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
-import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 
 public final class CommentHelper {
 
@@ -48,12 +48,13 @@ public final class CommentHelper {
 				}
 			}
 
-			if ((fbn != null) && (fbn.getTypeEntry() instanceof final InterfaceTypeEntry ifTypeEntry
-					&& ifTypeEntry.getInterface() != null)) {
-				final IInterfaceElement typeElement = ifTypeEntry.getInterface()
-						.getInterfaceElement(interfaceElement.getName());
-				if (typeElement != null && typeElement.getComment() != null) {
-					return typeElement.getComment();
+			if (fbn != null) {
+				final InterfaceList typeInterface = fbn.getTypeInterface();
+				if (typeInterface != null) {
+					final IInterfaceElement typeElement = typeInterface.getInterfaceElement(interfaceElement.getName());
+					if (typeElement != null && typeElement.getComment() != null) {
+						return typeElement.getComment();
+					}
 				}
 			}
 		}

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/VariableOperations.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/VariableOperations.java
@@ -53,6 +53,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 import org.eclipse.fordiac.ide.model.value.TypedValueConverter;
 
 @SuppressWarnings("java:S1452")
@@ -455,14 +456,12 @@ public final class VariableOperations {
 	}
 
 	public static VarDeclaration getTypeVariable(final VarDeclaration varDeclaration) {
-		final FBNetworkElement networkElement = varDeclaration.getFBNetworkElement();
-		if (networkElement != null) {
-			final FBType type = networkElement.getType();
-			if (type != null) {
-				final VarDeclaration typeVariable = type.getInterfaceList().getVariable(varDeclaration.getName());
-				if (typeVariable != null) {
-					return typeVariable;
-				}
+		final FBNetworkElement fbne = varDeclaration.getFBNetworkElement();
+		if ((fbne != null) && (fbne.getTypeEntry() instanceof final InterfaceTypeEntry ifTypeEntry
+				&& ifTypeEntry.getInterface() != null)) {
+			final VarDeclaration typeVariable = ifTypeEntry.getInterface().getVariable(varDeclaration.getName());
+			if (typeVariable != null) {
+				return typeVariable;
 			}
 		}
 		return null;

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/VariableOperations.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/VariableOperations.java
@@ -47,10 +47,8 @@ import org.eclipse.fordiac.ide.model.helpers.ArraySizeHelper;
 import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
 import org.eclipse.fordiac.ide.model.libraryElement.FB;
-import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement;
-import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
@@ -150,7 +148,7 @@ public final class VariableOperations {
 				}
 				if (hasInheritedInitialValue(varDeclaration)) {
 					// use variable from FB type since the initial value is inherited
-					final VarDeclaration typeVariable = getTypeVariable(varDeclaration);
+					final VarDeclaration typeVariable = varDeclaration.findInTypeInterface();
 					return newVariable(varDeclaration.getName(), evaluateResultType(varDeclaration),
 							cache.computeInitialValueIfAbsent(typeVariable, VariableOperations::doEvaluateValue));
 				}
@@ -425,7 +423,7 @@ public final class VariableOperations {
 	}
 
 	public static boolean hasInheritedInitialValue(final VarDeclaration varDeclaration) {
-		final VarDeclaration typeVariable = getTypeVariable(varDeclaration);
+		final VarDeclaration typeVariable = varDeclaration.findInTypeInterface();
 		if (typeVariable != null) {
 			return hasDeclaredInitialValue(typeVariable);
 		}
@@ -448,23 +446,9 @@ public final class VariableOperations {
 	}
 
 	public static String getInheritedInitialValue(final VarDeclaration varDeclaration) {
-		final VarDeclaration typeVariable = getTypeVariable(varDeclaration);
+		final VarDeclaration typeVariable = varDeclaration.findInTypeInterface();
 		if (typeVariable != null && hasDeclaredInitialValue(typeVariable)) {
 			return typeVariable.getValue().getValue();
-		}
-		return null;
-	}
-
-	public static VarDeclaration getTypeVariable(final VarDeclaration varDeclaration) {
-		final FBNetworkElement fbne = varDeclaration.getFBNetworkElement();
-		if (fbne != null) {
-			final InterfaceList typeInterface = fbne.getTypeInterface();
-			if (typeInterface != null) {
-				final VarDeclaration typeVariable = typeInterface.getVariable(varDeclaration.getName());
-				if (typeVariable != null) {
-					return typeVariable;
-				}
-			}
 		}
 		return null;
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/VariableOperations.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/VariableOperations.java
@@ -50,10 +50,10 @@ import org.eclipse.fordiac.ide.model.libraryElement.FB;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
-import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 import org.eclipse.fordiac.ide.model.value.TypedValueConverter;
 
 @SuppressWarnings("java:S1452")
@@ -457,11 +457,13 @@ public final class VariableOperations {
 
 	public static VarDeclaration getTypeVariable(final VarDeclaration varDeclaration) {
 		final FBNetworkElement fbne = varDeclaration.getFBNetworkElement();
-		if ((fbne != null) && (fbne.getTypeEntry() instanceof final InterfaceTypeEntry ifTypeEntry
-				&& ifTypeEntry.getInterface() != null)) {
-			final VarDeclaration typeVariable = ifTypeEntry.getInterface().getVariable(varDeclaration.getName());
-			if (typeVariable != null) {
-				return typeVariable;
+		if (fbne != null) {
+			final InterfaceList typeInterface = fbne.getTypeInterface();
+			if (typeInterface != null) {
+				final VarDeclaration typeVariable = typeInterface.getVariable(varDeclaration.getName());
+				if (typeVariable != null) {
+					return typeVariable;
+				}
 			}
 		}
 		return null;

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/widgets/TypeSelectionProposalProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/widgets/TypeSelectionProposalProvider.java
@@ -46,7 +46,6 @@ public class TypeSelectionProposalProvider implements IContentProposalProvider {
 	@Override
 	public IContentProposal[] getProposals(final String contents, final int position) {
 		final TypeLibrary typeLibrary = supplier.get();
-		contentProvider.getTypeEntries(typeLibrary).forEach(TypeEntry::getType);
 		return Stream.concat(
 				contentProvider.getTypes(typeLibrary).stream().filter(proposal -> matches(proposal.getName(), contents))
 						.map(this::createProposal),

--- a/plugins/org.eclipse.fordiac.ide.model/model/fordiac.genmodel
+++ b/plugins/org.eclipse.fordiac.ide.model/model/fordiac.genmodel
@@ -565,6 +565,8 @@
         <genParameters ecoreParameter="lib.ecore#//IInterfaceElement/validateName/diagnostics"/>
         <genParameters ecoreParameter="lib.ecore#//IInterfaceElement/validateName/context"/>
       </genOperations>
+      <genOperations ecoreOperation="lib.ecore#//IInterfaceElement/findInTypeInterface"
+          body="return org.eclipse.fordiac.ide.model.libraryElement.impl.InterfaceElementAnnotations.findInTypeInterface(this);"/>
     </genClasses>
     <genClasses ecoreClass="lib.ecore#//Import">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute lib.ecore#//Import/importedNamespace"/>
@@ -949,6 +951,8 @@
         <genParameters ecoreParameter="lib.ecore#//VarDeclaration/validateVarInOutSubappNetwork/diagnostics"/>
         <genParameters ecoreParameter="lib.ecore#//VarDeclaration/validateVarInOutSubappNetwork/context"/>
       </genOperations>
+      <genOperations ecoreOperation="lib.ecore#//VarDeclaration/findInTypeInterface"
+          body="return (InterfaceElementAnnotations.findInTypeInterface(this) instanceof VarDeclaration varDecl) ? varDecl : null;"/>
     </genClasses>
     <genClasses ecoreClass="lib.ecore#//VersionInfo">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute lib.ecore#//VersionInfo/author"/>

--- a/plugins/org.eclipse.fordiac.ide.model/model/fordiac.genmodel
+++ b/plugins/org.eclipse.fordiac.ide.model/model/fordiac.genmodel
@@ -497,6 +497,8 @@
       <genOperations ecoreOperation="lib.ecore#//FBNetworkElement/getOutput" body="return org.eclipse.fordiac.ide.model.annotations.FBNetworkElementAnnotations.getOutput(this, name);">
         <genParameters ecoreParameter="lib.ecore#//FBNetworkElement/getOutput/name"/>
       </genOperations>
+      <genOperations ecoreOperation="lib.ecore#//FBNetworkElement/getTypeInterface"
+          body="if(getTypeEntry() instanceof final org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry ifTypeEntry){&#xA;&#x9;return ifTypeEntry.getInterface();&#xA;}&#xA;return null;"/>
     </genClasses>
     <genClasses ecoreClass="lib.ecore#//FBType">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference lib.ecore#//FBType/interfaceList"/>

--- a/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
+++ b/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
@@ -1320,6 +1320,11 @@
       </eAnnotations>
       <eParameters name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     </eOperations>
+    <eOperations name="getTypeInterface" lowerBound="1" eType="#//InterfaceList">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="body" value="if(getTypeEntry() instanceof final org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry ifTypeEntry){&#xA;&#x9;return ifTypeEntry.getInterface();&#xA;}&#xA;return null;"/>
+      </eAnnotations>
+    </eOperations>
     <eStructuralFeatures xsi:type="ecore:EReference" name="interface" eType="#//InterfaceList"
         containment="true" eOpposite="#//InterfaceList/FBNetworkElement"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="mapping" eType="#//Mapping"/>

--- a/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
+++ b/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
@@ -1524,6 +1524,11 @@
         </eGenericType>
       </eParameters>
     </eOperations>
+    <eOperations name="findInTypeInterface" lowerBound="1" eType="#//IInterfaceElement">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="body" value="return org.eclipse.fordiac.ide.model.libraryElement.impl.InterfaceElementAnnotations.findInTypeInterface(this);"/>
+      </eAnnotations>
+    </eOperations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="isInput" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Boolean"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="inputConnections" upperBound="-1"
         eType="#//Connection" eOpposite="#//Connection/destination"/>
@@ -2535,6 +2540,11 @@
           <eTypeArguments eClassifier="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EJavaObject"/>
         </eGenericType>
       </eParameters>
+    </eOperations>
+    <eOperations name="findInTypeInterface" lowerBound="1" eType="#//VarDeclaration">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="body" value="return (InterfaceElementAnnotations.findInTypeInterface(this) instanceof VarDeclaration varDecl) ? varDecl : null;"/>
+      </eAnnotations>
     </eOperations>
     <eStructuralFeatures xsi:type="ecore:EReference" name="arraySize" eType="#//ArraySize"
         containment="true" eOpposite="#//ArraySize/varDeclaration"/>

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/FBNetworkElement.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/FBNetworkElement.java
@@ -261,4 +261,12 @@ public interface FBNetworkElement extends TypedConfigureableObject, Positionable
 	 */
 	IInterfaceElement getOutput(String name);
 
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @model kind="operation" required="true"
+	 * @generated
+	 */
+	InterfaceList getTypeInterface();
+
 } // FBNetworkElement

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/IInterfaceElement.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/IInterfaceElement.java
@@ -146,4 +146,12 @@ public interface IInterfaceElement extends ITypedElement, ConfigurableObject, Hi
 	 */
 	boolean validateName(DiagnosticChain diagnostics, Map<Object, Object> context);
 
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @model required="true"
+	 * @generated
+	 */
+	IInterfaceElement findInTypeInterface();
+
 } // IInterfaceElement

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/VarDeclaration.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/VarDeclaration.java
@@ -227,4 +227,12 @@ public interface VarDeclaration extends IInterfaceElement {
 	 */
 	boolean validateVarInOutSubappNetwork(DiagnosticChain diagnostics, Map<Object, Object> context);
 
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @model required="true"
+	 * @generated
+	 */
+	VarDeclaration findInTypeInterface();
+
 } // VarDeclaration

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/AdapterDeclarationImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/AdapterDeclarationImpl.java
@@ -46,6 +46,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.Connection;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.HiddenElement;
+import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
@@ -538,6 +539,16 @@ public class AdapterDeclarationImpl extends EObjectImpl implements AdapterDeclar
 	@Override
 	public boolean validateName(final DiagnosticChain diagnostics, final Map<Object, Object> context) {
 		return org.eclipse.fordiac.ide.model.libraryElement.impl.InterfaceElementAnnotations.validateName(this, diagnostics, context);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public IInterfaceElement findInTypeInterface() {
+		return org.eclipse.fordiac.ide.model.libraryElement.impl.InterfaceElementAnnotations.findInTypeInterface(this);
 	}
 
 	/**

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/ErrorMarkerInterfaceImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/ErrorMarkerInterfaceImpl.java
@@ -44,6 +44,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.ErrorMarkerInterface;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.HiddenElement;
+import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
@@ -409,6 +410,16 @@ public class ErrorMarkerInterfaceImpl extends EObjectImpl implements ErrorMarker
 	@Override
 	public boolean validateName(final DiagnosticChain diagnostics, final Map<Object, Object> context) {
 		return org.eclipse.fordiac.ide.model.libraryElement.impl.InterfaceElementAnnotations.validateName(this, diagnostics, context);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public IInterfaceElement findInTypeInterface() {
+		return org.eclipse.fordiac.ide.model.libraryElement.impl.InterfaceElementAnnotations.findInTypeInterface(this);
 	}
 
 	/**

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/EventImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/EventImpl.java
@@ -45,6 +45,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.HiddenElement;
 import org.eclipse.fordiac.ide.model.libraryElement.ICallable;
+import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
@@ -485,6 +486,16 @@ public class EventImpl extends EObjectImpl implements Event {
 	@Override
 	public boolean validateName(final DiagnosticChain diagnostics, final Map<Object, Object> context) {
 		return org.eclipse.fordiac.ide.model.libraryElement.impl.InterfaceElementAnnotations.validateName(this, diagnostics, context);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public IInterfaceElement findInTypeInterface() {
+		return org.eclipse.fordiac.ide.model.libraryElement.impl.InterfaceElementAnnotations.findInTypeInterface(this);
 	}
 
 	/**

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/FBNetworkElementImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/FBNetworkElementImpl.java
@@ -574,6 +574,19 @@ public abstract class FBNetworkElementImpl extends TypedConfigureableObjectImpl 
 	 * @generated
 	 */
 	@Override
+	public InterfaceList getTypeInterface() {
+		if(getTypeEntry() instanceof final org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry ifTypeEntry){
+			return ifTypeEntry.getInterface();
+		}
+		return null;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public void updatePositionFromScreenCoordinates(final int x, final int y) {
 		PositionAnnotation.updatePositionFromScreenCoordinates(this, x,y);
 	}

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
@@ -5614,6 +5614,8 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 		g1.getETypeArguments().add(g2);
 		addEParameter(op, g1, "context", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
+		addEOperation(iInterfaceElementEClass, this.getIInterfaceElement(), "findInTypeInterface", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+
 		initEClass(importEClass, Import.class, "Import", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEAttribute(getImport_ImportedNamespace(), theXMLTypePackage.getString(), "importedNamespace", null, 0, 1, Import.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
@@ -6097,6 +6099,8 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 		g2 = createEGenericType(ecorePackage.getEJavaObject());
 		g1.getETypeArguments().add(g2);
 		addEParameter(op, g1, "context", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+
+		addEOperation(varDeclarationEClass, this.getVarDeclaration(), "findInTypeInterface", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(versionInfoEClass, VersionInfo.class, "VersionInfo", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEAttribute(getVersionInfo_Author(), theXMLTypePackage.getString(), "author", "", 1, 1, VersionInfo.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$ //$NON-NLS-2$

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
@@ -5520,6 +5520,8 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 		op = addEOperation(fbNetworkElementEClass, this.getIInterfaceElement(), "getOutput", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 		addEParameter(op, ecorePackage.getEString(), "name", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
+		addEOperation(fbNetworkElementEClass, this.getInterfaceList(), "getTypeInterface", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+
 		initEClass(fbTypeEClass, FBType.class, "FBType", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getFBType_InterfaceList(), this.getInterfaceList(), this.getInterfaceList_FBType(), "interfaceList", null, 1, 1, FBType.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEReference(getFBType_Service(), this.getService(), null, "service", null, 0, 1, FBType.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/VarDeclarationImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/VarDeclarationImpl.java
@@ -741,6 +741,16 @@ public class VarDeclarationImpl extends EObjectImpl implements VarDeclaration {
 	 * @generated
 	 */
 	@Override
+	public VarDeclaration findInTypeInterface() {
+		return (InterfaceElementAnnotations.findInTypeInterface(this) instanceof VarDeclaration varDecl) ? varDecl : null;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public boolean validateType(final DiagnosticChain diagnostics, final Map<Object, Object> context) {
 		return org.eclipse.fordiac.ide.model.libraryElement.impl.TypedElementAnnotations.validateType(this, diagnostics, context);
 	}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/CommonElementImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/CommonElementImporter.java
@@ -1,8 +1,8 @@
 /********************************************************************************
- * Copyright (c) 2008, 2020 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
- *                          Johannes Kepler University, Linz
- *               2020, 2021  Primetals Technologies Austria GmbH
- *               2023 Martin Erich Jobst
+ * Copyright (c) 2008, 2025 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
+ *                          Johannes Kepler University, Linz,
+ *                          Primetals Technologies Austria GmbH,
+ *                          Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -106,7 +106,7 @@ public abstract class CommonElementImporter {
 	private static final boolean IS_VISIBLE = false;
 	private static final boolean IS_VAR_CONFIGED = true;
 
-	private static class ImporterStreams implements AutoCloseable {
+	protected static final class ImporterStreams implements AutoCloseable {
 		private final InputStream inputStream;
 		private final XMLStreamReader reader;
 
@@ -225,7 +225,7 @@ public abstract class CommonElementImporter {
 
 	protected abstract IChildHandler getBaseChildrenHandler();
 
-	private ImporterStreams createInputStreams(final InputStream fileInputStream) throws XMLStreamException {
+	protected ImporterStreams createInputStreams(final InputStream fileInputStream) throws XMLStreamException {
 		final XMLInputFactory factory = XMLInputFactory.newInstance();
 		factory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
 		factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/FBNetworkImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/FBNetworkImporter.java
@@ -43,7 +43,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.Connection;
 import org.eclipse.fordiac.ide.model.libraryElement.FB;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
-import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.Group;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
@@ -224,12 +223,14 @@ class FBNetworkImporter extends CommonElementImporter {
 			return addDependency(FordiacMarkerHelper.createTypeErrorMarkerFB(typeName, getTypeLibrary(),
 					LibraryElementPackage.eINSTANCE.getFBType()));
 		}
-		final FBType type = entry.getType();
-		if (type == null) {
-			return FordiacMarkerHelper.createErrorMarkerFB(typeName, entry);
-		}
 		final FB fb = BlockInstanceFactory.createFBInstanceForTypeEntry(entry);
-		fb.setInterface(type.getInterfaceList().copy());
+		InterfaceList fbInterface = entry.getInterface();
+		if (fbInterface == null) {
+			fbInterface = LibraryElementFactory.eINSTANCE.createInterfaceList();
+		} else {
+			fbInterface = fbInterface.copy();
+		}
+		fb.setInterface(fbInterface);
 		fb.setTypeEntry(entry);
 		return fb;
 	}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/FBTImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/FBTImporter.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2008, 2023  Profactor GmbH, TU Wien ACIN, fortiss GmbH,
+ * Copyright (c) 2008, 2025  Profactor GmbH, TU Wien ACIN, fortiss GmbH,
  *                           TU Wien/ACIN, Johannes Kepler University, Linz,
  *                           Primetals Technologies Austria GmbH,
  *                           Martin Erich Jobst
@@ -12,16 +12,17 @@
  *
  * Contributors:
  *  Gerhard Ebenhofer, Ingo Hegny, Alois Zoitl, Martin Jobst
- *    - initial API and implementation and/or initial documentation
+ *               - initial API and implementation and/or initial documentation
  *  Peter Gsellmann - incorporating simple fb
- *  Alois Zoitl - Changed XML parsing to Staxx cursor interface for improved
- *  			  parsing performance
+ *  Alois Zoitl  - Changed XML parsing to Staxx cursor interface for improved
+ *  			   parsing performance
  *  Martin Melik Merkumians - added import of internal FBs
  *  Martin Jobst - refactor marker handling
- *  Alois Zoitl - updated for new adapter FB handling
+ *  Alois Zoitl  - updated for new adapter FB handling
  ********************************************************************************/
 package org.eclipse.fordiac.ide.model.dataimport;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -116,6 +117,40 @@ public class FBTImporter extends TypeImporter {
 
 	protected FBTImporter(final CommonElementImporter importer) {
 		super(importer);
+	}
+
+	public FBType loadInterface() throws IOException, XMLStreamException, TypeImportException {
+		setElement(createRootModelElement());
+		try (ImporterStreams streams = createInputStreams(getInputStream())) {
+			proceedToStartElementNamed(getStartElementName());
+			readNameCommentAttributes(getElement());
+
+			boolean compilerInfo = false;
+			boolean interfaceList = false;
+
+			while (getReader().hasNext()) {
+				final int event = getReader().next();
+				if (XMLStreamConstants.START_ELEMENT == event) {
+					final String localName = getReader().getLocalName();
+					if (LibraryElementTags.COMPILER_INFO_ELEMENT.equals(localName)) {
+						getElement().setCompilerInfo(parseCompilerInfo());
+						compilerInfo = true;
+					} else if (getInterfaceListElementName().equals(localName)) {
+						getElement().setInterfaceList(parseInterfaceList(getInterfaceListElementName()));
+						interfaceList = true;
+					}
+				}
+				if (interfaceList && compilerInfo) {
+					break;
+				}
+			}
+		}
+		return getElement();
+	}
+
+	@SuppressWarnings("static-method") // allow subclasse to provide a different name (e.g., SubTypeImporter)
+	protected String getInterfaceListElementName() {
+		return LibraryElementTags.INTERFACE_LIST_ELEMENT;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/FBTImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/FBTImporter.java
@@ -78,7 +78,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.With;
 import org.eclipse.fordiac.ide.model.typelibrary.AdapterTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.EventTypeLibrary;
-import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.FBTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
 
 /** Managing class for importing *.fbt files */
@@ -995,15 +995,19 @@ public class FBTImporter extends TypeImporter {
 		final FB fb = LibraryElementFactory.eINSTANCE.createFB();
 		readNameCommentAttributes(fb);
 		final String typeFbElement = getAttributeValue(LibraryElementTags.TYPE_ATTRIBUTE);
-		TypeEntry entry = getTypeEntry(typeFbElement);
+		final FBTypeEntry entry = getTypeEntry(typeFbElement);
 		if (entry == null) {
-			entry = addDependency(
-					getTypeLibrary().createErrorTypeEntry(typeFbElement, LibraryElementPackage.eINSTANCE.getFBType()));
+			fb.setTypeEntry(addDependency(
+					getTypeLibrary().createErrorTypeEntry(typeFbElement, LibraryElementPackage.eINSTANCE.getFBType())));
+			fb.setInterface(LibraryElementFactory.eINSTANCE.createInterfaceList());
+		} else {
+			fb.setTypeEntry(entry);
+			final InterfaceList typeInterface = entry.getInterface();
+			fb.setInterface((typeInterface != null) ? typeInterface.copy()
+					: LibraryElementFactory.eINSTANCE.createInterfaceList());
 		}
-		fb.setTypeEntry(entry);
-		fb.setInterface(fb.getType().getInterfaceList().copy());
-		parseFBChildren(fb, LibraryElementTags.FB_ELEMENT);
 		type.getInternalFbs().add(fb);
+		parseFBChildren(fb, LibraryElementTags.FB_ELEMENT);
 	}
 
 	/**

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/SubAppNetworkImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/SubAppNetworkImporter.java
@@ -28,7 +28,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
-import org.eclipse.fordiac.ide.model.libraryElement.SubAppType;
 import org.eclipse.fordiac.ide.model.libraryElement.TypedSubApp;
 import org.eclipse.fordiac.ide.model.libraryElement.UntypedSubApp;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
@@ -103,13 +102,15 @@ class SubAppNetworkImporter extends FBNetworkImporter {
 			return addDependency(FordiacMarkerHelper.createTypeErrorMarkerFB(typeName, getTypeLibrary(),
 					LibraryElementPackage.eINSTANCE.getSubAppType()));
 		}
-		final SubAppType type = subEntry.getType();
-		if (type == null) {
-			return FordiacMarkerHelper.createErrorMarkerFB(typeName, subEntry);
-		}
 		final TypedSubApp subApp = LibraryElementFactory.eINSTANCE.createTypedSubApp();
 		subApp.setTypeEntry(subEntry);
-		subApp.setInterface(type.getInterfaceList().copy());
+		InterfaceList interfaceList = subApp.getInterface();
+		if (interfaceList == null) {
+			interfaceList = LibraryElementFactory.eINSTANCE.createInterfaceList();
+		} else {
+			interfaceList = interfaceList.copy();
+		}
+		subApp.setInterface(interfaceList);
 		return subApp;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/SubAppNetworkImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/SubAppNetworkImporter.java
@@ -104,7 +104,7 @@ class SubAppNetworkImporter extends FBNetworkImporter {
 		}
 		final TypedSubApp subApp = LibraryElementFactory.eINSTANCE.createTypedSubApp();
 		subApp.setTypeEntry(subEntry);
-		InterfaceList interfaceList = subApp.getInterface();
+		InterfaceList interfaceList = subEntry.getInterface();
 		if (interfaceList == null) {
 			interfaceList = LibraryElementFactory.eINSTANCE.createInterfaceList();
 		} else {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/SubAppTImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/SubAppTImporter.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2008, 2009, 2013 - 2017  Profactor GmbH, fortiss GmbH
- * 				 2020 Johannes Kepler University Linz
+ * Copyright (c) 2008, 2025 Profactor GmbH, fortiss GmbH,
+ *                          Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -115,6 +115,11 @@ public class SubAppTImporter extends FBTImporter {
 	@Override
 	protected void processWiths() {
 		// supapps may not have a with construct. Therefore we are doing nothing here
+	}
+
+	@Override
+	protected String getInterfaceListElementName() {
+		return LibraryElementTags.SUBAPPINTERFACE_LIST_ELEMENT;
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/InterfaceElementAnnotations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/InterfaceElementAnnotations.java
@@ -138,6 +138,28 @@ public final class InterfaceElementAnnotations {
 		return null;
 	}
 
+	static IInterfaceElement findInTypeInterface(final IInterfaceElement element) {
+		final FBNetworkElement fbnEl = element.getFBNetworkElement();
+		if (fbnEl == null) {
+			return null;
+		}
+
+		final InterfaceList typeInterface = fbnEl.getTypeInterface();
+		if (typeInterface == null) {
+			return null;
+		}
+
+		final IInterfaceElement typeIE = typeInterface.getInterfaceElement(element.getName());
+
+		if (typeIE instanceof final VarDeclaration varDecl && varDecl.isInOutVar() && !element.isIsInput()) {
+			// if the type pin is a varinout and the searched element is an output we need
+			// to get the output opposite
+			return varDecl.getInOutVarOpposite();
+		}
+
+		return typeIE;
+	}
+
 	private InterfaceElementAnnotations() {
 		throw new UnsupportedOperationException();
 	}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/VarDeclarationAnnotations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/VarDeclarationAnnotations.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Primetals Technologies Austria GmbH
+ * Copyright (c) 2023, 2025 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -26,7 +26,6 @@ import org.eclipse.fordiac.ide.model.errormarker.FordiacMarkerHelper;
 import org.eclipse.fordiac.ide.model.helpers.VarInOutHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.FB;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
-import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.FunctionFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
@@ -35,6 +34,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
 import org.eclipse.fordiac.ide.model.libraryElement.SubAppType;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.util.LibraryElementValidator;
+import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 
 public class VarDeclarationAnnotations {
 
@@ -251,14 +251,12 @@ public class VarDeclarationAnnotations {
 	public static VarDeclaration getTypeVariable(final VarDeclaration varDeclaration) {
 		if (varDeclaration != null) {
 			final FBNetworkElement fbne = varDeclaration.getFBNetworkElement();
-			if (fbne != null) {
-				final FBType type = fbne.getType();
-				if (type != null) {
-					final VarDeclaration typeVariable = type.getInterfaceList().getVariable(varDeclaration.getName());
-					return typeVariable.isInOutVar() && typeVariable.isIsInput() != varDeclaration.isIsInput()
-							? typeVariable.getInOutVarOpposite()
-							: typeVariable;
-				}
+			if ((fbne != null) && (fbne.getTypeEntry() instanceof final InterfaceTypeEntry ifTypeEntry
+					&& ifTypeEntry.getInterface() != null)) {
+				final VarDeclaration typeVariable = ifTypeEntry.getInterface().getVariable(varDeclaration.getName());
+				return typeVariable.isInOutVar() && typeVariable.isIsInput() != varDeclaration.isIsInput()
+						? typeVariable.getInOutVarOpposite()
+						: typeVariable;
 			}
 		}
 		return varDeclaration;

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/VarDeclarationAnnotations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/VarDeclarationAnnotations.java
@@ -25,7 +25,6 @@ import org.eclipse.fordiac.ide.model.datatype.helper.TypeDeclarationParser;
 import org.eclipse.fordiac.ide.model.errormarker.FordiacMarkerHelper;
 import org.eclipse.fordiac.ide.model.helpers.VarInOutHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.FB;
-import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.FunctionFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
@@ -238,29 +237,21 @@ public class VarDeclarationAnnotations {
 	}
 
 	static boolean hasAnyInputConnections(final VarDeclaration varDeclaration) {
-		return varDeclaration != null && (!varDeclaration.getInputConnections().isEmpty()
-				|| !getTypeVariable(varDeclaration).getInputConnections().isEmpty());
+		if (varDeclaration == null) {
+			return false;
+		}
+		final VarDeclaration typeIE = varDeclaration.findInTypeInterface();
+		return !varDeclaration.getInputConnections().isEmpty()
+				|| (typeIE != null && !typeIE.getInputConnections().isEmpty());
 	}
 
 	static boolean hasAnyOutputConnections(final VarDeclaration varDeclaration) {
-		return varDeclaration != null && (!varDeclaration.getOutputConnections().isEmpty()
-				|| !getTypeVariable(varDeclaration).getOutputConnections().isEmpty());
-	}
-
-	public static VarDeclaration getTypeVariable(final VarDeclaration varDeclaration) {
-		if (varDeclaration != null) {
-			final FBNetworkElement fbne = varDeclaration.getFBNetworkElement();
-			if (fbne != null) {
-				final InterfaceList typeInterface = fbne.getTypeInterface();
-				if (typeInterface != null) {
-					final VarDeclaration typeVariable = typeInterface.getVariable(varDeclaration.getName());
-					return typeVariable.isInOutVar() && typeVariable.isIsInput() != varDeclaration.isIsInput()
-							? typeVariable.getInOutVarOpposite()
-							: typeVariable;
-				}
-			}
+		if (varDeclaration == null) {
+			return false;
 		}
-		return varDeclaration;
+		final VarDeclaration typeIE = varDeclaration.findInTypeInterface();
+		return !varDeclaration.getOutputConnections().isEmpty()
+				|| (typeIE != null && !typeIE.getOutputConnections().isEmpty());
 	}
 
 	private VarDeclarationAnnotations() {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/VarDeclarationAnnotations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/VarDeclarationAnnotations.java
@@ -34,7 +34,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
 import org.eclipse.fordiac.ide.model.libraryElement.SubAppType;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.util.LibraryElementValidator;
-import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 
 public class VarDeclarationAnnotations {
 
@@ -251,12 +250,14 @@ public class VarDeclarationAnnotations {
 	public static VarDeclaration getTypeVariable(final VarDeclaration varDeclaration) {
 		if (varDeclaration != null) {
 			final FBNetworkElement fbne = varDeclaration.getFBNetworkElement();
-			if ((fbne != null) && (fbne.getTypeEntry() instanceof final InterfaceTypeEntry ifTypeEntry
-					&& ifTypeEntry.getInterface() != null)) {
-				final VarDeclaration typeVariable = ifTypeEntry.getInterface().getVariable(varDeclaration.getName());
-				return typeVariable.isInOutVar() && typeVariable.isIsInput() != varDeclaration.isIsInput()
-						? typeVariable.getInOutVarOpposite()
-						: typeVariable;
+			if (fbne != null) {
+				final InterfaceList typeInterface = fbne.getTypeInterface();
+				if (typeInterface != null) {
+					final VarDeclaration typeVariable = typeInterface.getVariable(varDeclaration.getName());
+					return typeVariable.isInOutVar() && typeVariable.isIsInput() != varDeclaration.isIsInput()
+							? typeVariable.getInOutVarOpposite()
+							: typeVariable;
+				}
 			}
 		}
 		return varDeclaration;

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/FBTypeEntry.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/FBTypeEntry.java
@@ -1,5 +1,5 @@
 /*********************************************************************************
- * Copyright (c) 2008, 2022 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
+ * Copyright (c) 2008, 2025 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
  * 							Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
@@ -17,7 +17,7 @@ package org.eclipse.fordiac.ide.model.typelibrary;
 
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 
-public interface FBTypeEntry extends TypeEntry {
+public interface FBTypeEntry extends InterfaceTypeEntry {
 
 	@Override
 	FBType getType();

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/InterfaceTypeEntry.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/InterfaceTypeEntry.java
@@ -1,0 +1,21 @@
+/*********************************************************************************
+ * Copyright (c) 2025 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Alois Zoitl - initial API and implementation and/or initial documentation
+ ********************************************************************************/
+package org.eclipse.fordiac.ide.model.typelibrary;
+
+import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
+
+public interface InterfaceTypeEntry extends TypeEntry {
+
+	InterfaceList getInterface();
+
+}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/SubAppTypeEntry.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/SubAppTypeEntry.java
@@ -17,7 +17,7 @@ package org.eclipse.fordiac.ide.model.typelibrary;
 
 import org.eclipse.fordiac.ide.model.libraryElement.SubAppType;
 
-public interface SubAppTypeEntry extends TypeEntry {
+public interface SubAppTypeEntry extends InterfaceTypeEntry {
 
 	@Override
 	SubAppType getType();

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/TypeEntry.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/TypeEntry.java
@@ -36,6 +36,7 @@ public interface TypeEntry extends Notifier {
 	String TYPE_ENTRY_TYPE_EDITABLE_FEATURE = "TYPE_ENTRY_TYPE_EDITABLE_FEATURE"; //$NON-NLS-1$
 	String TYPE_ENTRY_TYPE_LIBRARY_FEATURE = "TYPE_ENTRY_TYPE_LIBRARY"; //$NON-NLS-1$
 	String TYPE_ENTRY_EDITOR_INSTANCE_UPDATE_FEATURE = "TYPE_ENTRY_EDITOR_INSTANCE_UPDATE_FEATURE"; //$NON-NLS-1$
+	String TYPE_ENTRY_INTERFACE_FEATURE = "TYPE_ENTRY_INTERFACE_FEATURE"; //$NON-NLS-1$
 
 	int TYPE_ENTRY_FILE_FEATURE_ID = 1;
 	int TYPE_ENTRY_FILE_CONTENT_FEATURE_ID = 2;
@@ -43,14 +44,11 @@ public interface TypeEntry extends Notifier {
 	int TYPE_ENTRY_TYPE_EDITABLE_FEATURE_ID = 4;
 	int TYPE_ENTRY_TYPE_LIBRARY_FEATURE_ID = 5;
 	int TYPE_ENTRY_EDITOR_INSTANCE_UPDATE_FEATURE_ID = 6;
+	int TYPE_ENTRY_INTERFACE_FEATURE_ID = 7;
 
 	IFile getFile();
 
 	void setFile(IFile value);
-
-	long getLastModificationTimestamp();
-
-	void setLastModificationTimestamp(long value);
 
 	LibraryElement getType();
 

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractInterfaceTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractInterfaceTypeEntryImpl.java
@@ -1,0 +1,221 @@
+/*********************************************************************************
+ * Copyright (c) 2025 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Alois Zoitl - initial API and implementation and/or initial documentation
+ ********************************************************************************/
+package org.eclipse.fordiac.ide.model.typelibrary.impl;
+
+import java.lang.ref.SoftReference;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+import java.util.Spliterators;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.common.notify.NotificationChain;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.fordiac.ide.model.dataimport.FBTImporter;
+import org.eclipse.fordiac.ide.model.libraryElement.FBType;
+import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
+import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
+import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
+
+public abstract class AbstractInterfaceTypeEntryImpl<T extends FBType> extends AbstractCheckedTypeEntryImpl<T>
+		implements InterfaceTypeEntry {
+
+	private SoftReference<FBType> interfaceTypeRef;
+	private final AtomicLong lastInterfaceModificationTimestamp = new AtomicLong(IResource.NULL_STAMP);
+	private final AtomicReference<Set<TypeEntry>> ifDependencies = new AtomicReference<>(Collections.emptySet());
+
+	protected AbstractInterfaceTypeEntryImpl(final Class<T> typeClass) {
+		super(typeClass);
+	}
+
+	private InterfaceList basicGetInterface() {
+		final SoftReference<FBType> interfaceRefCached = interfaceTypeRef;
+		if (interfaceRefCached != null) {
+			final FBType interfaceTypeCache = interfaceRefCached.get();
+			if (interfaceTypeCache != null) {
+				return interfaceTypeCache.getInterfaceList();
+			}
+		}
+		return null;
+	}
+
+	@Override
+	protected FBType basicGetType() {
+		return (FBType) super.basicGetType();
+	}
+
+	protected synchronized NotificationChain basicSetInterface(final FBType newIfType,
+			NotificationChain notifications) {
+		final FBType oldIfType = (interfaceTypeRef != null) ? interfaceTypeRef.get() : null;
+		if (newIfType != null) {
+			encloseInResource(newIfType);
+			newIfType.setTypeEntry(this);
+			interfaceTypeRef = new SoftReference<>(newIfType);
+		} else {
+			interfaceTypeRef = null;
+		}
+		if (eNotificationRequired()) {
+			notifications = chainNotification(notifications,
+					new TypeEntryNotificationImpl(this, Notification.SET, TypeEntry.TYPE_ENTRY_INTERFACE_FEATURE,
+							TypeEntry.TYPE_ENTRY_INTERFACE_FEATURE_ID, oldIfType, newIfType));
+		}
+		return notifications;
+	}
+
+	private FBType createIntefaceTypeFromTypeCache(final FBType fbTypeCache) {
+		final FBType interfaceType = (FBType) EcoreUtil.create(fbTypeCache.eClass());
+		interfaceType.setName(fbTypeCache.getName());
+		interfaceType.setComment(fbTypeCache.getComment());
+		interfaceType.setCompilerInfo(EcoreUtil.copy(fbTypeCache.getCompilerInfo()));
+		interfaceType.setInterfaceList(fbTypeCache.getInterfaceList().copy());
+		updateInterfaceDependencies(StreamSupport
+				.stream(Spliterators.spliteratorUnknownSize(interfaceType.eAllContents(), 0), false)
+				.map(EObject::eCrossReferences).flatMap(Collection::stream).filter(LibraryElement.class::isInstance)
+				.map(LibraryElement.class::cast).map(LibraryElement::getTypeEntry).filter(Objects::nonNull)
+				.collect(Collectors.toUnmodifiableSet()));
+		return interfaceType;
+	}
+
+	@Override
+	public InterfaceList getInterface() {
+		// check if interface is present and current
+		InterfaceList interfaceList = basicGetInterface();
+		if (interfaceList != null) {
+			return interfaceList; // simple, non-contended case
+		}
+
+		// the hard way
+		NotificationChain notifications = null;
+		synchronized (this) {
+			// check again
+			interfaceList = basicGetInterface();
+			if (interfaceList != null) {
+				return interfaceList;
+			}
+			// _we_ need to (re-)load the interface
+
+			// get and check file
+			final IFile fileCached = getFile();
+			if (fileCached == null) {
+				return null; // no file, no type
+			}
+
+			// read modification stamp at the beginning to ensure the loaded interface is at
+			// least as recent as the read modification stamp
+			final long modificationStamp = fileCached.getModificationStamp();
+
+			final FBType newInterfaceType = loadInterface();
+			if (newInterfaceType == null) {
+				return null;
+			}
+
+			interfaceList = newInterfaceType.getInterfaceList();
+
+			notifications = basicSetInterface(newInterfaceType, notifications);
+
+			// update the last modification stamp _after_ setting the interface to ensure
+			// other readers see the new stamp only together with the new type
+			lastInterfaceModificationTimestamp.set(modificationStamp);
+		}
+		// dispatch notifications
+		if (notifications != null) {
+			notifications.dispatch();
+		}
+		return interfaceList;
+	}
+
+	private final boolean isInterfaceFileContentChanged() {
+		final IFile fileCached = getFile();
+		if (fileCached != null) {
+			final long modificationStamp = fileCached.getModificationStamp();
+			return modificationStamp != IResource.NULL_STAMP
+					&& modificationStamp != lastInterfaceModificationTimestamp.get();
+		}
+		return false;
+	}
+
+	private FBType loadInterface() {
+		// check if we have type cached to be used for the interface
+		final FBType fbTypeCache = basicGetType();
+		if (fbTypeCache != null) {
+			return createIntefaceTypeFromTypeCache(fbTypeCache);
+		}
+
+		try {
+			final FBTImporter importer = (FBTImporter) getImporter();
+			final FBType interfaceType = importer.loadInterface();
+			updateInterfaceDependencies(importer.getDependencies());
+			return interfaceType;
+		} catch (final Exception e) {
+			FordiacLogHelper.logWarning("Error loading type " + getFile().getName() + ": " + e.getMessage(), e); //$NON-NLS-1$ //$NON-NLS-2$
+			return null;
+		}
+	}
+
+	@Override
+	public void notifyChanged(final Notification notification) {
+		if ((notification.getFeature() == TypeEntry.TYPE_ENTRY_TYPE_FEATURE
+				|| notification.getFeature() == TypeEntry.TYPE_ENTRY_TYPE_LIBRARY_FEATURE)
+				&& ifDependencies.get().contains(notification.getNotifier())) {
+
+			NotificationChain notifications = null;
+			synchronized (this) {
+				notifications = basicSetInterface(null, notifications);
+			}
+
+			if (notifications != null) {
+				notifications.dispatch();
+			}
+		}
+		super.notifyChanged(notification);
+	}
+
+	@Override
+	protected NotificationChain performTypeRefresh(NotificationChain notifications) {
+		if (isInterfaceFileContentChanged()) {
+			// clear cached type
+			notifications = basicSetInterface(null, notifications);
+		}
+		return super.performTypeRefresh(notifications);
+	}
+
+	private void updateInterfaceDependencies(final Set<TypeEntry> dependencies) {
+		final Set<TypeEntry> oldDependencies = this.ifDependencies.getAndSet(Set.copyOf(dependencies));
+		oldDependencies.stream().filter(Predicate.not(dependencies::contains))
+				.forEachOrdered(entry -> entry.eAdapters().remove(this));
+		dependencies.stream().filter(Predicate.not(oldDependencies::contains))
+				.forEachOrdered(entry -> entry.eAdapters().add(this));
+	}
+
+	@Override
+	protected NotificationChain updateTypeOnSave(final LibraryElement savedType, NotificationChain notifications) {
+		final FBType newInterfaceType = createIntefaceTypeFromTypeCache((FBType) savedType);
+		final long modificationStamp = getFile().getModificationStamp();
+		notifications = basicSetInterface(newInterfaceType, notifications);
+		lastInterfaceModificationTimestamp.set(modificationStamp);
+
+		return super.updateTypeOnSave(savedType, notifications);
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
@@ -50,6 +50,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.resource.FordiacTypeResource;
+import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
@@ -60,7 +61,7 @@ import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 
 public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl implements TypeEntry, Adapter.Internal {
 
-	private static class TypeEntryNotificationImpl extends NotificationImpl {
+	protected static class TypeEntryNotificationImpl extends NotificationImpl {
 		protected final TypeEntry notifier;
 		protected final String feature;
 		protected final int featureID;
@@ -107,8 +108,6 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 	private final AtomicReference<Set<TypeEntry>> dependencies = new AtomicReference<>(Collections.emptySet());
 
 	private TypeLibrary typeLibrary;
-
-	private boolean updateTypeOnSave = true;
 
 	@Override
 	public IFile getFile() {
@@ -180,21 +179,10 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 	}
 
 	@Override
-	public final long getLastModificationTimestamp() {
-		return lastModificationTimestamp.get();
-	}
-
-	@Override
-	public final void setLastModificationTimestamp(final long newLastModificationTimestamp) {
-		lastModificationTimestamp.set(newLastModificationTimestamp);
-		lastModificationTimestampEditable.set(newLastModificationTimestamp);
-	}
-
-	@Override
 	public LibraryElement getType() {
 		// check if type is present and current
 		LibraryElement type = basicGetType();
-		if (type != null && !isFileContentChanged()) {
+		if (type != null) {
 			return type; // simple, non-contended case
 		}
 
@@ -203,7 +191,7 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 		synchronized (this) {
 			// check again
 			type = basicGetType();
-			if (type != null && !isFileContentChanged()) {
+			if (type != null) {
 				return type; // concurrent update
 			}
 
@@ -242,7 +230,7 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 		return typeRefCached != null ? typeRefCached.get() : null;
 	}
 
-	private boolean isFileContentChanged() {
+	private final boolean isFileContentChanged() {
 		final IFile fileCached = getFile();
 		if (fileCached != null) {
 			final long modificationStamp = fileCached.getModificationStamp();
@@ -473,7 +461,9 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 
 	@Override
 	public void notifyChanged(final Notification notification) {
-		if ((notification.getFeature() == TypeEntry.TYPE_ENTRY_TYPE_FEATURE
+		if (((notification.getFeature() == TypeEntry.TYPE_ENTRY_TYPE_FEATURE
+				&& !(notification.getNotifier() instanceof InterfaceTypeEntry))
+				|| notification.getFeature() == TypeEntry.TYPE_ENTRY_INTERFACE_FEATURE
 				|| notification.getFeature() == TypeEntry.TYPE_ENTRY_TYPE_LIBRARY_FEATURE)
 				&& dependencies.get().contains(notification.getNotifier())) {
 
@@ -565,25 +555,29 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 	public void refresh() {
 		NotificationChain notifications = null;
 		synchronized (this) {
-			// check content changed
-			if (isFileContentChanged()) {
-				// load type name
-				loadTypeNameFromFile();
-				// clear cached type
-				notifications = basicSetType(null, notifications);
-				// also notify changed contents
-				if (eNotificationRequired()) {
-					notifications = chainNotification(notifications,
-							new TypeEntryNotificationImpl(this, Notification.SET,
-									TypeEntry.TYPE_ENTRY_FILE_CONTENT_FEATURE,
-									TypeEntry.TYPE_ENTRY_FILE_CONTENT_FEATURE_ID, null, null));
-				}
-			}
+			notifications = performTypeRefresh(notifications);
 		}
 		// dispatch notifications
 		if (notifications != null) {
 			notifications.dispatch();
 		}
+	}
+
+	protected NotificationChain performTypeRefresh(NotificationChain notifications) {
+		// check content changed
+		if (isFileContentChanged()) {
+			// load type name
+			loadTypeNameFromFile();
+			// clear cached type
+			notifications = basicSetType(null, notifications);
+			// also notify changed contents
+			if (eNotificationRequired()) {
+				notifications = chainNotification(notifications,
+						new TypeEntryNotificationImpl(this, Notification.SET, TypeEntry.TYPE_ENTRY_FILE_CONTENT_FEATURE,
+								TypeEntry.TYPE_ENTRY_FILE_CONTENT_FEATURE_ID, null, null));
+			}
+		}
+		return notifications;
 	}
 
 	@Override
@@ -599,10 +593,6 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 		result.append(lastModificationTimestampEditable);
 		result.append(')');
 		return result.toString();
-	}
-
-	protected final void setUpdateTypeOnSave(final boolean updateTypeOnSave) {
-		this.updateTypeOnSave = updateTypeOnSave;
 	}
 
 	private void writeToFile(final InputStream fileContent, final AbstractTypeExporter exporter,
@@ -637,11 +627,7 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 			// to ensure readers see the new stamp only together with the new type editable
 			lastModificationTimestampEditable.set(modificationStamp);
 
-			// set type (if requested)
-			if (updateTypeOnSave) {
-				// make the edit result available for the reading entities
-				notifications = basicSetType(EcoreUtil.copy(exporter.getType()), notifications);
-			}
+			notifications = updateTypeOnSave(exporter.getType(), notifications);
 
 			// update the last modification stamp _after_ setting the type to ensure other
 			// readers see the new stamp only together with the new type
@@ -651,6 +637,12 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 		if (notifications != null) {
 			notifications.dispatch();
 		}
+	}
+
+	protected NotificationChain updateTypeOnSave(final LibraryElement savedType,
+			final NotificationChain notifications) {
+		// make the edit result available for the reading entities
+		return basicSetType(EcoreUtil.copy(savedType), notifications);
 	}
 
 	/**
@@ -711,7 +703,7 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 		return ""; //$NON-NLS-1$
 	}
 
-	private static NotificationChain chainNotification(final NotificationChain notifications,
+	protected static NotificationChain chainNotification(final NotificationChain notifications,
 			final TypeEntryNotificationImpl notification) {
 		if (notifications == null) {
 			return notification;

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AdapterTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AdapterTypeEntryImpl.java
@@ -34,7 +34,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.typelibrary.AdapterTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 
-public class AdapterTypeEntryImpl extends AbstractCheckedTypeEntryImpl<AdapterType> implements AdapterTypeEntry {
+public class AdapterTypeEntryImpl extends AbstractInterfaceTypeEntryImpl<AdapterType> implements AdapterTypeEntry {
 
 	public AdapterTypeEntryImpl() {
 		super(AdapterType.class);

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/ErrorAdapterTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/ErrorAdapterTypeEntryImpl.java
@@ -12,8 +12,15 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.model.typelibrary.impl;
 
+import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.model.typelibrary.ErrorTypeEntry;
 
 public class ErrorAdapterTypeEntryImpl extends AdapterTypeEntryImpl implements ErrorTypeEntry {
-	// marker class
+
+	@Override
+	public InterfaceList getInterface() {
+		return LibraryElementFactory.eINSTANCE.createInterfaceList();
+	}
+
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/ErrorFBTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/ErrorFBTypeEntryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Primetals Technologies Austria GmbH
+ * Copyright (c) 2022, 2025 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,8 +12,14 @@
  ******************************************************************************/
 package org.eclipse.fordiac.ide.model.typelibrary.impl;
 
+import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.model.typelibrary.ErrorTypeEntry;
 
 public class ErrorFBTypeEntryImpl extends FBTypeEntryImpl implements ErrorTypeEntry {
-	// marker class
+
+	@Override
+	public InterfaceList getInterface() {
+		return LibraryElementFactory.eINSTANCE.createInterfaceList();
+	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/ErrorSubAppTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/ErrorSubAppTypeEntryImpl.java
@@ -12,8 +12,14 @@
  ******************************************************************************/
 package org.eclipse.fordiac.ide.model.typelibrary.impl;
 
+import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.model.typelibrary.ErrorTypeEntry;
 
 public class ErrorSubAppTypeEntryImpl extends SubAppTypeEntryImpl implements ErrorTypeEntry {
-	// marker class
+
+	@Override
+	public InterfaceList getInterface() {
+		return LibraryElementFactory.eINSTANCE.createInterfaceList();
+	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/FBTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/FBTypeEntryImpl.java
@@ -34,7 +34,7 @@ import org.eclipse.fordiac.ide.model.typelibrary.FBTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 
-public class FBTypeEntryImpl extends AbstractCheckedTypeEntryImpl<FBType> implements FBTypeEntry {
+public class FBTypeEntryImpl extends AbstractInterfaceTypeEntryImpl<FBType> implements FBTypeEntry {
 
 	private static final Pattern TYPE_CLASS_PATTERN = Pattern.compile("<" + //$NON-NLS-1$
 			LibraryElementTags.BASIC_F_B_ELEMENT + ">|<" //$NON-NLS-1$

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/FunctionFBTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/FunctionFBTypeEntryImpl.java
@@ -22,7 +22,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.typelibrary.FunctionFBTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 
-public class FunctionFBTypeEntryImpl extends AbstractCheckedTypeEntryImpl<FunctionFBType>
+public class FunctionFBTypeEntryImpl extends AbstractInterfaceTypeEntryImpl<FunctionFBType>
 		implements FunctionFBTypeEntry {
 
 	public FunctionFBTypeEntryImpl() {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/SubAppTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/SubAppTypeEntryImpl.java
@@ -25,7 +25,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.SubAppType;
 import org.eclipse.fordiac.ide.model.typelibrary.SubAppTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 
-public class SubAppTypeEntryImpl extends AbstractCheckedTypeEntryImpl<SubAppType> implements SubAppTypeEntry {
+public class SubAppTypeEntryImpl extends AbstractInterfaceTypeEntryImpl<SubAppType> implements SubAppTypeEntry {
 
 	public SubAppTypeEntryImpl() {
 		super(SubAppType.class);

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/SystemEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/SystemEntryImpl.java
@@ -32,8 +32,6 @@ public class SystemEntryImpl extends AbstractCheckedTypeEntryImpl<AutomationSyst
 
 	public SystemEntryImpl() {
 		super(AutomationSystem.class);
-		// for system entries we don't want to perform any updates on save
-		setUpdateTypeOnSave(false);
 	}
 
 	@Override
@@ -97,6 +95,14 @@ public class SystemEntryImpl extends AbstractCheckedTypeEntryImpl<AutomationSyst
 	@Override
 	protected LibraryElement basicGetTypeEditable() {
 		return super.basicGetType();
+	}
+
+	@Override
+	protected NotificationChain updateTypeOnSave(final LibraryElement savedType,
+			final NotificationChain notifications) {
+		// for systems we are not maintaining a separate type so nothing needs to be
+		// done here
+		return notifications;
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.resourceediting/src/org/eclipse/fordiac/ide/resourceediting/editparts/ResourceDiagramEditPartFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.resourceediting/src/org/eclipse/fordiac/ide/resourceediting/editparts/ResourceDiagramEditPartFactory.java
@@ -16,7 +16,7 @@ package org.eclipse.fordiac.ide.resourceediting.editparts;
 import org.eclipse.fordiac.ide.application.editparts.ElementEditPartFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
-import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
+import org.eclipse.fordiac.ide.model.libraryElement.UntypedSubApp;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.ui.parts.GraphicalEditor;
 
@@ -33,9 +33,8 @@ public class ResourceDiagramEditPartFactory extends ElementEditPartFactory {
 
 	@Override
 	protected EditPart getPartForElement(final EditPart context, final Object modelElement) {
-		if (modelElement instanceof IInterfaceElement) {
-			final IInterfaceElement element = (IInterfaceElement) modelElement;
-			if (element.getFBNetworkElement() instanceof SubApp && null == element.getFBNetworkElement().getType()) {
+		if (modelElement instanceof final IInterfaceElement element) {
+			if (element.getFBNetworkElement() instanceof UntypedSubApp) {
 				return new UntypedSubAppInterfaceElementEditPartForResource();
 			}
 			return new InterfaceEditPartForResourceFBs();

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm/src/org/eclipse/fordiac/ide/structuredtextalgorithm/util/StructuredTextParseUtil.xtend
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm/src/org/eclipse/fordiac/ide/structuredtextalgorithm/util/StructuredTextParseUtil.xtend
@@ -142,7 +142,7 @@ class StructuredTextParseUtil {
 		List<String> infos) {
 		val parser = SERVICE_PROVIDER_FBT.get(IParser) as STAlgorithmParser
 		// use context from FB type since the type declaration is in the context of the FB type (and not an instance)
-		val typeVariable = decl.FBNetworkElement?.type?.interfaceList?.getVariable(decl.name) ?: decl
+		val typeVariable = decl.findInTypeInterface() ?: decl
 		decl.fullTypeName.parse(parser.grammarAccess.STTypeDeclarationRule, typeVariable?.eResource?.URI, null,
 			decl.name, typeVariable.getContainerOfType(LibraryElement), null, errors, warnings, infos)?.
 			rootASTElement as STTypeDeclaration

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/filters/TypedSubappFilter.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/filters/TypedSubappFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Primetals Technologies Germany GmbH
+ * Copyright (c) 2021, 2025 Primetals Technologies Germany GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,16 +12,15 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.systemmanagement.ui.filters;
 
-import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
+import org.eclipse.fordiac.ide.model.libraryElement.TypedSubApp;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerFilter;
 
 public class TypedSubappFilter extends ViewerFilter {
 
-
 	@Override
 	public boolean select(final Viewer viewer, final Object parentElement, final Object element) {
-		return !(element instanceof SubApp && ((SubApp) element).getType() != null);
+		return !(element instanceof TypedSubApp);
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/linkhelpers/SystemExplorerLinkHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/linkhelpers/SystemExplorerLinkHelper.java
@@ -158,7 +158,7 @@ public class SystemExplorerLinkHelper implements ILinkHelper {
 
 	private static EObject getBreadCrumbRefElement(final EObject sel) {
 		EObject refElement = sel;
-		if ((sel instanceof final FBNetworkElement fbnEl && fbnEl.getType() != null) || (sel instanceof Group)) {
+		if ((sel instanceof final FBNetworkElement fbnEl && fbnEl.getTypeEntry() != null) || (sel instanceof Group)) {
 			refElement = sel.eContainer().eContainer();
 		}
 		// For unfolded subapps find the next parent that is not expanded as refElement

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/systemexplorer/InstanceTypeDecorator.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/systemexplorer/InstanceTypeDecorator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Primetals Technologies Austria GmbH
+ * Copyright (c) 2021, 2025 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,7 +13,7 @@
 package org.eclipse.fordiac.ide.systemmanagement.ui.systemexplorer;
 
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
-import org.eclipse.fordiac.ide.model.libraryElement.FBType;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.jface.viewers.IDecoration;
 import org.eclipse.jface.viewers.ILabelProviderListener;
 import org.eclipse.jface.viewers.ILightweightLabelDecorator;
@@ -43,10 +43,10 @@ public class InstanceTypeDecorator implements ILightweightLabelDecorator {
 
 	@Override
 	public void decorate(final Object element, final IDecoration decoration) {
-		if (element instanceof FBNetworkElement) {
-			final FBType type = ((FBNetworkElement) element).getType();
-			if (null != type) {
-				decoration.addSuffix(" - " + type.getName()); //$NON-NLS-1$
+		if (element instanceof final FBNetworkElement fbnEl) {
+			final TypeEntry typeEntry = fbnEl.getTypeEntry();
+			if (typeEntry != null) {
+				decoration.addSuffix(" - " + typeEntry.getTypeName()); //$NON-NLS-1$
 			}
 		}
 	}

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/changelistener/FordiacResourceChangeListener.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/changelistener/FordiacResourceChangeListener.java
@@ -162,8 +162,7 @@ public class FordiacResourceChangeListener implements IResourceChangeListener {
 		final IFile file = (IFile) delta.getResource();
 
 		final TypeEntry typeEntryForFile = TypeLibraryManager.INSTANCE.getTypeEntryForFile(file);
-		if (typeEntryForFile != null
-				&& typeEntryForFile.getLastModificationTimestamp() != file.getModificationStamp()) {
+		if (typeEntryForFile != null) {
 			typeEntryForFile.refresh();
 		}
 	}

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/connection/ConnectionsToStructRefactoring.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/connection/ConnectionsToStructRefactoring.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Primetals Technologies Austria GmbH
+ * Copyright (c) 2024, 2025 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -41,6 +41,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.ServiceInterfaceFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.With;
 import org.eclipse.fordiac.ide.model.search.types.BlockTypeInstanceSearch;
+import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
@@ -246,8 +247,8 @@ public class ConnectionsToStructRefactoring extends Refactoring {
 			status.merge(RefactoringStatus.createFatalErrorStatus(
 					MessageFormat.format(Messages.ConnectionsToStructRefactoring_InvalidName, target)));
 		}
-		if ((TypeLibraryManager.INSTANCE.getTypeEntryForURI(fbURI).getType() instanceof final FBType fbType)
-				&& (fbType.getInterfaceList().getAllInterfaceElements().stream()
+		if ((TypeLibraryManager.INSTANCE.getTypeEntryForURI(fbURI) instanceof final InterfaceTypeEntry ifTypeEntry)
+				&& (ifTypeEntry.getInterface().getAllInterfaceElements().stream()
 						.anyMatch(port -> port.getName().equals(name)) && !nameCol.contains(name))) {
 			status.merge(RefactoringStatus.createFatalErrorStatus(
 					MessageFormat.format(Messages.ConnectionsToStructRefactoring_NameExists, target)));

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/rename/RenameElementRefactoringHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/rename/RenameElementRefactoringHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Martin Erich Jobst
+ * Copyright (c) 2024, 2025 Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,9 +19,9 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
-import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 import org.eclipse.fordiac.ide.typemanagement.refactoring.RefactoringUtil;
 import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 import org.eclipse.gef.EditPart;
@@ -67,12 +67,9 @@ public class RenameElementRefactoringHandler extends AbstractHandler {
 		}
 		if (element instanceof final IInterfaceElement interfaceElement) {
 			final FBNetworkElement fbNetworkElement = interfaceElement.getFBNetworkElement();
-			if (fbNetworkElement != null && fbNetworkElement.getTypeEntry() != null) {
-				final FBType fbType = fbNetworkElement.getType();
-				if (fbType != null) {
-					return getElementURI(fbType.getInterfaceList().getInterfaceElement(interfaceElement.getName()));
-				}
-				return null; // do not refactor typed instances
+			if (fbNetworkElement != null
+					&& fbNetworkElement.getTypeEntry() instanceof final InterfaceTypeEntry ifTypeEntry) {
+				return getElementURI(ifTypeEntry.getInterface().getInterfaceElement(interfaceElement.getName()));
 			}
 			// fall through
 		}

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/rename/RenameElementRefactoringHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/rename/RenameElementRefactoringHandler.java
@@ -21,7 +21,6 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
-import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.typemanagement.refactoring.RefactoringUtil;
 import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 import org.eclipse.gef.EditPart;
@@ -67,13 +66,9 @@ public class RenameElementRefactoringHandler extends AbstractHandler {
 		}
 		if (element instanceof final IInterfaceElement interfaceElement) {
 			final FBNetworkElement fbNetworkElement = interfaceElement.getFBNetworkElement();
-			if (fbNetworkElement != null) {
-				final InterfaceList typeInterface = fbNetworkElement.getTypeInterface();
-				if (typeInterface != null) {
-					return getElementURI(typeInterface.getInterfaceElement(interfaceElement.getName()));
-				}
+			if (fbNetworkElement != null && fbNetworkElement.getTypeEntry() != null) {
+				return getElementURI(interfaceElement.findInTypeInterface());
 			}
-			// fall through
 		}
 		if (element instanceof final EObject eObject) {
 			return EcoreUtil.getURI(eObject);

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/rename/RenameElementRefactoringHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/rename/RenameElementRefactoringHandler.java
@@ -21,7 +21,7 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
-import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
+import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.typemanagement.refactoring.RefactoringUtil;
 import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 import org.eclipse.gef.EditPart;
@@ -67,9 +67,11 @@ public class RenameElementRefactoringHandler extends AbstractHandler {
 		}
 		if (element instanceof final IInterfaceElement interfaceElement) {
 			final FBNetworkElement fbNetworkElement = interfaceElement.getFBNetworkElement();
-			if (fbNetworkElement != null
-					&& fbNetworkElement.getTypeEntry() instanceof final InterfaceTypeEntry ifTypeEntry) {
-				return getElementURI(ifTypeEntry.getInterface().getInterfaceElement(interfaceElement.getName()));
+			if (fbNetworkElement != null) {
+				final InterfaceList typeInterface = fbNetworkElement.getTypeInterface();
+				if (typeInterface != null) {
+					return getElementURI(typeInterface.getInterfaceElement(interfaceElement.getName()));
+				}
 			}
 			// fall through
 		}

--- a/tests/org.eclipse.fordiac.ide.test.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeTypeCommandTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeTypeCommandTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.params.provider.Arguments;
 public class ChangeTypeCommandTest extends FBNetworkTestBase {
 
 	private static State changeDataInputType(final State state) {
-		final InterfaceList fb = state.getFunctionblock().getType().getInterfaceList();
+		final InterfaceList fb = state.getFunctionblock().getInterface();
 
 		state.setCommand(ChangeDataTypeCommand.forDataType(fb.getInputVars().get(0),
 				getDatatypelib().getType(FordiacKeywords.LWORD)));
@@ -33,14 +33,14 @@ public class ChangeTypeCommandTest extends FBNetworkTestBase {
 	}
 
 	private static void validateDataInputType(final State state, final State oldState, final TestFunction t) {
-		final InterfaceList fb = state.getFunctionblock().getType().getInterfaceList();
+		final InterfaceList fb = state.getFunctionblock().getInterface();
 		t.test(fb.getInputVars().get(0).getTypeName(), FordiacKeywords.LWORD);
 		t.test(fb.getInputVars().get(0).getType(), getDatatypelib().getType(FordiacKeywords.LWORD));
 	}
 
 	private static void validateDataInputTypeNetworkElements(final State state, final State oldState,
 			final TestFunction t) {
-		final InterfaceList fb = state.getFunctionblock().getType().getInterfaceList();
+		final InterfaceList fb = state.getFunctionblock().getInterface();
 		final InterfaceList fb1 = state.getFbNetwork().getNetworkElements().get(0).getInterface();
 		final InterfaceList fb2 = state.getFbNetwork().getNetworkElements().get(1).getInterface();
 

--- a/tests/org.eclipse.fordiac.ide.test.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/ConnectionCommandsTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/ConnectionCommandsTest.java
@@ -29,10 +29,10 @@ public class ConnectionCommandsTest extends FBNetworkTestBase {
 
 	public static State addIOWiths(final State state) {
 		final CompoundCommand c = new CompoundCommand();
-		c.add(new WithCreateCommand(state.getFunctionblock().getType().getInterfaceList().getEventInputs().get(0),
-				state.getFunctionblock().getType().getInterfaceList().getInputVars().get(0)));
-		c.add(new WithCreateCommand(state.getFunctionblock().getType().getInterfaceList().getEventOutputs().get(0),
-				state.getFunctionblock().getType().getInterfaceList().getOutputVars().get(0)));
+		c.add(new WithCreateCommand(state.getFunctionblock().getInterface().getEventInputs().get(0),
+				state.getFunctionblock().getInterface().getInputVars().get(0)));
+		c.add(new WithCreateCommand(state.getFunctionblock().getInterface().getEventOutputs().get(0),
+				state.getFunctionblock().getInterface().getOutputVars().get(0)));
 		state.setCommand(c);
 		return commandExecution(state);
 	}
@@ -43,7 +43,6 @@ public class ConnectionCommandsTest extends FBNetworkTestBase {
 		state = WithCreateTest.updateNetworkElements(state);
 		return state;
 	}
-
 
 	public static State workingAddDataConnection(final State state) {
 		addDataConnection(state);
@@ -120,7 +119,8 @@ public class ConnectionCommandsTest extends FBNetworkTestBase {
 
 		t.test(state.getMessages().isEmpty());
 		t.test(fb1.getEventOutputs().get(0).getOutputConnections().size(), 1);
-		t.test(fb1.getEventOutputs().get(0).getOutputConnections().get(0).getDestination(), fb2.getEventInputs().get(0));
+		t.test(fb1.getEventOutputs().get(0).getOutputConnections().get(0).getDestination(),
+				fb2.getEventInputs().get(0));
 	}
 
 	private static Collection<Arguments> twoFunctionBlocks(final List<ExecutionDescription<?>> executionDescriptions) {
@@ -128,7 +128,7 @@ public class ConnectionCommandsTest extends FBNetworkTestBase {
 				ConnectionCommandsTest::initState, //
 				(StateVerifier<State>) CommandTestBase::verifyNothing, //
 				executionDescriptions //
-				);
+		);
 	}
 
 	private static State deleteDataConnection(final State state) {
@@ -179,54 +179,54 @@ public class ConnectionCommandsTest extends FBNetworkTestBase {
 				new ExecutionDescription<>("Add data connection between data interface points", //$NON-NLS-1$
 						ConnectionCommandsTest::workingAddDataConnection, //
 						ConnectionCommandsTest::verifyDataConnection //
-						), //
+				), //
 				new ExecutionDescription<>("Add event connection between event interface points", //$NON-NLS-1$
 						ConnectionCommandsTest::workingAddEventConnection, //
 						ConnectionCommandsTest::verifyEventConnection //
-						), //
+				), //
 				new ExecutionDescription<>("Delete data connection between event interface points", //$NON-NLS-1$
 						ConnectionCommandsTest::deleteDataConnection, //
 						ConnectionCommandsTest::verifyDeleteDataConnection //
-						), //
+				), //
 				new ExecutionDescription<>("Delete event connection between event interface points", //$NON-NLS-1$
 						ConnectionCommandsTest::deleteEventConnection, //
 						ConnectionCommandsTest::verifyDeleteEventConnection //
-						) //
-				)));
+				) //
+		)));
 
 		commands.addAll(twoFunctionBlocks(List.of( //
 				new ExecutionDescription<>("Add reverse data connection between data interface points", //$NON-NLS-1$
 						ConnectionCommandsTest::workingAddReverseDataConnection, //
 						ConnectionCommandsTest::verifyDataConnection //
-						), //
+				), //
 				new ExecutionDescription<>("Add reverse event connection between event interface points", //$NON-NLS-1$
 						ConnectionCommandsTest::workingAddReverseEventConnection, //
 						ConnectionCommandsTest::verifyEventConnection //
-						), //
+				), //
 				new ExecutionDescription<>("Delete data connection between event interface points", //$NON-NLS-1$
 						ConnectionCommandsTest::deleteDataConnection, //
 						ConnectionCommandsTest::verifyDeleteDataConnection //
-						), //
+				), //
 				new ExecutionDescription<>("Delete event connection between event interface points", //$NON-NLS-1$
 						ConnectionCommandsTest::deleteEventConnection, //
 						ConnectionCommandsTest::verifyDeleteEventConnection //
-						) //
-				)));
+				) //
+		)));
 
 		commands.addAll(twoFunctionBlocks(List.of( //
 				new ExecutionDescription<>("Add reverse data connection between data interface points", //$NON-NLS-1$
 						ConnectionCommandsTest::workingAddReverseDataConnection, //
 						ConnectionCommandsTest::verifyDataConnection //
-						), //
+				), //
 				new ExecutionDescription<>("Add reverse event connection between event interface points", //$NON-NLS-1$
 						ConnectionCommandsTest::workingAddReverseEventConnection, //
 						ConnectionCommandsTest::verifyEventConnection //
-						), //
+				), //
 				new ExecutionDescription<>("Delete second functionblock und remove connections", //$NON-NLS-1$
 						ConnectionCommandsTest::deleteFB2, //
 						ConnectionCommandsTest::verifyDeleteFB2 //
-						) //
-				)));
+				) //
+		)));
 		return commands;
 	}
 }

--- a/tests/org.eclipse.fordiac.ide.test.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/FBCreateCommandTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/FBCreateCommandTest.java
@@ -48,17 +48,17 @@ public class FBCreateCommandTest extends FBNetworkTestBase {
 		t.test(state.getFbNetwork().getNetworkElements().get(0).getName());
 		t.test(state.getFbNetwork().getNetworkElements().get(0).eContainer());
 		t.test(state.getFbNetwork().getNetworkElements().get(0).getInterface().getEventInputs()
-				.equals(state.getFunctionblock().getType().getInterfaceList().getEventInputs()));
+				.equals(state.getFunctionblock().getInterface().getEventInputs()));
 		t.test(state.getFbNetwork().getNetworkElements().get(0).getInterface().getEventOutputs()
-				.equals(state.getFunctionblock().getType().getInterfaceList().getEventOutputs()));
+				.equals(state.getFunctionblock().getInterface().getEventOutputs()));
 		t.test(state.getFbNetwork().getNetworkElements().get(0).getInterface().getInputVars()
-				.equals(state.getFunctionblock().getType().getInterfaceList().getInputVars()));
+				.equals(state.getFunctionblock().getInterface().getInputVars()));
 		t.test(state.getFbNetwork().getNetworkElements().get(0).getInterface().getOutputVars()
-				.equals(state.getFunctionblock().getType().getInterfaceList().getOutputVars()));
+				.equals(state.getFunctionblock().getInterface().getOutputVars()));
 		t.test(state.getFbNetwork().getNetworkElements().get(0).getInterface().getPlugs()
-				.equals(state.getFunctionblock().getType().getInterfaceList().getPlugs()));
+				.equals(state.getFunctionblock().getInterface().getPlugs()));
 		t.test(state.getFbNetwork().getNetworkElements().get(0).getInterface().getSockets()
-				.equals(state.getFunctionblock().getType().getInterfaceList().getSockets()));
+				.equals(state.getFunctionblock().getInterface().getSockets()));
 	}
 
 	// parameter creation function
@@ -67,8 +67,8 @@ public class FBCreateCommandTest extends FBNetworkTestBase {
 				new ExecutionDescription<>("Add Functionblock", //$NON-NLS-1$
 						FBCreateCommandTest::executeCommand, //
 						FBCreateCommandTest::verifyState //
-						) //
-				);
+				) //
+		);
 
 		return createCommands(executionDescriptions);
 	}

--- a/tests/org.eclipse.fordiac.ide.test.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/WithCreateTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/WithCreateTest.java
@@ -32,19 +32,19 @@ public class WithCreateTest extends FBNetworkTestBase {
 		final CompoundCommand c = new CompoundCommand();
 
 		c.add(new CreateInterfaceElementCommand(EventTypeLibrary.getInstance().getType(null),
-				state.getFunctionblock().getType().getInterfaceList(), /* isInput */ true, /* index */ 0));
+				state.getFunctionblock().getInterface(), /* isInput */ true, /* index */ 0));
 		c.add(new CreateInterfaceElementCommand(EventTypeLibrary.getInstance().getType(null),
-				state.getFunctionblock().getType().getInterfaceList(), /* isInput */ false, /* index */ 0));
+				state.getFunctionblock().getInterface(), /* isInput */ false, /* index */ 0));
 
 		c.add(new CreateInterfaceElementCommand(getDatatypelib().getType(FordiacKeywords.BOOL),
-				state.getFunctionblock().getType().getInterfaceList(), /* isInput */ true, /* index */ 0));
+				state.getFunctionblock().getInterface(), /* isInput */ true, /* index */ 0));
 		c.add(new CreateInterfaceElementCommand(getDatatypelib().getType(FordiacKeywords.BOOL),
-				state.getFunctionblock().getType().getInterfaceList(), /* isInput */ false, /* index */ 0));
+				state.getFunctionblock().getInterface(), /* isInput */ false, /* index */ 0));
 
 		c.add(new CreateInterfaceElementCommand(getDatatypelib().getType(FordiacKeywords.DWORD),
-				state.getFunctionblock().getType().getInterfaceList(), /* isInput */ true, /* index */ 1));
+				state.getFunctionblock().getInterface(), /* isInput */ true, /* index */ 1));
 		c.add(new CreateInterfaceElementCommand(getDatatypelib().getType(FordiacKeywords.DWORD),
-				state.getFunctionblock().getType().getInterfaceList(), /* isInput */ false, /* index */ 1));
+				state.getFunctionblock().getInterface(), /* isInput */ false, /* index */ 1));
 
 		c.add(new FBCreateCommand(state.getFunctionblock(), state.getFbNetwork(), 0, 0));
 
@@ -63,27 +63,26 @@ public class WithCreateTest extends FBNetworkTestBase {
 		t.test(state.getFbNetwork().getNetworkElements().get(0).getInterface().getEventOutputs().size(), 1);
 		t.test(state.getFbNetwork().getNetworkElements().get(0).getInterface().getInputVars().size(), 2);
 		t.test(state.getFbNetwork().getNetworkElements().get(0).getInterface().getOutputVars().size(), 2);
-		t.test(state.getFunctionblock().getType().getInterfaceList().getEventInputs().get(0).getWith().isEmpty());
+		t.test(state.getFunctionblock().getInterface().getEventInputs().get(0).getWith().isEmpty());
 		t.test(state.getFbNetwork().getNetworkElements().get(0).getInterface().getEventInputs().get(0).getWith()
 				.isEmpty());
 	}
 
 	private static State addWith(final State state) {
-		state.setCommand(
-				new WithCreateCommand(state.getFunctionblock().getType().getInterfaceList().getEventInputs().get(0),
-						state.getFunctionblock().getType().getInterfaceList().getInputVars().get(0)));
+		state.setCommand(new WithCreateCommand(state.getFunctionblock().getInterface().getEventInputs().get(0),
+				state.getFunctionblock().getInterface().getInputVars().get(0)));
 
 		return commandExecution(state);
 	}
 
 	private static void verifyAddWith(final State state, final State oldState, final TestFunction t) {
-		t.test(!state.getFunctionblock().getType().getInterfaceList().getEventInputs().get(0).getWith().isEmpty());
+		t.test(!state.getFunctionblock().getInterface().getEventInputs().get(0).getWith().isEmpty());
 		t.test(state.getFbNetwork().getNetworkElements().get(0).getInterface().getEventInputs().get(0).getWith()
 				.isEmpty());
 
 		final WithCreateCommand c = new WithCreateCommand(
-				state.getFunctionblock().getType().getInterfaceList().getEventInputs().get(0),
-				state.getFunctionblock().getType().getInterfaceList().getInputVars().get(0));
+				state.getFunctionblock().getInterface().getEventInputs().get(0),
+				state.getFunctionblock().getInterface().getInputVars().get(0));
 		t.test(c.getEvent());
 		t.test(c.getVarDeclaration());
 	}
@@ -98,26 +97,28 @@ public class WithCreateTest extends FBNetworkTestBase {
 		return commandExecution(state);
 	}
 
-	private static void verifyUpdateNetworkElementsAddedWith(final State state, final State oldState, final TestFunction t) {
-		t.test(!state.getFunctionblock().getType().getInterfaceList().getEventInputs().get(0).getWith().isEmpty());
+	private static void verifyUpdateNetworkElementsAddedWith(final State state, final State oldState,
+			final TestFunction t) {
+		t.test(!state.getFunctionblock().getInterface().getEventInputs().get(0).getWith().isEmpty());
 		t.test(!state.getFbNetwork().getNetworkElements().get(0).getInterface().getEventInputs().get(0).getWith()
 				.isEmpty());
 	}
 
 	private static State deleteWith(final State state) {
 		state.setCommand(new DeleteWithCommand(
-				state.getFunctionblock().getType().getInterfaceList().getEventInputs().get(0).getWith().get(0)));
+				state.getFunctionblock().getInterface().getEventInputs().get(0).getWith().get(0)));
 		return commandExecution(state);
 	}
 
 	private static void verifyDeleteWith(final State state, final State oldState, final TestFunction t) {
-		t.test(state.getFunctionblock().getType().getInterfaceList().getEventInputs().get(0).getWith().isEmpty());
+		t.test(state.getFunctionblock().getInterface().getEventInputs().get(0).getWith().isEmpty());
 		t.test(!state.getFbNetwork().getNetworkElements().get(0).getInterface().getEventInputs().get(0).getWith()
 				.isEmpty());
 	}
 
-	private static void verifyUpdateNetworkElementsDeletedWith(final State state, final State oldState, final TestFunction t) {
-		t.test(state.getFunctionblock().getType().getInterfaceList().getEventInputs().get(0).getWith().isEmpty());
+	private static void verifyUpdateNetworkElementsDeletedWith(final State state, final State oldState,
+			final TestFunction t) {
+		t.test(state.getFunctionblock().getInterface().getEventInputs().get(0).getWith().isEmpty());
 		t.test(state.getFbNetwork().getNetworkElements().get(0).getInterface().getEventInputs().get(0).getWith()
 				.isEmpty());
 	}
@@ -128,21 +129,19 @@ public class WithCreateTest extends FBNetworkTestBase {
 	}
 
 	private static State nullEvent(final State state) {
-		state.setCommand(new WithCreateCommand(null,
-				state.getFunctionblock().getType().getInterfaceList().getInputVars().get(0)));
+		state.setCommand(new WithCreateCommand(null, state.getFunctionblock().getInterface().getInputVars().get(0)));
 		return disabledCommandExecution(state);
 	}
 
 	private static State nullInput(final State state) {
-		state.setCommand(new WithCreateCommand(
-				state.getFunctionblock().getType().getInterfaceList().getEventInputs().get(0), null));
+		state.setCommand(new WithCreateCommand(state.getFunctionblock().getInterface().getEventInputs().get(0), null));
 		return disabledCommandExecution(state);
 	}
 
 	private static State onEventOutput(final State state) {
 		final WithCreateCommand c = new WithCreateCommand();
-		c.setEvent(state.getFunctionblock().getType().getInterfaceList().getEventOutputs().get(0));
-		c.setVarDeclaration(state.getFunctionblock().getType().getInterfaceList().getInputVars().get(0));
+		c.setEvent(state.getFunctionblock().getInterface().getEventOutputs().get(0));
+		c.setVarDeclaration(state.getFunctionblock().getInterface().getInputVars().get(0));
 
 		state.setCommand(c);
 
@@ -150,16 +149,14 @@ public class WithCreateTest extends FBNetworkTestBase {
 	}
 
 	private static State onOutput(final State state) {
-		state.setCommand(
-				new WithCreateCommand(state.getFunctionblock().getType().getInterfaceList().getEventInputs().get(0),
-						state.getFunctionblock().getType().getInterfaceList().getOutputVars().get(0)));
+		state.setCommand(new WithCreateCommand(state.getFunctionblock().getInterface().getEventInputs().get(0),
+				state.getFunctionblock().getInterface().getOutputVars().get(0)));
 		return disabledCommandExecution(state);
 	}
 
 	private static State addExistingWith(final State state) {
-		state.setCommand(
-				new WithCreateCommand(state.getFunctionblock().getType().getInterfaceList().getEventInputs().get(0),
-						state.getFunctionblock().getType().getInterfaceList().getInputVars().get(0)));
+		state.setCommand(new WithCreateCommand(state.getFunctionblock().getInterface().getEventInputs().get(0),
+				state.getFunctionblock().getInterface().getInputVars().get(0)));
 		return disabledCommandExecution(state);
 	}
 
@@ -176,52 +173,52 @@ public class WithCreateTest extends FBNetworkTestBase {
 				new ExecutionDescription<>("Prepare Functionblocks", //$NON-NLS-1$
 						WithCreateTest::createInterfaceElements, //
 						WithCreateTest::verifyFBCreation //
-						), //
+				), //
 				new ExecutionDescription<>("Add with at functionblock", //$NON-NLS-1$
 						WithCreateTest::addWith, //
 						WithCreateTest::verifyAddWith //
-						), //
+				), //
 				new ExecutionDescription<>("Update Network Elements", //$NON-NLS-1$
 						WithCreateTest::updateNetworkElements, //
 						WithCreateTest::verifyUpdateNetworkElementsAddedWith //
-						), //
+				), //
 				new ExecutionDescription<>("Delete With from functionblock", //$NON-NLS-1$
 						WithCreateTest::deleteWith, //
 						WithCreateTest::verifyDeleteWith //
-						), //
+				), //
 				new ExecutionDescription<>("Update Network Elements", //$NON-NLS-1$
 						WithCreateTest::updateNetworkElements, //
 						WithCreateTest::verifyUpdateNetworkElementsDeletedWith //
-						), //
+				), //
 				new ExecutionDescription<>("Create With without inferface data", //$NON-NLS-1$
 						WithCreateTest::nullAll, //
 						CommandTestBase::verifyNothing //
-						), //
+				), //
 				new ExecutionDescription<>("Create With without event", //$NON-NLS-1$
 						WithCreateTest::nullEvent, //
 						CommandTestBase::verifyNothing //
-						), //
+				), //
 				new ExecutionDescription<>("Create With without input", //$NON-NLS-1$
 						WithCreateTest::nullInput, //
 						CommandTestBase::verifyNothing //
-						), //
+				), //
 				new ExecutionDescription<>("Create With on event-output", //$NON-NLS-1$
 						WithCreateTest::onEventOutput, //
 						WithCreateTest::verifyNothing //
-						), //
+				), //
 				new ExecutionDescription<>("Create With on output", //$NON-NLS-1$
 						WithCreateTest::onOutput, //
 						WithCreateTest::verifyNothing //
-						), //
+				), //
 				new ExecutionDescription<>("Add with at functionblock", //$NON-NLS-1$
 						WithCreateTest::addWith, //
 						WithCreateTest::verifyAddWith //
-						), //
+				), //
 				new ExecutionDescription<>("Add with at functionblock that already exists", //$NON-NLS-1$
 						WithCreateTest::addExistingWith, //
 						WithCreateTest::verifyAddExistingWith //
-						) //
-				);
+				) //
+		);
 		return createCommands(executionDescriptions);
 	}
 

--- a/tests/org.eclipse.fordiac.ide.test.model.commands/src/org/eclipse/fordiac/ide/model/commands/testinfra/CreateInterfaceElementCommandTestBase.java
+++ b/tests/org.eclipse.fordiac.ide.test.model.commands/src/org/eclipse/fordiac/ide/model/commands/testinfra/CreateInterfaceElementCommandTestBase.java
@@ -50,13 +50,13 @@ public abstract class CreateInterfaceElementCommandTestBase extends FBNetworkTes
 				CreateInterfaceElementCommandTestBase::initializeState, //
 				(StateVerifier<State>) CreateInterfaceElementCommandTestBase::verifyInitialState, //
 				executionDescriptions //
-				));
+		));
 
 		return commands;
 	}
 
 	protected static InterfaceList getTypeInterfaceList(final State s) {
-		return s.getFunctionblock().getType().getInterfaceList();
+		return s.getFunctionblock().getInterface();
 	}
 
 	protected static InterfaceList getInstanceInterfaceList(final State s) {
@@ -70,15 +70,15 @@ public abstract class CreateInterfaceElementCommandTestBase extends FBNetworkTes
 		return commandExecution(state);
 	}
 
-	private static <V extends IInterfaceElement> State executeReorder(final State state, final Function<State, EList<V>> translator,
-			final int index, final boolean direction) {
+	private static <V extends IInterfaceElement> State executeReorder(final State state,
+			final Function<State, EList<V>> translator, final int index, final boolean direction) {
 		final EList<V> list = translator.apply(state);
 		state.setCommand(new ChangeInterfaceOrderCommand(list.get(index), direction));
 		return commandExecution(state);
 	}
 
-	private static <V extends IInterfaceElement> State executeReorder(final State state, final Function<State, EList<V>> translator,
-			final int index, final int newPosition) {
+	private static <V extends IInterfaceElement> State executeReorder(final State state,
+			final Function<State, EList<V>> translator, final int index, final int newPosition) {
 		final EList<V> list = translator.apply(state);
 		state.setCommand(new ChangeInterfaceOrderCommand(list.get(index), newPosition));
 		return commandExecution(state);
@@ -94,7 +94,8 @@ public abstract class CreateInterfaceElementCommandTestBase extends FBNetworkTes
 	}
 
 	protected static <V extends IInterfaceElement> Collection<ExecutionDescription<State>> createReordering(
-			final Function<State, EList<V>> translator, final String element1, final String element2, final String element3) {
+			final Function<State, EList<V>> translator, final String element1, final String element2,
+			final String element3) {
 		return List.of( //
 				new ExecutionDescription<>("validate order", //$NON-NLS-1$
 						CreateInterfaceElementCommandTestBase::executeNOP, //
@@ -120,7 +121,7 @@ public abstract class CreateInterfaceElementCommandTestBase extends FBNetworkTes
 						(final State s) -> executeReorder(s, translator, 0, 2), //
 						(final State s, final State o, final TestFunction t) -> verifyOrder(s, t, translator, element1,
 								element2, element3)) //
-				);
+		);
 	}
 
 	private static State executeUpdate(final State state) {
@@ -143,7 +144,7 @@ public abstract class CreateInterfaceElementCommandTestBase extends FBNetworkTes
 				new ExecutionDescription<>("update FB", // //$NON-NLS-1$
 						CreateInterfaceElementCommandTestBase::executeUpdate, //
 						v) //
-				);
+		);
 	}
 
 }

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/AttributeTypeEntryMock.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/AttributeTypeEntryMock.java
@@ -1,5 +1,5 @@
 /*********************************************************************************
- * Copyright (c) 2022 Primetals Technologies Austria GmbH
+ * Copyright (c) 2022, 2025 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -52,16 +52,6 @@ public class AttributeTypeEntryMock extends BasicNotifierImpl implements Attribu
 	@Override
 	public void setFile(final IFile value) {
 		file = value;
-	}
-
-	@Override
-	public long getLastModificationTimestamp() {
-		return 0;
-	}
-
-	@Override
-	public void setLastModificationTimestamp(final long value) {
-		// currently not needed in mock
 	}
 
 	@Override

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/DataTypeEntryMock.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/DataTypeEntryMock.java
@@ -1,5 +1,5 @@
 /*********************************************************************************
- * Copyright (c) 2022 Primetals Technologies Austria GmbH
+ * Copyright (c) 2022, 2025 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -53,16 +53,6 @@ public final class DataTypeEntryMock extends BasicNotifierImpl implements DataTy
 	@Override
 	public void setFile(final IFile value) {
 		file = value;
-	}
-
-	@Override
-	public long getLastModificationTimestamp() {
-		return 0;
-	}
-
-	@Override
-	public void setLastModificationTimestamp(final long value) {
-		// currently not needed in mock
 	}
 
 	@Override

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/FBTypeEntryMock.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/FBTypeEntryMock.java
@@ -1,5 +1,5 @@
 /*********************************************************************************
- * Copyright (c) 2022 Primetals Technologies Austria GmbH
+ * Copyright (c) 2022, 2025 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -21,6 +21,7 @@ import org.eclipse.emf.common.notify.impl.BasicNotifierImpl;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
+import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.typelibrary.FBTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
@@ -54,16 +55,6 @@ public class FBTypeEntryMock extends BasicNotifierImpl implements FBTypeEntry {
 	}
 
 	@Override
-	public long getLastModificationTimestamp() {
-		return 0;
-	}
-
-	@Override
-	public void setLastModificationTimestamp(final long value) {
-		// currently not needed in mock
-	}
-
-	@Override
 	public void setType(final LibraryElement value) {
 		fbType = (FBType) value;
 	}
@@ -90,6 +81,11 @@ public class FBTypeEntryMock extends BasicNotifierImpl implements FBTypeEntry {
 	@Override
 	public FBType getType() {
 		return fbType;
+	}
+
+	@Override
+	public InterfaceList getInterface() {
+		return fbType.getInterfaceList();
 	}
 
 	/**

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/SubAppTypeEntryMock.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/typelibrary/SubAppTypeEntryMock.java
@@ -1,5 +1,5 @@
 /*********************************************************************************
- * Copyright (c) 2022 Primetals Technologies Austria GmbH
+ * Copyright (c) 2022, 2025 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -20,6 +20,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.emf.common.notify.impl.BasicNotifierImpl;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
+import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.libraryElement.SubAppType;
@@ -55,16 +56,6 @@ public final class SubAppTypeEntryMock extends BasicNotifierImpl implements SubA
 	}
 
 	@Override
-	public long getLastModificationTimestamp() {
-		return 0;
-	}
-
-	@Override
-	public void setLastModificationTimestamp(final long value) {
-		// currently not needed in mock
-	}
-
-	@Override
 	public void setType(final LibraryElement value) {
 		subAppType = (SubAppType) value;
 	}
@@ -91,6 +82,11 @@ public final class SubAppTypeEntryMock extends BasicNotifierImpl implements SubA
 	@Override
 	public SubAppType getType() {
 		return subAppType;
+	}
+
+	@Override
+	public InterfaceList getInterface() {
+		return subAppType.getInterfaceList();
 	}
 
 	/**


### PR DESCRIPTION
FB, Adapter Interface, and Subapplication type entries now provide an possibility to only parse the interface. This reduces parsing effort for larger types as for instances only the interface would be needed.