### PR TITLE
Fix exporting of large files

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/CommonElementExporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/CommonElementExporter.java
@@ -117,7 +117,12 @@ public class CommonElementExporter {
 
 		@Override
 		public int available() throws IOException {
-			return currentDataBuffer.remaining();
+			int remaining = currentDataBuffer.remaining();
+			if ((remaining == 0) && bufferIterator.hasNext()) {
+				currentDataBuffer = bufferIterator.next();
+				remaining = currentDataBuffer.remaining();
+			}
+			return remaining;
 		}
 
 		@Override


### PR DESCRIPTION
ByteBufferInputStream didn't correctly treat the buffer list in available().