### PR TITLE
Updates F_SEL_E functions to standardise events

### DIFF
--- a/data/typelibrary/utils-3.0.0/typelib/selection/F_SEL_E_2.fbt
+++ b/data/typelibrary/utils-3.0.0/typelib/selection/F_SEL_E_2.fbt
@@ -12,11 +12,11 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="REQ0" Type="Event" Comment="">
-				<With Var="IN0"/>
-			</Event>
-			<Event Name="REQ1" Type="Event" Comment="">
+			<Event Name="REQ1" Type="Event">
 				<With Var="IN1"/>
+			</Event>
+			<Event Name="REQ2" Type="Event">
+				<With Var="IN2"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
@@ -25,8 +25,8 @@
 			</Event>
 		</EventOutputs>
 		<InputVars>
-			<VarDeclaration Name="IN0" Type="ANY" Comment="Selectable input variable"/>
 			<VarDeclaration Name="IN1" Type="ANY" Comment="Selectable input variable"/>
+			<VarDeclaration Name="IN2" Type="ANY" Comment="Selectable input variable"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="OUT" Type="ANY" Comment="Selected input"/>

--- a/data/typelibrary/utils-3.0.0/typelib/selection/F_SEL_E_3.fbt
+++ b/data/typelibrary/utils-3.0.0/typelib/selection/F_SEL_E_3.fbt
@@ -12,14 +12,14 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="REQ0" Type="Event" Comment="">
-				<With Var="IN0"/>
-			</Event>
-			<Event Name="REQ1" Type="Event" Comment="">
+			<Event Name="REQ1" Type="Event">
 				<With Var="IN1"/>
 			</Event>
-			<Event Name="REQ2" Type="Event" Comment="">
+			<Event Name="REQ2" Type="Event">
 				<With Var="IN2"/>
+			</Event>
+			<Event Name="REQ3" Type="Event">
+				<With Var="IN3"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
@@ -28,9 +28,9 @@
 			</Event>
 		</EventOutputs>
 		<InputVars>
-			<VarDeclaration Name="IN0" Type="ANY" Comment="Selectable input variable"/>
 			<VarDeclaration Name="IN1" Type="ANY" Comment="Selectable input variable"/>
 			<VarDeclaration Name="IN2" Type="ANY" Comment="Selectable input variable"/>
+			<VarDeclaration Name="IN3" Type="ANY" Comment="Selectable input variable"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="OUT" Type="ANY" Comment="Selected input"/>

--- a/data/typelibrary/utils-3.0.0/typelib/selection/F_SEL_E_4.fbt
+++ b/data/typelibrary/utils-3.0.0/typelib/selection/F_SEL_E_4.fbt
@@ -12,17 +12,17 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="REQ0" Type="Event" Comment="">
-				<With Var="IN0"/>
-			</Event>
-			<Event Name="REQ1" Type="Event" Comment="">
+			<Event Name="REQ1" Type="Event">
 				<With Var="IN1"/>
 			</Event>
-			<Event Name="REQ2" Type="Event" Comment="">
+			<Event Name="REQ2" Type="Event">
 				<With Var="IN2"/>
 			</Event>
-			<Event Name="REQ3" Type="Event" Comment="">
+			<Event Name="REQ3" Type="Event">
 				<With Var="IN3"/>
+			</Event>
+			<Event Name="REQ4" Type="Event">
+				<With Var="IN4"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
@@ -31,10 +31,10 @@
 			</Event>
 		</EventOutputs>
 		<InputVars>
-			<VarDeclaration Name="IN0" Type="ANY" Comment="Selectable input variable"/>
 			<VarDeclaration Name="IN1" Type="ANY" Comment="Selectable input variable"/>
 			<VarDeclaration Name="IN2" Type="ANY" Comment="Selectable input variable"/>
 			<VarDeclaration Name="IN3" Type="ANY" Comment="Selectable input variable"/>
+			<VarDeclaration Name="IN4" Type="ANY" Comment="Selectable input variable"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="OUT" Type="ANY" Comment="Selected input"/>


### PR DESCRIPTION
Updates F_SEL_E function blocks to remove REQ0 event and rename other events for consistency.

This change aligns the event naming and structure of the F_SEL_E function blocks, enhancing readability and maintainability across the typelibrary.
