### PR TITLE
LibraryElementLabelProvider may be Called even if file is not yet there

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/navigator/LibraryElementLabelProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/navigator/LibraryElementLabelProvider.java
@@ -56,6 +56,9 @@ public class LibraryElementLabelProvider extends AdapterFactoryLabelProvider {
 	 * which can not directly be used as this class is an Eclipse internal class.
 	 */
 	private static ImageDescriptor decorateImage(final IResource element, final ImageDescriptor imageDescriptor) {
+		if (!element.exists()) {
+			return imageDescriptor;
+		}
 		final ImageDescriptor overlay = getErrorOverlay(element);
 		if (overlay != null) {
 			return new DecorationOverlayIcon(imageDescriptor, overlay, IDecoration.BOTTOM_LEFT);


### PR DESCRIPTION
The LibraryElementLabelProvider want to add error/warning overlays. This must not be done when the resource is not (yet) existing.