### PR TITLE
Rework ant task generation to handle out of tree builds

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.ant/.externalToolBuilders/AntTaskBuilder.launch
+++ b/plugins/org.eclipse.fordiac.ide.ant/.externalToolBuilders/AntTaskBuilder.launch
@@ -7,11 +7,10 @@
     <booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
     <booleanAttribute key="org.eclipse.debug.ui.ATTR_LAUNCH_IN_BACKGROUND" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
     <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.ant.ui.AntClasspathProvider"/>
     <booleanAttribute key="org.eclipse.jdt.launching.DEFAULT_CLASSPATH" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
-    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.ant.internal.launching.remote.InternalAntRunner"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.fordiac.ide.ant"/>
     <stringAttribute key="org.eclipse.ui.externaltools.ATTR_BUILD_SCOPE" value="${working_set:&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#13;&#10;&lt;resources&gt;&#13;&#10;&lt;item path=&quot;/org.eclipse.fordiac.ide.ant/scripts/buildExtraJAR.xml&quot; type=&quot;1&quot;/&gt;&#13;&#10;&lt;item path=&quot;/org.eclipse.fordiac.ide.ant/src_ant&quot; type=&quot;2&quot;/&gt;&#13;&#10;&lt;/resources&gt;}"/>
     <stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${workspace_loc:/org.eclipse.fordiac.ide.ant/scripts/buildExtraJAR.xml}"/>

--- a/plugins/org.eclipse.fordiac.ide.ant/scripts/buildExtraJAR.xml
+++ b/plugins/org.eclipse.fordiac.ide.ant/scripts/buildExtraJAR.xml
@@ -8,7 +8,10 @@
       <property name="plugin.destination" value="${basedir}"/>
       <property name="build.result.folder" value="${basedir}/ant_tasks"/>
       <property name="version.suffix" value="_3.1.0"/>
-      <property name="target.home" value="${basedir}/../../.metadata/.plugins/org.eclipse.pde.core/.bundle_pool"/>
+      <eclipse.convertPath resourcepath="/" property="workspace_loc"/>
+      <property name="target.home" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/.bundle_pool"/>
+      <property name="ant.build.javac.source" value="21"/>
+      <property name="ant.build.javac.target" value="21"/>
    </target>
 
    <target name="properties" if="eclipse.running">


### PR DESCRIPTION
When the ant plugin was not in the right place build errors where reported. With this fix the ant task build is independent from the location of the code.