### PR TITLE
Adds TypeHash attribute to adapter types

### DIFF
--- a/data/typelibrary/events-1.0.0/typelib/ARTimeOut.adp
+++ b/data/typelibrary/events-1.0.0/typelib/ARTimeOut.adp
@@ -39,4 +39,5 @@
       </ServiceTransaction>
     </ServiceSequence>
   </Service>
+	<Attribute Name="TypeHash" Value="''"/>
 </AdapterType>

--- a/data/typelibrary/events-1.0.0/typelib/ATimeOut.adp
+++ b/data/typelibrary/events-1.0.0/typelib/ATimeOut.adp
@@ -40,4 +40,5 @@
       </ServiceTransaction>
     </ServiceSequence>
   </Service>
+	<Attribute Name="TypeHash" Value="''"/>
 </AdapterType>

--- a/data/typelibrary/events-3.0.0/typelib/ARTimeOut.adp
+++ b/data/typelibrary/events-3.0.0/typelib/ARTimeOut.adp
@@ -43,4 +43,5 @@
       </ServiceTransaction>
     </ServiceSequence>
   </Service>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </AdapterType>

--- a/data/typelibrary/events-3.0.0/typelib/ATimeOut.adp
+++ b/data/typelibrary/events-3.0.0/typelib/ATimeOut.adp
@@ -43,4 +43,5 @@
       </ServiceTransaction>
     </ServiceSequence>
   </Service>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </AdapterType>


### PR DESCRIPTION
Adds a TypeHash attribute to the ATimeOut and ARTimeOut adapter types
in both events-1.0.0 and events-3.0.0 typelibraries.

This addition aims to facilitate type identification and management within
the system.
