### PR TITLE
Fix for: Generating Test Infrastructure within IEC 61499

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/DefaultRunFBType.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/DefaultRunFBType.java
@@ -342,6 +342,9 @@ public class DefaultRunFBType implements IRunFBTypeVisitor {
 		final var newEventOccurrence = OperationalSemanticsFactory.eINSTANCE.createEventOccurrence();
 		newEventOccurrence.setFbRuntime(newFBTypeRT);
 		newEventOccurrence.setEvent(output);
+		if (runtime instanceof FBNetworkRuntime) {
+			newEventOccurrence.setParentFB(output.getBlockFBNetworkElement());
+		}
 		return newEventOccurrence;
 	}
 


### PR DESCRIPTION
The plug-in generates a test infrastructure directly within IEC 61499 for a test specification. Due to changes with the standard libraries, this feature did not work anymore at all - the adapter / FB types were not found, causing NPEs. This fix updates the names to ensure that they can be identified correctly.