### PR TITLE
Show warnings and error annotations for transitions

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editparts/ECTransitionEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editparts/ECTransitionEditPart.java
@@ -35,6 +35,9 @@ import org.eclipse.fordiac.ide.fbtypeeditor.ecc.figures.ECTransitionFigure;
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.policies.ECTransitionFeedbackEditPolicy;
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.policies.TransitionBendPointEditPolicy;
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.preferences.FBTypeEditorPreferenceConstants;
+import org.eclipse.fordiac.ide.gef.annotation.AnnotableGraphicalEditPart;
+import org.eclipse.fordiac.ide.gef.annotation.GraphicalAnnotationModelEvent;
+import org.eclipse.fordiac.ide.gef.annotation.GraphicalAnnotationStyles;
 import org.eclipse.fordiac.ide.gef.editparts.AbstractDirectEditableEditPart;
 import org.eclipse.fordiac.ide.gef.editparts.ZoomScalableFreeformRootEditPart;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeConditionExpressionCommand;
@@ -65,7 +68,7 @@ import org.eclipse.gef.tools.DirectEditManager;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.util.IPropertyChangeListener;
 
-public class ECTransitionEditPart extends AbstractConnectionEditPart {
+public class ECTransitionEditPart extends AbstractConnectionEditPart implements AnnotableGraphicalEditPart {
 
 	private DirectEditManager manager;
 
@@ -363,5 +366,11 @@ public class ECTransitionEditPart extends AbstractConnectionEditPart {
 	@Override
 	public ECTransitionFigure getFigure() {
 		return (ECTransitionFigure) super.getFigure();
+	}
+
+	@Override
+	public void updateAnnotations(final GraphicalAnnotationModelEvent event) {
+		GraphicalAnnotationStyles.updateAnnotationFeedback(getFigure().getLabel(), getModel(), event);
+		getFigure().getToolTip().refreshAnotations(getModel(), event.getModel());
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/figures/ECCToolTip.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/figures/ECCToolTip.java
@@ -1,8 +1,7 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2009, 2016 Profactor GmbH, fortiss GmbH
- * 				 2019 Johannes Kepler University
- * 				 2020 Johannes Kepler University Linz
- * 				 2020 Primetals Technologies Germany GmbH
+ * Copyright (c) 2008, 2025 Profactor GmbH, fortiss GmbH,
+ *                          Johannes Kepler University Linz,
+ *                          Primetals Technologies Germany GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -39,40 +38,36 @@ import org.eclipse.fordiac.ide.gef.figures.VerticalLineCompartmentFigure;
 public class ECCToolTip extends Figure {
 
 	private final TextFlow content = new TextFlow();
-
-	private final FlowPage fp = new FlowPage();
-
 	private final Label nameLabel = new Label();
-
-	private final Figure line = new VerticalLineCompartmentFigure();
 
 	public ECCToolTip() {
 		setLayoutManager(new GridLayout());
+		add(nameLabel);
+		setConstraint(nameLabel, new GridData(PositionConstants.CENTER, PositionConstants.MIDDLE, true, true));
+
+		final Figure line = new VerticalLineCompartmentFigure();
+		add(line);
+		setConstraint(line, new GridData(PositionConstants.CENTER, PositionConstants.MIDDLE, true, true));
+		content.setLayoutManager(new ParagraphTextLayout(content, ParagraphTextLayout.WORD_WRAP_HARD));
+
+		final FlowPage fp = new FlowPage();
+		fp.add(content);
+		line.add(fp);
+		line.setConstraint(fp, new GridData(PositionConstants.CENTER, PositionConstants.MIDDLE, false, true));
 	}
 
 	protected void setLabel(final String name, final String comment) {
 		nameLabel.setText(name);
-		add(nameLabel);
-		setConstraint(nameLabel, new GridData(PositionConstants.CENTER, PositionConstants.MIDDLE, true, true));
 
 		setLabelContent(comment);
 	}
 
 	private void setLabelContent(final String text) {
-		add(line);
-		setConstraint(line, new GridData(PositionConstants.CENTER, PositionConstants.MIDDLE, true, true));
-
 		if ((text != null) && (!text.isEmpty())) {
 			content.setText(text);
 		} else {
 			content.setText("[not set]");
 		}
-		content.setLayoutManager(new ParagraphTextLayout(content, ParagraphTextLayout.WORD_WRAP_HARD));
-		fp.add(content);
-		line.add(fp);
-		line.setConstraint(fp, new GridData(PositionConstants.CENTER, PositionConstants.MIDDLE, false, true));
-
-		revalidate();
-		repaint();
 	}
+
 }

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/figures/ECTransitionToolTipFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/figures/ECTransitionToolTipFigure.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2020 Johannes Kepler University Linz
- * 				 2020 Primetals Technologies Germany GmbH
+ * Copyright (c) 2020, 2025 Johannes Kepler University Linz,
+ *                          Primetals Technologies Germany GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,16 +18,39 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.fbtypeeditor.ecc.figures;
 
+import org.eclipse.draw2d.Figure;
+import org.eclipse.draw2d.GridData;
+import org.eclipse.draw2d.Label;
+import org.eclipse.draw2d.PositionConstants;
+import org.eclipse.draw2d.ToolbarLayout;
+import org.eclipse.fordiac.ide.gef.annotation.GraphicalAnnotationModel;
+import org.eclipse.fordiac.ide.gef.annotation.GraphicalAnnotationStyles;
 import org.eclipse.fordiac.ide.model.libraryElement.ECState;
 import org.eclipse.fordiac.ide.model.libraryElement.ECTransition;
 
 public class ECTransitionToolTipFigure extends ECCToolTip {
 
-	public void setECTransition(ECTransition transition) {
+	private final Figure annotationContainer = new Figure();
+
+	public ECTransitionToolTipFigure() {
+		add(annotationContainer);
+		annotationContainer.setLayoutManager(new ToolbarLayout());
+		setConstraint(annotationContainer, new GridData(PositionConstants.LEFT, PositionConstants.MIDDLE, true, true));
+	}
+
+	public void setECTransition(final ECTransition transition) {
 		final ECState des = transition.getDestination();
 		final String desName = (des == null) ? null : des.getName();
 
-		setLabel(transition.getSource().getName() + " -> " + desName, transition.getComment());
+		setLabel(transition.getSource().getName() + " -> " + desName, transition.getComment()); //$NON-NLS-1$
+	}
+
+	public void refreshAnotations(final ECTransition transition, final GraphicalAnnotationModel annotationModel) {
+		annotationContainer.removeAll();
+		if (transition != null && annotationModel != null) {
+			annotationModel.getAnnotations(transition).stream().forEach(annotation -> annotationContainer
+					.add(new Label(annotation.getText(), GraphicalAnnotationStyles.getAnnotationImage(annotation))));
+		}
 	}
 
 }


### PR DESCRIPTION
Transition conditions are showing the error or warning overlay. The tooltip the message. Furthermore the tooltip code has been cleaned.

Related to #1668.