### PR TITLE
Prevent duplicate type entry adapters and file notifications

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/TypeEntryAdapter.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/TypeEntryAdapter.java
@@ -104,11 +104,14 @@ public class TypeEntryAdapter extends AbstractTypeEntryAdapter {
 			handleFileContentChange();
 			break;
 		case TypeEntry.TYPE_ENTRY_FILE_FEATURE:
-			Display.getDefault().asyncExec(() -> {
-				if (!editorClosed() && notification.getNewValue() instanceof final IFile newFile) {
-					getEditor().setInput(new FileEditorInput(newFile));
-				}
-			});
+			if (notification.getNewValue() instanceof final IFile newFile) {
+				final FileEditorInput newEditorInput = new FileEditorInput(newFile);
+				Display.getDefault().execute(() -> {
+					if (!editorClosed() && !newEditorInput.equals(getEditor().getEditorInput())) {
+						getEditor().setInput(newEditorInput);
+					}
+				});
+			}
 			break;
 		case TypeEntry.TYPE_ENTRY_EDITOR_INSTANCE_UPDATE_FEATURE:
 			// if there is no typeEntry inside, then the notification is used wrong, and for

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/editors/AutomationSystemEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/editors/AutomationSystemEditor.java
@@ -515,7 +515,7 @@ public class AutomationSystemEditor extends AbstractBreadCrumbEditor implements 
 
 				final var entry = system == null ? TypeLibraryManager.INSTANCE.getTypeEntryForFile(fileEI.getFile())
 						: system.getTypeEntry();
-				if (entry != null) {
+				if (entry != null && !entry.eAdapters().contains(typeEntryAdapter)) {
 					entry.eAdapters().add(typeEntryAdapter);
 				}
 			}

--- a/plugins/org.eclipse.fordiac.ide.typeeditor/src/org/eclipse/fordiac/ide/typeeditor/AbstractTypeEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.typeeditor/src/org/eclipse/fordiac/ide/typeeditor/AbstractTypeEditor.java
@@ -513,7 +513,10 @@ public abstract class AbstractTypeEditor extends AbstractCloseAbleFormEditor imp
 				}
 				commandStack.setUndoContext(new ObjectUndoContext(typeEditorInput.getContent()));
 			}
-			typeEditorInput.getTypeEntry().eAdapters().add(typeEntryAdapter);
+			final TypeEntry typeEntry = typeEditorInput.getTypeEntry();
+			if (!typeEntry.eAdapters().contains(typeEntryAdapter)) {
+				typeEntry.eAdapters().add(typeEntryAdapter);
+			}
 			setInputWithNotify(typeEditorInput);
 		} else {
 			setInputWithNotify(input);


### PR DESCRIPTION
There was an additional type entry adapter added after each file change, combined with the possibility of reacting to duplicate notifications for a new file. This adds appropriate checks and also performs the update synchronously if already in the UI thread to reduce the possibility of race conditions.