### PR TITLE
Avoid unnecessary reload after dependency change

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.bulkeditor/src/org/eclipse/fordiac/ide/bulkeditor/editors/BulkEditorTypeEntryAdapter.java
+++ b/plugins/org.eclipse.fordiac.ide.bulkeditor/src/org/eclipse/fordiac/ide/bulkeditor/editors/BulkEditorTypeEntryAdapter.java
@@ -34,13 +34,12 @@ public class BulkEditorTypeEntryAdapter extends AbstractTypeEntryAdapter {
 	public void notifyChanged(final Notification notification) {
 		super.notifyChanged(notification);
 
-		String feature = ""; //$NON-NLS-1$
-		if (notification.getFeature() instanceof final String string) {
-			feature = string;
+		if (!(notification.getFeature() instanceof final String feature)) {
+			return;
 		}
 
 		// make sure type was reloaded and not just loaded
-		if (feature.equals(TypeEntry.TYPE_ENTRY_TYPE_FEATURE) && (notification.getOldValue() != null)) {
+		if (feature.equals(TypeEntry.TYPE_ENTRY_FILE_CONTENT_FEATURE)) {
 			if (notification.getNotifier() instanceof final TypeEntry tEntry) {
 				changedFiles.add(tEntry.getFile().getFullPath().toOSString());
 			}

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/TypeEntryAdapter.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/TypeEntryAdapter.java
@@ -95,18 +95,11 @@ public class TypeEntryAdapter extends AbstractTypeEntryAdapter {
 			return;
 		}
 
-		String feature = ""; //$NON-NLS-1$
-		if (notification.getFeature() instanceof final String string) {
-			feature = string;
+		if (!(notification.getFeature() instanceof final String feature)) {
+			return;
 		}
 
 		switch (feature) {
-		case TypeEntry.TYPE_ENTRY_TYPE_FEATURE:
-			// make sure type was reloaded and not just loaded
-			if (notification.getOldValue() != null) {
-				handleFileContentChange();
-			}
-			break;
 		case TypeEntry.TYPE_ENTRY_FILE_CONTENT_FEATURE:
 			handleFileContentChange();
 			break;

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
@@ -632,6 +632,13 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 			// update the last modification stamp _after_ setting the type to ensure other
 			// readers see the new stamp only together with the new type
 			lastModificationTimestamp.set(modificationStamp);
+
+			// send out file content notifications to update editors
+			if (eNotificationRequired()) {
+				notifications = chainNotification(notifications,
+						new TypeEntryNotificationImpl(this, Notification.SET, TypeEntry.TYPE_ENTRY_FILE_CONTENT_FEATURE,
+								TypeEntry.TYPE_ENTRY_FILE_CONTENT_FEATURE_ID, null, null));
+			}
 		}
 		// dispatch notifications
 		if (notifications != null) {


### PR DESCRIPTION
Send notifications for changed file content when saving in the type entry and no longer react to type changes for editor reload.