### PR TITLE
Fixed Eclipse Nattable Dependencies

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.product/org.eclipse.fordiac.ide.product
+++ b/plugins/org.eclipse.fordiac.ide.product/org.eclipse.fordiac.ide.product
@@ -102,6 +102,7 @@
    </features>
 
    <configurations>
+      <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="2" />
       <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />


### PR DESCRIPTION
Eclipse Nattable 2.7.0 is not providing Eclipse Collection as part of their update site. This has to be added by consumers of Eclipse Nattable. Also Eclipse Collection requires Apache SpiFly as dependency and also as part of the runtime configuration.

See also: https://github.com/eclipse-nattable/nattable/issues/174