### PR TITLE
LibraryManager on UpdateDependencie Actively Refreshes TypeLib

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/LibraryManager.java
+++ b/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/LibraryManager.java
@@ -755,6 +755,8 @@ public enum LibraryManager {
 
 		FordiacMarkerHelper.updateMarkers(project.getFile(MANIFEST), FordiacErrorMarker.LIBRARY_MARKER, markerList,
 				true);
+
+		TypeLibraryManager.INSTANCE.getTypeLibrary(project).refresh();
 	}
 
 	private void buildDependencies(final Map<String, DependencyNode> deps, final Map<String, ResolveNode> res,

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/TypeLibrary.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/TypeLibrary.java
@@ -197,35 +197,6 @@ public final class TypeLibrary {
 		return fileMap.get(typeFile);
 	}
 
-	/**
-	 * Clear and reload the entire type library
-	 *
-	 * <p>
-	 * This is a dangerous operation, since it will effectively <em>detach</em>
-	 * anyone currently holding a type entry from this type library, including any
-	 * listeners. For most use cases, use {@link #refresh()} instead.
-	 *
-	 * @see #refresh()
-	 */
-	private void reload() {
-		adapterTypes.clear();
-		attributeTypes.clear();
-		deviceTypes.clear();
-		fbTypes.clear();
-		resourceTypes.clear();
-		segmentTypes.clear();
-		subAppTypes.clear();
-		systems.clear();
-		globalConstants.clear();
-		dataTypeLib.clear();
-		programTypes.clear();
-		fileMap.clear();
-		packages.clear();
-		deleteTypeLibraryMarkers(project);
-		buildpath = BuildpathUtil.loadBuildpath(project);
-		checkAdditions(project);
-	}
-
 	public DataTypeLibrary getDataTypeLibrary() {
 		return dataTypeLib;
 	}
@@ -248,19 +219,24 @@ public final class TypeLibrary {
 	}
 
 	public TypeEntry createTypeEntry(final IFile file) {
-		if (BuildpathUtil.findSourceFolder(buildpath, file).isEmpty()) {
+		if (file == null || BuildpathUtil.findSourceFolder(buildpath, file).isEmpty()) {
 			return null;
 		}
-		final TypeEntry entry = fileMap.computeIfAbsent(file, TypeEntryFactory.INSTANCE::createTypeEntry);
-		if (entry != null) {
-			final Optional<String> message = IdentifierVerifier.verifyIdentifier(entry.getTypeName());
-			if (message.isEmpty()) {
-				addTypeEntry(entry);
-			} else {
+
+		return fileMap.computeIfAbsent(file, f -> {
+			final TypeEntry entry = TypeEntryFactory.INSTANCE.createTypeEntry(file);
+			if (entry != null) {
+				final Optional<String> message = IdentifierVerifier.verifyIdentifier(entry.getTypeName());
+				if (message.isEmpty()) {
+					// add is adding the entry to file map and all other containers required
+					entry.setTypeLibrary(this);
+					addTypeEntryNameReference(entry);
+					return entry;
+				}
 				createTypeLibraryMarker(file, message.get());
 			}
-		}
-		return entry;
+			return null;
+		});
 	}
 
 	public TypeEntry createErrorTypeEntry(final String typeName, final EClass typeClass) {

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/SystemManager.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/SystemManager.java
@@ -124,12 +124,10 @@ public enum SystemManager {
 
 		ManifestHelper.createProjectManifest(project, includedLibraries.keySet());
 
-		TypeLibraryManager.INSTANCE.getTypeLibrary(project); // insert the project into the project list
 		project.refreshLocal(IResource.DEPTH_ONE, monitor);
 		return project;
 	}
 
-	@SuppressWarnings("static-method")
 	public synchronized AutomationSystem createNewSystem(final IContainer location, final String name,
 			final IProgressMonitor monitor) throws CoreException {
 		final IFile systemFile = location.getFile(new Path(name + SystemManager.SYSTEM_FILE_ENDING_WITH_DOT));
@@ -156,7 +154,6 @@ public enum SystemManager {
 		return null;
 	}
 
-	@SuppressWarnings("static-method")
 	public synchronized AutomationSystem getSystem(final IFile systemFile) {
 		final TypeLibrary typeLibrary = TypeLibraryManager.INSTANCE.getTypeLibrary(systemFile.getProject());
 		SystemEntry sysEntry = (SystemEntry) typeLibrary.getTypeEntry(systemFile);
@@ -166,7 +163,6 @@ public enum SystemManager {
 		return sysEntry != null ? sysEntry.getSystem() : null;
 	}
 
-	@SuppressWarnings("static-method")
 	public synchronized List<AutomationSystem> getProjectSystems(final IProject project) {
 		return TypeLibraryManager.INSTANCE.getTypeLibrary(project).getSystems().stream().map(SystemEntry::getSystem)
 				.toList();


### PR DESCRIPTION
There where situations where new libs added by the LibraryManager where not directly visible to the xtext builder.

As part of this change clean-ups in the TypeLib for better creating new entries and outdated code in the SystemManager where done.