### PR TITLE
Support full type name in type prefix for generic variables

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/value/EnumValue.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/value/EnumValue.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 
 import org.eclipse.fordiac.ide.model.data.EnumeratedType;
 import org.eclipse.fordiac.ide.model.data.EnumeratedValue;
+import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 
 public final class EnumValue implements AnyDerivedValue {
 	private final EnumeratedValue value;
@@ -56,7 +57,7 @@ public final class EnumValue implements AnyDerivedValue {
 
 	@Override
 	public String toString() {
-		return getType().getName() + '#' + value.getName();
+		return PackageNameHelper.getFullTypeName(getType()) + '#' + value.getName();
 	}
 
 	public EnumeratedValue getValue() {

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/AbstractVariable.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/AbstractVariable.java
@@ -19,6 +19,7 @@ import org.eclipse.fordiac.ide.model.data.EnumeratedType;
 import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes;
 import org.eclipse.fordiac.ide.model.eval.value.Value;
 import org.eclipse.fordiac.ide.model.eval.value.ValueOperations;
+import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
 import org.eclipse.fordiac.ide.model.value.TypedValue;
@@ -40,10 +41,11 @@ public abstract class AbstractVariable<T extends Value> implements Variable<T> {
 
 	@Override
 	public String toString(final boolean pretty) {
+		final LibraryElement valueType = getValue().getType();
 		if (type instanceof final DataType dataType && IecTypes.GenericTypes.isAnyType(dataType)
-				&& !(getValue().getType() instanceof AnyDurationType || getValue().getType() instanceof AnyDateType
-						|| getValue().getType() instanceof EnumeratedType)) {
-			return getValue().getType().getName() + '#' + getValue().toString(pretty);
+				&& !(valueType instanceof AnyDurationType || valueType instanceof AnyDateType
+						|| valueType instanceof EnumeratedType)) {
+			return PackageNameHelper.getFullTypeName(valueType) + '#' + getValue().toString(pretty);
 		}
 		return getValue().toString(pretty);
 	}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/TypedValueConverter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/TypedValueConverter.java
@@ -69,7 +69,7 @@ public final class TypedValueConverter implements ValueConverter<Object> {
 			ElementaryTypes.LDATE_AND_TIME);
 
 	private static final String TYPE_PREFIX_FORMAT = "%s#%s"; //$NON-NLS-1$
-	private static final Pattern TYPE_PREFIX_PATTERN = Pattern.compile("\\G([_a-zA-Z]\\w*+)#"); //$NON-NLS-1$
+	private static final Pattern TYPE_PREFIX_PATTERN = Pattern.compile("\\G([_a-zA-Z][a-zA-Z_0-9:]*+)#"); //$NON-NLS-1$
 
 	private static final String TIME_SHORT_FORM = "T"; //$NON-NLS-1$
 	private static final String LTIME_SHORT_FORM = "LT"; //$NON-NLS-1$


### PR DESCRIPTION
The type prefix required for generic variables must include the full type name, such as for struct types. Also use the full type name for enum values.