### PR TITLE
Fix matching of version ranges with CMake in forte_ng export

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/cmake/CMakeListsTemplate.java
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/cmake/CMakeListsTemplate.java
@@ -205,7 +205,7 @@ public abstract class CMakeListsTemplate extends ForteNgExportTemplate {
 	protected static CharSequence generateWriteBasicPackageVersionFile(final CharSequence name) {
 		return "write_basic_package_version_file(" + System.lineSeparator() //$NON-NLS-1$
 				+ ("${CMAKE_CURRENT_BINARY_DIR}/" + name.toString().toLowerCase() + "-config-version.cmake" //$NON-NLS-1$ //$NON-NLS-2$
-						+ System.lineSeparator() + "COMPATIBILITY SameMajorVersion" + System.lineSeparator() //$NON-NLS-1$
+						+ System.lineSeparator() + "COMPATIBILITY AnyNewerVersion" + System.lineSeparator() //$NON-NLS-1$
 				).indent(INDENT) //
 				+ ")" + System.lineSeparator(); //$NON-NLS-1$
 	}


### PR DESCRIPTION
When matching version ranges, CMake still takes the compatibility specified by the package into account. This means, for example, a version range `0.0.0...<2.0.0` will _not_ match a package with version `1.2.0` when using `SameMajorVersion`, despite being inside the range requested. This changes the compatibility to `AnyNewerVersion` for generated CMake files to work around the problem.