### PR TITLE
Gracefully handle empty type hash attributes

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
@@ -438,7 +438,11 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 		}
 		final Attribute typeHashAttribute = getTypeHashAttribute(type);
 		if (typeHashAttribute != null) {
-			return StringValueConverter.INSTANCE.toValue(typeHashAttribute.getValue());
+			final String value = typeHashAttribute.getValue();
+			if (value.isEmpty()) {
+				return value;
+			}
+			return StringValueConverter.INSTANCE.toValue(value);
 		}
 		return LibraryElementHasher.hash(type);
 	}


### PR DESCRIPTION
This defaults to an empty string when the value of the type hash attribute is empty, instead of throwing an exception.