### PR TITLE
Provide better logging and fail early if editparts can not be created

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/ElementEditPartFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/ElementEditPartFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023  Profactor GmbH, fortiss GmbH, Johannes Kepler University,
+ * Copyright (c) 2008, 2025  Profactor GmbH, fortiss GmbH, Johannes Kepler University,
  * 							 Primetals Technologies Germany GmbH
  *
  * This program and the accompanying materials are made available under the
@@ -66,7 +66,7 @@ public class ElementEditPartFactory extends Abstract4diacEditPartFactory {
 			return getPartForFBNetwork(network);
 		}
 		if (modelElement instanceof final FBNetworkElement fbnel) {
-			return getPartForFBNetworkElement(fbnel);
+			return getPartForFBNetworkElement(context, fbnel);
 		}
 		if (modelElement instanceof StructuredType) {
 			return new StructuredTypeEditPart();
@@ -100,11 +100,11 @@ public class ElementEditPartFactory extends Abstract4diacEditPartFactory {
 			return new TargetInterfaceElementEditPart();
 		}
 
-		throw createEditpartCreationException(modelElement);
+		throw createEditpartCreationException(context, modelElement);
 
 	}
 
-	private static EditPart getPartForFBNetworkElement(final FBNetworkElement element) {
+	private static EditPart getPartForFBNetworkElement(final EditPart context, final FBNetworkElement element) {
 		if (element instanceof ErrorMarkerFBNElement) {
 			return new ErrorMarkerFBNEditPart();
 		}
@@ -135,7 +135,7 @@ public class ElementEditPartFactory extends Abstract4diacEditPartFactory {
 			return new CommentEditPart();
 		}
 
-		throw createEditpartCreationException(element);
+		throw createEditpartCreationException(context, element);
 	}
 
 	@SuppressWarnings("static-method") // not static to allow subclasses to provide own elements

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editparts/ECCEditPartFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editparts/ECCEditPartFactory.java
@@ -1,6 +1,7 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2012, 2013 Profactor GmbH, fortiss GmbH
- * 
+ * Copyright (c) 2008, 2025 Profactor GmbH, fortiss GmbH,
+ *                          Primetals Technologies Austria GmbH
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -25,7 +26,7 @@ import org.eclipse.gef.ui.parts.GraphicalEditor;
  */
 public class ECCEditPartFactory extends Abstract4diacEditPartFactory {
 
-	public ECCEditPartFactory(GraphicalEditor editor) {
+	public ECCEditPartFactory(final GraphicalEditor editor) {
 		super(editor);
 	}
 
@@ -49,7 +50,7 @@ public class ECCEditPartFactory extends Abstract4diacEditPartFactory {
 			return new ECActionOutputEventEditPart();
 		}
 
-		throw createEditpartCreationException(modelElement);
+		throw createEditpartCreationException(context, modelElement);
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/editparts/ServiceSequenceEditPartFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/editparts/ServiceSequenceEditPartFactory.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008 - 2016 Profactor GmbH, TU Wien ACIN, fortiss GmbH
+ * Copyright (c) 2008, 2025 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
+ *                          Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -54,7 +55,7 @@ public class ServiceSequenceEditPartFactory extends Abstract4diacEditPartFactory
 		if (modelElement instanceof ConnectingConnection) {
 			return new ConnectingConnectionEditPart();
 		}
-		throw createEditpartCreationException(modelElement);
+		throw createEditpartCreationException(context, modelElement);
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editparts/FBInterfaceEditPartFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editparts/FBInterfaceEditPartFactory.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2011 - 2017 Profactor GmbH, TU Wien ACIN, fortiss GmbH
+ * Copyright (c) 2011, 2025 Profactor GmbH, TU Wien ACIN, fortiss GmbH,,
+ *                          Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -68,7 +69,7 @@ public class FBInterfaceEditPartFactory extends Abstract4diacEditPartFactory {
 		if (modelElement instanceof TypeField) {
 			return new TypeEditPart(typeLib);
 		}
-		throw createEditpartCreationException(modelElement);
+		throw createEditpartCreationException(context, modelElement);
 	}
 
 	// make it protected none static so that subclasses can override it and provide

--- a/plugins/org.eclipse.fordiac.ide.gef/plugin.properties
+++ b/plugins/org.eclipse.fordiac.ide.gef/plugin.properties
@@ -18,8 +18,6 @@
 AbstractAttributeSection_CreateAttribute=create attribute
 AbstractAttributeSection_DeleteSelectedAttribute=delete selected attribute
 AdjustConnectionCommand_WrongConnectionSegmentIndex=Wrong connection segment index ({0}) provided to AdjustConnectionCommand!
-Abstract4diacEditPartFactory_ERROR_CantCreatePartForModelElement=Can't create part for model element
-Abstract4diacEditPartFactory_LABEL_RUNTIMEException_CantCreateModelForElement=Can't create part for model element: {0}.
 AbstractViewEditPart_ERROR_createFigure=Error in createFigure()
 AppearancePropertySection_LABLE_Color=Background Color
 AppearancePropertySection_LABEL_BackgroundColor=Background Color...

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/Messages.java
@@ -28,8 +28,6 @@ public final class Messages extends NLS {
 	public static String AbstractAttributeSection_DeleteSelectedAttribute;
 	public static String AdjustConnectionCommand_WrongConnectionSegmentIndex;
 	public static String AbstractViewEditPart_ERROR_createFigure;
-	public static String Abstract4diacEditPartFactory_ERROR_CantCreatePartForModelElement;
-	public static String Abstract4diacEditPartFactory_LABEL_RUNTIMEException_CantCreateModelForElement;
 	public static String AppearancePropertySection_ChangeBackgroundColor;
 	public static String AppearancePropertySection_LABEL_BackgroundColor;
 	public static String AppearancePropertySection_LABEL_ChooseColor;

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/Abstract4diacEditPartFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/Abstract4diacEditPartFactory.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2016 fortiss GmbH
+ * Copyright (c) 2016, 2025 fortiss GmbH, Primetals Technologies Austria GmbH
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -13,10 +14,8 @@ package org.eclipse.fordiac.ide.gef.editparts;
 
 import java.text.MessageFormat;
 
-import org.eclipse.fordiac.ide.gef.Messages;
 import org.eclipse.fordiac.ide.gef.annotation.GraphicalAnnotation;
 import org.eclipse.fordiac.ide.gef.annotation.GraphicalAnnotationStyles;
-import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartFactory;
 import org.eclipse.gef.ui.parts.GraphicalEditor;
@@ -36,39 +35,37 @@ public abstract class Abstract4diacEditPartFactory implements EditPartFactory {
 	@Override
 	public EditPart createEditPart(final EditPart context, final Object modelElement) {
 		// get EditPart for model element
-		EditPart part = null;
-		try {
-			if (modelElement instanceof final IEditPartCreator epCreator) {
-				// this if needs be the first check so that plugins can more easily provide
-				// special behavior for derived classes
-				// (e.g., interface elements for monitored adapters)
-				part = epCreator.createEditPart();
-			} else if (modelElement instanceof final IConnectionEditPartCreator connCreator) {
-				part = connCreator.createEditPart();
-			} else if (modelElement instanceof final GraphicalAnnotation annotation) {
-				part = GraphicalAnnotationStyles.getAnnotationEditPart(annotation);
-			} else {
-				part = getPartForElement(context, modelElement);
-			}
-			if (null != part) {
-				part.setModel(modelElement);
-			}
-		} catch (final RuntimeException e) {
-			FordiacLogHelper.logError(Messages.Abstract4diacEditPartFactory_ERROR_CantCreatePartForModelElement, e);
+		final EditPart part = switch (modelElement) {
+		// this if needs be the first check so that plugins can more easily provide
+		// special behavior for derived classes
+		// (e.g., interface elements for monitored adapters)
+		case final IEditPartCreator epCreator -> epCreator.createEditPart();
+		case final IConnectionEditPartCreator connCreator -> connCreator.createEditPart();
+		case final GraphicalAnnotation annotation -> GraphicalAnnotationStyles.getAnnotationEditPart(annotation);
+		default -> getPartForElement(context, modelElement);
+		};
+		if (null == part) {
+			throw createEditpartCreationException(context, modelElement);
 		}
+		part.setModel(modelElement);
 		return part;
 	}
 
 	/**
 	 * Maps an object to an EditPart.
 	 *
-	 * @throws RuntimeException if no match was found (programming error)
+	 * @throws IllegalArgumentException if no match was found (programming error)
 	 */
 	protected abstract EditPart getPartForElement(EditPart context, Object modelElement);
 
-	protected static RuntimeException createEditpartCreationException(final Object modelElement) {
-		return new RuntimeException(MessageFormat.format(
-				Messages.Abstract4diacEditPartFactory_LABEL_RUNTIMEException_CantCreateModelForElement,
-				((modelElement != null) ? modelElement.getClass().getName() : "null"))); //$NON-NLS-1$
+	protected static RuntimeException createEditpartCreationException(final EditPart context,
+			final Object modelElement) {
+		return new IllegalArgumentException(
+				MessageFormat.format("Can''t create part for model element: {0} for context {1}", //$NON-NLS-1$
+						getClassName(modelElement), getClassName(context)));
+	}
+
+	protected static String getClassName(final Object obj) {
+		return (obj != null) ? obj.getClass().getName() : "null"; //$NON-NLS-1$
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/editparts/SystemConfEditPartFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/editparts/SystemConfEditPartFactory.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2012 - 2017 Profactor GbmH, TU Wien ACIN, fortiss GmbH
+ * Copyright (c) 2008, 2025 Profactor GbmH, TU Wien ACIN, fortiss GmbH,
+ *                          Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -56,7 +57,7 @@ public class SystemConfEditPartFactory extends Abstract4diacEditPartFactory {
 		if (modelElement instanceof ResourceContainer) {
 			return new ResourceContainerEditPart();
 		}
-		throw createEditpartCreationException(modelElement);
+		throw createEditpartCreationException(context, modelElement);
 
 	}
 


### PR DESCRIPTION
GEF Classic expects that for each model object given to the editpart factory an editpart is created. So if our factories can not create one we will throw an exception and provide more feedback in the log message to find such issues earlier.