### PR TITLE
Added CLIENT_0_1 and CLIENT_1_0

### DIFF
--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_0_1.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_0_1.fbt
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="CLIENT_0_1" Comment="Connect to a SERVER_1 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-19-26" Remarks="Created from CLIENT_1">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::net">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Open new connection (QI = TRUE) / Close connection (QI = FALSE)">
+				<With Var="QI"/>
+				<With Var="ID"/>
+			</Event>
+			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
+				<With Var="QI"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="New connection established (QI = TRUE) / connection closed (QI = FALSE)">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="CNF" Type="Event" Comment="New data available from Server">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+				<With Var="RD_1"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL"/>
+			<VarDeclaration Name="ID" Type="WSTRING"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL"/>
+			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+			<VarDeclaration Name="RD_1" Type="ANY"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_1_0.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_1_0.fbt
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="CLIENT_1_0" Comment="Connect to a SERVER_1 Block">
+	<Identification Standard="61499-2" Description="Copyright (c) 2017, 2025 fortiss GmbH , Johannes Kepler University Linz &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  ">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Alois Zoitl" Date="2025-19-26" Remarks="Created from CLIENT_1">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::net">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Open new connection (QI = TRUE) / Close connection (QI = FALSE)">
+				<With Var="QI"/>
+				<With Var="ID"/>
+			</Event>
+			<Event Name="REQ" Type="Event" Comment="Send data to Server, Request Data from Server">
+				<With Var="QI"/>
+				<With Var="SD_1"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="New connection established (QI = TRUE) / connection closed (QI = FALSE)">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+			<Event Name="CNF" Type="Event" Comment="New data available from Server">
+				<With Var="QO"/>
+				<With Var="STATUS"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL"/>
+			<VarDeclaration Name="ID" Type="WSTRING"/>
+			<VarDeclaration Name="SD_1" Type="ANY"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="QO" Type="BOOL"/>
+			<VarDeclaration Name="STATUS" Type="WSTRING"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_CLIENT'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>


### PR DESCRIPTION
These client blocks are helpfull for reading or writing single values in a remote OPC UA server. They can also serve as templates for accessing more then one value.