### PR TITLE
Use input of open type editor in Xtext refactorings

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.st/src/org/eclipse/fordiac/ide/fbtypeeditor/st/StructuredTextFBTypeEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.st/src/org/eclipse/fordiac/ide/fbtypeeditor/st/StructuredTextFBTypeEditor.java
@@ -13,6 +13,7 @@
 package org.eclipse.fordiac.ide.fbtypeeditor.st;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.fordiac.ide.fbtypeeditor.editors.FBTypeXtextEditor;
 import org.eclipse.fordiac.ide.model.edit.TypeEntryAdapter;
@@ -26,6 +27,7 @@ import org.eclipse.fordiac.ide.structuredtextcore.util.STCoreMapper;
 import org.eclipse.fordiac.ide.ui.FordiacMessages;
 import org.eclipse.fordiac.ide.ui.imageprovider.FordiacImage;
 import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.part.MultiPageEditorSite;
 import org.eclipse.xtext.resource.ILocationInFileProvider;
 import org.eclipse.xtext.util.ITextRegion;
 
@@ -134,6 +136,13 @@ public class StructuredTextFBTypeEditor extends FBTypeXtextEditor
 		final TypeEntryAdapter typeEntryAdapter = getTypeEntryAdapter();
 		if (typeEntryAdapter != null) {
 			typeEntryAdapter.setBlockUpdates(block);
+		}
+	}
+
+	@Override
+	public void doSaveOuterEditor(final IProgressMonitor monitor) {
+		if (getEditorSite() instanceof final MultiPageEditorSite multiPageEditorSite) {
+			multiPageEditorSite.getMultiPageEditor().doSave(monitor);
 		}
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/editor/STCoreNestedEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/editor/STCoreNestedEditor.java
@@ -12,6 +12,9 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.structuredtextcore.ui.editor;
 
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.ui.ISaveablePart;
+
 public interface STCoreNestedEditor {
 
 	/**
@@ -20,4 +23,12 @@ public interface STCoreNestedEditor {
 	 * @param block true to block updates, false otherwise
 	 */
 	void setBlockUpdates(boolean block);
+
+	/**
+	 * Save the outer editor
+	 *
+	 * @param monitor The progress monitor
+	 * @see ISaveablePart#doSave(IProgressMonitor)
+	 */
+	void doSaveOuterEditor(IProgressMonitor monitor);
 }

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/EditorDocumentChange.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/EditorDocumentChange.java
@@ -19,22 +19,21 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.text.edits.UndoEdit;
 import org.eclipse.ui.IEditorPart;
-import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.texteditor.IDocumentProvider;
 
 public class EditorDocumentChange extends ProviderDocumentChange {
 
 	private final IEditorPart editorPart;
 
-	public EditorDocumentChange(final String name, final IFileEditorInput editorInput,
-			final IDocumentProvider documentProvider, final IEditorPart editorPart) {
-		super(name, editorInput, documentProvider);
+	public EditorDocumentChange(final String name, final IEditorPart editorPart,
+			final IDocumentProvider documentProvider) {
+		super(name, editorPart.getEditorInput(), documentProvider);
 		this.editorPart = editorPart;
 	}
 
-	public EditorDocumentChange(final String name, final IFileEditorInput editorInput,
-			final IDocumentProvider documentProvider, final IEditorPart editorPart, final boolean doSave) {
-		super(name, editorInput, documentProvider, doSave);
+	public EditorDocumentChange(final String name, final IEditorPart editorPart,
+			final IDocumentProvider documentProvider, final boolean doSave) {
+		super(name, editorPart.getEditorInput(), documentProvider, doSave);
 		this.editorPart = editorPart;
 	}
 
@@ -45,6 +44,9 @@ public class EditorDocumentChange extends ProviderDocumentChange {
 				nestedEditor.setBlockUpdates(true);
 			}
 			super.commit(document, pm);
+			if (isDoSave() && editorPart instanceof final STCoreNestedEditor nestedEditor) {
+				nestedEditor.doSaveOuterEditor(pm);
+			}
 		} finally {
 			if (editorPart instanceof final STCoreNestedEditor nestedEditor) {
 				nestedEditor.setBlockUpdates(false);
@@ -54,7 +56,6 @@ public class EditorDocumentChange extends ProviderDocumentChange {
 
 	@Override
 	protected Change createUndoChange(final UndoEdit edit) {
-		return new EditorDocumentUndoChange(getName(), getEditorInput(), getDocumentProvider(), edit, editorPart,
-				isDoSave());
+		return new EditorDocumentUndoChange(getName(), editorPart, getDocumentProvider(), edit, isDoSave());
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/EditorDocumentUndoChange.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/EditorDocumentUndoChange.java
@@ -19,17 +19,15 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.text.edits.UndoEdit;
 import org.eclipse.ui.IEditorPart;
-import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.texteditor.IDocumentProvider;
 
 public class EditorDocumentUndoChange extends ProviderDocumentUndoChange {
 
 	private final IEditorPart editorPart;
 
-	public EditorDocumentUndoChange(final String name, final IFileEditorInput editorInput,
-			final IDocumentProvider documentProvider, final UndoEdit undoEdit, final IEditorPart editorPart,
-			final boolean doSave) {
-		super(name, editorInput, documentProvider, undoEdit, doSave);
+	public EditorDocumentUndoChange(final String name, final IEditorPart editorPart,
+			final IDocumentProvider documentProvider, final UndoEdit undoEdit, final boolean doSave) {
+		super(name, editorPart.getEditorInput(), documentProvider, undoEdit, doSave);
 		this.editorPart = editorPart;
 	}
 
@@ -40,6 +38,9 @@ public class EditorDocumentUndoChange extends ProviderDocumentUndoChange {
 				nestedEditor.setBlockUpdates(true);
 			}
 			super.commit(document, pm);
+			if (isDoSave() && editorPart instanceof final STCoreNestedEditor nestedEditor) {
+				nestedEditor.doSaveOuterEditor(pm);
+			}
 		} finally {
 			if (editorPart instanceof final STCoreNestedEditor nestedEditor) {
 				nestedEditor.setBlockUpdates(false);
@@ -49,8 +50,7 @@ public class EditorDocumentUndoChange extends ProviderDocumentUndoChange {
 
 	@Override
 	protected Change createUndoChange(final UndoEdit edit) {
-		return new EditorDocumentUndoChange(getName(), getEditorInput(), getDocumentProvider(), edit, editorPart,
-				isDoSave());
+		return new EditorDocumentUndoChange(getName(), editorPart, getDocumentProvider(), edit, isDoSave());
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/ExtractCallableRefactoring.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/ExtractCallableRefactoring.java
@@ -63,7 +63,6 @@ import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 import org.eclipse.text.edits.MultiTextEdit;
 import org.eclipse.text.edits.ReplaceEdit;
 import org.eclipse.text.edits.TextEdit;
-import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.formatting.IWhitespaceInformationProvider;
 import org.eclipse.xtext.nodemodel.ICompositeNode;
@@ -285,8 +284,8 @@ public class ExtractCallableRefactoring extends Refactoring {
 
 	@Override
 	public Change createChange(final IProgressMonitor pm) throws CoreException, OperationCanceledException {
-		final ProviderDocumentChange change = new EditorDocumentChange(getName(),
-				(IFileEditorInput) editor.getEditorInput(), editor.getDocumentProvider(), editor, false);
+		final ProviderDocumentChange change = new EditorDocumentChange(getName(), editor, editor.getDocumentProvider(),
+				false);
 		change.setEdit(createTextEdit());
 		change.setTextType(editor.getDocument().getResourceURI().fileExtension());
 		return change;

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/ProviderDocumentChange.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/ProviderDocumentChange.java
@@ -20,22 +20,23 @@ import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 import org.eclipse.ltk.core.refactoring.TextChange;
 import org.eclipse.text.edits.UndoEdit;
+import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.texteditor.IDocumentProvider;
 
 public class ProviderDocumentChange extends TextChange {
 
-	private final IFileEditorInput editorInput;
+	private final IEditorInput editorInput;
 	private final IDocumentProvider documentProvider;
 	private final boolean doSave;
 	private long modificationStamp = -1L;
 
-	public ProviderDocumentChange(final String name, final IFileEditorInput editorInput,
+	public ProviderDocumentChange(final String name, final IEditorInput editorInput,
 			final IDocumentProvider documentProvider) {
 		this(name, editorInput, documentProvider, true);
 	}
 
-	public ProviderDocumentChange(final String name, final IFileEditorInput editorInput,
+	public ProviderDocumentChange(final String name, final IEditorInput editorInput,
 			final IDocumentProvider documentProvider, final boolean doSave) {
 		super(name);
 		this.editorInput = editorInput;
@@ -97,10 +98,13 @@ public class ProviderDocumentChange extends TextChange {
 
 	@Override
 	public Object[] getAffectedObjects() {
-		return new Object[] { editorInput.getFile() };
+		if (editorInput instanceof final IFileEditorInput fileEditorInput) {
+			return new Object[] { fileEditorInput.getFile() };
+		}
+		return new Object[0];
 	}
 
-	public IFileEditorInput getEditorInput() {
+	public IEditorInput getEditorInput() {
 		return editorInput;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/ProviderDocumentUndoChange.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/ProviderDocumentUndoChange.java
@@ -24,6 +24,7 @@ import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 import org.eclipse.ltk.internal.core.refactoring.Changes;
 import org.eclipse.text.edits.MalformedTreeException;
 import org.eclipse.text.edits.UndoEdit;
+import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.texteditor.IDocumentProvider;
 
@@ -31,12 +32,12 @@ import org.eclipse.ui.texteditor.IDocumentProvider;
 public class ProviderDocumentUndoChange extends Change {
 
 	private final String name;
-	private final IFileEditorInput editorInput;
+	private final IEditorInput editorInput;
 	private final IDocumentProvider documentProvider;
 	private final UndoEdit undoEdit;
 	private final boolean doSave;
 
-	public ProviderDocumentUndoChange(final String name, final IFileEditorInput editorInput,
+	public ProviderDocumentUndoChange(final String name, final IEditorInput editorInput,
 			final IDocumentProvider documentProvider, final UndoEdit undoEdit, final boolean doSave) {
 		this.name = name;
 		this.editorInput = editorInput;
@@ -52,12 +53,18 @@ public class ProviderDocumentUndoChange extends Change {
 
 	@Override
 	public Object getModifiedElement() {
-		return editorInput.getFile();
+		if (editorInput instanceof final IFileEditorInput fileEditorInput) {
+			return fileEditorInput.getFile();
+		}
+		return null;
 	}
 
 	@Override
 	public Object[] getAffectedObjects() {
-		return new Object[] { editorInput.getFile() };
+		if (editorInput instanceof final IFileEditorInput fileEditorInput) {
+			return new Object[] { fileEditorInput.getFile() };
+		}
+		return new Object[0];
 	}
 
 	@Override
@@ -124,7 +131,7 @@ public class ProviderDocumentUndoChange extends Change {
 		return new ProviderDocumentUndoChange(name, editorInput, documentProvider, edit, doSave);
 	}
 
-	public IFileEditorInput getEditorInput() {
+	public IEditorInput getEditorInput() {
 		return editorInput;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/STCoreChangeConverter.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/STCoreChangeConverter.java
@@ -190,8 +190,7 @@ public class STCoreChangeConverter extends ChangeConverter {
 		if (editor != null) {
 			final IDocumentProvider documentProvider = editor.getDocumentProvider();
 			if (documentProvider != null) {
-				return new EditorDocumentChange(change.getOldURI().lastSegment(), editorInput, documentProvider,
-						editor);
+				return new EditorDocumentChange(change.getOldURI().lastSegment(), editor, documentProvider);
 			}
 		}
 		final IDocumentProvider documentProvider = getDocumentProvider(change.getOldURI());


### PR DESCRIPTION
Use the editor input of the open editor and save via the outer type editor to ensure a consistent state between the type editor and the Xtext editor tab.