### PR TITLE
Makes selection FBs generic

### DIFF
--- a/data/typelibrary/utils-3.0.0/typelib/selection/F_SEL_E_2.fbt
+++ b/data/typelibrary/utils-3.0.0/typelib/selection/F_SEL_E_2.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="F_SEL_E_2" Comment="selection (event-based selection)">
+<FBType Name="F_SEL_E_2" Comment="selection (event-based selection) (generic FB)">
 	<Identification Standard="61131-3" Classification="standard selection function" Description="Copyright (c) 2012, 2022 TU Wien ACIN, HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Organization="TU Wien ACIN" Version="1.0" Author="Monika Wenger" Date="2012-03-25">
@@ -32,5 +32,6 @@
 			<VarDeclaration Name="OUT" Type="ANY" Comment="Selected input"/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_F_SEL_E'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/utils-3.0.0/typelib/selection/F_SEL_E_3.fbt
+++ b/data/typelibrary/utils-3.0.0/typelib/selection/F_SEL_E_3.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="F_SEL_E_3" Comment="selection event-based selection)">
+<FBType Name="F_SEL_E_3" Comment="selection event-based selection) (generic FB)">
 	<Identification Standard="61131-3" Classification="standard selection function" Description="Copyright (c) 2012, 2022 TU Wien ACIN, HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Organization="TU Wien ACIN" Version="1.0" Author="Monika Wenger" Date="2012-03-25">
@@ -36,5 +36,6 @@
 			<VarDeclaration Name="OUT" Type="ANY" Comment="Selected input"/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_F_SEL_E'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/utils-3.0.0/typelib/selection/F_SEL_E_4.fbt
+++ b/data/typelibrary/utils-3.0.0/typelib/selection/F_SEL_E_4.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="F_SEL_E_4" Comment="selection event-based selection)">
+<FBType Name="F_SEL_E_4" Comment="selection event-based selection) (generic FB)">
 	<Identification Standard="61131-3" Classification="standard selection function" Description="Copyright (c) 2012, 2022 TU Wien ACIN, HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Organization="TU Wien ACIN" Version="1.0" Author="Monika Wenger" Date="2012-03-25">
@@ -40,5 +40,6 @@
 			<VarDeclaration Name="OUT" Type="ANY" Comment="Selected input"/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_F_SEL_E'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>


### PR DESCRIPTION
Marks the selection FBs (F_SEL_E_2, F_SEL_E_3, F_SEL_E_4) as generic
by adding the "GenericClassName" attribute.
This allows them to be used as templates for generating
new FBs with different data types.
