### PR TITLE
Renamed org.eclipse.fordiac.ide.emf.compare.matchengine package

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.emf.compare/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.emf.compare/plugin.xml
@@ -25,7 +25,7 @@
    <extension
          point="org.eclipse.emf.compare.rcp.matchEngine">
       <engineFactory
-            class="org.eclipse.fordiac.ide.emf.compare.MatchEngine.FordiacMatchEngineFactory"
+            class="org.eclipse.fordiac.ide.emf.compare.matchengine.FordiacMatchEngineFactory"
             ranking="300">
       </engineFactory>
    </extension>

--- a/plugins/org.eclipse.fordiac.ide.emf.compare/src/org/eclipse/fordiac/ide/emf/compare/matchengine/FordiacIdentifierEObjectMatcher.java
+++ b/plugins/org.eclipse.fordiac.ide.emf.compare/src/org/eclipse/fordiac/ide/emf/compare/matchengine/FordiacIdentifierEObjectMatcher.java
@@ -31,7 +31,7 @@
  *
  */
 
-package org.eclipse.fordiac.ide.emf.compare.MatchEngine;
+package org.eclipse.fordiac.ide.emf.compare.matchengine;
 
 import static org.eclipse.emf.compare.EMFCompare.DIAGNOSTIC_SOURCE;
 

--- a/plugins/org.eclipse.fordiac.ide.emf.compare/src/org/eclipse/fordiac/ide/emf/compare/matchengine/FordiacMatchEngine.java
+++ b/plugins/org.eclipse.fordiac.ide.emf.compare/src/org/eclipse/fordiac/ide/emf/compare/matchengine/FordiacMatchEngine.java
@@ -11,7 +11,7 @@
  *   Michael Oberlehner - initial API and implementation and/or initial documentation
  *   Fabio Gandolfi - improvement for comparisons
  *******************************************************************************/
-package org.eclipse.fordiac.ide.emf.compare.MatchEngine;
+package org.eclipse.fordiac.ide.emf.compare.matchengine;
 
 import java.util.function.Function;
 

--- a/plugins/org.eclipse.fordiac.ide.emf.compare/src/org/eclipse/fordiac/ide/emf/compare/matchengine/FordiacMatchEngineFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.emf.compare/src/org/eclipse/fordiac/ide/emf/compare/matchengine/FordiacMatchEngineFactory.java
@@ -10,7 +10,7 @@
  * Contributors:
  *   Michael Oberlehner - initial API and implementation and/or initial documentation
  *******************************************************************************/
-package org.eclipse.fordiac.ide.emf.compare.MatchEngine;
+package org.eclipse.fordiac.ide.emf.compare.matchengine;
 
 import org.eclipse.emf.compare.match.IMatchEngine;
 import org.eclipse.emf.compare.scope.IComparisonScope;


### PR DESCRIPTION
To follow Java naming conventions the `org.eclipse.fordiac.ide.emf.compare.MatchEngine` package was renamed to `org.eclipse.fordiac.ide.emf.compare.matchengine.