### PR TITLE
Fix gitlab import wizard ignoring token and url

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gitlab/src/org/eclipse/fordiac/ide/gitlab/management/GitLabDownloader.java
+++ b/plugins/org.eclipse.fordiac.ide.gitlab/src/org/eclipse/fordiac/ide/gitlab/management/GitLabDownloader.java
@@ -38,7 +38,6 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.fordiac.ide.gitlab.Messages;
 import org.eclipse.fordiac.ide.gitlab.Package;
 import org.eclipse.fordiac.ide.gitlab.Project;
-import org.eclipse.fordiac.ide.gitlab.preferences.PreferenceConstants;
 import org.eclipse.fordiac.ide.gitlab.treeviewer.LeafNode;
 import org.eclipse.fordiac.ide.library.DownloadResult;
 import org.eclipse.fordiac.ide.library.IArchiveDownloader;
@@ -74,18 +73,19 @@ public class GitLabDownloader implements IArchiveDownloader {
 
 	private boolean active;
 
-	public GitLabDownloader() {
-		init();
+	public GitLabDownloader(final String token, final String baseUrl) {
+		init(token, baseUrl);
 		versionComparator = new VersionComparator();
 		active = true;
 	}
 
-	public void init() {
-		baseUrl = PreferenceConstants.getURL();
+	public void init(final String token, final String baseUrl) {
 		if (!baseUrl.isBlank() && !baseUrl.endsWith("/")) { //$NON-NLS-1$
-			baseUrl = baseUrl + "/"; //$NON-NLS-1$
+			this.baseUrl = baseUrl + "/"; //$NON-NLS-1$
+		} else {
+			this.baseUrl = baseUrl;
 		}
-		token = PreferenceConstants.getToken();
+		this.token = token;
 	}
 
 	public Map<String, List<LeafNode>> getPackagesAndLeaves() {

--- a/plugins/org.eclipse.fordiac.ide.gitlab/src/org/eclipse/fordiac/ide/gitlab/wizard/GitLabImportWizardPage.java
+++ b/plugins/org.eclipse.fordiac.ide.gitlab/src/org/eclipse/fordiac/ide/gitlab/wizard/GitLabImportWizardPage.java
@@ -61,7 +61,7 @@ public class GitLabImportWizardPage extends WizardPage {
 	}
 
 	private void connect() {
-		downloadManager = new GitLabDownloader();
+		downloadManager = new GitLabDownloader(getToken(), getUrl());
 		downloadManager.fetchProjectsAndPackages();
 
 	}


### PR DESCRIPTION
Gitlab downloader ignored the value of token and URL fields and used the preference values only