### PR TITLE
Integrate MRU tracker with element creation workflow

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editors/NewInstanceCellEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editors/NewInstanceCellEditor.java
@@ -16,9 +16,11 @@ package org.eclipse.fordiac.ide.gef.editors;
 
 import java.util.List;
 
+import org.eclipse.core.resources.IProject;
 import org.eclipse.fordiac.ide.gef.Messages;
 import org.eclipse.fordiac.ide.gef.utilities.CellEditorLayoutFactory;
 import org.eclipse.fordiac.ide.model.edit.providers.ResultListLabelProvider;
+import org.eclipse.fordiac.ide.model.typelibrary.MostRecentlyUsedTracker;
 import org.eclipse.fordiac.ide.model.typelibrary.PaletteFilter;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
@@ -60,6 +62,7 @@ public class NewInstanceCellEditor extends TextCellEditor {
 	private boolean blockTableSelection = false;
 	private TypeEntry selectedEntry = null;
 	protected Text textControl;
+	private MostRecentlyUsedTracker mruTracker;
 
 	private ResultListLabelProvider resultListLabelProvider;
 
@@ -85,6 +88,19 @@ public class NewInstanceCellEditor extends TextCellEditor {
 
 	public void setTypeLibrary(final TypeLibrary typeLib) {
 		paletteFilter = new PaletteFilter(typeLib);
+
+		// Initialize MRU tracker for the current project
+		if (typeLib != null && mruTracker == null) {
+			try {
+				final IProject project = typeLib.getProject();
+				if (project != null && project.exists()) {
+					mruTracker = new MostRecentlyUsedTracker(project);
+				}
+			} catch (final Exception e) {
+				System.err.println("Failed to initialize MRUTracker: " + e.getMessage());
+				e.printStackTrace();
+			}
+		}
 	}
 
 	@Override
@@ -135,6 +151,14 @@ public class NewInstanceCellEditor extends TextCellEditor {
 	@Override
 	public Object doGetValue() {
 		if (null != selectedEntry) {
+			if (mruTracker != null && !mruTracker.isDisposed()) {
+				try {
+					mruTracker.recordUsage(selectedEntry);
+					System.out.println("DEBUG: Recorded usage of: " + selectedEntry.getFullTypeName());
+				} catch (final Exception e) {
+					System.err.println("Failed to record MRU usage: " + e.getMessage());
+				}
+			}
 			return selectedEntry;
 		}
 		return super.doGetValue();


### PR DESCRIPTION
This Pr connects the `MostRecentlyUsedTracker` (from PR #1799 ) to the element creation workflow. Now when users create function blocks via the search dialog, the tracker automatically records usage for later retrieval.

Changes:
- Add MRU tracker instance to `NewInstanceCellEditor`
- Initialize tracker in `setTypeLibrary()` with project from TypeLibrary
- Record usage in `doGetValue()` when element is selected
- Add debug output to verify tracking is working

This enables automatic MRU tracking without requiring any user action. Debug output will now appear in the console showing MRU list updates as users create function blocks.

Depends on: PR #1 (MRU infrastructure)

### How to Verify

1. Open an FB editor in a project.
2. Create FBs via type-to-search
3. Check console for debug prints
4. Verify per-project prefs file (project/.settings/org.eclipse.fordiac.ide.gef.prefs) updates with the MRU list.
5. Test edge cases: Delete project -> no errors; new project -> empty MRU.

UI display of MRU items will come in follow-up PR