### PR TITLE
Deployment Value create didn not handle configure able types

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.deployment/src/org/eclipse/fordiac/ide/deployment/util/DeploymentHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src/org/eclipse/fordiac/ide/deployment/util/DeploymentHelper.java
@@ -84,7 +84,7 @@ public final class DeploymentHelper {
 
 	private static boolean equalsTypeValue(final Value value, final VarDeclaration variable) {
 		final VarDeclaration typeVariable = variable.findInTypeInterface();
-		if (typeVariable == null) {
+		if (typeVariable == null || GenericTypes.isAnyType(typeVariable.getType())) {
 			return false;
 		}
 		final Value destinationTypeValue = VariableOperations.newVariable(typeVariable).getValue();


### PR DESCRIPTION
For configurable types the type pin may be of generic type. When checking for the type value this led to an exception.