### PR TITLE
LibraryBuilder not reporting on removed links

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/LibraryManager.java
+++ b/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/LibraryManager.java
@@ -146,7 +146,7 @@ public enum LibraryManager {
 	 * accordingly
 	 */
 	private void checkLibChanges(final SubMonitor progress) {
-		progress.beginTask("Check for library changes", 10); //$NON-NLS-1$
+		progress.beginTask(Messages.LibraryManager_ChekForLibraryChanges, 10);
 		if (watchService == null) {
 			return;
 		}
@@ -412,7 +412,7 @@ public enum LibraryManager {
 	}
 
 	private void setStandardLibsReadOnly() {
-		final WorkspaceJob job = new WorkspaceJob("Set standard libraries read only") { //$NON-NLS-1$
+		final WorkspaceJob job = new WorkspaceJob(Messages.LibraryManager_SetStandardLibrariesReadOnly) {
 
 			@Override
 			public IStatus runInWorkspace(final IProgressMonitor monitor) throws CoreException {
@@ -606,7 +606,7 @@ public enum LibraryManager {
 	private DownloadResult<java.net.URI> libraryDownload(final String symbolicName, final VersionRange versionRange,
 			final Version preferred, final IProject project, final boolean autoImport, final boolean resolve,
 			final SubMonitor progress) throws OperationCanceledException {
-		progress.setTaskName("Library download: " + symbolicName); //$NON-NLS-1$
+		progress.setTaskName(MessageFormat.format(Messages.LibraryManager_LibraryDownload, symbolicName));
 		FordiacLogHelper.logInfo("Attempting to download library " + symbolicName + " with version " + versionRange //$NON-NLS-1$ //$NON-NLS-2$
 				+ " preferring " + preferred); //$NON-NLS-1$
 
@@ -652,7 +652,8 @@ public enum LibraryManager {
 	 * @param versionRange version range of dependency
 	 */
 	public void updateLibrary(final IProject project, final String symbolicName, final String versionRange) {
-		final WorkspaceJob job = new WorkspaceJob("Update Library package: " + symbolicName + " = " + versionRange) { //$NON-NLS-1$//$NON-NLS-2$
+		final WorkspaceJob job = new WorkspaceJob(
+				MessageFormat.format(Messages.LibraryManager_UpdateLibraryPackage, symbolicName, versionRange)) {
 
 			@Override
 			public IStatus runInWorkspace(final IProgressMonitor monitor) throws CoreException {
@@ -678,10 +679,12 @@ public enum LibraryManager {
 	 * This method will remove already linked libraries if they cause conflicts or
 	 * are no longer needed
 	 *
-	 * @param project selected project
+	 * @param project  selected project
+	 * @param manifest
+	 * @throws CoreException
 	 */
-	public void resolveDependencies(final IProject project, final IProgressMonitor monitor)
-			throws OperationCanceledException {
+	public void resolveDependencies(final IProject project, final Manifest projectManifest,
+			final IProgressMonitor monitor) throws OperationCanceledException, CoreException {
 		final Map<String, DependencyNode> deps = new HashMap<>();
 		final Map<String, ResolveNode> res = new HashMap<>();
 		final Map<String, Version> preferred = new HashMap<>();
@@ -689,9 +692,8 @@ public enum LibraryManager {
 
 		final Queue<String> queue = new LinkedList<>(); // symbolicNames
 
-		final SubMonitor progress = SubMonitor.convert(monitor, "Resolving library dependencies", 100); //$NON-NLS-1$
-
-		final Manifest projectManifest = ManifestHelper.getContainerManifest(project);
+		final SubMonitor progress = SubMonitor.convert(monitor, Messages.LibraryManager_ResolvingLibraryDependencies,
+				100);
 
 		if (projectManifest == null) {
 			return;
@@ -770,7 +772,7 @@ public enum LibraryManager {
 	private void buildDependencies(final Map<String, DependencyNode> deps, final Map<String, ResolveNode> res,
 			final Map<String, Version> preferred, final Queue<String> queue, final SubMonitor progress)
 			throws OperationCanceledException {
-		progress.setTaskName("Building dependency graph"); //$NON-NLS-1$
+		progress.setTaskName(Messages.LibraryManager_BuildingDependencyGraph);
 		while (!queue.isEmpty()) {
 			progress.setWorkRemaining(Math.max(queue.size(), 10));
 			final String symbolicName = queue.poll();
@@ -847,17 +849,13 @@ public enum LibraryManager {
 		}
 	}
 
-	private static void cleanupLinks(final Map<String, IFolder> linked, final SubMonitor progress) {
-		progress.setTaskName("Removing unnecessary links"); //$NON-NLS-1$
+	private static void cleanupLinks(final Map<String, IFolder> linked, final SubMonitor progress)
+			throws CoreException {
+		progress.setTaskName(Messages.LibraryManager_RemovingUnnecessaryLinks);
 		progress.setWorkRemaining(linked.size());
-		linked.values().forEach(f -> {
-			try {
-				f.delete(true, null);
-				progress.worked(1);
-			} catch (final CoreException e) {
-				// empty
-			}
-		});
+		for (final IFolder folder : linked.values()) {
+			folder.delete(true, progress.split(1));
+		}
 	}
 
 	/**
@@ -875,7 +873,7 @@ public enum LibraryManager {
 		if (!standardLibFolder.exists() || !externalLibFolder.exists()) {
 			return;
 		}
-		progress.beginTask("Finding preferred library versions", 100); //$NON-NLS-1$
+		progress.beginTask(Messages.LibraryManager_FindingPreferredLibraryVersion, 100);
 		final IResourceVisitor visitor = res -> {
 			if (res instanceof final IFolder libFolder) {
 				progress.setWorkRemaining(100).worked(1);
@@ -925,7 +923,7 @@ public enum LibraryManager {
 		final boolean usePref = prefVersion != null && range.includes(prefVersion);
 		LibraryRecord rec;
 
-		progress.setTaskName("Resolving dependency: " + symbolicName); //$NON-NLS-1$
+		progress.setTaskName(Messages.LibraryManager_ResolvingDependency + symbolicName);
 		progress.setWorkRemaining(100);
 
 		if (stdlibraries.containsKey(symbolicName)) {

--- a/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/Messages.java
@@ -29,9 +29,33 @@ public class Messages extends NLS {
 	public static String ImportFailedOnLinkCreation;
 	public static String InstanceUpdate;
 
+	public static String LibraryBuilder_CleaningLibrary;
+
+	public static String LibraryBuilder_LibraryBuild;
+
+	public static String LibraryBuilder_ResolveProjectDependencies;
+
+	public static String LibraryManager_BuildingDependencyGraph;
+
+	public static String LibraryManager_ChekForLibraryChanges;
+
 	public static String LibraryManager_DownloadJobName;
 
+	public static String LibraryManager_FindingPreferredLibraryVersion;
+
+	public static String LibraryManager_LibraryDownload;
+
+	public static String LibraryManager_RemovingUnnecessaryLinks;
+
+	public static String LibraryManager_ResolvingDependency;
+
+	public static String LibraryManager_ResolvingLibraryDependencies;
+
+	public static String LibraryManager_SetStandardLibrariesReadOnly;
+
 	public static String LibraryManager_UnresolvableDependencies;
+
+	public static String LibraryManager_UpdateLibraryPackage;
 
 	public static String PreferenceForceLoad;
 	public static String PreferenceLoadingGroup;

--- a/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/builder/LibraryBuilder.java
+++ b/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/builder/LibraryBuilder.java
@@ -27,10 +27,12 @@ import org.eclipse.core.resources.IResourceDeltaVisitor;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.fordiac.ide.library.LibraryManager;
+import org.eclipse.fordiac.ide.library.Messages;
 import org.eclipse.fordiac.ide.library.model.library.Manifest;
 import org.eclipse.fordiac.ide.library.model.util.ManifestHelper;
 import org.eclipse.fordiac.ide.model.errormarker.FordiacErrorMarker;
@@ -44,7 +46,7 @@ public class LibraryBuilder extends IncrementalProjectBuilder {
 	@Override
 	protected IProject[] build(final int kind, final Map<String, String> args, final IProgressMonitor monitor)
 			throws CoreException {
-		final SubMonitor progress = SubMonitor.convert(monitor, "Resolve Project Dependencies", 1); //$NON-NLS-1$
+		final SubMonitor progress = SubMonitor.convert(monitor, Messages.LibraryBuilder_ResolveProjectDependencies, 1);
 		final IProject project = getProject();
 		final Manifest manifest = ManifestHelper.getContainerManifest(project);
 		if (manifest != null) {
@@ -70,7 +72,7 @@ public class LibraryBuilder extends IncrementalProjectBuilder {
 
 	@Override
 	protected void clean(final IProgressMonitor monitor) throws CoreException {
-		final SubMonitor progress = SubMonitor.convert(monitor, "Cleaning Library", 1); //$NON-NLS-1$
+		final SubMonitor progress = SubMonitor.convert(monitor, Messages.LibraryBuilder_CleaningLibrary, 1);
 		FordiacMarkerHelper.updateMarkers(getProject().getFile(LibraryManager.MANIFEST),
 				FordiacErrorMarker.LIBRARY_MARKER, Collections.emptyList(), true);
 		progress.worked(1);
@@ -83,9 +85,10 @@ public class LibraryBuilder extends IncrementalProjectBuilder {
 		return getProject();
 	}
 
-	private static void fullBuild(final IProject project, final Manifest manifest, final IProgressMonitor monitor) {
-		final SubMonitor progress = SubMonitor.convert(monitor, "Library build", 1); //$NON-NLS-1$
-		LibraryManager.INSTANCE.resolveDependencies(project, progress.split(1));
+	private static void fullBuild(final IProject project, final Manifest manifest, final IProgressMonitor monitor)
+			throws OperationCanceledException, CoreException {
+		final SubMonitor progress = SubMonitor.convert(monitor, Messages.LibraryBuilder_LibraryBuild, 1);
+		LibraryManager.INSTANCE.resolveDependencies(project, manifest, progress.split(1));
 	}
 
 	private final IResourceDeltaVisitor visitor = delta -> {

--- a/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/messages.properties
+++ b/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/messages.properties
@@ -21,8 +21,20 @@ ErrorMarkerVersionRangeEmpty=Library {0}: version range is empty - caused by: {1
 ImportFailed=The library structure is incorrect, cannot import it!
 ImportFailedOnLinkCreation=Couldn't import the library! Reason: {0}
 InstanceUpdate=Instance Update
+LibraryBuilder_CleaningLibrary=Cleaning Library
+LibraryBuilder_LibraryBuild=Library build
+LibraryBuilder_ResolveProjectDependencies=Resolve Project Dependencies
+LibraryManager_BuildingDependencyGraph=Building dependency graph
+LibraryManager_ChekForLibraryChanges=Check for library changes
 LibraryManager_DownloadJobName=Download Library package: {0} - {1}
+LibraryManager_FindingPreferredLibraryVersion=Finding preferred library versions
+LibraryManager_LibraryDownload=Library download: {0}
+LibraryManager_RemovingUnnecessaryLinks=Removing unnecessary links
+LibraryManager_ResolvingDependency=Resolving dependency: 
+LibraryManager_ResolvingLibraryDependencies=Resolving library dependencies
+LibraryManager_SetStandardLibrariesReadOnly=Set standard libraries read only
 LibraryManager_UnresolvableDependencies=Build aborted due to unresolvable dependencies. Fix dependencies and perform a clean build.
+LibraryManager_UpdateLibraryPackage=Update Library package: {0} = {1}
 
 OldTypeLibVersionCouldNotBeDeleted=There was a problem while importing the new Type Library version, old one could not be deleted!
 

--- a/tests/org.eclipse.fordiac.ide.test.library/src/org/eclipse/fordiac/ide/test/library/LibraryImportTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.library/src/org/eclipse/fordiac/ide/test/library/LibraryImportTest.java
@@ -37,6 +37,7 @@ import org.eclipse.core.runtime.jobs.IJobManager;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.fordiac.ide.library.IArchiveDownloader;
 import org.eclipse.fordiac.ide.library.LibraryManager;
+import org.eclipse.fordiac.ide.library.model.library.Manifest;
 import org.eclipse.fordiac.ide.library.model.util.ManifestHelper;
 import org.eclipse.fordiac.ide.model.errormarker.FordiacErrorMarker;
 import org.eclipse.fordiac.ide.model.errormarker.FordiacMarkerHelper;
@@ -212,7 +213,8 @@ class LibraryImportTest {
 	void testImportWithResolve() throws Exception {
 		LibraryManager.INSTANCE.importLibrary(project, java.net.URI.create(LIB_LOC + TEST02 + "-" + V1_0_0), //$NON-NLS-1$
 				true, false);
-		LibraryManager.INSTANCE.resolveDependencies(project, null);
+		final Manifest projectManifest = ManifestHelper.getContainerManifest(project);
+		LibraryManager.INSTANCE.resolveDependencies(project, projectManifest, null);
 
 		waitForBuild();
 


### PR DESCRIPTION
The LibraryBuilder didn't stop and report on library links that could not be removed. Furthermore all strings are now exported.