### PR TITLE
signalprocessing-1.0.0  Adds an empty "TypeHash" attribute

### DIFF
--- a/data/typelibrary/signalprocessing-1.0.0/typelib/FIELDBUS_PERCENT_TO_WORD.fct
+++ b/data/typelibrary/signalprocessing-1.0.0/typelib/FIELDBUS_PERCENT_TO_WORD.fct
@@ -41,4 +41,5 @@ FIELDBUS_PERCENT_TO_WORD := UDINT_TO_WORD(REAL_TO_UDINT(RI
 END_FUNCTION
 ]]></ST>
 	</FunctionBody>
+	<Attribute Name="TypeHash" Value="''"/>
 </Function>

--- a/data/typelibrary/signalprocessing-1.0.0/typelib/FIELDBUS_WORD_TO_PERCENT.fct
+++ b/data/typelibrary/signalprocessing-1.0.0/typelib/FIELDBUS_WORD_TO_PERCENT.fct
@@ -50,4 +50,5 @@ END_IF;
 END_FUNCTION
 ]]></ST>
 	</FunctionBody>
+	<Attribute Name="TypeHash" Value="''"/>
 </Function>

--- a/data/typelibrary/signalprocessing-1.0.0/typelib/SCALE.fct
+++ b/data/typelibrary/signalprocessing-1.0.0/typelib/SCALE.fct
@@ -51,4 +51,5 @@ END_FUNCTION
 
 ]]></ST>
 	</FunctionBody>
+	<Attribute Name="TypeHash" Value="''"/>
 </Function>

--- a/data/typelibrary/signalprocessing-1.0.0/typelib/SCALE_LIM.fct
+++ b/data/typelibrary/signalprocessing-1.0.0/typelib/SCALE_LIM.fct
@@ -69,4 +69,5 @@ END_FUNCTION
 
 ]]></ST>
 	</FunctionBody>
+	<Attribute Name="TypeHash" Value="''"/>
 </Function>


### PR DESCRIPTION
Adds an empty "TypeHash" attribute to several function definitions
within the signalprocessing type library.

This change ensures consistency and prepares for future type
hashing implementation.
