### PR TITLE
Fix missing values when copying interface from cache in type entry

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractInterfaceTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractInterfaceTypeEntryImpl.java
@@ -31,6 +31,7 @@ import org.eclipse.emf.common.notify.NotificationChain;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.model.dataimport.BlockTypeImporter;
+import org.eclipse.fordiac.ide.model.helpers.InterfaceListCopier;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
@@ -88,7 +89,7 @@ public abstract class AbstractInterfaceTypeEntryImpl<T extends FBType> extends A
 		interfaceType.setName(fbTypeCache.getName());
 		interfaceType.setComment(fbTypeCache.getComment());
 		interfaceType.setCompilerInfo(EcoreUtil.copy(fbTypeCache.getCompilerInfo()));
-		interfaceType.setInterfaceList(fbTypeCache.getInterfaceList().copy());
+		interfaceType.setInterfaceList(InterfaceListCopier.copy(fbTypeCache.getInterfaceList(), true, true));
 		updateInterfaceDependencies(StreamSupport
 				.stream(Spliterators.spliteratorUnknownSize(interfaceType.eAllContents(), 0), false)
 				.map(EObject::eCrossReferences).flatMap(Collection::stream).filter(LibraryElement.class::isInstance)


### PR DESCRIPTION
The type entry uses a copy of the interface from an already cached type when available. The copy did not include the initial values or comments of the original. This resolves the problem by always including the values and comments in the copy.