### PR TITLE
Ensure graphical annotations used as model children have edit parts

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.deployment.debug.ui/src/org/eclipse/fordiac/ide/deployment/debug/ui/annotation/WatchValueAnnotationStyler.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug.ui/src/org/eclipse/fordiac/ide/deployment/debug/ui/annotation/WatchValueAnnotationStyler.java
@@ -50,6 +50,11 @@ public class WatchValueAnnotationStyler implements GraphicalAnnotationStyler {
 	}
 
 	@Override
+	public boolean hasEditPart(final GraphicalAnnotation annotation) {
+		return annotation instanceof WatchValueAnnotation;
+	}
+
+	@Override
 	public EditPart getEditPart(final GraphicalAnnotation annotation) {
 		if (annotation instanceof final WatchValueAnnotation watchValueAnnotation) {
 			if (watchValueAnnotation.getElement() instanceof AdapterDeclaration) {
@@ -57,6 +62,6 @@ public class WatchValueAnnotationStyler implements GraphicalAnnotationStyler {
 			}
 			return new WatchValueEditPart();
 		}
-		return null;
+		return GraphicalAnnotationStyler.super.getEditPart(annotation);
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/annotation/GraphicalAnnotationStyler.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/annotation/GraphicalAnnotationStyler.java
@@ -29,7 +29,11 @@ public interface GraphicalAnnotationStyler {
 
 	Image getOverlayImage(GraphicalAnnotation annotation);
 
+	default boolean hasEditPart(final GraphicalAnnotation annotation) {
+		return false;
+	}
+
 	default EditPart getEditPart(final GraphicalAnnotation annotation) {
-		return null;
+		throw new UnsupportedOperationException("No EditPart for annotation " + annotation); //$NON-NLS-1$
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/annotation/GraphicalAnnotationStyles.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/annotation/GraphicalAnnotationStyles.java
@@ -75,12 +75,21 @@ public final class GraphicalAnnotationStyles {
 		return null;
 	}
 
-	public static EditPart getAnnotationEditPart(final GraphicalAnnotation annotation) {
+	public static boolean hasAnnotationEditPart(final GraphicalAnnotation annotation) {
+		final GraphicalAnnotationStyle style = getAnnotationStyle(annotation);
+		if (style != null) {
+			return style.styler().hasEditPart(annotation);
+		}
+		return false;
+	}
+
+	public static EditPart getAnnotationEditPart(final GraphicalAnnotation annotation)
+			throws UnsupportedOperationException {
 		final GraphicalAnnotationStyle style = getAnnotationStyle(annotation);
 		if (style != null) {
 			return style.styler().getEditPart(annotation);
 		}
-		return null;
+		throw new UnsupportedOperationException("No style for annotation " + annotation); //$NON-NLS-1$
 	}
 
 	public static void updateAnnotationFeedback(final IFigure annonFigure, final Object target,

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/AbstractFBNetworkEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/AbstractFBNetworkEditPart.java
@@ -28,6 +28,7 @@ import org.eclipse.fordiac.ide.gef.annotation.AnnotableGraphicalEditPart;
 import org.eclipse.fordiac.ide.gef.annotation.FordiacAnnotationUtil;
 import org.eclipse.fordiac.ide.gef.annotation.GraphicalAnnotationModel;
 import org.eclipse.fordiac.ide.gef.annotation.GraphicalAnnotationModelEvent;
+import org.eclipse.fordiac.ide.gef.annotation.GraphicalAnnotationStyles;
 import org.eclipse.fordiac.ide.gef.router.MoveableRouter;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
@@ -72,7 +73,8 @@ public abstract class AbstractFBNetworkEditPart extends AbstractDiagramEditPart 
 
 		final GraphicalAnnotationModel annotationModel = FordiacAnnotationUtil.getAnnotationModel(this);
 		if (annotationModel != null) {
-			children.addAll(annotationModel.getAnnotations(getModel()));
+			annotationModel.getAnnotations(getModel()).stream().filter(GraphicalAnnotationStyles::hasAnnotationEditPart)
+					.forEachOrdered(children::add);
 		}
 
 		return children;


### PR DESCRIPTION
Filter graphical annotations used as model children to ensure they have an associated annotation styler that will provide proper edit parts. Also throw an exception when attempting to get an edit part for an annotation that has none to fail early in such cases.