### PR TITLE
Fix stuck single window flag in log helper

### DIFF
--- a/plugins/org.eclipse.fordiac.ide/src/org/eclipse/fordiac/ide/FordiacLogListener.java
+++ b/plugins/org.eclipse.fordiac.ide/src/org/eclipse/fordiac/ide/FordiacLogListener.java
@@ -67,9 +67,12 @@ public class FordiacLogListener implements ILogListener {
 
 	@Override
 	public void logging(final IStatus status, final String plugin) {
-		if ((status.getSeverity() == IStatus.ERROR) && (null != status.getException()) && !singleWindow.getAndSet(true)
+		if ((status.getSeverity() == IStatus.ERROR) && (null != status.getException())
 				&& (status.getPlugin().startsWith(Activator.PLUGIN_ID)
-						|| status.getPlugin().equals(PlatformUI.PLUGIN_ID))) {
+						|| status.getPlugin().equals(PlatformUI.PLUGIN_ID))
+				// checking/setting the flag must be last, so that we only set it when actually
+				// showing an error dialog and resetting the flag afterwards
+				&& !singleWindow.getAndSet(true)) {
 			// inform the user that an error has happened
 			// we currently only treat errors with exception and from a 4diac IDE or the
 			// Platform UI plug-in as noteworthy


### PR DESCRIPTION
The single window flag was set even when no error dialog was shown, which meant it was never reset and no further dialogs were shown at all. This only sets the flag when actually showing an error dialog and resetting the flag afterwards.