### PR TITLE
Changing Adapter Type in CFBs Added wrong Error Event Pins #1916

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractUpdateBlockFBNElementCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractUpdateBlockFBNElementCommand.java
@@ -395,12 +395,12 @@ public abstract class AbstractUpdateBlockFBNElementCommand extends Command
 
 	private void processEvents(final InterfaceList interfaceList) {
 		for (final Event input : interfaceList.getEventInputs()) {
-			if (input.getInputConnections().isEmpty() || (!input.getAttributes().isEmpty())) {
+			if (input.getInputConnections().isEmpty() && !input.getAttributes().isEmpty()) {
 				updateSelectedInterface(input, newElement);
 			}
 		}
 		for (final Event output : interfaceList.getEventOutputs()) {
-			if (output.getOutputConnections().isEmpty() || (!output.getAttributes().isEmpty())) {
+			if (output.getOutputConnections().isEmpty() && !output.getAttributes().isEmpty()) {
 				updateSelectedInterface(output, newElement);
 			}
 		}


### PR DESCRIPTION
The FB update code didn't correctly check when pins need to be preserved. This lead to error pins when there shouldn't be ones. This was most visible for changing adapter types in CFBs but happened also for all other FB instances.

Fixes https://github.com/eclipse-4diac/4diac-ide/issues/1916