### PR TITLE
Avoid unnecessary refreshes at the end of inserting FBs

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/AbstractCreateInstanceDirectEditPolicy.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/AbstractCreateInstanceDirectEditPolicy.java
@@ -104,4 +104,9 @@ public abstract class AbstractCreateInstanceDirectEditPolicy extends DirectEditP
 		return new Point(location.x, location.y).scale(1.0 / getZoom());
 	}
 
+	@Override
+	protected void eraseDirectEditFeedback(final DirectEditRequest request) {
+		// for creating instances we do not need to do anything for erasing the feedback
+	}
+
 }


### PR DESCRIPTION
When inserting FBs with the inline option (e.g., double click) at the end GEF is automatically refreshing the whole parent edit part. This is not really necessary and removed with this commit.