### PR TITLE
Harden against selection and update notifications during shutdown #1808

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editors/FBNetworkEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editors/FBNetworkEditor.java
@@ -62,6 +62,8 @@ import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.util.TransferDropTargetListener;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Event;
+import org.eclipse.ui.IActionBars;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.actions.ActionFactory;
 
 /**
@@ -263,6 +265,10 @@ public class FBNetworkEditor extends DiagramEditorWithFlyoutPalette {
 	}
 
 	private void handleActivationChanged(final Event event) {
+		if (PlatformUI.getWorkbench().isClosing()) {
+			return;
+		}
+
 		final boolean activated = event.type == SWT.Activate;
 
 		setAction(ActionFactory.COPY.getId(), activated);
@@ -274,10 +280,12 @@ public class FBNetworkEditor extends DiagramEditorWithFlyoutPalette {
 
 	private void setAction(final String actionId, final boolean activated) {
 		final IAction action = getActionRegistry().getAction(actionId);
-		if (activated && getEditorSite().getActionBars().getGlobalActionHandler(actionId) != action) {
-			getEditorSite().getActionBars().setGlobalActionHandler(actionId, action);
-		} else if (!activated && getEditorSite().getActionBars().getGlobalActionHandler(actionId) == action) {
-			getEditorSite().getActionBars().setGlobalActionHandler(actionId, null);
+		final IActionBars actionBars = getEditorSite().getActionBars();
+
+		if (activated && actionBars.getGlobalActionHandler(actionId) != action) {
+			actionBars.setGlobalActionHandler(actionId, action);
+		} else if (!activated && actionBars.getGlobalActionHandler(actionId) == action) {
+			actionBars.setGlobalActionHandler(actionId, null);
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.ui/src/org/eclipse/fordiac/ide/ui/editors/AbstractCloseAbleFormEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.ui/src/org/eclipse/fordiac/ide/ui/editors/AbstractCloseAbleFormEditor.java
@@ -14,8 +14,11 @@ package org.eclipse.fordiac.ide.ui.editors;
 
 import org.eclipse.e4.ui.model.application.ui.basic.MPart;
 import org.eclipse.e4.ui.workbench.modeling.EPartService;
+import org.eclipse.swt.custom.CTabFolder;
+import org.eclipse.swt.widgets.Item;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.forms.editor.FormEditor;
+import org.eclipse.ui.part.MultiPageEditorPart;
 
 /* extension of the form editor allowing to close an child editor by providing the editor instance
  *
@@ -34,18 +37,35 @@ public abstract class AbstractCloseAbleFormEditor extends FormEditor {
 
 	private boolean closeInChildren(final IEditorPart childEditor) {
 		for (final Object child : pages) {
-			if ((child instanceof AbstractCloseAbleFormEditor)
-					&& (((AbstractCloseAbleFormEditor) child).closeChildEditor(childEditor))) {
+			if (child instanceof final AbstractCloseAbleFormEditor closeableFormEditor
+					&& closeableFormEditor.closeChildEditor(childEditor)) {
 				return true;
 			}
 		}
 		return false;
 	}
 
+	/**
+	 * This is a re-implementation of {@link MultiPageEditorPart#getEditor(int)}.
+	 * The original method does not check if the item is already disposed. This can
+	 * lead to a problem if any of the listeners is called and asked for the editor
+	 * during the dispose process.
+	 */
+	@Override
+	protected IEditorPart getEditor(final int pageIndex) {
+		final Item item = ((CTabFolder) getContainer()).getItem(pageIndex); // getItem in MultiPageEditorPart is private
+																			// so we have to do this
+		if (item != null && !item.isDisposed() && item.getData() instanceof final IEditorPart ep) {
+			return ep;
+		}
+		return null;
+	}
+
 	@Override
 	protected void pageChange(final int newPageIndex) {
 		super.pageChange(newPageIndex);
-		// notify the part service that we have a new page activated. This is needed that for example link with editor
+		// notify the part service that we have a new page activated. This is needed
+		// that for example link with editor
 		// gets notified.
 		final EPartService partService = getSite().getService(EPartService.class);
 		final MPart activePart = partService.getActivePart();


### PR DESCRIPTION
On Linux the description editor's web browsers sends selection and other update notifications which can not be correctly handled. This commit adds checks to protect against so that a save and correct shutdown is happening.

Fixes: https://github.com/eclipse-4diac/4diac-ide/issues/1808