### PR TITLE
Remove stale watch annotations when terminated

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.deployment.debug.ui/src/org/eclipse/fordiac/ide/deployment/debug/ui/annotation/WatchValueAnnotationProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug.ui/src/org/eclipse/fordiac/ide/deployment/debug/ui/annotation/WatchValueAnnotationProvider.java
@@ -68,7 +68,8 @@ public class WatchValueAnnotationProvider implements GraphicalAnnotationProvider
 				handleWatchChanged(watch, add, changed);
 			case final DeploymentDebugStackFrame stackFrame when event.getKind() == DebugEvent.CHANGE ->
 				handleWatchesChanged(stackFrame, add, remove, changed);
-			case final DeploymentDebugTarget debugTarget when event.getKind() == DebugEvent.TERMINATE -> reload();
+			case final DeploymentDebugTarget debugTarget when event.getKind() == DebugEvent.TERMINATE ->
+				handleTerminated();
 			default -> {
 				return;
 			}
@@ -141,6 +142,10 @@ public class WatchValueAnnotationProvider implements GraphicalAnnotationProvider
 	protected boolean isRelevant(final DebugEvent event) {
 		return event.getSource() instanceof final DeploymentDebugElement element
 				&& element.getDebugTarget().getSystem().getTypeEntry().getFile().equals(model.getResource());
+	}
+
+	private void handleTerminated() {
+		model.removeAnnotationIf(WatchValueAnnotation.class::isInstance);
 	}
 
 	@Override


### PR DESCRIPTION
A recent optimization for graphical annotations introduced a problem causing stale watch annotations to remain after the monitoring session had terminated. This correctly removes the stale watch annotations.

Fixes https://github.com/eclipse-4diac/4diac-ide/issues/1795