### PR TITLE
fixed enablement check in map Handler

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/MapHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/MapHandler.java
@@ -195,7 +195,7 @@ public class MapHandler extends AbstractHandler {
 	private static boolean allFbsAreMapable(final List<FBNetworkElement> fbs) {
 		for (final FBNetworkElement fb : fbs) {
 			if (fb.getOuterFBNetworkElement() instanceof SubApp
-					|| (fb instanceof final BlockFBNetworkElement bfb && bfb.getInterface().getErrorMarker().isEmpty())
+					|| !(fb instanceof final BlockFBNetworkElement bfb && bfb.getInterface().getErrorMarker().isEmpty())
 					|| fb.getTypeEntry() instanceof ErrorTypeEntry) {
 				return false;
 			}


### PR DESCRIPTION
During upgrading the model to the BlockFBNetworkElement the enablement check for mapping was wrongly updated.