### PR TITLE
Sync all Xtext editors before move or rename resource refactorings

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/plugin.xml
@@ -620,7 +620,7 @@
  <extension
        point="org.eclipse.ltk.core.refactoring.renameParticipants">
     <renameParticipant
-          class="org.eclipse.fordiac.ide.structuredtextcore.ui.STCoreExecutableExtensionFactory:org.eclipse.xtext.ui.refactoring2.participant.XtextRenameResourceParticipant"
+          class="org.eclipse.fordiac.ide.structuredtextcore.ui.STCoreExecutableExtensionFactory:org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreRenameResourceParticipant"
           id="org.eclipse.fordiac.ide.structuredtextcore.ui.renameParticipant"
           name="ST Rename Resource Participant">
        <enablement>
@@ -633,7 +633,7 @@
  <extension
        point="org.eclipse.ltk.core.refactoring.moveParticipants">
     <moveParticipant
-          class="org.eclipse.fordiac.ide.structuredtextcore.ui.STCoreExecutableExtensionFactory:org.eclipse.xtext.ui.refactoring2.participant.XtextMoveResourceParticipant"
+          class="org.eclipse.fordiac.ide.structuredtextcore.ui.STCoreExecutableExtensionFactory:org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.STCoreMoveResourceParticipant"
           id="org.eclipse.fordiac.ide.structuredtextcore.ui.moveParticipant"
           name="ST Move Resource Participant">
        <enablement>

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/STCoreMoveResourceParticipant.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/STCoreMoveResourceParticipant.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Martin Erich Jobst
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Martin Jobst - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.eclipse.xtext.ui.refactoring.ui.SyncUtil;
+import org.eclipse.xtext.ui.refactoring2.participant.XtextMoveResourceParticipant;
+
+import com.google.inject.Inject;
+
+@SuppressWarnings("restriction")
+public class STCoreMoveResourceParticipant extends XtextMoveResourceParticipant {
+
+	@Inject
+	private SyncUtil syncUtil;
+
+	@Override
+	protected boolean initialize(final Object element) {
+		try {
+			syncUtil.totalSync(true, true, false);
+		} catch (final InvocationTargetException e) {
+			return false;
+		} catch (final InterruptedException e) {
+			Thread.currentThread().interrupt();
+			return false;
+		}
+		return super.initialize(element);
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/STCoreRenameResourceParticipant.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/STCoreRenameResourceParticipant.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Martin Erich Jobst
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Martin Jobst - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.eclipse.xtext.ui.refactoring.ui.SyncUtil;
+import org.eclipse.xtext.ui.refactoring2.participant.XtextRenameResourceParticipant;
+
+import com.google.inject.Inject;
+
+@SuppressWarnings("restriction")
+public class STCoreRenameResourceParticipant extends XtextRenameResourceParticipant {
+
+	@Inject
+	private SyncUtil syncUtil;
+
+	@Override
+	protected boolean initialize(Object element) {
+		try {
+			syncUtil.totalSync(true, true, false);
+		} catch (InvocationTargetException e) {
+			return false;
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			return false;
+		}
+		return super.initialize(element);
+	}
+}


### PR DESCRIPTION
This is necessary to avoid race conditions in the dirty state support when moving or renaming a resource while an Xtext editor is open.