### PR TITLE
ContentAdapter for EditParts need to Check if EditPart is Active

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractFBNElementEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractFBNElementEditPart.java
@@ -126,10 +126,13 @@ public abstract class AbstractFBNElementEditPart extends AbstractPositionableEle
 				super.notifyChanged(notification);
 				if (!notification.isTouch()) {
 					Display.getDefault().execute(() -> {
-						refreshChildren();
-						// this ensure that parameters are correctly updated when pins are added or
-						// removed (e.g., errormarkerpins are deleted)
-						getParent().refresh();
+						// check if editpart has not been removed in the meantime
+						if (isActive()) {
+							refreshChildren();
+							// this ensure that parameters are correctly updated when pins are added or
+							// removed (e.g., errormarkerpins are deleted)
+							getParent().refresh();
+						}
 					});
 				}
 			}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/SubAppForFBNetworkEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/SubAppForFBNetworkEditPart.java
@@ -85,7 +85,12 @@ public class SubAppForFBNetworkEditPart extends AbstractFBNElementEditPart imple
 		@Override
 		public void notifyChanged(final Notification notification) {
 			if (!notification.isTouch()) {
-				Display.getDefault().execute(() -> handleRefresh(notification));
+				Display.getDefault().execute(() -> {
+					// check if editpart has not been removed in the meantime
+					if (isActive()) {
+						handleRefresh(notification);
+					}
+				});
 			}
 			super.notifyChanged(notification);
 		}

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/InterfaceEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/InterfaceEditPart.java
@@ -406,7 +406,12 @@ public abstract class InterfaceEditPart extends AbstractConnectableEditPart
 						|| LibraryElementPackage.eINSTANCE.getIInterfaceElement_OutputConnections().equals(feature)
 						|| LibraryElementPackage.eINSTANCE.getINamedElement_Name().equals(feature)
 						|| LibraryElementPackage.eINSTANCE.getINamedElement_Comment().equals(feature)) {
-					Display.getDefault().execute(() -> refresh());
+					Display.getDefault().execute(() -> {
+						// check if editpart has not been removed in the meantime
+						if (isActive()) {
+							refresh();
+						}
+					});
 				}
 				super.notifyChanged(notification);
 			}
@@ -428,14 +433,12 @@ public abstract class InterfaceEditPart extends AbstractConnectableEditPart
 
 	@Override
 	public void deactivate() {
-		if (isActive()) {
-			super.deactivate();
-			getModel().eAdapters().remove(getContentAdapter());
-			((AdvancedScrollingGraphicalViewer) getViewer()).getPreferencesCache().getStoreProvider()
-					.removePropertyChangeListener(preferenceListener);
-			getModel().eAdapters().remove(getContentAdapter());
-			removeSourcePinAdapter();
-		}
+		super.deactivate();
+		getModel().eAdapters().remove(getContentAdapter());
+		((AdvancedScrollingGraphicalViewer) getViewer()).getPreferencesCache().getStoreProvider()
+				.removePropertyChangeListener(preferenceListener);
+		getModel().eAdapters().remove(getContentAdapter());
+		removeSourcePinAdapter();
 	}
 
 	private ConnectionAnchor sourceConAnchor = null;


### PR DESCRIPTION
When a content adapter is refreshing editparts in the display thread it can happen that the editpart was removed in the mean-time. Therefore an isActive check is needed there.