### PR TITLE
Fixed Issues for Editing FunctionTypes

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editparts/InterfaceContainerEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/editparts/InterfaceContainerEditPart.java
@@ -24,6 +24,7 @@ import org.eclipse.emf.common.notify.Adapter;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.fordiac.ide.fbtypeeditor.policies.EventInputContainerLayoutEditPolicy;
 import org.eclipse.fordiac.ide.fbtypeeditor.policies.EventOutputContainerLayoutEditPolicy;
+import org.eclipse.fordiac.ide.fbtypeeditor.policies.InterfaceElementSelectionLayoutPolicy;
 import org.eclipse.fordiac.ide.fbtypeeditor.policies.PlugContainerLayoutEditPolicy;
 import org.eclipse.fordiac.ide.fbtypeeditor.policies.SocketContainerLayoutEditPolicy;
 import org.eclipse.fordiac.ide.fbtypeeditor.policies.VarInOutInputContainerLayoutEditPolicy;
@@ -78,6 +79,7 @@ public class InterfaceContainerEditPart extends AbstractGraphicalEditPart {
 	@Override
 	protected void createEditPolicies() {
 		if (!isInterfaceEditable()) {
+			installEditPolicy(EditPolicy.LAYOUT_ROLE, new InterfaceElementSelectionLayoutPolicy());
 			return;
 		}
 

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/policies/InterfaceElementSelectionLayoutPolicy.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/policies/InterfaceElementSelectionLayoutPolicy.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sebastian Hollersbacher - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.fbtypeeditor.policies;
+
+import org.eclipse.draw2d.geometry.Insets;
+import org.eclipse.fordiac.ide.gef.policies.ModifiedNonResizeableEditPolicy;
+import org.eclipse.fordiac.ide.gef.preferences.GefPreferenceConstants;
+import org.eclipse.gef.EditPart;
+import org.eclipse.gef.EditPolicy;
+import org.eclipse.gef.Request;
+import org.eclipse.gef.commands.Command;
+import org.eclipse.gef.editpolicies.LayoutEditPolicy;
+import org.eclipse.gef.requests.CreateRequest;
+
+public class InterfaceElementSelectionLayoutPolicy extends LayoutEditPolicy {
+	@Override
+	protected EditPolicy createChildEditPolicy(final EditPart child) {
+		return new ModifiedNonResizeableEditPolicy(GefPreferenceConstants.CORNER_DIM_HALF, new Insets(1));
+	}
+
+	@Override
+	protected Command getCreateCommand(final CreateRequest request) {
+		return null;
+	}
+
+	@Override
+	protected Command getMoveChildrenCommand(final Request request) {
+		return null;
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/filters/AttributeFilter.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/filters/AttributeFilter.java
@@ -47,6 +47,11 @@ public class AttributeFilter implements IFilter {
 		case final ConfigurableObject configurableObject -> configurableObject;
 		case final FBNetwork fbNetwork -> parseObject(fbNetwork.eContainer());
 		case final EditPart editpart -> parseObject(editpart.getModel());
+		// handle exception: typefield of interface elements of functions
+		case final IAdaptable adaptable when adaptable
+				.getAdapter(ConfigurableObject.class) instanceof final IInterfaceElement ie
+				&& ie.getFBType() instanceof FunctionFBType ->
+			null;
 		case final IAdaptable adaptable -> adaptable.getAdapter(ConfigurableObject.class);
 		case final TextSelection textSel -> getConfObjectFromActiveEditor();
 		case null, default -> null;

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/RefactorElementPropertyTester.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/RefactorElementPropertyTester.java
@@ -18,6 +18,7 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.ErrorMarkerInterface;
 import org.eclipse.fordiac.ide.model.libraryElement.FB;
+import org.eclipse.fordiac.ide.model.libraryElement.FunctionFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
@@ -42,6 +43,9 @@ public class RefactorElementPropertyTester extends PropertyTester {
 		}
 
 		if (element instanceof final IInterfaceElement ie && !(ie instanceof ErrorMarkerInterface)) {
+			if (ie.getFBType() instanceof FunctionFBType) {
+				return false;
+			}
 			if (ie.getBlockFBNetworkElement() != null) {
 				return isEditableTypeEntry(ie.getBlockFBNetworkElement().getTypeEntry());
 			}


### PR DESCRIPTION
Issues include:
- Editing Attributes for FunctionType Pins should not be possible
- Selecting Pins in TypeEditor does not give feedback
- RenameElement should not be possible for Pins in FunctionType