### PR TITLE
Introduce dedicated instance and full copy methods for interface list

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/PasteCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/PasteCommand.java
@@ -258,7 +258,7 @@ public class PasteCommand extends Command implements ScopedCommand {
 				copiedElement.setTypeEntry(dstTypeLib.createErrorTypeEntry(element.getFullTypeName(),
 						element.getTypeEntry().getTypeEClass()));
 				if (element instanceof final BlockFBNetworkElement bfbElement) {
-					((BlockFBNetworkElement) copiedElement).setInterface(bfbElement.getInterface().copy());
+					((BlockFBNetworkElement) copiedElement).setInterface(bfbElement.getInterface().fullCopy());
 				}
 			}
 		} else if (copiedElement instanceof final BlockFBNetworkElement copiedBlockElement) {

--- a/plugins/org.eclipse.fordiac.ide.deployment.eval/src/org/eclipse/fordiac/ide/deployment/eval/fb/DeploymentFBNetworkElementEvaluator.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.eval/src/org/eclipse/fordiac/ide/deployment/eval/fb/DeploymentFBNetworkElementEvaluator.java
@@ -62,7 +62,7 @@ public abstract class DeploymentFBNetworkElementEvaluator<T extends FBType, I ex
 		super(type, context, variables, parent);
 		instance.setName(getName() + "_" + UUID.randomUUID().toString()); //$NON-NLS-1$
 		instance.setTypeEntry(getType().getTypeEntry());
-		instance.setInterface(getType().getInterfaceList().copy());
+		instance.setInterface(getType().getInterfaceList().instanceCopy());
 		this.instance = instance;
 		this.eventCounters = instance.getInterface().getEventOutputs().stream()
 				.collect(Collectors.toUnmodifiableMap(Function.identity(), unused -> new AtomicInteger()));

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/CompositeTestFBGenerator.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/CompositeTestFBGenerator.java
@@ -122,7 +122,7 @@ public class CompositeTestFBGenerator extends AbstractCompositeFBGenerator {
 		compEl.setTypeEntry(compType);
 		addPosition(compEl, x + (double) 200, y + (double) 150);
 
-		compEl.setInterface(compEl.getType().getInterfaceList().copy());
+		compEl.setInterface(compEl.getType().getInterfaceList().instanceCopy());
 
 		net.getNetworkElements().add(compEl);
 		final String name = NameRepository.createUniqueName(compEl, "TESTAPPFB1");//$NON-NLS-1$
@@ -169,13 +169,13 @@ public class CompositeTestFBGenerator extends AbstractCompositeFBGenerator {
 	private void createConnToRunAllFB() {
 
 		// connection from the composite to the runallFB
-		InterfaceList runAllInterface = runAllFB.getInterface();
+		final InterfaceList runAllInterface = runAllFB.getInterface();
 		getEventConns().add(createEventConn(compositeFB.getInterfaceList().getEvent(EVENT_RUNALL),
 				(Event) runAllInterface.getInterfaceElement(List.of(EVENT_RUNALL))));
 
 		// connect muxFB outputs to the runallFB, so the runallFB knows, when to start
 		// the next test case
-		InterfaceList muxInterface = muxFB.getInterface();
+		final InterfaceList muxInterface = muxFB.getInterface();
 		getEventConns().add(createEventConn((Event) muxInterface.getInterfaceElement(List.of(EVENT_SUCCESS)),
 				(Event) runAllInterface.getInterfaceElement(List.of(EVENT_LASTCOMPLETE))));
 		getEventConns().add(createEventConn((Event) muxInterface.getInterfaceElement(List.of(EVENT_ERROR)),

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/internal/AbstractCompositeFBGenerator.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/testappgen/internal/AbstractCompositeFBGenerator.java
@@ -77,7 +77,7 @@ public abstract class AbstractCompositeFBGenerator extends AbstractBlockGenerato
 		final BlockFBNetworkElement el = LibraryElementFactory.eINSTANCE.createFB();
 		el.setTypeEntry(blockToAdd.getTypeEntry());
 		addPosition(el, x, y);
-		el.setInterface(blockToAdd.getInterfaceList().copy());
+		el.setInterface(blockToAdd.getInterfaceList().instanceCopy());
 
 		net.getNetworkElements().add(el);
 		final String name = NameRepository.createUniqueName(el, "TESTAPPFB1"); //$NON-NLS-1$

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractUpdateBlockFBNElementCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractUpdateBlockFBNElementCommand.java
@@ -282,7 +282,7 @@ public abstract class AbstractUpdateBlockFBNElementCommand extends Command
 					: adpType.getInterfaceList());
 		}
 		if (typeInterface != null) {
-			newElement.setInterface(typeInterface.copy());
+			newElement.setInterface(typeInterface.instanceCopy());
 		} else {
 			newElement.setInterface(LibraryElementFactory.eINSTANCE.createInterfaceList());
 		}

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeFbTypeCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeFbTypeCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Primetals Technologies Austria GmbH
+ * Copyright (c) 2021, 2025 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -68,7 +68,7 @@ public class ChangeFbTypeCommand extends Command implements ScopedCommand {
 
 	private void setFBType(final FBTypeEntry entry) {
 		fb.setTypeEntry(entry);
-		fb.setInterface(entry.getInterface().copy());
+		fb.setInterface(entry.getInterface().instanceCopy());
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/MapCommunicationCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/MapCommunicationCommand.java
@@ -13,7 +13,6 @@
 package org.eclipse.fordiac.ide.model.commands.change;
 
 import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.eclipse.fordiac.ide.model.helpers.InterfaceListCopier;
 import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.CommunicationChannel;
 import org.eclipse.fordiac.ide.model.libraryElement.CommunicationMappingTarget;
@@ -45,7 +44,7 @@ public class MapCommunicationCommand extends MapToCommand {
 		comm.setName(srcElement.getName());
 		comm.setPosition(EcoreUtil.copy(srcElement.getPosition()));
 		comm.setTypeEntry(srcElement.getTypeEntry());
-		comm.setInterface(InterfaceListCopier.copy(srcElement.getInterface(), true, true));
+		comm.setInterface(srcElement.getInterface().fullCopy());
 		target.getMappedElements().add(comm);
 		return comm;
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/UntypeSubAppCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/UntypeSubAppCommand.java
@@ -46,6 +46,6 @@ public class UntypeSubAppCommand extends AbstractUpdateBlockFBNElementCommand {
 
 	@Override
 	protected void setInterface() {
-		newElement.setInterface(oldElement.getTypeInterface().copy());
+		newElement.setInterface(oldElement.getTypeInterface().fullCopy());
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/UpdateInternalFBCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/UpdateInternalFBCommand.java
@@ -64,7 +64,7 @@ public class UpdateInternalFBCommand extends Command implements ScopedCommand {
 
 	protected void createNewFB() {
 		newElement = createCopiedFBEntry(oldElement);
-		newElement.setInterface(newElement.getTypeInterface().copy());
+		newElement.setInterface(newElement.getTypeInterface().instanceCopy());
 		newElement.setName(oldElement.getName());
 		createValues();
 		transferInstanceComments();

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/AdapterFBCreateCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/AdapterFBCreateCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2024 TU Wien ACIN, Profactor GmbH, fortiss GmbH
+ * Copyright (c) 2012, 2025 TU Wien ACIN, Profactor GmbH, fortiss GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -71,7 +71,7 @@ class AdapterFBCreateCommand extends FBCreateCommand {
 		final InterfaceList src = (adapterDecl != null && !adapterDecl.isIsInput())
 				? type.getPlugType().getInterfaceList()
 				: type.getInterfaceList();
-		return src.copy();
+		return src.instanceCopy();
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/CreateInternalFBCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/CreateInternalFBCommand.java
@@ -66,7 +66,7 @@ public class CreateInternalFBCommand extends CreationCommand implements ScopedCo
 		internalFB = LibraryElementFactory.eINSTANCE.createFB();
 		internalFB.setTypeEntry(fbTypeEntry);
 		internalFB.setComment(""); //$NON-NLS-1$
-		internalFB.setInterface(fbTypeEntry.getInterface().copy());
+		internalFB.setInterface(fbTypeEntry.getInterface().instanceCopy());
 		getInteralFBList().add(index, internalFB);
 		internalFB.setName(NameRepository.createUniqueName(internalFB, name));
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/CreateSubAppInstanceCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/CreateSubAppInstanceCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2016, 2017 fortiss GmbH
+ * Copyright (c) 2014, 2025 fortiss GmbH, Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -43,7 +43,7 @@ public class CreateSubAppInstanceCommand extends AbstractCreateFBNetworkElementC
 		if (interfaceList == null) {
 			interfaceList = LibraryElementFactory.eINSTANCE.createInterfaceList();
 		} else {
-			interfaceList = interfaceList.copy();
+			interfaceList = interfaceList.instanceCopy();
 		}
 		return interfaceList;
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/FBCreateCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/FBCreateCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 Profactor GmbH, TU Wien ACIN, fortiss GmbH
+ * Copyright (c) 2008, 2025 Profactor GmbH, TU Wien ACIN, fortiss GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -85,7 +85,7 @@ public class FBCreateCommand extends AbstractCreateFBNetworkElementCommand {
 		if (interfaceList == null) {
 			interfaceList = LibraryElementFactory.eINSTANCE.createInterfaceList();
 		} else {
-			interfaceList = interfaceList.copy();
+			interfaceList = interfaceList.instanceCopy();
 		}
 		return interfaceList;
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/insert/InsertFBCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/insert/InsertFBCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Primetals Technologies Germany GmbH
+ * Copyright (c) 2021, 2025 Primetals Technologies Germany GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -47,7 +47,7 @@ public class InsertFBCommand extends Command implements ScopedCommand {
 			internalFB = LibraryElementFactory.eINSTANCE.createFB();
 		}
 		internalFB.setTypeEntry(fb.getTypeEntry());
-		internalFB.setInterface(fb.getInterface().copy());
+		internalFB.setInterface(fb.getInterface().instanceCopy());
 		internalFB.setComment(""); //$NON-NLS-1$
 		redo();
 		internalFB.setName(NameRepository.createUniqueName(internalFB, fb.getName()));

--- a/plugins/org.eclipse.fordiac.ide.model/model/fordiac.genmodel
+++ b/plugins/org.eclipse.fordiac.ide.model/model/fordiac.genmodel
@@ -643,7 +643,8 @@
       <genOperations ecoreOperation="lib.ecore#//InterfaceList/getAdapter" body="return InterfaceListAnnotations.getAdapter(this, name);">
         <genParameters ecoreParameter="lib.ecore#//InterfaceList/getAdapter/name"/>
       </genOperations>
-      <genOperations ecoreOperation="lib.ecore#//InterfaceList/copy" body="return org.eclipse.fordiac.ide.model.helpers.InterfaceListCopier.copy(this);"/>
+      <genOperations ecoreOperation="lib.ecore#//InterfaceList/instanceCopy" body="return org.eclipse.fordiac.ide.model.helpers.InterfaceListCopier.copy(this, false, false);"/>
+      <genOperations ecoreOperation="lib.ecore#//InterfaceList/fullCopy" body="return org.eclipse.fordiac.ide.model.helpers.InterfaceListCopier.copy(this, true, true);"/>
       <genOperations ecoreOperation="lib.ecore#//InterfaceList/getAllInputs" body="return InterfaceListAnnotations.getAllInputs(this);"/>
       <genOperations ecoreOperation="lib.ecore#//InterfaceList/getAllOutputs" body="return InterfaceListAnnotations.getAllOutputs(this);"/>
       <genOperations ecoreOperation="lib.ecore#//InterfaceList/getInput" body="return InterfaceListAnnotations.getInput(this, path);">

--- a/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
+++ b/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
@@ -1662,9 +1662,14 @@
       </eAnnotations>
       <eParameters name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     </eOperations>
-    <eOperations name="copy" lowerBound="1" eType="#//InterfaceList">
+    <eOperations name="instanceCopy" lowerBound="1" eType="#//InterfaceList">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
-        <details key="body" value="return org.eclipse.fordiac.ide.model.helpers.InterfaceListCopier.copy(this);"/>
+        <details key="body" value="return org.eclipse.fordiac.ide.model.helpers.InterfaceListCopier.copy(this, false, false);"/>
+      </eAnnotations>
+    </eOperations>
+    <eOperations name="fullCopy" lowerBound="1" eType="#//InterfaceList">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="body" value="return org.eclipse.fordiac.ide.model.helpers.InterfaceListCopier.copy(this, true, true);"/>
       </eAnnotations>
     </eOperations>
     <eOperations name="getAllInputs" eType="#//InterfaceElementStream">

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/InterfaceList.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/InterfaceList.java
@@ -224,7 +224,15 @@ public interface InterfaceList extends EObject {
 	 * @model required="true"
 	 * @generated
 	 */
-	InterfaceList copy();
+	InterfaceList instanceCopy();
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @model required="true"
+	 * @generated
+	 */
+	InterfaceList fullCopy();
 
 	/**
 	 * <!-- begin-user-doc -->

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/InterfaceListImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/InterfaceListImpl.java
@@ -344,12 +344,23 @@ public class InterfaceListImpl extends EObjectImpl implements InterfaceList {
 	}
 
 	/**
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
-	public InterfaceList copy() {
-		return org.eclipse.fordiac.ide.model.helpers.InterfaceListCopier.copy(this);
+	public InterfaceList instanceCopy() {
+		return org.eclipse.fordiac.ide.model.helpers.InterfaceListCopier.copy(this, false, false);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public InterfaceList fullCopy() {
+		return org.eclipse.fordiac.ide.model.helpers.InterfaceListCopier.copy(this, true, true);
 	}
 
 	/**

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
@@ -5707,7 +5707,9 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 		op = addEOperation(interfaceListEClass, this.getAdapterDeclaration(), "getAdapter", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 		addEParameter(op, ecorePackage.getEString(), "name", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		addEOperation(interfaceListEClass, this.getInterfaceList(), "copy", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEOperation(interfaceListEClass, this.getInterfaceList(), "instanceCopy", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+
+		addEOperation(interfaceListEClass, this.getInterfaceList(), "fullCopy", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		addEOperation(interfaceListEClass, this.getInterfaceElementStream(), "getAllInputs", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/FBNetworkImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/FBNetworkImporter.java
@@ -111,30 +111,20 @@ class FBNetworkImporter extends CommonElementImporter {
 
 	protected boolean handleFBNetworkChild(final String name) throws XMLStreamException, TypeImportException {
 		switch (name) {
-		case LibraryElementTags.FB_ELEMENT:
-			parseFB();
-			break;
-		case LibraryElementTags.GROUP_ELEMENT:
-			parseGroup();
-			break;
-		case LibraryElementTags.COMMENT_ELEMENT:
-			parseComment();
-			break;
-		case LibraryElementTags.EVENT_CONNECTIONS_ELEMENT:
-			parseConnectionList(LibraryElementPackage.eINSTANCE.getEventConnection(), fbNetwork.getEventConnections(),
-					LibraryElementTags.EVENT_CONNECTIONS_ELEMENT);
-			break;
-		case LibraryElementTags.DATA_CONNECTIONS_ELEMENT:
-			parseConnectionList(LibraryElementPackage.eINSTANCE.getDataConnection(), fbNetwork.getDataConnections(),
-					LibraryElementTags.DATA_CONNECTIONS_ELEMENT);
-			break;
-		case LibraryElementTags.ADAPTERCONNECTIONS_ELEMENT:
-			parseConnectionList(LibraryElementPackage.eINSTANCE.getAdapterConnection(),
-					fbNetwork.getAdapterConnections(), LibraryElementTags.ADAPTERCONNECTIONS_ELEMENT);
-			break;
-		default:
+		case LibraryElementTags.FB_ELEMENT -> parseFB();
+		case LibraryElementTags.GROUP_ELEMENT -> parseGroup();
+		case LibraryElementTags.COMMENT_ELEMENT -> parseComment();
+		case LibraryElementTags.EVENT_CONNECTIONS_ELEMENT -> parseConnectionList(LibraryElementPackage.eINSTANCE.getEventConnection(), fbNetwork.getEventConnections(),
+				LibraryElementTags.EVENT_CONNECTIONS_ELEMENT);
+		case LibraryElementTags.DATA_CONNECTIONS_ELEMENT -> parseConnectionList(LibraryElementPackage.eINSTANCE.getDataConnection(), fbNetwork.getDataConnections(),
+				LibraryElementTags.DATA_CONNECTIONS_ELEMENT);
+		case LibraryElementTags.ADAPTERCONNECTIONS_ELEMENT -> parseConnectionList(LibraryElementPackage.eINSTANCE.getAdapterConnection(),
+				fbNetwork.getAdapterConnections(), LibraryElementTags.ADAPTERCONNECTIONS_ELEMENT);
+		default -> {
 			return false;
 		}
+		}
+		;
 		return true;
 	}
 
@@ -228,7 +218,7 @@ class FBNetworkImporter extends CommonElementImporter {
 		if (fbInterface == null) {
 			fbInterface = LibraryElementFactory.eINSTANCE.createInterfaceList();
 		} else {
-			fbInterface = fbInterface.copy();
+			fbInterface = fbInterface.instanceCopy();
 		}
 		fb.setInterface(fbInterface);
 		fb.setTypeEntry(entry);

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/FBTImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/FBTImporter.java
@@ -108,42 +108,34 @@ public class FBTImporter extends BlockTypeImporter {
 	protected IChildHandler getBaseChildrenHandler() {
 		return name -> {
 			switch (name) {
-			case LibraryElementTags.IDENTIFICATION_ELEMENT:
-				parseIdentification(getElement());
-				break;
-			case LibraryElementTags.VERSION_INFO_ELEMENT:
-				parseVersionInfo(getElement());
-				break;
-			case LibraryElementTags.COMPILER_INFO_ELEMENT:
-				getElement().setCompilerInfo(parseCompilerInfo());
-				break;
-			case LibraryElementTags.INTERFACE_LIST_ELEMENT:
-				getElement().setInterfaceList(
-						getInterfaceListImporter().parseInterfaceList(LibraryElementTags.INTERFACE_LIST_ELEMENT));
-				break;
-			case LibraryElementTags.BASIC_F_B_ELEMENT:
+			case LibraryElementTags.IDENTIFICATION_ELEMENT -> parseIdentification(getElement());
+			case LibraryElementTags.VERSION_INFO_ELEMENT -> parseVersionInfo(getElement());
+			case LibraryElementTags.COMPILER_INFO_ELEMENT -> getElement().setCompilerInfo(parseCompilerInfo());
+			case LibraryElementTags.INTERFACE_LIST_ELEMENT -> getElement().setInterfaceList(
+					getInterfaceListImporter().parseInterfaceList(LibraryElementTags.INTERFACE_LIST_ELEMENT));
+			case LibraryElementTags.BASIC_F_B_ELEMENT -> {
 				setElement(convertToBasicType(getElement()));
 				parseBasicFB((BasicFBType) getElement());
-				break;
-			case LibraryElementTags.SIMPLE_F_B_ELEMENT:
+			}
+			case LibraryElementTags.SIMPLE_F_B_ELEMENT -> {
 				setElement(convertToSimpleType(getElement()));
 				parseSimpleFB((SimpleFBType) getElement());
-				break;
-			case LibraryElementTags.FBNETWORK_ELEMENT:
+			}
+			case LibraryElementTags.FBNETWORK_ELEMENT -> {
 				// parse the composite FBs as last
 				setElement(convertToCompositeType(getElement()));
 				parseFBNetwork((CompositeFBType) getElement());
-				break;
-			case LibraryElementTags.SERVICE_ELEMENT:
-				parseService(getElement());
-				break;
-			case LibraryElementTags.ATTRIBUTE_ELEMENT:
+			}
+			case LibraryElementTags.SERVICE_ELEMENT -> parseService(getElement());
+			case LibraryElementTags.ATTRIBUTE_ELEMENT -> {
 				parseGenericAttributeNode(getElement());
 				proceedToEndElementNamed(LibraryElementTags.ATTRIBUTE_ELEMENT);
-				break;
-			default:
+			}
+			default -> {
 				return false;
 			}
+			}
+			;
 			return true;
 		};
 	}
@@ -316,19 +308,18 @@ public class FBTImporter extends BlockTypeImporter {
 			if (XMLStreamConstants.START_ELEMENT == event) {
 
 				switch (getReader().getLocalName()) {
-				case LibraryElementTags.FBD_ELEMENT, LibraryElementTags.LD_ELEMENT:
-					throw new TypeImportException("Algorithm: Unsupported Algorithmtype (only ST and Other possible)!"); //$NON-NLS-1$
-				case LibraryElementTags.ST_ELEMENT:
+				case LibraryElementTags.FBD_ELEMENT, LibraryElementTags.LD_ELEMENT -> throw new TypeImportException("Algorithm: Unsupported Algorithmtype (only ST and Other possible)!"); //$NON-NLS-1$
+				case LibraryElementTags.ST_ELEMENT -> {
 					retVal = LibraryElementFactory.eINSTANCE.createSTAlgorithm();
 					parseST((STAlgorithm) retVal);
-					break;
-				case LibraryElementTags.OTHER_ELEMENT:
+				}
+				case LibraryElementTags.OTHER_ELEMENT -> {
 					retVal = LibraryElementFactory.eINSTANCE.createOtherAlgorithm();
 					parseOtherAlg((OtherAlgorithm) retVal);
-					break;
-				default:
-					throw unknownXMLChildException();
 				}
+				default -> throw unknownXMLChildException();
+				}
+				;
 
 			} else if (XMLStreamConstants.END_ELEMENT == event) {
 				if (!getReader().getLocalName().equals(LibraryElementTags.ALGORITHM_ELEMENT)) {
@@ -541,16 +532,13 @@ public class FBTImporter extends BlockTypeImporter {
 
 		processChildren(LibraryElementTags.ECC_ELEMENT, name -> {
 			switch (name) {
-			case LibraryElementTags.ECSTATE_ELEMENT:
-				parseECState(ecc); // IEC 61499 ->
-				// "START" state is the first in the list
-				break;
-			case LibraryElementTags.ECTRANSITION_ELEMENT:
-				parseECTransition(ecc);
-				break;
-			default:
+			case LibraryElementTags.ECSTATE_ELEMENT -> parseECState(ecc); // IEC 61499 ->
+			case LibraryElementTags.ECTRANSITION_ELEMENT -> parseECTransition(ecc);
+			default -> {
 				return false;
 			}
+			}
+			;
 			return true;
 		});
 		type.setECC(ecc);
@@ -781,7 +769,7 @@ public class FBTImporter extends BlockTypeImporter {
 		} else {
 			fb.setTypeEntry(entry);
 			final InterfaceList typeInterface = entry.getInterface();
-			fb.setInterface((typeInterface != null) ? typeInterface.copy()
+			fb.setInterface((typeInterface != null) ? typeInterface.instanceCopy()
 					: LibraryElementFactory.eINSTANCE.createInterfaceList());
 		}
 		type.getInternalFbs().add(fb);

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/InterfaceListImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/InterfaceListImporter.java
@@ -85,24 +85,16 @@ public class InterfaceListImporter extends TypeImporter {
 				parseEventList(interfaceList.getEventOutputs(), outputEventListName, false);
 			} else {
 				switch (name) {
-				case LibraryElementTags.INPUT_VARS_ELEMENT:
-					parseVariableList(LibraryElementTags.INPUT_VARS_ELEMENT, interfaceList.getInputVars(), true);
-					break;
-				case LibraryElementTags.OUTPUT_VARS_ELEMENT:
-					parseVariableList(LibraryElementTags.OUTPUT_VARS_ELEMENT, interfaceList.getOutputVars(), false);
-					break;
-				case LibraryElementTags.SOCKETS_ELEMENT:
-					parseAdapterList(interfaceList.getSockets(), LibraryElementTags.SOCKETS_ELEMENT, true);
-					break;
-				case LibraryElementTags.PLUGS_ELEMENT:
-					parseAdapterList(interfaceList.getPlugs(), LibraryElementTags.PLUGS_ELEMENT, false);
-					break;
-				case LibraryElementTags.INOUT_VARS_ELEMENT:
-					parseVariableList(LibraryElementTags.INOUT_VARS_ELEMENT, interfaceList.getInOutVars(), true);
-					break;
-				default:
+				case LibraryElementTags.INPUT_VARS_ELEMENT -> parseVariableList(LibraryElementTags.INPUT_VARS_ELEMENT, interfaceList.getInputVars(), true);
+				case LibraryElementTags.OUTPUT_VARS_ELEMENT -> parseVariableList(LibraryElementTags.OUTPUT_VARS_ELEMENT, interfaceList.getOutputVars(), false);
+				case LibraryElementTags.SOCKETS_ELEMENT -> parseAdapterList(interfaceList.getSockets(), LibraryElementTags.SOCKETS_ELEMENT, true);
+				case LibraryElementTags.PLUGS_ELEMENT -> parseAdapterList(interfaceList.getPlugs(), LibraryElementTags.PLUGS_ELEMENT, false);
+				case LibraryElementTags.INOUT_VARS_ELEMENT -> parseVariableList(LibraryElementTags.INOUT_VARS_ELEMENT, interfaceList.getInOutVars(), true);
+				default -> {
 					return false;
 				}
+				}
+				;
 			}
 			return true;
 		});
@@ -220,7 +212,7 @@ public class InterfaceListImporter extends TypeImporter {
 		aFB.setName(adapter.getName());
 
 		if (null != aFB.getType() && null != aFB.getType().getInterfaceList()) {
-			aFB.setInterface(aFB.getType().getInterfaceList().copy());
+			aFB.setInterface(aFB.getType().getInterfaceList().instanceCopy());
 		} else {
 			// if we don't have a type or interface list set an empty interface list to
 			// adapter

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/MappingTargetCreator.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/MappingTargetCreator.java
@@ -14,7 +14,6 @@ package org.eclipse.fordiac.ide.model.dataimport;
 
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.model.helpers.BlockInstanceFactory;
-import org.eclipse.fordiac.ide.model.helpers.InterfaceListCopier;
 import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableFB;
 import org.eclipse.fordiac.ide.model.libraryElement.FB;
@@ -39,7 +38,7 @@ public final class MappingTargetCreator {
 				created.setTypeEntry(srcElement.getTypeEntry());
 			}
 			// use the src interface to get all parameters
-			created.setInterface(InterfaceListCopier.copy(srcElement.getInterface(), true, true));
+			created.setInterface(srcElement.getInterface().fullCopy());
 			created.setPosition(EcoreUtil.copy(srcElement.getPosition()));
 			if (srcElement instanceof final ConfigurableFB srcConfFB) {
 				((ConfigurableFB) created).setDataType(srcConfFB.getDataType());

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/SubAppNetworkImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/SubAppNetworkImporter.java
@@ -99,7 +99,7 @@ class SubAppNetworkImporter extends FBNetworkImporter {
 		if (interfaceList == null) {
 			interfaceList = LibraryElementFactory.eINSTANCE.createInterfaceList();
 		} else {
-			interfaceList = interfaceList.copy();
+			interfaceList = interfaceList.instanceCopy();
 		}
 		subApp.setInterface(interfaceList);
 		return subApp;

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/SystemImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/SystemImporter.java
@@ -335,7 +335,7 @@ public class SystemImporter extends CommonElementImporter {
 						comm.setName(copyCommunication.getName());
 						comm.setPosition(EcoreUtil.copy(copyCommunication.getPosition()));
 						comm.setTypeEntry(copyCommunication.getTypeEntry());
-						comm.setInterface(copyCommunication.getType().getInterfaceList().copy());
+						comm.setInterface(copyCommunication.getType().getInterfaceList().instanceCopy());
 						channel.getMappedElements().add(comm);
 						return comm;
 					}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/InterfaceListCopier.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/InterfaceListCopier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Johannes Kepler University Linz
+ * Copyright (c) 2020, 2025 Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -36,8 +36,9 @@ public final class InterfaceListCopier {
 	/**
 	 * Create a new copy of the source interface list
 	 *
-	 * @param src        source interface list
-	 * @param copyValues flag indicating if initial values should be copied or not
+	 * @param src          source interface list
+	 * @param copyValues   flag indicating if initial values should be copied or not
+	 * @param copyComments flag indicating if comments should be copied or not
 	 * @return
 	 */
 	public static InterfaceList copy(final InterfaceList src, final boolean copyValues, final boolean copyComments) {
@@ -81,10 +82,6 @@ public final class InterfaceListCopier {
 
 		return copy;
 
-	}
-
-	public static InterfaceList copy(final InterfaceList src) {
-		return copy(src, false, false);
 	}
 
 	public static void copyVarList(final Collection<VarDeclaration> destVars, final Collection<VarDeclaration> srcVars,

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractInterfaceTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractInterfaceTypeEntryImpl.java
@@ -31,7 +31,6 @@ import org.eclipse.emf.common.notify.NotificationChain;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.model.dataimport.BlockTypeImporter;
-import org.eclipse.fordiac.ide.model.helpers.InterfaceListCopier;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
@@ -89,7 +88,7 @@ public abstract class AbstractInterfaceTypeEntryImpl<T extends FBType> extends A
 		interfaceType.setName(fbTypeCache.getName());
 		interfaceType.setComment(fbTypeCache.getComment());
 		interfaceType.setCompilerInfo(EcoreUtil.copy(fbTypeCache.getCompilerInfo()));
-		interfaceType.setInterfaceList(InterfaceListCopier.copy(fbTypeCache.getInterfaceList(), true, true));
+		interfaceType.setInterfaceList(fbTypeCache.getInterfaceList().fullCopy());
 		updateInterfaceDependencies(StreamSupport
 				.stream(Spliterators.spliteratorUnknownSize(interfaceType.eAllContents(), 0), false)
 				.map(EObject::eCrossReferences).flatMap(Collection::stream).filter(LibraryElement.class::isInstance)

--- a/tests/org.eclipse.fordiac.ide.test.model.eval/src/org/eclipse/fordiac/ide/test/model/eval/AbstractEvaluatorTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model.eval/src/org/eclipse/fordiac/ide/test/model/eval/AbstractEvaluatorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Martin Erich Jobst
+ * Copyright (c) 2024, 2025 Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -31,7 +31,6 @@ import org.eclipse.fordiac.ide.model.eval.fb.FBEvaluatorFactory;
 import org.eclipse.fordiac.ide.model.eval.st.StructuredTextEvaluatorFactory;
 import org.eclipse.fordiac.ide.model.eval.value.AnyElementaryValue;
 import org.eclipse.fordiac.ide.model.eval.variable.ElementaryVariable;
-import org.eclipse.fordiac.ide.model.helpers.InterfaceListCopier;
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
 import org.eclipse.fordiac.ide.model.libraryElement.AttributeDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.Event;
@@ -81,7 +80,7 @@ public abstract class AbstractEvaluatorTest {
 		final FB fb = LibraryElementFactory.eINSTANCE.createFB();
 		fb.setName(instanceName);
 		fb.setTypeEntry(instanceType.getTypeEntry());
-		fb.setInterface(InterfaceListCopier.copy(instanceType.getInterfaceList()));
+		fb.setInterface(instanceType.getInterfaceList().instanceCopy());
 		return fb;
 	}
 


### PR DESCRIPTION
The previous copy method did only copy a subset required for instance creation. This was easily misused leading to strange behavior.