### PR TITLE
Adapter plug got socket interface on create / after type update

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractUpdateBlockFBNElementCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractUpdateBlockFBNElementCommand.java
@@ -40,6 +40,7 @@ import org.eclipse.fordiac.ide.model.data.DataType;
 import org.eclipse.fordiac.ide.model.data.EventType;
 import org.eclipse.fordiac.ide.model.datatype.helper.InternalAttributeDeclarations;
 import org.eclipse.fordiac.ide.model.errormarker.FordiacErrorMarkerInterfaceHelper;
+import org.eclipse.fordiac.ide.model.libraryElement.AdapterFB;
 import org.eclipse.fordiac.ide.model.libraryElement.AdapterType;
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
 import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
@@ -59,6 +60,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.TypedSubApp;
 import org.eclipse.fordiac.ide.model.libraryElement.Value;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.impl.ConfigurableFBManagement;
+import org.eclipse.fordiac.ide.model.typelibrary.AdapterTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.commands.CompoundCommand;
@@ -225,7 +227,13 @@ public abstract class AbstractUpdateBlockFBNElementCommand extends Command
 	}
 
 	protected void setInterface() {
-		final InterfaceList typeInterface = newElement.getTypeInterface();
+		InterfaceList typeInterface = newElement.getTypeInterface();
+		if (newElement instanceof final AdapterFB adapterFB
+				&& adapterFB.getTypeEntry() instanceof final AdapterTypeEntry adapterTypeEntry) {
+			final AdapterType adpType = adapterTypeEntry.getType();
+			typeInterface = (adapterFB.isPlug() ? adpType.getPlugType().getInterfaceList()
+					: adpType.getInterfaceList());
+		}
 		if (typeInterface != null) {
 			newElement.setInterface(typeInterface.copy());
 		} else {

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/AdapterFBCreateCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/AdapterFBCreateCommand.java
@@ -15,6 +15,7 @@ package org.eclipse.fordiac.ide.model.commands.create;
 
 import org.eclipse.fordiac.ide.model.libraryElement.AdapterDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.AdapterFB;
+import org.eclipse.fordiac.ide.model.libraryElement.AdapterType;
 import org.eclipse.fordiac.ide.model.libraryElement.CompositeFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
@@ -66,7 +67,11 @@ class AdapterFBCreateCommand extends FBCreateCommand {
 
 	@Override
 	protected InterfaceList createInterfaceList() {
-		return getAdapterFB().getType().getInterfaceList().copy();
+		final AdapterType type = (AdapterType) getTypeEntry().getType();
+		final InterfaceList src = (adapterDecl != null && !adapterDecl.isIsInput())
+				? type.getPlugType().getInterfaceList()
+				: type.getInterfaceList();
+		return src.copy();
 	}
 
 }


### PR DESCRIPTION
Creating the first adapter PLUG sometimes produced the socket interface (events/data on the wrong side).
Updating the type of an adapter fb could flip an existing PLUG to the socket interface.