### PR TITLE
Upgraded to Eclipse Nebula Widgets 3.2

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.product/org.eclipse.fordiac.ide.product
+++ b/plugins/org.eclipse.fordiac.ide.product/org.eclipse.fordiac.ide.product
@@ -30,8 +30,6 @@
       </vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
-      <vmArgsWin>-Dorg.eclipse.swt.browser.DefaultType=IE
-      </vmArgsWin>
    </launcherArgs>
 
    <windowImages i16="/org.eclipse.fordiac.ide/icons/4diac16.png" i32="/org.eclipse.fordiac.ide/icons/4diac32.png" i48="/org.eclipse.fordiac.ide/icons/4diac48.png" i64="/org.eclipse.fordiac.ide/icons/4diac64.png" i128="/org.eclipse.fordiac.ide/icons/4diac128.png" i256="/org.eclipse.fordiac.ide/icons/4diac256.png"/>

--- a/plugins/org.eclipse.fordiac.ide.product/org.eclipse.fordiac.ide.product.target
+++ b/plugins/org.eclipse.fordiac.ide.product/org.eclipse.fordiac.ide.product.target
@@ -9,7 +9,7 @@
 			<unit id="org.eclipse.elk.libavoid.feature.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/nebula/updates/milestone/latest"/>
+			<repository location="https://download.eclipse.org/nebula/updates/release/3.2.0"/>
 			<unit id="org.eclipse.nebula.feature.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
With Eclipse Nebual Widgets version 3.2 the richtext editor issue with edge browser has been fixed. Therefore also the workaround of using IE is removed.

Fixes: https://github.com/eclipse-4diac/4diac-ide/issues/1565