### PR TITLE
Removed GEF Classic Source Features from Target Platform

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.product/org.eclipse.fordiac.ide.product.target
+++ b/plugins/org.eclipse.fordiac.ide.product/org.eclipse.fordiac.ide.product.target
@@ -19,10 +19,8 @@
 			<repository location="https://download.eclipse.org/tools/gef/classic/nightly/latest/"/>
 			<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.draw2d.sdk.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.draw2d.source.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.gef.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.gef.sdk.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.gef.source.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="http://download.eclipse.org/modeling/emf/compare/updates/releases/3.3/R202406060900"/>


### PR DESCRIPTION
Source features are deprecated therefore GEF Classic removed them from their update site. For details see the discussion at the GEF Classic PR: https://github.com/eclipse-gef/gef-classic/pull/773