### PR TITLE
Display MRU items in search dialog and remove debug output

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editors/NewInstanceCellEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editors/NewInstanceCellEditor.java
@@ -16,8 +16,10 @@ package org.eclipse.fordiac.ide.gef.editors;
 
 import java.util.List;
 
+import org.eclipse.core.resources.IProject;
 import org.eclipse.fordiac.ide.gef.Messages;
 import org.eclipse.fordiac.ide.gef.utilities.CellEditorLayoutFactory;
+import org.eclipse.fordiac.ide.gef.utilities.MostRecentlyUsedTracker;
 import org.eclipse.fordiac.ide.model.edit.providers.ResultListLabelProvider;
 import org.eclipse.fordiac.ide.model.typelibrary.PaletteFilter;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
@@ -60,6 +62,7 @@ public class NewInstanceCellEditor extends TextCellEditor {
 	private boolean blockTableSelection = false;
 	private TypeEntry selectedEntry = null;
 	protected Text textControl;
+	private MostRecentlyUsedTracker mruTracker;
 
 	private ResultListLabelProvider resultListLabelProvider;
 
@@ -85,6 +88,19 @@ public class NewInstanceCellEditor extends TextCellEditor {
 
 	public void setTypeLibrary(final TypeLibrary typeLib) {
 		paletteFilter = new PaletteFilter(typeLib);
+
+		// Initialize MRU tracker for the current project
+		if (typeLib != null && mruTracker == null) {
+			try {
+				final IProject project = typeLib.getProject();
+				if (project != null && project.exists()) {
+					mruTracker = new MostRecentlyUsedTracker(project);
+				}
+			} catch (final Exception e) {
+				System.err.println("Failed to initialize MRUTracker: " + e.getMessage());
+				e.printStackTrace();
+			}
+		}
 	}
 
 	@Override
@@ -135,6 +151,14 @@ public class NewInstanceCellEditor extends TextCellEditor {
 	@Override
 	public Object doGetValue() {
 		if (null != selectedEntry) {
+			if (mruTracker != null && !mruTracker.isDisposed()) {
+				try {
+					mruTracker.recordUsage(selectedEntry.getTypeName());
+					System.out.println("DEBUG: Recorded usage of: " + selectedEntry.getTypeName());
+				} catch (final Exception e) {
+					System.err.println("Failed to record MRU usage: " + e.getMessage());
+				}
+			}
 			return selectedEntry;
 		}
 		return super.doGetValue();

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editors/NewInstanceCellEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editors/NewInstanceCellEditor.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.gef.editors;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.core.resources.IProject;
@@ -101,6 +102,11 @@ public class NewInstanceCellEditor extends TextCellEditor {
 				e.printStackTrace();
 			}
 		}
+
+		// Trigger update now that paletteFilter is initialized
+		if (textControl != null && !textControl.isDisposed()) {
+			updateSelectionList();
+		}
 	}
 
 	@Override
@@ -151,14 +157,15 @@ public class NewInstanceCellEditor extends TextCellEditor {
 	@Override
 	public Object doGetValue() {
 		if (null != selectedEntry) {
+			// Record usage in MRU tracker
 			if (mruTracker != null && !mruTracker.isDisposed()) {
 				try {
 					mruTracker.recordUsage(selectedEntry.getTypeName());
-					System.out.println("DEBUG: Recorded usage of: " + selectedEntry.getTypeName());
 				} catch (final Exception e) {
 					System.err.println("Failed to record MRU usage: " + e.getMessage());
 				}
 			}
+
 			return selectedEntry;
 		}
 		return super.doGetValue();
@@ -208,18 +215,65 @@ public class NewInstanceCellEditor extends TextCellEditor {
 
 	protected void updateSelectionList() {
 		blockTableSelection = true;
-		if (textControl.getText().length() >= 2) {
-			final List<TypeEntry> entries = paletteFilter.findFBAndSubappTypes((textControl.getText()));
-			resultListLabelProvider.setSearchString(textControl.getText());
+		final String searchText = textControl.getText();
+
+		if (searchText.length() >= 2) {
+			// Normal search with 2+ characters
+			final List<TypeEntry> entries = paletteFilter.findFBAndSubappTypes(searchText);
+			resultListLabelProvider.setSearchString(searchText);
 			tableViewer.setInput(entries);
 			if (!entries.isEmpty()) {
 				selectItemAtIndex(0);
 			}
 			markDirty();
+		} else if (searchText.length() == 0) {
+			// Show MRU when search is empty
+			showMRUList();
+		} else {
+			// 1 character typed - hide list (keep current behavior)
+			tableViewer.setInput(null);
+		}
+
+		blockTableSelection = false;
+	}
+
+	/**
+	 * Show the MRU (Most Recently Used) list when no search text is entered.
+	 */
+	private void showMRUList() {
+		if (paletteFilter == null) {
+			tableViewer.setInput(null);
+			return;
+		}
+
+		if (mruTracker == null || mruTracker.isDisposed()) {
+			tableViewer.setInput(null);
+			return;
+		}
+
+		final List<String> mruTypeNames = mruTracker.getMRUList();
+
+		if (mruTypeNames.isEmpty()) {
+			tableViewer.setInput(null);
+			return;
+		}
+
+		// Convert type names to TypeEntry objects
+		final List<TypeEntry> mruEntries = new ArrayList<>();
+		for (final String typeName : mruTypeNames) {
+			final TypeEntry entry = paletteFilter.findTypeEntry(typeName);
+			if (entry != null) {
+				mruEntries.add(entry);
+			}
+		}
+
+		if (!mruEntries.isEmpty()) {
+			resultListLabelProvider.setSearchString(""); // No highlighting for MRU
+			tableViewer.setInput(mruEntries);
+			selectItemAtIndex(0);
 		} else {
 			tableViewer.setInput(null);
 		}
-		blockTableSelection = false;
 	}
 
 	private void handleKeyPress(final Event event, final Text textControl) {

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/utilities/MostRecentlyUsedTracker.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/utilities/MostRecentlyUsedTracker.java
@@ -69,9 +69,6 @@ public class MostRecentlyUsedTracker {
 			this.preferences = projectScope.getNode(PREF_NODE);
 			loadFromPreferences();
 
-			// TODO: Remove debug output after UI integration is complete
-			System.out.println("[MRU] Initialized for project: " + project.getName());
-			System.out.println("[MRU] Loaded " + mruList.size() + " items: " + mruList);
 		} else {
 			this.preferences = null;
 			this.mruList = new LinkedList<>();
@@ -103,10 +100,6 @@ public class MostRecentlyUsedTracker {
 		}
 
 		saveToPreferences();
-
-		// TODO: Remove debug output after UI integration is complete
-		System.out.println("[MRU] Recorded usage: " + fbTypeName);
-		System.out.println("[MRU] Current list: " + mruList);
 	}
 
 	/**
@@ -169,8 +162,7 @@ public class MostRecentlyUsedTracker {
 				}
 			}
 		} catch (final IllegalStateException e) {
-			// TODO: Remove debug output after UI integration is complete
-			System.out.println("[MRU] Preference node removed, cannot load");
+			// Preference node has been removed (project deleted) - silent handling
 		} catch (final Exception e) {
 			System.err.println("[MRU] Failed to load preferences: " + e.getMessage());
 		}
@@ -201,9 +193,6 @@ public class MostRecentlyUsedTracker {
 			preferences.flush();
 
 		} catch (final IllegalStateException e) {
-			// Preference node has been removed (project is being deleted)
-			// TODO: Remove debug output after UI integration is complete
-			System.out.println("[MRU] Preference node removed, cannot save");
 			disposed = true;
 		} catch (final BackingStoreException e) {
 			System.err.println("[MRU] Failed to save preferences: " + e.getMessage());

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/utilities/MostRecentlyUsedTracker.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/utilities/MostRecentlyUsedTracker.java
@@ -1,0 +1,233 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Wolfgang Schedl.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Wolfgang Schedl - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.fordiac.ide.gef.utilities;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ProjectScope;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.osgi.service.prefs.BackingStoreException;
+
+/**
+ * Tracks Most Recently Used (MRU) function block types per project.
+ *
+ * This class maintains a per-project history of recently used FB types and
+ * stores them in Eclipse project-scoped preferences. The MRU list is ordered
+ * with the most recently used item first, and is limited to a maximum of 5
+ * entries.
+ */
+public class MostRecentlyUsedTracker {
+
+	/** Preference node ID for storing MRU data */
+	private static final String PREF_NODE = "org.eclipse.fordiac.ide.gef";
+
+	/** Preference key for MRU list */
+	private static final String PREF_KEY = "mru_fb_types"; //$NON-NLS-1$
+
+	/** Delimiter for serializing MRU list */
+	private static final String DELIMITER = ";"; //$NON-NLS-1$
+
+	/** Maximum number of items to keep in MRU list */
+	private static final int MAX_MRU_ITEMS = 5;
+
+	/** Eclipse preferences for this project */
+	private IEclipsePreferences preferences;
+
+	/** The project this tracker is associated with */
+	private IProject currentProject;
+
+	/** In-memory MRU list (most recent first) */
+	private LinkedList<String> mruList;
+
+	/** Flag indicating if this tracker has been disposed */
+	private boolean disposed = false;
+
+	/**
+	 * Create an MRU tracker for a specific project.
+	 *
+	 * @param project the project to track MRU for, or null
+	 */
+	public MostRecentlyUsedTracker(final IProject project) {
+		this.currentProject = project;
+
+		if (project != null && project.exists()) {
+			final ProjectScope projectScope = new ProjectScope(project);
+			this.preferences = projectScope.getNode(PREF_NODE);
+			loadFromPreferences();
+
+			// TODO: Remove debug output after UI integration is complete
+			System.out.println("[MRU] Initialized for project: " + project.getName());
+			System.out.println("[MRU] Loaded " + mruList.size() + " items: " + mruList);
+		} else {
+			this.preferences = null;
+			this.mruList = new LinkedList<>();
+		}
+	}
+
+	/**
+	 * Record that a FB type was used (created/inserted). Moves the type to the
+	 * front of the MRU list.
+	 *
+	 * @param fbTypeName the full type name (e.g., "E_CYCLE", "E_SWITCH")
+	 */
+	public synchronized void recordUsage(final String fbTypeName) {
+		if (disposed || fbTypeName == null || fbTypeName.isEmpty()) {
+			return;
+		}
+
+		if (currentProject == null || !currentProject.exists()) {
+			return;
+		}
+
+		// Remove if already exists (to move to front)
+		mruList.remove(fbTypeName);
+
+		mruList.addFirst(fbTypeName);
+
+		while (mruList.size() > MAX_MRU_ITEMS) {
+			mruList.removeLast();
+		}
+
+		saveToPreferences();
+
+		// TODO: Remove debug output after UI integration is complete
+		System.out.println("[MRU] Recorded usage: " + fbTypeName);
+		System.out.println("[MRU] Current list: " + mruList);
+	}
+
+	/**
+	 * Get the MRU list in order (most recent first).
+	 *
+	 * @return unmodifiable list of type names, or empty list if disposed
+	 */
+	public synchronized List<String> getMRUList() {
+		if (disposed || currentProject == null || !currentProject.exists()) {
+			return new ArrayList<>();
+		}
+		return new ArrayList<>(mruList);
+	}
+
+	/**
+	 * Clear the MRU history for this project.
+	 */
+	public synchronized void clear() {
+		if (disposed) {
+			return;
+		}
+		mruList.clear();
+		saveToPreferences();
+	}
+
+	/**
+	 * Dispose of this MRUTracker and release resources. Should be called when the
+	 * editor is closed or project is deleted.
+	 */
+	public synchronized void dispose() {
+		if (disposed) {
+			return;
+		}
+
+		disposed = true;
+		preferences = null;
+		currentProject = null;
+		mruList.clear();
+	}
+
+	/**
+	 * Load MRU list from Eclipse preferences.
+	 */
+	private void loadFromPreferences() {
+		mruList = new LinkedList<>();
+
+		if (preferences == null || disposed) {
+			return;
+		}
+
+		try {
+			final String stored = preferences.get(PREF_KEY, "");
+
+			if (stored != null && !stored.isEmpty()) {
+				final String[] items = stored.split(DELIMITER);
+				for (final String item : items) {
+					if (!item.isEmpty()) {
+						mruList.add(item);
+					}
+				}
+			}
+		} catch (final IllegalStateException e) {
+			// TODO: Remove debug output after UI integration is complete
+			System.out.println("[MRU] Preference node removed, cannot load");
+		} catch (final Exception e) {
+			System.err.println("[MRU] Failed to load preferences: " + e.getMessage());
+		}
+	}
+
+	/**
+	 * Save MRU list to Eclipse preferences.
+	 */
+	private void saveToPreferences() {
+		if (preferences == null || disposed) {
+			return;
+		}
+
+		if (currentProject == null || !currentProject.exists()) {
+			return;
+		}
+
+		try {
+			final StringBuilder sb = new StringBuilder();
+			for (int i = 0; i < mruList.size(); i++) {
+				if (i > 0) {
+					sb.append(DELIMITER);
+				}
+				sb.append(mruList.get(i));
+			}
+
+			preferences.put(PREF_KEY, sb.toString());
+			preferences.flush();
+
+		} catch (final IllegalStateException e) {
+			// Preference node has been removed (project is being deleted)
+			// TODO: Remove debug output after UI integration is complete
+			System.out.println("[MRU] Preference node removed, cannot save");
+			disposed = true;
+		} catch (final BackingStoreException e) {
+			System.err.println("[MRU] Failed to save preferences: " + e.getMessage());
+		} catch (final Exception e) {
+			System.err.println("Unexpected error saving MRU: " + e.getMessage());
+			e.printStackTrace();
+		}
+	}
+
+	/**
+	 * Get the project this tracker is associated with.
+	 *
+	 * @return the project, or null if none
+	 */
+	public IProject getProject() {
+		return currentProject;
+	}
+
+	/**
+	 * Check if this tracker has been disposed.
+	 *
+	 * @return true if disposed, false otherwise
+	 */
+	public boolean isDisposed() {
+		return disposed;
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/PaletteFilter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/PaletteFilter.java
@@ -35,6 +35,30 @@ public class PaletteFilter {
 				Stream.concat(typeLib.getFbTypes().stream(), typeLib.getSubAppTypes().stream()))).toList();
 	}
 
+	/**
+	 * Find a specific TypeEntry by its exact type name.
+	 *
+	 * @param typeName the full type name (e.g., "E_CYCLE")
+	 * @return the TypeEntry or null if not found
+	 */
+	public TypeEntry findTypeEntry(final String typeName) {
+		if (typeName == null || typeName.isEmpty()) {
+			return null;
+		}
+
+		// Reuse existing search - search for the type name
+		final List<TypeEntry> results = findFBAndSubappTypes(typeName);
+
+		// Find exact match (not just substring)
+		for (final TypeEntry entry : results) {
+			if (typeName.equals(entry.getTypeName())) {
+				return entry;
+			}
+		}
+
+		return null;
+	}
+
 	private Stream<TypeEntry> findTypes(final String searchString, final Stream<TypeEntry> stream) {
 		setSearchPattern(searchString);
 		return stream.filter(entry -> matcher.matches(entry.getFullTypeName()))


### PR DESCRIPTION
This PR completes the MRU feature by adding UI display of recently used function blocks in the search dialog. When users open the dialog with an empty search field, they now see their most recently used FBs for quick access.
This PR also removes all debug output added in PR #1799 and PR #1800 , as the feature is now fully functional and visible through the UI.

### Dependencies
-  Requires #1799 (MRU infrastructure)
-  Requires #1800 (integration with creation workflow)

### Details
Changes to `NewInstanceCellEditor`:
- Modified updateSelectionList() to show MRU when search is empty
- Added showMRUList() method to populate with MRU items

Changes to `PaletteFilter`:
- Added findTypeEntry() method to find exact type by name
- Reuses existing findFBAndSubappTypes() for consistency
- Converts MRU type names (strings) to TypeEntry objects

Changes to `MostRecentlyUsedTracker`:
- Removed all debug statements
- Cleaned up TODO markers

UX:
- Open search dialog with empty field → see recently used FBs
- Type 1 character → list hides
- Type 2+ characters → normal search results appear
- MRU updates automatically as users create elements

Example Screenshot:
<img width="402" height="239" alt="image" src="https://github.com/user-attachments/assets/f5a6d73b-1662-44b5-b957-4e665a6b785e" />