### PR TITLE
Save connections also when it is to an errormarker block

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/FBNetworkExporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/FBNetworkExporter.java
@@ -284,8 +284,7 @@ class FBNetworkExporter extends CommonElementExporter {
 	}
 
 	private static boolean isExportableConnectionEndpoint(final IInterfaceElement endPoint) {
-		return (endPoint != null) && isExportableErrorMarker(endPoint.getBlockFBNetworkElement())
-				&& (endPoint.eContainer() instanceof InterfaceList);
+		return (endPoint != null) && (endPoint.eContainer() instanceof InterfaceList);
 	}
 
 	public static boolean isExportableErrorMarker(final FBNetworkElement fbNetworkElement) {


### PR DESCRIPTION
Connections to error marker blocks would have been lost on save.