### PR TITLE
Check package name when applying special handling for FBs

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/LibraryElementTags.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/LibraryElementTags.java
@@ -182,9 +182,11 @@ public final class LibraryElementTags {
 	public static final String DOCUMENTATION = "Documentation"; //$NON-NLS-1$
 
 	public static final String TYPENAME_FMOVE = "F_MOVE"; //$NON-NLS-1$
+	public static final String PACKAGE_NAME_FMOVE = "iec61131::selection"; //$NON-NLS-1$
 	public static final String F_MOVE_CONFIG = "DataType"; //$NON-NLS-1$
 	public static final String TYPENAME_MUX = "STRUCT_MUX"; //$NON-NLS-1$
 	public static final String TYPENAME_DEMUX = "STRUCT_DEMUX"; //$NON-NLS-1$
+	public static final String PACKAGE_NAME_MUXERS = "eclipse4diac::convert"; //$NON-NLS-1$
 	public static final String STRUCT_MANIPULATOR_CONFIG = "StructuredType"; //$NON-NLS-1$
 	public static final String DEMUX_VISIBLE_CHILDREN = "VisibleChildren"; //$NON-NLS-1$
 	public static final String VARIABLE_SEPARATOR = ","; //$NON-NLS-1$

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/BlockInstanceFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/BlockInstanceFactory.java
@@ -44,19 +44,26 @@ public final class BlockInstanceFactory {
 		if (entry.getTypeName().startsWith(LibraryElementTags.FB_TYPE_COMM_MESSAGE)) {
 			return LibraryElementFactory.eINSTANCE.createCommunicationChannel();
 		}
-		if (LibraryElementTags.TYPENAME_MUX.equals(entry.getTypeName())) {
+		if (LibraryElementTags.TYPENAME_MUX.equals(entry.getTypeName())
+				&& matchesPackageName(entry, LibraryElementTags.PACKAGE_NAME_MUXERS)) {
 			return LibraryElementFactory.eINSTANCE.createMultiplexer();
 		}
-		if (LibraryElementTags.TYPENAME_DEMUX.equals(entry.getTypeName())) {
+		if (LibraryElementTags.TYPENAME_DEMUX.equals(entry.getTypeName())
+				&& matchesPackageName(entry, LibraryElementTags.PACKAGE_NAME_MUXERS)) {
 			return LibraryElementFactory.eINSTANCE.createDemultiplexer();
 		}
-		if (LibraryElementTags.TYPENAME_FMOVE.equals(entry.getTypeName())) {
+		if (LibraryElementTags.TYPENAME_FMOVE.equals(entry.getTypeName())
+				&& matchesPackageName(entry, LibraryElementTags.PACKAGE_NAME_FMOVE)) {
 			return LibraryElementFactory.eINSTANCE.createConfigurableMoveFB();
 		}
 		if (LibraryElementPackage.Literals.COMPOSITE_FB_TYPE.equals(entry.getTypeEClass())) {
 			return LibraryElementFactory.eINSTANCE.createCFBInstance();
 		}
 		return LibraryElementFactory.eINSTANCE.createFB();
+	}
+
+	private static boolean matchesPackageName(final TypeEntry entry, final String packageName) {
+		return entry.getPackageName().isEmpty() || entry.getPackageName().equals(packageName);
 	}
 
 	private BlockInstanceFactory() {


### PR DESCRIPTION
The block instance factory did not check for the package name when applying special handling for certain FB types. This meant any FB type with a matching name would receive special handling, even if it was from a different package.