### PR TITLE
Handle connection attributes on mapping #1542

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/MapToCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/MapToCommand.java
@@ -201,7 +201,7 @@ public class MapToCommand extends Command implements ScopedCommand {
 						&& varDeclaration.isIsInput()) {
 					source = varDeclaration.getInOutVarOpposite();
 				}
-				addConnectionCreateCommand(source, destination, connection.isVisible());
+				addConnectionCreateCommand(source, destination, connection);
 			}
 		});
 	}
@@ -231,7 +231,7 @@ public class MapToCommand extends Command implements ScopedCommand {
 						&& varDeclaration.isIsInput()) {
 					source = varDeclaration.getInOutVarOpposite();
 				}
-				addConnectionCreateCommand(source, destination, connection.isVisible());
+				addConnectionCreateCommand(source, destination, connection);
 				if ((destination instanceof AdapterDeclaration) || (destination instanceof VarDeclaration)) {
 					checkForDeleteConnections(destination);
 				}
@@ -244,12 +244,13 @@ public class MapToCommand extends Command implements ScopedCommand {
 	}
 
 	private void addConnectionCreateCommand(final IInterfaceElement source, final IInterfaceElement destination,
-			final boolean visible) {
+			final Connection refCon) {
 		final AbstractConnectionCreateCommand cmd = getConnectionCreateCmd(source);
 		if (null != cmd) {
 			cmd.setSource(source);
 			cmd.setDestination(destination);
-			cmd.setVisible(visible);
+			cmd.setVisible(refCon.isVisible());
+			cmd.setAttributes(refCon.getAttributes());
 			// as we are creating the connection as part of the mapping command we don't
 			// need to perform a mapping check
 			cmd.setPerformMappingCheck(false);


### PR DESCRIPTION
On mapping attributes where not transfered to the mapped connection. Without it connection negation was lost.

Addresses: https://github.com/eclipse-4diac/4diac-ide/issues/1542