### PR TITLE
Fixed Instance Creation in Resources #1918

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/PaletteFilter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/PaletteFilter.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.model.libraryElement.CompositeFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
@@ -45,13 +46,16 @@ public class PaletteFilter {
 			return Stream.concat(typeLib.getFbTypes().stream(), typeLib.getSubAppTypes().stream());
 		}
 
-		final EObject host = hostNetwork.eContainer();
+		final EObject host = EcoreUtil.getRootContainer(hostNetwork.eContainer());
 		final Stream<TypeEntry> stream = host instanceof CompositeFBType && !(host instanceof SubAppType)
 				? typeLib.getFbTypes().stream().map(TypeEntry.class::cast)
 				: Stream.concat(typeLib.getFbTypes().stream(), typeLib.getSubAppTypes().stream());
 
-		final TypeEntry selfEntry = ((LibraryElement) host).getTypeEntry();
-		return stream.filter(te -> te != selfEntry);
+		if (host instanceof final LibraryElement le) {
+			final TypeEntry selfEntry = le.getTypeEntry();
+			return stream.filter(te -> te != selfEntry);
+		}
+		return stream;
 	}
 
 	private Stream<TypeEntry> findTypes(final String searchString, final Stream<TypeEntry> stream) {

--- a/plugins/org.eclipse.fordiac.ide.resourceediting/src/org/eclipse/fordiac/ide/resourceediting/editparts/FBNetworkContainerEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.resourceediting/src/org/eclipse/fordiac/ide/resourceediting/editparts/FBNetworkContainerEditPart.java
@@ -26,16 +26,11 @@ import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.impl.AdapterImpl;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.fordiac.ide.application.editparts.FBNetworkEditPart;
-import org.eclipse.fordiac.ide.application.policies.FBNetworkXYLayoutEditPolicy;
 import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.Connection;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
-import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.GraphicalEditPart;
-import org.eclipse.gef.Request;
-import org.eclipse.gef.commands.Command;
-import org.eclipse.gef.editpolicies.RootComponentEditPolicy;
 import org.eclipse.swt.graphics.Point;
 
 /**
@@ -108,30 +103,6 @@ public class FBNetworkContainerEditPart extends FBNetworkEditPart {
 			return vIO;
 		}
 		return null;
-	}
-
-	@Override
-	protected void createEditPolicies() {
-		super.createEditPolicies();
-
-		installEditPolicy(EditPolicy.COMPONENT_ROLE, new RootComponentEditPolicy());
-		installEditPolicy(EditPolicy.LAYOUT_ROLE, new FBNetworkXYLayoutEditPolicy());
-	}
-
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.eclipse.gef.editparts.AbstractEditPart#performRequest(org.eclipse.gef
-	 * .Request)
-	 */
-	@Override
-	public void performRequest(final Request req) {
-		final Command cmd = getCommand(req);
-		if ((cmd != null) && cmd.canExecute()) {
-			getViewer().getEditDomain().getCommandStack().execute(cmd);
-		}
-		super.performRequest(req);
 	}
 
 	@Override


### PR DESCRIPTION
The FBNetworkEditPart in resources did more then it should do. Furthermore there was an issue in the PaletteFilter when the host was not the root element.

fixes #1918