### PR TITLE
Fix handling of missing configurable FB types

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/ElementEditPartFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/ElementEditPartFactory.java
@@ -20,7 +20,6 @@
 package org.eclipse.fordiac.ide.application.editparts;
 
 import org.eclipse.fordiac.ide.gef.editparts.Abstract4diacEditPartFactory;
-import org.eclipse.fordiac.ide.model.LibraryElementTags;
 import org.eclipse.fordiac.ide.model.data.StructuredType;
 import org.eclipse.fordiac.ide.model.libraryElement.Comment;
 import org.eclipse.fordiac.ide.model.libraryElement.CommunicationChannel;
@@ -115,8 +114,14 @@ public class ElementEditPartFactory extends Abstract4diacEditPartFactory {
 		if (element instanceof ConfigurableMoveFB) {
 			return new ConfigurableMoveFBEditPart();
 		}
-		if (element instanceof final FB fb) {
-			return getPartForFBInstances(fb);
+		if (element instanceof Multiplexer) {
+			return new MultiplexerEditPart();
+		}
+		if (element instanceof Demultiplexer) {
+			return new DemultiplexerEditPart();
+		}
+		if (element instanceof FB) {
+			return new FBEditPart();
 		}
 		if (element instanceof SubApp) {
 			return new SubAppForFBNetworkEditPart();
@@ -129,19 +134,6 @@ public class ElementEditPartFactory extends Abstract4diacEditPartFactory {
 		}
 
 		throw createEditpartCreationException(context, element);
-	}
-
-	protected static EditPart getPartForFBInstances(final FB fb) {
-		if (fb.getTypeEntry() != null && fb.getTypeEntry().getTypeName() != null) {
-			final String typeName = fb.getTypeEntry().getTypeName();
-			if (typeName.contentEquals(LibraryElementTags.TYPENAME_MUX)) {
-				return new MultiplexerEditPart();
-			}
-			if (typeName.contentEquals(LibraryElementTags.TYPENAME_DEMUX)) {
-				return new DemultiplexerEditPart();
-			}
-		}
-		return new FBEditPart();
 	}
 
 	@SuppressWarnings("static-method") // not static to allow subclasses to provide own elements

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractUpdateBlockFBNElementCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractUpdateBlockFBNElementCommand.java
@@ -44,6 +44,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.AdapterType;
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
 import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableFB;
+import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableMoveFB;
 import org.eclipse.fordiac.ide.model.libraryElement.Connection;
 import org.eclipse.fordiac.ide.model.libraryElement.Demultiplexer;
 import org.eclipse.fordiac.ide.model.libraryElement.ErrorMarkerFBNElement;
@@ -168,16 +169,43 @@ public abstract class AbstractUpdateBlockFBNElementCommand extends Command
 
 	protected void handleConfigurableFB() {
 		// for the configurable fb we have to transfer the data type
-		if (newElement instanceof final ConfigurableFB configFb
-				&& oldElement instanceof final ConfigurableFB oldConfigFb) {
-			configFb.setDataType(oldConfigFb.getDataType());
+		if (newElement instanceof final ConfigurableFB configFb) {
+			if (oldElement instanceof final ConfigurableFB oldConfigFb) {
+				configFb.setDataType(oldConfigFb.getDataType());
 
-			if (configFb instanceof final Demultiplexer newDemux && oldConfigFb instanceof final Demultiplexer oldDemux
-					&& oldDemux.isIsConfigured()) {
-				newDemux.loadConfiguration(LibraryElementTags.DEMUX_VISIBLE_CHILDREN,
-						ConfigurableFBManagement.buildVisibleChildrenString(oldDemux.getMemberVars()));
+				if (configFb instanceof final Demultiplexer newDemux
+						&& oldConfigFb instanceof final Demultiplexer oldDemux && oldDemux.isIsConfigured()) {
+					newDemux.loadConfiguration(LibraryElementTags.DEMUX_VISIBLE_CHILDREN,
+							ConfigurableFBManagement.buildVisibleChildrenString(oldDemux.getMemberVars()));
+				} else {
+					configFb.updateConfiguration();
+				}
 			} else {
-				configFb.updateConfiguration();
+				// transfer data from error marker
+				handleConFBUpdateFromErrorMarker(configFb);
+			}
+		}
+	}
+
+	private void handleConFBUpdateFromErrorMarker(final ConfigurableFB configFb) {
+		if (configFb instanceof ConfigurableMoveFB) {
+			final String dataTypeName = oldElement.getAttributeValue(LibraryElementTags.F_MOVE_CONFIG);
+			if (dataTypeName != null) {
+				configFb.loadConfiguration(LibraryElementTags.F_MOVE_CONFIG, dataTypeName);
+			}
+		} else {
+			// we are a struct muxer
+			final String dataTypeName = oldElement.getAttributeValue(LibraryElementTags.STRUCT_MANIPULATOR_CONFIG);
+			if (dataTypeName != null) {
+				configFb.loadConfiguration(LibraryElementTags.STRUCT_MANIPULATOR_CONFIG, dataTypeName);
+
+				if (configFb instanceof Demultiplexer) {
+					final String visibleChildren = oldElement
+							.getAttributeValue(LibraryElementTags.DEMUX_VISIBLE_CHILDREN);
+					if (visibleChildren != null) {
+						configFb.loadConfiguration(LibraryElementTags.DEMUX_VISIBLE_CHILDREN, visibleChildren);
+					}
+				}
 			}
 		}
 	}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/BlockInstanceFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/BlockInstanceFactory.java
@@ -18,6 +18,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.FB;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.typelibrary.AdapterTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.ErrorTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.FBTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.SubAppTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
@@ -41,6 +42,9 @@ public final class BlockInstanceFactory {
 	}
 
 	public static FB createFBInstanceForTypeEntry(final FBTypeEntry entry) {
+		if (entry instanceof ErrorTypeEntry) {
+			return LibraryElementFactory.eINSTANCE.createFB();
+		}
 		if (entry.getTypeName().startsWith(LibraryElementTags.FB_TYPE_COMM_MESSAGE)) {
 			return LibraryElementFactory.eINSTANCE.createCommunicationChannel();
 		}


### PR DESCRIPTION
The block instance and edit part factory created specialized instances even when the respective FB types were missing, which caused problems during loading and editing. This prevents special handling when dealing with error types.