### PR TITLE
Add configurable maximum total request size for deployment

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.deployment.iec61499/src/org/eclipse/fordiac/ide/deployment/iec61499/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.iec61499/src/org/eclipse/fordiac/ide/deployment/iec61499/Messages.java
@@ -60,9 +60,11 @@ public final class Messages extends NLS {
 	public static String DynamicTypeLoadDeploymentExecutor_LUAScriptForAdapterTypeNotExecuted;
 
 	public static String EthernetDeviceManagementCommunicationHandler_CouldNotConnectToDevice;
+	public static String EthernetDeviceManagementCommunicationHandler_MaxRequestSizeExceeded;
 
 	public static String EthernetComHandler_InvalidMgmtID;
 
+	public static String HoloblocDeploymentPreferencePage_MaxRequestSize;
 	public static String HoloblocDeploymentPreferences_PreferencePageDescription;
 	public static String HoloblocDeploymentPreferences_ConnectionTimout;
 

--- a/plugins/org.eclipse.fordiac.ide.deployment.iec61499/src/org/eclipse/fordiac/ide/deployment/iec61499/handlers/EthernetDeviceManagementCommunicationHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.iec61499/src/org/eclipse/fordiac/ide/deployment/iec61499/handlers/EthernetDeviceManagementCommunicationHandler.java
@@ -1,5 +1,7 @@
 /*******************************************************************************
- * Copyright (c) 2013 - 2018 fortiss GmbH, Johannes Kepler University
+ * Copyright (c) 2013, 2025 fortiss GmbH, Johannes Kepler University
+ *                          Martin Erich Jobst
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -9,6 +11,7 @@
  * Contributors:
  *   Alois Zoitl, Florian Noack, Monika Wenger - initial API and implementation and/or initial documentation
  *   Alois Zoitl - Harmonized deployment and monitoring
+ *   Martin Erich Jobst - add maximum request size
  *******************************************************************************/
 package org.eclipse.fordiac.ide.deployment.iec61499.handlers;
 
@@ -36,6 +39,7 @@ public class EthernetDeviceManagementCommunicationHandler implements IDeviceMana
 	private Socket socket;
 	private DataOutputStream outputStream;
 	private DataInputStream inputStream;
+	private final int maxRequestSize = IEC61499PreferenceConstants.getMaxRequestSize();
 	private static final int LOWER_INVALID_PORT = 1023;
 	private static final int UPPER_INVALID_PORT = 65536;
 	private static final long MS_SLEEP_IN_DISCONNECT = 50;
@@ -82,7 +86,7 @@ public class EthernetDeviceManagementCommunicationHandler implements IDeviceMana
 		} catch (final IOException e) {
 			throw new DeploymentException(Messages.DeploymentExecutor_DisconnectFailed, e);
 		} catch (final InterruptedException e) {
-			Thread.currentThread().interrupt();  // mark interruption
+			Thread.currentThread().interrupt(); // mark interruption
 			FordiacLogHelper.logError(e.getMessage(), e);
 		}
 	}
@@ -108,6 +112,12 @@ public class EthernetDeviceManagementCommunicationHandler implements IDeviceMana
 
 	@Override
 	public String sendREQ(final String destination, final String request) throws IOException {
+		final int totalSize = destination.length() + request.length() + 6;
+		if (totalSize > maxRequestSize) {
+			throw new IOException(
+					MessageFormat.format(Messages.EthernetDeviceManagementCommunicationHandler_MaxRequestSizeExceeded,
+							Integer.valueOf(totalSize), Integer.valueOf(maxRequestSize)));
+		}
 		String response = ""; //$NON-NLS-1$
 		if (outputStream != null && inputStream != null) {
 			outputStream.writeByte(ASN1_TAG_IECSTRING);

--- a/plugins/org.eclipse.fordiac.ide.deployment.iec61499/src/org/eclipse/fordiac/ide/deployment/iec61499/messages.properties
+++ b/plugins/org.eclipse.fordiac.ide.deployment.iec61499/src/org/eclipse/fordiac/ide/deployment/iec61499/messages.properties
@@ -52,9 +52,11 @@ DynamicTypeLoadDeploymentExecutor_LUAScriptForFBTypeNotExecuted=LUA script for "
 DynamicTypeLoadDeploymentExecutor_LUAScriptForAdapterTypeNotExecuted=LUA script for "{0}" AdapterType not executed.
 
 EthernetDeviceManagementCommunicationHandler_CouldNotConnectToDevice=Could not connect to device.
+EthernetDeviceManagementCommunicationHandler_MaxRequestSizeExceeded=The request with a total size of {0} bytes exceeds the maximum size of {1} bytes
 
 EthernetComHandler_InvalidMgmtID=The given value for MGR_ID is not valid! The value was: {0}
 
+HoloblocDeploymentPreferencePage_MaxRequestSize=Maximum Request Size in bytes
 HoloblocDeploymentPreferences_PreferencePageDescription=Preferences for the deployment according to the IEC 61499 compliance profile for feasibility demonstrations.
 HoloblocDeploymentPreferences_ConnectionTimout=Connection Timeout in ms
 

--- a/plugins/org.eclipse.fordiac.ide.deployment.iec61499/src/org/eclipse/fordiac/ide/deployment/iec61499/preferences/HoloblocDeploymentPreferencePage.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.iec61499/src/org/eclipse/fordiac/ide/deployment/iec61499/preferences/HoloblocDeploymentPreferencePage.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2017 Profactor GmbH, fortiss GmbH
+ * Copyright (c) 2009, 2025 Profactor GmbH, fortiss GmbH
+ *                          Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -10,6 +11,7 @@
  * Contributors:
  *   Gerhard Ebenhofer, Alois Zoitl
  *     - initial API and implementation and/or initial documentation
+ *   Martin Erich Jobst - add maximum request size
  *******************************************************************************/
 package org.eclipse.fordiac.ide.deployment.iec61499.preferences;
 
@@ -40,14 +42,17 @@ public class HoloblocDeploymentPreferencePage extends FieldEditorPreferencePage 
 	 */
 	@Override
 	public void createFieldEditors() {
-
-		final IntegerFieldEditor integerFieldEditor = new IntegerFieldEditor(
+		final IntegerFieldEditor connectionTimeoutEditor = new IntegerFieldEditor(
 				IEC61499PreferenceConstants.P_CONNECTION_TIMEOUT,
-				Messages.HoloblocDeploymentPreferences_ConnectionTimout, getFieldEditorParent(), 3000);
-		integerFieldEditor.setValidRange(1, 60000);
+				Messages.HoloblocDeploymentPreferences_ConnectionTimout, getFieldEditorParent());
+		connectionTimeoutEditor.setValidRange(1, 60000);
+		addField(connectionTimeoutEditor);
 
-		addField(integerFieldEditor);
-
+		final IntegerFieldEditor maxRequestSizeEditor = new IntegerFieldEditor(
+				IEC61499PreferenceConstants.P_MAX_REQUEST_SIZE,
+				Messages.HoloblocDeploymentPreferencePage_MaxRequestSize, getFieldEditorParent());
+		maxRequestSizeEditor.setValidRange(1, Integer.MAX_VALUE);
+		addField(maxRequestSizeEditor);
 	}
 
 	/*

--- a/plugins/org.eclipse.fordiac.ide.deployment.iec61499/src/org/eclipse/fordiac/ide/deployment/iec61499/preferences/IEC61499PreferenceConstants.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.iec61499/src/org/eclipse/fordiac/ide/deployment/iec61499/preferences/IEC61499PreferenceConstants.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2024 Primetals Technologies Austria GmbH
+ * Copyright (c) 2024, 2025 Primetals Technologies Austria GmbH
+ *                          Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,6 +10,7 @@
  *
  * Contributors:
  *   Patrick Aigner - initial API and implementation and/or initial documentation
+ *   Martin Erich Jobst - add maximum request size
  *******************************************************************************/
 package org.eclipse.fordiac.ide.deployment.iec61499.preferences;
 
@@ -22,9 +24,11 @@ public class IEC61499PreferenceConstants {
 	}
 
 	public static final String P_CONNECTION_TIMEOUT = "Connection Timeout"; //$NON-NLS-1$
+	public static final String P_MAX_REQUEST_SIZE = "MaxRequestSize"; //$NON-NLS-1$
 
 	/* default connection timeout value in ms */
 	public static final int P_CONNECTION_TIMEOUT_DEFAULT = 3000;
+	public static final int P_MAX_REQUEST_SIZE_DEFAULT = 1500;
 
 	/*
 	 * check if there is a connection timeout value set and if not return the
@@ -33,5 +37,10 @@ public class IEC61499PreferenceConstants {
 	public static int getConnectionTimeout() {
 		return Platform.getPreferencesService().getInt(DEPLOYMENT_IEC61499_PREFERENCES_ID, P_CONNECTION_TIMEOUT,
 				P_CONNECTION_TIMEOUT_DEFAULT, null);
+	}
+
+	public static int getMaxRequestSize() {
+		return Platform.getPreferencesService().getInt(DEPLOYMENT_IEC61499_PREFERENCES_ID, P_MAX_REQUEST_SIZE,
+				P_MAX_REQUEST_SIZE_DEFAULT, null);
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.deployment.iec61499/src/org/eclipse/fordiac/ide/deployment/iec61499/preferences/PreferenceInitializer.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.iec61499/src/org/eclipse/fordiac/ide/deployment/iec61499/preferences/PreferenceInitializer.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2017 Profactor GmbH, fortiss GmbH
+ * Copyright (c) 2009, 2025 Profactor GmbH, fortiss GmbH
+ *                          Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -10,6 +11,7 @@
  * Contributors:
  *   Gerhard Ebenhofer, Alois Zoitl
  *     - initial API and implementation and/or initial documentation
+ *   Martin Erich Jobst - add maximum request size
  *******************************************************************************/
 package org.eclipse.fordiac.ide.deployment.iec61499.preferences;
 
@@ -28,6 +30,8 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 				.getNode(IEC61499PreferenceConstants.DEPLOYMENT_IEC61499_PREFERENCES_ID);
 		preferences.putInt(IEC61499PreferenceConstants.P_CONNECTION_TIMEOUT,
 				IEC61499PreferenceConstants.P_CONNECTION_TIMEOUT_DEFAULT);
+		preferences.putInt(IEC61499PreferenceConstants.P_MAX_REQUEST_SIZE,
+				IEC61499PreferenceConstants.P_MAX_REQUEST_SIZE_DEFAULT);
 
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.deployment/src/org/eclipse/fordiac/ide/deployment/DownloadRunnable.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src/org/eclipse/fordiac/ide/deployment/DownloadRunnable.java
@@ -383,7 +383,7 @@ public class DownloadRunnable implements IRunnableWithProgress, IDeploymentListe
 
 	private void handleDeploymentException(final Device device, final DeploymentException e) {
 		result = Status.error(MessageFormat.format(Messages.DownloadRunnable_DownloadErrorDetails, device.getName(),
-				DeploymentHelper.getMgrIDSafe(device), e.getMessage()), e);
+				DeploymentHelper.getMgrIDSafe(device), e.getMessage()), e.getCause());
 	}
 
 	public IStatus getResult() {


### PR DESCRIPTION
Also adjust the handling of deployment exceptions to show the low-level cause in the resulting error dialog.