### PR TITLE
Generating Test Infrastructure within IEC 61499

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/CompositeTestFBGenerator.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/CompositeTestFBGenerator.java
@@ -117,6 +117,7 @@ public class CompositeTestFBGenerator extends AbstractCompositeFBGenerator {
 
 	private void addTimeOutFB(final FBNetwork net, final FB fb, final int x, final int y) {
 		final BlockFBNetworkElement compEl = LibraryElementFactory.eINSTANCE.createCFBInstance();
+
 		final TypeEntry compType = sourceType.getTypeLibrary().getFBTypeEntry(TestGenBlockNames.TIMEOUT_COMPOSITE_NAME);
 		compEl.setTypeEntry(compType);
 		addPosition(compEl, x + (double) 200, y + (double) 150);

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/TestGenBlockNames.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/TestGenBlockNames.java
@@ -1,10 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2025 Johannes Kepler University Linz
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Melanie Winter
+ *     - initial API and implementation and/or initial documentation
+ *   Bianca Wiesmayr - updated identifiers
+ *******************************************************************************/
+
 package org.eclipse.fordiac.ide.fb.interpreter.testappgen;
 
 public class TestGenBlockNames {
 
-	public static final String TIMEOUT_ADAPTER_NAME = "ATimeOutS"; //$NON-NLS-1$
+	public static final String TIMEOUT_ADAPTER_NAME = "iec61499::events::atimeout"; //$NON-NLS-1$
 	public static final String TIMEOUT_PIN_NAME = "DT1"; //$NON-NLS-1$
-	public static final String TIMEOUT_COMPOSITE_NAME = "E_TimeOutS"; //$NON-NLS-1$
+	public static final String TIMEOUT_COMPOSITE_NAME = "iec61499::events::E_TimeOut"; //$NON-NLS-1$
 	public static final String MATCH_TIMEOUT_PINNAME = "timeout"; //$NON-NLS-1$
 
 	private TestGenBlockNames() {


### PR DESCRIPTION
The plug-in generates a test infrastructure directly within IEC 61499 for a test specification. Due to changes with the standard libraries, this feature did not work anymore at all - the adapter / FB types were not found, causing NPEs. This fix updates the names to ensure that they can be identified correctly.