### PR TITLE
Fix lookup of unqualified data types in importer

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/AttributeTypeImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/AttributeTypeImporter.java
@@ -94,7 +94,7 @@ public class AttributeTypeImporter extends TypeImporter {
 		directlyDerivedType.setName(attribute.getName());
 
 		final String baseTypeName = getAttributeValue(LibraryElementTags.BASE_TYPE_ATTRIBUTE);
-		final DataType baseType = getType(baseTypeName, getDataTypeLibrary()::getType);
+		final DataType baseType = getDataType(baseTypeName);
 		directlyDerivedType.setBaseType(baseType);
 
 		final String initalValue = getAttributeValue(LibraryElementTags.INITIALVALUE_ATTRIBUTE);

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/CommonElementImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/CommonElementImporter.java
@@ -46,9 +46,11 @@ import org.eclipse.emf.ecore.resource.Resource.Diagnostic;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.model.LibraryElementTags;
 import org.eclipse.fordiac.ide.model.Messages;
+import org.eclipse.fordiac.ide.model.data.DataType;
 import org.eclipse.fordiac.ide.model.dataimport.exceptions.TypeImportException;
 import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes;
 import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes.ElementaryTypes;
+import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes.GenericTypes;
 import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes.HelperTypes;
 import org.eclipse.fordiac.ide.model.datatype.helper.InternalAttributeDeclarations;
 import org.eclipse.fordiac.ide.model.errormarker.FordiacErrorMarkerInterfaceHelper;
@@ -438,7 +440,7 @@ public abstract class CommonElementImporter {
 			if (typeName.equals(HelperTypes.CDATA.getName())) {
 				attribute.setType(HelperTypes.CDATA);
 			} else {
-				attribute.setType(getType(typeName, getDataTypeLibrary()::getType));
+				attribute.setType(getDataType(typeName));
 			}
 		} else {
 			// AttributeDeclarations
@@ -1045,10 +1047,11 @@ public abstract class CommonElementImporter {
 		return addDependency(ImportHelper.resolveImport(name, getElement(), typeResolver, unused -> null));
 	}
 
-	protected <T extends LibraryElement> T getType(final String name, final Function<String, T> typeResolver) {
+	protected DataType getDataType(final String name) {
 		if (name == null) {
-			return null;
+			return GenericTypes.ANY;
 		}
-		return addDependency(ImportHelper.resolveImport(name, getElement(), typeResolver, unused -> null));
+		return addDependency(ImportHelper.resolveImport(name, getElement(), getDataTypeLibrary()::getTypeIfExists,
+				getDataTypeLibrary()::getType));
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/FBTImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/FBTImporter.java
@@ -401,7 +401,7 @@ public class FBTImporter extends BlockTypeImporter {
 		DataType type = null;
 		final String typeName = getAttributeValue(LibraryElementTags.TYPE_ATTRIBUTE);
 		if (null != typeName && !typeName.isEmpty()) {
-			type = getType(typeName, getDataTypeLibrary()::getType);
+			type = getDataType(typeName);
 		}
 
 		Method retVal = null;

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/TypeImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/TypeImporter.java
@@ -69,7 +69,7 @@ public abstract class TypeImporter extends CommonElementImporter {
 		if (null == typeName) {
 			throw new TypeImportException(Messages.Import_ERROR_InputVariableTypeNotDefined);
 		}
-		final DataType dataType = getType(typeName, getDataTypeLibrary()::getType);
+		final DataType dataType = getDataType(typeName);
 		v.setType(dataType);
 
 		final String arraySize = getAttributeValue(LibraryElementTags.ARRAYSIZE_ATTRIBUTE);


### PR DESCRIPTION
The importer resolved data types using `DataTypeLibrary.getType()`, which immediately returns an error data type when the type could not be found. That meant that no further lookup using the current package or imports was attempted. This fixes the lookup to use `getTypeIfExists()` and only afterwards fall back to creating error types with `getType()`. It also fixes handling of `null` type names, which should use `ANY` instead of `null`.