### PR TITLE
Deleting struct demuxers leads to widget disposed errors #1889

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/StructManipulatorSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/StructManipulatorSection.java
@@ -144,6 +144,10 @@ public abstract class StructManipulatorSection extends AbstractSection implement
 
 		if (topItemPath != null) {
 			Display.getDefault().asyncExec(() -> {
+				if (memberViewerTree.isDisposed()) {
+					return;
+				}
+
 				// Force tree refresh
 				memberViewerTree.update();
 				memberViewerTree.redraw();


### PR DESCRIPTION
Fixes: https://github.com/eclipse-4diac/4diac-ide/issues/1889