### PR TITLE
Fix exception when identification is null

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/TypeInfoSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/TypeInfoSection.java
@@ -97,7 +97,7 @@ public abstract class TypeInfoSection extends AbstractDoubleColumnSection {
 	@Override
 	protected void addContentAdapter() {
 		super.addContentAdapter();
-		if (getType() != null) {
+		if (getType() != null && getType().getIdentification() != null) {
 			getType().getIdentification().eAdapters().add(typeInfoAdapter);
 		}
 	}
@@ -105,7 +105,7 @@ public abstract class TypeInfoSection extends AbstractDoubleColumnSection {
 	@Override
 	protected void removeContentAdapter() {
 		super.removeContentAdapter();
-		if (getType() != null) {
+		if (getType() != null && getType().getIdentification() != null) {
 			getType().getIdentification().eAdapters().remove(typeInfoAdapter);
 		}
 	}


### PR DESCRIPTION
FBs with broken references still have a type, but their identification is null, causing an exception when viewing the type info section.