### PR TITLE
Harmonized `org.eclipse.fordiac.ide.fb.interpreter.design` versions

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter.design/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter.design/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.fordiac.ide.fb.interpreter.design;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-Activator: org.eclipse.fordiac.ide.fb.interpreter.design.Activator
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,
@@ -10,7 +10,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.resources,
  org.eclipse.sirius,
  org.eclipse.sirius.common.acceleo.aql,
- org.eclipse.fordiac.ide.fb.interpreter;bundle-version="3.0.0"
+ org.eclipse.fordiac.ide.fb.interpreter
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: %providerName


### PR DESCRIPTION
This plugin's ersion and manifest was not aligned with the other 4diac IDE plugins.