### PR TITLE
Fix watchpoint annotation on FB instances

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.deployment.debug.ui/src/org/eclipse/fordiac/ide/deployment/debug/ui/annotation/WatchpointAnnotationStyler.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug.ui/src/org/eclipse/fordiac/ide/deployment/debug/ui/annotation/WatchpointAnnotationStyler.java
@@ -30,7 +30,8 @@ public class WatchpointAnnotationStyler implements GraphicalAnnotationStyler {
 
 	@Override
 	public void applyStyles(final IFigure figure, final GraphicalAnnotation annotation) {
-		if (figure instanceof final FBShape fbShape && FigureUtilities.isAncestor(fbShape, fbShape.getTypeLabel())) {
+		if (figure.getParent() instanceof final FBShape fbShape
+				&& FigureUtilities.isAncestor(fbShape, fbShape.getTypeLabel())) {
 			fbShape.getTypeLabel().setOverlayIcon(getOverlayImage(annotation));
 		} else {
 			final Image image = getImage(annotation);
@@ -42,7 +43,8 @@ public class WatchpointAnnotationStyler implements GraphicalAnnotationStyler {
 
 	@Override
 	public void removeStyles(final IFigure figure, final GraphicalAnnotation annotation) {
-		if (figure instanceof final FBShape fbShape && FigureUtilities.isAncestor(fbShape, fbShape.getTypeLabel())) {
+		if (figure.getParent() instanceof final FBShape fbShape
+				&& FigureUtilities.isAncestor(fbShape, fbShape.getTypeLabel())) {
 			fbShape.getTypeLabel().setOverlayIcon(null);
 		} else {
 			GraphicalAnnotationStyles.removeAnnotationBorders(figure);


### PR DESCRIPTION
There were recent changes regarding how annotations on FBN elements are shown[^1], which caused watchpoint annotations to appear in the wrong place. This fixes the problem by checking for the correct figure.

[^1]: see also https://github.com/eclipse-4diac/4diac-ide/pull/1797/commits/a4a850f4bf165ec8c9ddc5c38222383ad2660a95