### PR TITLE
Changing Adpater Types for Basics Didn't Correctly Update the Model

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeAdapterFBCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeAdapterFBCommand.java
@@ -19,25 +19,14 @@ package org.eclipse.fordiac.ide.model.commands.change;
 
 import org.eclipse.fordiac.ide.model.libraryElement.AdapterDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.AdapterFB;
-import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
-import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 
-public final class ChangeAdapterFBCommand extends UpdateFBTypeCommand {
+/**
+ * This class is only used by the {@link ChangeDataTypeCommand}
+ */
+final class ChangeAdapterFBCommand extends UpdateFBTypeCommand {
 
 	public ChangeAdapterFBCommand(final AdapterDeclaration adpDecl) {
 		super(adpDecl.getAdapterFB(), null);
-	}
-
-	@Override
-	protected BlockFBNetworkElement createCopiedFBEntry(final BlockFBNetworkElement srcElement) {
-		final AdapterFB copy = LibraryElementFactory.eINSTANCE.createAdapterFB();
-		if (null == getEntry()) {
-			copy.setTypeEntry(srcElement.getTypeEntry());
-		} else {
-			copy.setTypeEntry(getEntry());
-		}
-		copy.setAdapterDecl(((AdapterFB) srcElement).getAdapterDecl());
-		return copy;
 	}
 
 	@Override
@@ -51,7 +40,7 @@ public final class ChangeAdapterFBCommand extends UpdateFBTypeCommand {
 	@Override
 	public void undo() {
 		super.undo();
-		setAdapterFB((AdapterFB) oldElement);
+		setAdapterFB(getOldElement());
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeDataTypeCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeDataTypeCommand.java
@@ -77,10 +77,13 @@ public final class ChangeDataTypeCommand extends AbstractChangeInterfaceElementC
 			result.getAdditionalCommands().add(new ChangeDataTypeCommand(
 					subApp.getOpposite().getInterfaceElement(interfaceElement.getName()), dataType));
 		}
-		if (interfaceElement instanceof final AdapterDeclaration adapterDeclaration
-				&& interfaceElement.getFBType() instanceof final CompositeFBType compositeFBType
-				&& !(compositeFBType instanceof SubAppType)) {
-			result.getAdditionalCommands().add(new ChangeAdapterFBCommand(adapterDeclaration));
+		if (interfaceElement instanceof final AdapterDeclaration adapterDeclaration) {
+			if (interfaceElement.getFBType() instanceof final CompositeFBType compositeFBType
+					&& !(compositeFBType instanceof SubAppType)) {
+				result.getAdditionalCommands().add(new ChangeAdapterFBCommand(adapterDeclaration));
+			} else {
+				result.getAdditionalCommands().add(new ChangeInterfaceAdapterFBCommand(adapterDeclaration));
+			}
 		}
 		return result;
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeInterfaceAdapterFBCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeInterfaceAdapterFBCommand.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Johannes Kepler University
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Alois Zoitl - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.model.commands.change;
+
+import java.util.Objects;
+
+import org.eclipse.fordiac.ide.model.libraryElement.AdapterDeclaration;
+import org.eclipse.fordiac.ide.model.libraryElement.AdapterFB;
+import org.eclipse.fordiac.ide.model.libraryElement.AdapterType;
+import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
+import org.eclipse.gef.commands.Command;
+
+/**
+ * This class is only used by the {@link ChangeDataTypeCommand}
+ */
+class ChangeInterfaceAdapterFBCommand extends Command {
+
+	private final AdapterDeclaration adpDecl;
+	private final AdapterFB oldAdapterFB;
+	protected AdapterFB newAdapterFB;
+
+	public ChangeInterfaceAdapterFBCommand(final AdapterDeclaration adpDecl) {
+		this.adpDecl = Objects.requireNonNull(adpDecl);
+		oldAdapterFB = adpDecl.getInterfaceOnlyAdapterFB();
+	}
+
+	@Override
+	public void execute() {
+		newAdapterFB = createAdapterFB(adpDecl);
+		setAdapterFB(newAdapterFB);
+	}
+
+	@Override
+	public void undo() {
+		setAdapterFB(oldAdapterFB);
+	}
+
+	@Override
+	public void redo() {
+		setAdapterFB(newAdapterFB);
+	}
+
+	private void setAdapterFB(final AdapterFB fb) {
+		adpDecl.setAdapterFB(fb);
+		adpDecl.setInterfaceOnlyAdapterFB(fb);
+	}
+
+	private static AdapterFB createAdapterFB(final AdapterDeclaration adpDecl) {
+		final AdapterType adpType = adpDecl.getType();
+
+		final AdapterFB adapterFB = LibraryElementFactory.eINSTANCE.createAdapterFB();
+		adapterFB.setAdapterDecl(adpDecl);
+		adapterFB.setTypeEntry(adpType.getTypeEntry());
+		final InterfaceList typeInterface = (adapterFB.isPlug() ? adpType.getPlugType().getInterfaceList()
+				: adpType.getInterfaceList());
+		adapterFB.setInterface(typeInterface.copy());
+		adapterFB.setName(adpDecl.getName());
+		return adapterFB;
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/TypeEntryAdapter.java
+++ b/plugins/org.eclipse.fordiac.ide.model.edit/src/org/eclipse/fordiac/ide/model/edit/TypeEntryAdapter.java
@@ -28,6 +28,7 @@ import org.eclipse.fordiac.ide.model.commands.change.UpdateFBTypeCommand;
 import org.eclipse.fordiac.ide.model.commands.change.UpdateInternalFBCommand;
 import org.eclipse.fordiac.ide.model.data.AnyDerivedType;
 import org.eclipse.fordiac.ide.model.data.StructuredType;
+import org.eclipse.fordiac.ide.model.libraryElement.AdapterDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
 import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableFB;
@@ -38,9 +39,11 @@ import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.StructManipulator;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.search.types.AdapterTypeInstanceSearch;
 import org.eclipse.fordiac.ide.model.search.types.AttributeTypeInstanceSearch;
 import org.eclipse.fordiac.ide.model.search.types.BlockTypeInstanceSearch;
 import org.eclipse.fordiac.ide.model.search.types.DataTypeInstanceSearch;
+import org.eclipse.fordiac.ide.model.typelibrary.AdapterTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.AttributeTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.DataTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.FBTypeEntry;
@@ -138,17 +141,31 @@ public class TypeEntryAdapter extends AbstractTypeEntryAdapter {
 					// our editor was closed no update needed
 					return;
 				}
-				if ((typeEntry instanceof FBTypeEntry || typeEntry instanceof SubAppTypeEntry)) {
-					handleBlockTypeDependencyUpdate(editedElement, typeEntry);
+
+				switch (typeEntry) {
+				// adapter type entry needs to be before FBTypeEntry
+				case final AdapterTypeEntry adpEntry -> handleAdapterTypeDependenyUpdate(editedElement, adpEntry);
+				case final FBTypeEntry fbEntry -> handleBlockTypeDependencyUpdate(editedElement, typeEntry);
+				case final SubAppTypeEntry subAppEntry -> handleBlockTypeDependencyUpdate(editedElement, typeEntry);
+				case final AttributeTypeEntry atEntry -> handleAttributeTypeEntryUpdate(editedElement, atEntry);
+				case final DataTypeEntry dtEntry -> handleDataTypeEntryUpdate(editedElement, dtEntry);
+				default -> {
+					// do nothing
 				}
-				if (typeEntry instanceof final DataTypeEntry dtEntry) {
-					handleDataTypeEntryUpdate(editedElement, dtEntry);
-				}
-				if (typeEntry instanceof final AttributeTypeEntry atEntry) {
-					handleAttributeTypeEntryUpdate(editedElement, atEntry);
 				}
 			});
 		}
+	}
+
+	private static void handleAdapterTypeDependenyUpdate(final LibraryElement editedElement,
+			final AdapterTypeEntry adpEntry) {
+		final AdapterTypeInstanceSearch search = new AdapterTypeInstanceSearch(editedElement, adpEntry);
+		final List<? extends EObject> result = search.performSearch();
+		result.forEach(r -> {
+			if (r instanceof final AdapterDeclaration adpDecl) {
+				ChangeDataTypeCommand.forDataType(adpDecl, adpEntry.getType()).execute();
+			}
+		});
 	}
 
 	private static void handleAttributeTypeEntryUpdate(final LibraryElement editedElement,

--- a/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/types/AdapterTypeInstanceSearch.java
+++ b/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/types/AdapterTypeInstanceSearch.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Johannes Kepler University Linz
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Alois Zoitl - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.model.search.types;
+
+import java.util.stream.Stream;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.fordiac.ide.model.libraryElement.AdapterDeclaration;
+import org.eclipse.fordiac.ide.model.libraryElement.Application;
+import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
+import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.FBType;
+import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
+import org.eclipse.fordiac.ide.model.libraryElement.SubAppType;
+import org.eclipse.fordiac.ide.model.libraryElement.UntypedSubApp;
+import org.eclipse.fordiac.ide.model.typelibrary.AdapterTypeEntry;
+
+public class AdapterTypeInstanceSearch extends IEC61499ElementSearch {
+
+	public AdapterTypeInstanceSearch(final LibraryElement typeEditable, final AdapterTypeEntry adpEntry) {
+		super(new LibraryElementSearchContext(typeEditable), createSearchFilter(adpEntry),
+				new DataTypeInstanceSearchChildrenProvider());
+	}
+
+	private static IEC61499SearchFilter createSearchFilter(final AdapterTypeEntry adpEntry) {
+		return searchCandidate -> (searchCandidate instanceof final AdapterDeclaration adpDecl
+				&& adpEntry == adpDecl.getType().getTypeEntry());
+	}
+
+	private static final class DataTypeInstanceSearchChildrenProvider implements ISearchChildrenProvider {
+		@Override
+		public boolean hasChildren(final EObject obj) {
+			return (obj instanceof FBType) || (obj instanceof AutomationSystem) || (obj instanceof UntypedSubApp)
+					|| (obj instanceof final Application) || (obj instanceof FBNetworkElement);
+		}
+
+		@Override
+		public Stream<? extends EObject> getChildren(final EObject obj) {
+			if (obj instanceof final FBType fbType) {
+				return getFBTypeChildren(fbType);
+			}
+			if (obj instanceof final AutomationSystem system) {
+				return system.getApplication().stream();
+			}
+
+			if (obj instanceof final Application application) {
+				return application.getFBNetwork().getNetworkElements().stream();
+			}
+
+			if (obj instanceof final UntypedSubApp untypedSubapp) {
+				return getUntypedSubappChildren(untypedSubapp);
+			}
+
+			if (obj instanceof final BlockFBNetworkElement elem) {
+				return Stream.concat(elem.getAttributes().stream(),
+						SearchChildrenProviderHelper.getInterfaceListChildren(elem.getInterface()));
+			}
+
+			return Stream.empty();
+		}
+
+		private static Stream<AdapterDeclaration> getInterfaceListChildren(final InterfaceList interfaceList) {
+			return Stream.concat(interfaceList.getSockets().stream(), interfaceList.getPlugs().stream());
+		}
+
+		private static Stream<? extends EObject> getFBTypeChildren(final FBType fbType) {
+			Stream<? extends EObject> retval = getInterfaceListChildren(fbType.getInterfaceList());
+			if (fbType instanceof final SubAppType subAppType) {
+				// we may have a network with untyped subapps inside
+				retval = Stream.concat(retval, subAppType.getFBNetwork().getNetworkElements().stream());
+			}
+
+			return retval;
+		}
+
+		private static Stream<? extends EObject> getUntypedSubappChildren(final UntypedSubApp untypedSubapp) {
+			Stream<? extends EObject> retval = getInterfaceListChildren(untypedSubapp.getInterface());
+			retval = Stream.concat(retval, untypedSubapp.getSubAppNetwork().getNetworkElements().stream());
+			return retval;
+		}
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/types/SearchChildrenProviderHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/types/SearchChildrenProviderHelper.java
@@ -20,10 +20,10 @@ import org.eclipse.fordiac.ide.model.data.DirectlyDerivedType;
 import org.eclipse.fordiac.ide.model.data.StructuredType;
 import org.eclipse.fordiac.ide.model.libraryElement.AttributeDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType;
+import org.eclipse.fordiac.ide.model.libraryElement.CompositeFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
-import org.eclipse.fordiac.ide.model.libraryElement.SubAppType;
 import org.eclipse.fordiac.ide.model.libraryElement.UntypedSubApp;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 
@@ -38,9 +38,9 @@ public class SearchChildrenProviderHelper {
 			retval = Stream.concat(retval, baseFBType.getInternalVars().stream());
 			retval = Stream.concat(retval, baseFBType.getInternalConstVars().stream());
 		}
-		if (fbType instanceof final SubAppType subappType) {
-			// we may have untyped subapps inside
-			retval = Stream.concat(retval, getFBNetworkChildren(subappType.getFBNetwork()));
+		if (fbType instanceof final CompositeFBType cfbType) { // cfbtype includes subapptype
+			// we may have a network with children inside
+			retval = Stream.concat(retval, getFBNetworkChildren(cfbType.getFBNetwork()));
 		}
 
 		return retval;


### PR DESCRIPTION
As the model now relies on a AdapterFB instance for all FB types the change adapter type command needs to update the AdapterFB for all FB Types.

This is a precondition for fixing: #1916