### PR TITLE
Handle copying folders in CopyTypeParticipant

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/PackageNameHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/PackageNameHelper.java
@@ -15,6 +15,7 @@ package org.eclipse.fordiac.ide.model.helpers;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IPath;
@@ -109,6 +110,13 @@ public final class PackageNameHelper {
 		final TypeLibrary typeLibrary = TypeLibraryManager.INSTANCE.getTypeLibrary(file.getProject());
 		final IPath relativePath = BuildpathUtil.findRelativePath(typeLibrary.getBuildpath(), file.getParent())
 				.orElse(file.getParent().getFullPath());
+		return Stream.of(relativePath.segments()).collect(Collectors.joining(PACKAGE_NAME_DELIMITER));
+	}
+
+	public static String getPackageNameFromContainer(final IContainer container) {
+		final TypeLibrary typeLibrary = TypeLibraryManager.INSTANCE.getTypeLibrary(container.getProject());
+		final IPath relativePath = BuildpathUtil.findRelativePath(typeLibrary.getBuildpath(), container)
+				.orElse(container.getFullPath());
 		return Stream.of(relativePath.segments()).collect(Collectors.joining(PACKAGE_NAME_DELIMITER));
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/systemexplorer/SystemExplorerPasteAction.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/systemexplorer/SystemExplorerPasteAction.java
@@ -31,6 +31,7 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.fordiac.ide.typemanagement.refactoring.copy.FordiacCopyProcessor;
 import org.eclipse.fordiac.ide.typemanagement.refactoring.copy.UserCopyRefactoringQueries;
 import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
+import org.eclipse.jface.dialogs.ErrorDialog;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.CheckConditionsOperation;
@@ -181,7 +182,7 @@ import org.eclipse.ui.part.ResourceTransfer;
 				FordiacLogHelper.logWarning("copy refactoring change could not be created"); //$NON-NLS-1$
 			}
 		} catch (final CoreException e) {
-			FordiacLogHelper.logWarning("performing copy refactoring change failed", e); //$NON-NLS-1$
+			ErrorDialog.openError(shell, null, null, e.getStatus());
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/plugin.properties
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/plugin.properties
@@ -126,6 +126,7 @@ FordiacCopyProcessor_CompositeChangeName=Copy resources.
 CopyResourceChange_Name=Copy resource ''{0}'' to ''{1}''
 CopyTypeChange_CannotLoadResource=Cannot load resource ''{0}''
 CopyTypeChange_CannotSaveResource=Cannot save resource ''{0}''
+CopyTypeChange_RenamePackage=Rename package to match folder structure
 
 Copy_OverwriteDialog_Title=Resource Exists
 Copy_OverwriteDialog_Message=Resource Exists. Do you wish to overwrite it?

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/plugin.properties
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/plugin.properties
@@ -126,7 +126,7 @@ FordiacCopyProcessor_CompositeChangeName=Copy resources.
 CopyResourceChange_Name=Copy resource ''{0}'' to ''{1}''
 CopyTypeChange_CannotLoadResource=Cannot load resource ''{0}''
 CopyTypeChange_CannotSaveResource=Cannot save resource ''{0}''
-CopyTypeChange_RenamePackage=Rename package to match folder structure
+CopyTypeChange_RenamePackage=Rename package(s) to match folder structure
 
 Copy_OverwriteDialog_Title=Resource Exists
 Copy_OverwriteDialog_Message=Resource Exists. Do you wish to overwrite it?

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/Messages.java
@@ -147,6 +147,7 @@ public final class Messages extends NLS {
 	public static String CopyResourceChange_Name;
 	public static String CopyTypeChange_CannotLoadResource;
 	public static String CopyTypeChange_CannotSaveResource;
+	public static String CopyTypeChange_RenamePackage;
 
 	public static String Copy_OverwriteDialog_Title;
 	public static String Copy_OverwriteDialog_Message;

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/copy/CopyTypeChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/copy/CopyTypeChange.java
@@ -37,17 +37,16 @@ import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 
 public class CopyTypeChange extends Change {
 
-	private final String name;
 	private final URI destination;
+	private String newPackageName;
 
-	protected CopyTypeChange(final String name, final URI destination) {
-		this.name = name;
+	protected CopyTypeChange(final URI destination) {
 		this.destination = destination;
 	}
 
 	@Override
 	public void initializeValidationData(final IProgressMonitor pm) {
-		// nothing to do
+		newPackageName = PackageNameHelper.getPackageNameFromURI(destination);
 	}
 
 	@Override
@@ -57,7 +56,7 @@ public class CopyTypeChange extends Change {
 
 	@Override
 	public String getName() {
-		return name;
+		return MessageFormat.format(Messages.MoveTypeToPackage_RenamePackageTo, newPackageName);
 	}
 
 	@Override
@@ -77,7 +76,7 @@ public class CopyTypeChange extends Change {
 		if (!element.getName().equals(typeName)) {
 			element.setName(typeName);
 		}
-		PackageNameHelper.setPackageName(element, PackageNameHelper.getPackageNameFromURI(destination));
+		PackageNameHelper.setPackageName(element, newPackageName);
 		try {
 			resource.get().save(Map.of());
 		} catch (final IOException e) {

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/copy/CopyTypeChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/copy/CopyTypeChange.java
@@ -19,10 +19,8 @@ package org.eclipse.fordiac.ide.typemanagement.refactoring.copy;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
@@ -40,31 +38,21 @@ import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 public class CopyTypeChange extends Change {
 
 	private final String name;
-	private final IFile origin;
 	private final URI destination;
-	private final String newPackageName;
-	private String oldPackageName;
 
-	protected CopyTypeChange(final String newPackageName, final String name, final IFile origin,
-			final URI destination) {
-		this.newPackageName = newPackageName;
+	protected CopyTypeChange(final String name, final URI destination) {
 		this.name = name;
-		this.origin = origin;
 		this.destination = destination;
 	}
 
 	@Override
 	public void initializeValidationData(final IProgressMonitor pm) {
-		oldPackageName = PackageNameHelper.getPackageNameFromFile(origin);
+		// nothing to do
 	}
 
 	@Override
 	public RefactoringStatus isValid(final IProgressMonitor pm) throws CoreException, OperationCanceledException {
-		final RefactoringStatus status = new RefactoringStatus();
-		if (Objects.equals(oldPackageName, newPackageName)) {
-			status.addWarning(Messages.MoveTypeToPackage_PackageNameIsTheSame);
-		}
-		return status;
+		return new RefactoringStatus();
 	}
 
 	@Override
@@ -79,7 +67,7 @@ public class CopyTypeChange extends Change {
 			throw new CoreException(
 					Status.error(MessageFormat.format(Messages.CopyTypeChange_CannotLoadResource, destination)));
 		}
-		final var optElement = CopyTypeParticipant.getLibraryElement(resource.get());
+		final var optElement = getLibraryElement(resource.get());
 		if (optElement.isEmpty()) {
 			return null;
 		}
@@ -89,7 +77,7 @@ public class CopyTypeChange extends Change {
 		if (!element.getName().equals(typeName)) {
 			element.setName(typeName);
 		}
-		PackageNameHelper.setPackageName(element, newPackageName);
+		PackageNameHelper.setPackageName(element, PackageNameHelper.getPackageNameFromURI(destination));
 		try {
 			resource.get().save(Map.of());
 		} catch (final IOException e) {
@@ -123,5 +111,10 @@ public class CopyTypeChange extends Change {
 			return Optional.empty();
 		}
 		return Optional.of(resource);
+	}
+
+	private static Optional<LibraryElement> getLibraryElement(final Resource resource) {
+		return resource.getContents().stream().filter(LibraryElement.class::isInstance).map(LibraryElement.class::cast)
+				.findFirst();
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/copy/CopyTypeParticipant.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/copy/CopyTypeParticipant.java
@@ -16,44 +16,36 @@
 
 package org.eclipse.fordiac.ide.typemanagement.refactoring.copy;
 
-import java.text.MessageFormat;
-import java.util.Optional;
-
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.emf.common.util.URI;
-import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.fordiac.ide.model.IdentifierVerifier;
-import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
-import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
 import org.eclipse.fordiac.ide.typemanagement.Messages;
 import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.CompositeChange;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 import org.eclipse.ltk.core.refactoring.participants.CheckConditionsContext;
 import org.eclipse.ltk.core.refactoring.participants.CopyParticipant;
 
 public class CopyTypeParticipant extends CopyParticipant {
 
-	private IFile origin;
-	private URI destinationURI;
-	private String newPackageName;
+	private CompositeChange change;
 
 	@Override
 	protected boolean initialize(final Object element) {
-		if (element instanceof final IFile file
+		if (element instanceof final IResource resource
 				&& getArguments().getDestination() instanceof final IContainer destination) {
-			if (TypeLibraryManager.INSTANCE.getTypeEntryForFile(file) == null) {
+			change = new CompositeChange(getName());
+			final URI destURI = URI.createPlatformResourceURI(destination.getFullPath().toString(), true);
+			try {
+				addElement(resource, destURI);
+			} catch (final CoreException e) {
 				return false;
 			}
-
-			origin = file;
-			destinationURI = URI.createPlatformResourceURI(destination.getFullPath().append(file.getName()).toString(),
-					true);
-			newPackageName = PackageNameHelper.getPackageNameFromURI(destinationURI);
 			return true;
 		}
 		return false;
@@ -61,27 +53,29 @@ public class CopyTypeParticipant extends CopyParticipant {
 
 	@Override
 	public String getName() {
-		return MessageFormat.format(Messages.MoveTypeToPackage_RenamePackageTo, newPackageName);
+		return Messages.CopyTypeChange_RenamePackage;
 	}
 
 	@Override
 	public RefactoringStatus checkConditions(final IProgressMonitor pm, final CheckConditionsContext context)
 			throws OperationCanceledException {
-		final RefactoringStatus status = new RefactoringStatus();
-		final Optional<String> errorMessage = IdentifierVerifier.verifyPackageName(newPackageName);
-		if (errorMessage.isPresent()) {
-			status.addFatalError(errorMessage.get());
-		}
-		return status;
+		return new RefactoringStatus();
 	}
 
 	@Override
 	public Change createChange(final IProgressMonitor pm) throws CoreException, OperationCanceledException {
-		return new CopyTypeChange(newPackageName, getName(), origin, destinationURI);
+		return change;
 	}
 
-	public static Optional<LibraryElement> getLibraryElement(final Resource resource) {
-		return resource.getContents().stream().filter(LibraryElement.class::isInstance).map(LibraryElement.class::cast)
-				.findFirst();
+	private void addElement(final IResource resource, final URI destination) throws CoreException {
+		if (resource instanceof final IFile file) {
+			if (TypeLibraryManager.INSTANCE.getTypeEntryForFile(file) != null) {
+				change.add(new CopyTypeChange(getName(), destination.appendSegment(file.getName())));
+			}
+		} else if (resource instanceof final IContainer container) {
+			for (final IResource member : container.members()) {
+				addElement(member, destination.appendSegment(container.getName()));
+			}
+		}
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/copy/CopyTypeParticipant.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/copy/CopyTypeParticipant.java
@@ -16,6 +16,8 @@
 
 package org.eclipse.fordiac.ide.typemanagement.refactoring.copy;
 
+import java.util.Optional;
+
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
@@ -23,6 +25,8 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.fordiac.ide.model.IdentifierVerifier;
+import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
 import org.eclipse.fordiac.ide.typemanagement.Messages;
 import org.eclipse.ltk.core.refactoring.Change;
@@ -33,20 +37,22 @@ import org.eclipse.ltk.core.refactoring.participants.CopyParticipant;
 
 public class CopyTypeParticipant extends CopyParticipant {
 
-	private CompositeChange change;
+	private IResource resource;
+	private IContainer destination;
 
 	@Override
 	protected boolean initialize(final Object element) {
-		if (element instanceof final IResource resource
-				&& getArguments().getDestination() instanceof final IContainer destination) {
-			change = new CompositeChange(getName());
-			final URI destURI = URI.createPlatformResourceURI(destination.getFullPath().toString(), true);
+		if (element instanceof final IResource res
+				&& getArguments().getDestination() instanceof final IContainer dest) {
+			resource = res;
+			destination = dest;
 			try {
-				addElement(resource, destURI);
+				if (hasRelevantFile(res)) {
+					return true;
+				}
 			} catch (final CoreException e) {
 				return false;
 			}
-			return true;
 		}
 		return false;
 	}
@@ -59,23 +65,53 @@ public class CopyTypeParticipant extends CopyParticipant {
 	@Override
 	public RefactoringStatus checkConditions(final IProgressMonitor pm, final CheckConditionsContext context)
 			throws OperationCanceledException {
-		return new RefactoringStatus();
+		final RefactoringStatus status = new RefactoringStatus();
+		final String packageNameContainer = PackageNameHelper.getPackageNameFromContainer(destination);
+		final Optional<String> errorMessage = IdentifierVerifier.verifyPackageName(packageNameContainer);
+		if (errorMessage.isPresent()) {
+			status.addFatalError(errorMessage.get());
+		}
+		return status;
 	}
 
 	@Override
 	public Change createChange(final IProgressMonitor pm) throws CoreException, OperationCanceledException {
+		final CompositeChange change = new CompositeChange(getName());
+		final URI destURI = URI.createPlatformResourceURI(destination.getFullPath().toString(), true);
+		try {
+			addElement(change, resource, destURI);
+		} catch (final CoreException e) {
+			return null;
+		}
 		return change;
 	}
 
-	private void addElement(final IResource resource, final URI destination) throws CoreException {
+	private void addElement(final CompositeChange change, final IResource resource, final URI destination)
+			throws CoreException {
 		if (resource instanceof final IFile file) {
 			if (TypeLibraryManager.INSTANCE.getTypeEntryForFile(file) != null) {
-				change.add(new CopyTypeChange(getName(), destination.appendSegment(file.getName())));
+				change.add(new CopyTypeChange(destination.appendSegment(file.getName())));
 			}
 		} else if (resource instanceof final IContainer container) {
 			for (final IResource member : container.members()) {
-				addElement(member, destination.appendSegment(container.getName()));
+				addElement(change, member, destination.appendSegment(container.getName()));
 			}
 		}
+	}
+
+	private boolean hasRelevantFile(final IResource resource) throws CoreException {
+		if (resource instanceof final IFile file) {
+			if (TypeLibraryManager.INSTANCE.getTypeEntryForFile(file) != null) {
+				return true;
+			}
+		} else if (resource instanceof final IContainer container) {
+			for (final IResource member : container.members()) {
+				if (hasRelevantFile(member)) {
+					return true;
+				}
+			}
+			return false;
+		}
+		return false;
 	}
 }


### PR DESCRIPTION
Previously, the package name for types was not updated when their parent folder was copy-pasted.