### PR TITLE
Do not update mapped resource FBs

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractUpdateFBNElementCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractUpdateFBNElementCommand.java
@@ -84,17 +84,25 @@ public abstract class AbstractUpdateFBNElementCommand extends Command implements
 	protected FBNetworkElement newElement;
 
 	/** The FBNetworkElement which should be updated */
-	protected FBNetworkElement oldElement;
+	protected final FBNetworkElement oldElement;
 	/** The index where the fbNetwork element should be added */
 	protected int oldIndex;
 
-	protected FBNetwork network;
+	protected final FBNetwork network;
 
 	protected TypeEntry entry;
 
 	protected AbstractUpdateFBNElementCommand(final FBNetworkElement oldElement) {
-		this.oldElement = Objects.requireNonNull(oldElement);
+		this.oldElement = selectOldElement(oldElement);
 		this.network = Objects.requireNonNull(this.oldElement.getFbNetwork(), "Element not in a network"); //$NON-NLS-1$
+	}
+
+	private static FBNetworkElement selectOldElement(final FBNetworkElement oldElement) {
+		final FBNetworkElement selectedElement = Objects.requireNonNull(oldElement);
+		if (selectedElement.isMapped() && selectedElement.getMapping().getTo().equals(selectedElement)) {
+			return selectedElement.getOpposite();
+		}
+		return selectedElement;
 	}
 
 	@Override
@@ -103,10 +111,6 @@ public abstract class AbstractUpdateFBNElementCommand extends Command implements
 		List<ConnData> resourceConns = null;
 
 		if (oldElement.isMapped()) {
-			if (network.equals(oldElement.getResource().getFBNetwork())) {
-				oldElement = oldElement.getOpposite();
-				network = oldElement.getFbNetwork();
-			}
 			resource = oldElement.getResource();
 			resourceConns = getResourceCons();
 			unmapCmd = new UnmapCommand(oldElement);
@@ -117,10 +121,8 @@ public abstract class AbstractUpdateFBNElementCommand extends Command implements
 
 		checkGroup(oldElement, newElement); // needs to be done before anything is changed on the old element Bug
 		// 579570
-		if (network != null) {
-			oldIndex = network.getNetworkElements().indexOf(oldElement);
-			network.getNetworkElements().add(oldIndex, newElement);
-		}
+		oldIndex = network.getNetworkElements().indexOf(oldElement);
+		network.getNetworkElements().add(oldIndex, newElement);
 
 		handleErrorMarker();
 		// Find connectionless pins which should be saved
@@ -143,9 +145,7 @@ public abstract class AbstractUpdateFBNElementCommand extends Command implements
 		transferVisibleAndVarConfigAttributes(oldElement.getInterface().getOutputVars());
 		transferVisibleAndVarConfigAttributes(oldElement.getInterface().getInOutVars());
 
-		if (network != null) {
-			network.getNetworkElements().remove(oldElement);
-		}
+		network.getNetworkElements().remove(oldElement);
 
 		newElement.setName(oldElement.getName());
 

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/MapToCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/MapToCommand.java
@@ -19,6 +19,7 @@ package org.eclipse.fordiac.ide.model.commands.change;
 import java.util.Set;
 
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.model.commands.Messages;
 import org.eclipse.fordiac.ide.model.commands.ScopedCommand;
 import org.eclipse.fordiac.ide.model.commands.create.AbstractConnectionCreateCommand;
@@ -158,7 +159,7 @@ public class MapToCommand extends Command implements ScopedCommand {
 	}
 
 	private AutomationSystem getAutomationSystem() {
-		return srcElement.getFbNetwork().getApplication().getAutomationSystem();
+		return (AutomationSystem) EcoreUtil.getRootContainer(srcElement);
 	}
 
 	protected void checkConnections() {

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/TypeEntryAdapter.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/TypeEntryAdapter.java
@@ -178,8 +178,14 @@ public class TypeEntryAdapter extends AbstractTypeEntryAdapter {
 					if (fbnEl instanceof final FB fb && fbnEl.eContainer() == editedElement) {
 						return new UpdateInternalFBCommand(fb, typeEntry);
 					}
+
+					if (fbnEl.isMapped() && fbnEl.getMapping().getTo() == fbnEl) {
+						// the resource side will be update by its opposite so we do not need to do it
+						// here
+						return null;
+					}
 					return new UpdateFBTypeCommand(fbnEl, typeEntry);
-				}).forEach(Command::execute);
+				}).filter(Objects::nonNull).filter(Command::canExecute).forEach(Command::execute);
 
 		if (isActiveEditor()) {
 			performLocationRestore();
@@ -213,7 +219,7 @@ public class TypeEntryAdapter extends AbstractTypeEntryAdapter {
 				return new ConfigureFBCommand(configFB, dataType);
 			}
 			return null;
-		}).filter(Objects::nonNull).forEach(Command::execute);
+		}).filter(Objects::nonNull).filter(Command::canExecute).forEach(Command::execute);
 	}
 
 	private void performLocationRestore() {


### PR DESCRIPTION
Dependency updates where done on both in the applications and in the resources. Mapped FBs where considered twice. This could lead to strange situations in the model. Now we are only updating resource FBs if they are not mapped.