### PR TITLE
Avoid reset when disposing validation job

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/validation/ValidationJob.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/validation/ValidationJob.java
@@ -138,8 +138,10 @@ public class ValidationJob extends UIJob {
 	}
 
 	public void dispose() {
-		setEnabled(false);
 		commandStackEventListener.uninstall(commandStack);
+		enabled = false;
+		queue.clear();
+		cancel();
 	}
 
 	public boolean isEnabled() {


### PR DESCRIPTION
The validation job also performed a reset when it was disposed, which includes a reload of the annotation model. As the annotation model is also disposed immediately thereafter, this is unnecessary and may potentially even cause problems. This avoids the unnecessary reset.