### PR TITLE
Clean-up init and refresh in property sheets

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/CommentPropertySection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/CommentPropertySection.java
@@ -68,14 +68,4 @@ public class CommentPropertySection extends AbstractSection {
 		}
 		return null;
 	}
-
-	@Override
-	protected void setInputCode() {
-		// Nothing for now
-	}
-
-	@Override
-	protected void setInputInit() {
-		// nothing to do for now
-	}
 }

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/ConfigurableMoveFBSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/ConfigurableMoveFBSection.java
@@ -298,17 +298,9 @@ public class ConfigurableMoveFBSection extends AbstractSection implements Comman
 	}
 
 	@Override
-	protected void setInputCode() {
-		// Currently nothing needs to be done here
-	}
-
-	@Override
-	protected void setInputInit() {
-		// Currently nothing needs to be done here
-	}
-
-	@Override
 	protected void performRefresh() {
+		typeSelectionWidget.refresh();
+
 		if (getType() == null) {
 			inputDataMemberAccessViewer.setInput(null);
 			outputDataMemberAccessViewer.setInput(null);

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/CreateConnectionSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/CreateConnectionSection.java
@@ -171,14 +171,4 @@ public class CreateConnectionSection extends AbstractSection {
 	private static String getFBName(final INamedElement element) {
 		return ((INamedElement) element.eContainer().eContainer()).getName();
 	}
-
-	@Override
-	protected void setInputCode() {
-		// nothing to do here
-	}
-
-	@Override
-	protected void setInputInit() {
-		// nothing to do here
-	}
 }

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/GroupPropertySection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/GroupPropertySection.java
@@ -203,15 +203,4 @@ public class GroupPropertySection extends AbstractDoubleColumnSection {
 		}
 		return null;
 	}
-
-	@Override
-	protected void setInputCode() {
-		// Nothing for now
-	}
-
-	@Override
-	protected void setInputInit() {
-		// nothing to do for now
-	}
-
 }

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/InfoPropertySection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/InfoPropertySection.java
@@ -209,18 +209,8 @@ public class InfoPropertySection extends AbstractSection {
 	}
 
 	@Override
-	protected void setInputCode() {
-		// DO NOTHING
-	}
-
-	@Override
-	protected void setInputInit() {
-		formatPage();
-	}
-
-	@Override
 	protected void performRefresh() {
-		// DO NOTHING
+		formatPage();
 	}
 
 	private void formatPage() {

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/InstancePropertySection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/InstancePropertySection.java
@@ -125,11 +125,25 @@ public class InstancePropertySection extends AbstractSection {
 
 	@Override
 	protected void performRefresh() {
-		if (!nameText.isDisposed() && !nameText.getParent().isDisposed()) {
-			nameText.setText(getType().getName() != null ? getType().getName() : ""); //$NON-NLS-1$
-			commentText.setText(getType().getComment() != null ? getType().getComment() : ""); //$NON-NLS-1$
-			outputTable.refresh();
+		if (getType() != null) {
+			if (!nameText.isDisposed() && !nameText.getParent().isDisposed()) {
+				nameText.setText(getType().getName() != null ? getType().getName() : ""); //$NON-NLS-1$
+				commentText.setText(getType().getComment() != null ? getType().getComment() : ""); //$NON-NLS-1$
+			}
+
+			final List<VarDeclaration> allInputs = new ArrayList<>();
+			final InterfaceList fbInterface = getType().getInterface();
+			allInputs.addAll(fbInterface.getInputVars());
+			allInputs.addAll(fbInterface.getInOutVars());
+			inputDataProvider.setInput(allInputs);
+
+			final List<VarDeclaration> allOutputs = new ArrayList<>();
+			allOutputs.addAll(fbInterface.getOutputVars());
+			allOutputs.addAll(fbInterface.getOutMappedInOutVars());
+			outputDataProvider.setInput(allOutputs);
+
 			inputTable.refresh();
+			outputTable.refresh();
 		}
 	}
 
@@ -285,29 +299,6 @@ public class InstancePropertySection extends AbstractSection {
 			return fbNetworkElement;
 		}
 		return null;
-	}
-
-	@Override
-	protected void setInputCode() {
-		// Nothing for now
-	}
-
-	@Override
-	protected void setInputInit() {
-		if (getType() != null) {
-			final List<VarDeclaration> allInputs = new ArrayList<>();
-			final InterfaceList fbInterface = getType().getInterface();
-			allInputs.addAll(fbInterface.getInputVars());
-			allInputs.addAll(fbInterface.getInOutVars());
-			inputDataProvider.setInput(allInputs);
-
-			final List<VarDeclaration> allOutputs = new ArrayList<>();
-			allOutputs.addAll(fbInterface.getOutputVars());
-			allOutputs.addAll(fbInterface.getOutMappedInOutVars());
-			outputDataProvider.setInput(allOutputs);
-		}
-		inputTable.refresh();
-		outputTable.refresh();
 	}
 
 	protected final Adapter interfaceAdapter = new EContentAdapter() {

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/InterfaceElementSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/InterfaceElementSection.java
@@ -343,11 +343,6 @@ public class InterfaceElementSection extends AbstractDoubleColumnSection {
 	}
 
 	@Override
-	protected void setInputInit() {
-		// no implementation needed
-	}
-
-	@Override
 	public void dispose() {
 		super.dispose();
 		if (refreshJob != null) {

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/StructManipulatorSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/StructManipulatorSection.java
@@ -342,6 +342,7 @@ public abstract class StructManipulatorSection extends AbstractSection implement
 
 	@Override
 	protected void performRefresh() {
+		typeSelectionWidget.refresh();
 		if ((null != getType().getFbNetwork()) && !blockRefresh) {
 			refreshStructTypeTable();
 		}
@@ -397,16 +398,6 @@ public abstract class StructManipulatorSection extends AbstractSection implement
 				}
 			}
 		}
-	}
-
-	@Override
-	protected void setInputCode() {
-		// Currently nothing needs to be done here
-	}
-
-	@Override
-	protected void setInputInit() {
-		// Currently nothing needs to be done here
 	}
 
 	protected CheckboxTreeViewer getViewer() {

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/VarConfigurationSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/VarConfigurationSection.java
@@ -142,18 +142,8 @@ public class VarConfigurationSection extends AbstractSection {
 	}
 
 	@Override
-	protected void setInputCode() {
-		// Not needed currently
-	}
-
-	@Override
-	protected void setInputInit() {
-		inputDataProvider.setInput(collectVarConfigs());
-		inputTable.refresh();
-	}
-
-	@Override
 	protected void performRefresh() {
+		inputDataProvider.setInput(collectVarConfigs());
 		inputTable.refresh();
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.attributetypeeditor/src/org/eclipse/fordiac/ide/attributetypeeditor/properties/AttributeTargetSection.java
+++ b/plugins/org.eclipse.fordiac.ide.attributetypeeditor/src/org/eclipse/fordiac/ide/attributetypeeditor/properties/AttributeTargetSection.java
@@ -207,14 +207,4 @@ public class AttributeTargetSection extends AbstractSection {
 		}
 		return null;
 	}
-
-	@Override
-	protected void setInputCode() {
-		// nothing to do here
-	}
-
-	@Override
-	protected void setInputInit() {
-		// nothing to do here
-	}
 }

--- a/plugins/org.eclipse.fordiac.ide.datatypeeditor/src/org/eclipse/fordiac/ide/datatypeeditor/properties/DataTypeInfoSection.java
+++ b/plugins/org.eclipse.fordiac.ide.datatypeeditor/src/org/eclipse/fordiac/ide/datatypeeditor/properties/DataTypeInfoSection.java
@@ -88,11 +88,6 @@ public class DataTypeInfoSection extends AbstractSection {
 	}
 
 	@Override
-	protected void setInputCode() {
-		// currently nothing to do here
-	}
-
-	@Override
 	protected void performRefresh() {
 		commentText.setText((null != getType().getComment()) ? getType().getComment() : ""); //$NON-NLS-1$
 		typeInfoWidget.refresh();

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/properties/ActionSection.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/properties/ActionSection.java
@@ -190,14 +190,4 @@ public class ActionSection extends AbstractSection {
 		algorithmCombo
 				.select((null == alg) ? algorithmCombo.getItemCount() - 1 : algorithmCombo.indexOf(alg.getName()));
 	}
-
-	@Override
-	protected void setInputCode() {
-		// nothing to be done here
-	}
-
-	@Override
-	protected void setInputInit() {
-		// nothing to be done here
-	}
 }

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/properties/AlgorithmsSection.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/properties/AlgorithmsSection.java
@@ -68,11 +68,6 @@ public class AlgorithmsSection extends AbstractSection {
 	}
 
 	@Override
-	protected void setInputCode() {
-		// no action needed
-	}
-
-	@Override
 	protected void setInputInit() {
 		getAlgorithmList().initialize(getType());
 	}

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/properties/AbstractPrimitiveSection.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/properties/AbstractPrimitiveSection.java
@@ -269,9 +269,4 @@ public abstract class AbstractPrimitiveSection extends AbstractDoubleColumnSecti
 			customEventText.setText(currentEvent);
 		}
 	}
-
-	@Override
-	protected void setInputInit() {
-		// currently nothing to be done here
-	}
 }

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/properties/ServiceSection.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/properties/ServiceSection.java
@@ -267,11 +267,6 @@ public class ServiceSection extends AbstractSection {
 		sequencesViewer.setInput(null);
 	}
 
-	@Override
-	protected void setInputInit() {
-		// currently nothing to be done here
-	}
-
 	private static Composite createButtonContainer(final FormToolkit widgetFactory, final Composite parent) {
 		final Composite container = widgetFactory.createComposite(parent, SWT.NONE);
 		final GridData buttonCompLayoutData = new GridData(SWT.CENTER, SWT.TOP, false, true);

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/properties/ServiceSequenceSection.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/properties/ServiceSequenceSection.java
@@ -233,11 +233,6 @@ public class ServiceSequenceSection extends AbstractSection {
 		transactionsViewer.setInput(null);
 	}
 
-	@Override
-	protected void setInputInit() {
-		// currently nothing to be done here
-	}
-
 	protected static class TransactionLabelProvider extends LabelProvider implements ITableLabelProvider {
 		private static final int INDEX_COL_INDEX = 0;
 		private static final int INPUT_PRIMITIVE_COL_INDEX = 1;

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/properties/TransactionSection.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/properties/TransactionSection.java
@@ -288,11 +288,6 @@ public class TransactionSection extends AbstractSection {
 	}
 
 	@Override
-	protected void setInputCode() {
-		// nothing to do here
-	}
-
-	@Override
 	protected void setInputInit() {
 		outputPrimitivesViewer.setCellEditors(createCellEditors(outputPrimitivesViewer.getTable()));
 		outputPrimitivesViewer.setCellModifier(new TransactionCellModifier());

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/properties/AdapterInterfaceElementSection.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/properties/AdapterInterfaceElementSection.java
@@ -72,7 +72,6 @@ public class AdapterInterfaceElementSection extends AbstractDoubleColumnSection 
 	@Override
 	protected void setInputInit() {
 		setupPinInfoWidget(getType());
-
 	}
 
 	protected void setupPinInfoWidget(final IInterfaceElement ie) {

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/properties/DataInterfaceElementSection.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/properties/DataInterfaceElementSection.java
@@ -154,12 +154,15 @@ public class DataInterfaceElementSection extends AdapterInterfaceElementSection 
 				setupPinInfoWidget(getType());
 			}
 		}
-		if (null == getCurrentCommandStack()) { // disable all fields
-			withEventsViewer.setInput(null);
-			Arrays.stream(withEventsViewer.getTable().getItems()).forEach(item -> item.setGrayed(true));
-		} else {
-			deSelectAllWidget.setCommandStack(getCurrentCommandStack());
-		}
+		deSelectAllWidget.setEnabled(getCurrentCommandStack() != null);
+		deSelectAllWidget.setCommandStack(getCurrentCommandStack());
+	}
+
+	@Override
+	protected void setInputCode() {
+		super.setInputCode();
+		withEventsViewer.setInput(null);
+		Arrays.stream(withEventsViewer.getTable().getItems()).forEach(item -> item.setGrayed(true));
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/properties/EventInterfaceElementSection.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor/src/org/eclipse/fordiac/ide/fbtypeeditor/properties/EventInterfaceElementSection.java
@@ -113,13 +113,15 @@ public class EventInterfaceElementSection extends AdapterInterfaceElementSection
 	@Override
 	protected void setInputInit() {
 		super.setInputInit();
-		deSelectAllWidget.setEnabled(true);
-		if (null == getCurrentCommandStack()) { // disable all fields
-			withEventsViewer.setInput(null);
-			Arrays.stream(withEventsViewer.getTable().getItems()).forEach(item -> item.setGrayed(true));
-		} else {
-			deSelectAllWidget.setCommandStack(getCurrentCommandStack());
-		}
+		deSelectAllWidget.setEnabled(getCurrentCommandStack() != null);
+		deSelectAllWidget.setCommandStack(getCurrentCommandStack());
+	}
+
+	@Override
+	protected void setInputCode() {
+		super.setInputCode();
+		withEventsViewer.setInput(null);
+		Arrays.stream(withEventsViewer.getTable().getItems()).forEach(item -> item.setGrayed(true));
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AbstractEditInterfaceSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AbstractEditInterfaceSection.java
@@ -148,16 +148,6 @@ public abstract class AbstractEditInterfaceSection<T extends IInterfaceElement> 
 	}
 
 	@Override
-	protected void setInputCode() {
-		// nothing to be done here
-	}
-
-	@Override
-	protected void setInputInit() {
-		// nothing to be done here
-	}
-
-	@Override
 	protected void performRefresh() {
 		setTableInput();
 		inputTable.refresh();

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AbstractEditVarInOutSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AbstractEditVarInOutSection.java
@@ -126,11 +126,6 @@ public abstract class AbstractEditVarInOutSection extends AbstractSection
 	}
 
 	@Override
-	protected void setInputCode() {
-		// not needed
-	}
-
-	@Override
 	protected void performRefresh() {
 		setTableInput();
 		inputTable.refresh();
@@ -142,11 +137,6 @@ public abstract class AbstractEditVarInOutSection extends AbstractSection
 	}
 
 	protected abstract void setTableInput();
-
-	@Override
-	protected void setInputInit() {
-		// nothing to do
-	}
 
 	@Override
 	public void dispose() {

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AbstractInterfaceSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AbstractInterfaceSection.java
@@ -260,14 +260,4 @@ public abstract class AbstractInterfaceSection extends AbstractDoubleColumnSecti
 			return element.toString();
 		}
 	}
-
-	@Override
-	protected void setInputInit() {
-		// currently nothing to do here
-	}
-
-	@Override
-	protected void setInputCode() {
-		// currently nothing to do here
-	}
 }

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AbstractInternalVarsSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AbstractInternalVarsSection.java
@@ -180,14 +180,7 @@ public abstract class AbstractInternalVarsSection extends AbstractSection
 
 	@Override
 	protected void setInputInit() {
-		final BaseFBType currentType = getType();
-		provider.setInput(currentType != null ? getVarList() : Collections.emptyList());
-		table.refresh();
-	}
-
-	@Override
-	protected void setInputCode() {
-		// nothing to do here
+		provider.setInput(getType() != null ? getVarList() : Collections.emptyList());
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AbstractSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AbstractSection.java
@@ -53,9 +53,13 @@ public abstract class AbstractSection extends AbstractPropertySection implements
 
 	protected abstract Object getInputType(Object input);
 
-	protected abstract void setInputCode();
+	protected void setInputCode() {
+		// do nothing by default
+	}
 
-	protected abstract void setInputInit();
+	protected void setInputInit() {
+		// do nothing by default
+	}
 
 	/**
 	 * Subclasses shall perform all actions to refresh the data in the property

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AppearancePropertySection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AppearancePropertySection.java
@@ -122,15 +122,4 @@ public class AppearancePropertySection extends AbstractSection {
 		}
 		return null;
 	}
-
-	@Override
-	protected void setInputCode() {
-		// currently nothing to do here
-	}
-
-	@Override
-	protected void setInputInit() {
-		// currently nothing to do here
-	}
-
 }

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AttributeSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AttributeSection.java
@@ -273,15 +273,8 @@ public class AttributeSection extends AbstractSection implements I4diacNatTableU
 	}
 
 	@Override
-	protected void setInputCode() {
-		// nothing to do here
-	}
-
-	@Override
 	protected void setInputInit() {
-		provider.setInput(getFilteredAttributeList());
 		buttons.setEnabled(isTypeEditable());
-		table.refresh();
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/ConnectionSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/ConnectionSection.java
@@ -153,14 +153,4 @@ public class ConnectionSection extends AbstractSection {
 	private static String getFBNameFromIInterfaceElement(final IInterfaceElement element) {
 		return (element.eContainer().eContainer() instanceof final FBNetworkElement fbne) ? fbne.getName() : ""; //$NON-NLS-1$
 	}
-
-	@Override
-	protected void setInputCode() {
-		// nothing needed to be done here
-	}
-
-	@Override
-	protected void setInputInit() {
-		// nothing needed to be done here
-	}
 }

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/InterfaceElementSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/InterfaceElementSection.java
@@ -177,14 +177,4 @@ public class InterfaceElementSection extends AbstractSection {
 	protected IInterfaceElement getType() {
 		return (IInterfaceElement) type;
 	}
-
-	@Override
-	protected void setInputInit() {
-		// currently nothing needs to be done here
-	}
-
-	@Override
-	protected void setInputCode() {
-		// currently nothing needs to be done here
-	}
 }

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/InternalFbsSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/InternalFbsSection.java
@@ -29,8 +29,8 @@ import org.eclipse.fordiac.ide.model.commands.insert.InsertFBCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.FB;
 import org.eclipse.fordiac.ide.model.typelibrary.FBTypeEntry;
-import org.eclipse.fordiac.ide.model.ui.nat.FBTypeSelectionTreeContentProvider;
 import org.eclipse.fordiac.ide.model.ui.nat.FBTreeNodeLabelProvider;
+import org.eclipse.fordiac.ide.model.ui.nat.FBTypeSelectionTreeContentProvider;
 import org.eclipse.fordiac.ide.model.ui.widgets.FBTypeSelectionContentProvider;
 import org.eclipse.fordiac.ide.model.ui.widgets.TypeSelectionButton;
 import org.eclipse.fordiac.ide.ui.widget.AddDeleteReorderToolbarWidget;
@@ -154,18 +154,6 @@ public class InternalFbsSection extends AbstractSection implements I4diacNatTabl
 	@Override
 	protected Object getInputType(final Object input) {
 		return BaseFBFilter.getFBTypeFromSelectedElement(input);
-	}
-
-	@Override
-	protected void setInputCode() {
-		// nothing to do here
-	}
-
-	@Override
-	protected void setInputInit() {
-		final BaseFBType currentType = getType();
-		provider.setInput(currentType != null ? currentType.getInternalFbs() : Collections.emptyList());
-		table.refresh();
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/widgets/PinInfoBasicWidget.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/widgets/PinInfoBasicWidget.java
@@ -89,10 +89,10 @@ public class PinInfoBasicWidget implements CommandExecutor {
 			if ((null != type.getName()) && (null != type.getComment())) {
 				nameText.setText(type.getName());
 				commentText.setText(type.getComment());
-				typeSelectionWidget.refresh();
-				typeDeclarationEditor.refresh();
-				checkFieldEnablements();
 			}
+			typeSelectionWidget.refresh();
+			typeDeclarationEditor.refresh();
+			checkFieldEnablements();
 			commandExecutor = commandExecutorBuffer;
 		}
 

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/widgets/TypeSelectionWidget.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/widgets/TypeSelectionWidget.java
@@ -20,15 +20,12 @@ import org.eclipse.fordiac.ide.model.data.DataType;
 import org.eclipse.fordiac.ide.model.data.StructuredType;
 import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes;
 import org.eclipse.fordiac.ide.model.helpers.ImportHelper;
-import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableFB;
-import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableMoveFB;
 import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableObject;
 import org.eclipse.fordiac.ide.model.libraryElement.Event;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
-import org.eclipse.fordiac.ide.model.libraryElement.StructManipulator;
+import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
-import org.eclipse.fordiac.ide.model.libraryElement.impl.InterfaceElementAnnotations;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
 import org.eclipse.fordiac.ide.model.ui.editors.DataTypeDropdown;
@@ -146,43 +143,21 @@ public class TypeSelectionWidget {
 		this.configurableObject = type;
 		this.contentProvider = contentProvider;
 		this.treeContentProvider = treeContentProvider;
-
-		if (type instanceof final StructManipulator structManipulator) {
-			final String newName = ImportHelper.deresolveImport(
-					PackageNameHelper.getFullTypeName(structManipulator.getDataType()),
-					PackageNameHelper.getContainerPackageName(type), ImportHelper.getContainerImports(type));
-			tableViewer.setInput(new String[] { newName });
-			resizeTextField();
-		} else if (type instanceof final VarDeclaration varDecl) {
-			tableViewer.setInput(new String[] { InterfaceElementAnnotations.getFullTypeName(varDecl) });
-		} else if (type instanceof final IInterfaceElement interfaceElement) {
-			tableViewer.setInput(new String[] { interfaceElement.getType().getName() });
-		} else if (type instanceof final ConfigurableMoveFB moveFb) {
-			if (moveFb.getDataType() == null) {
-				tableViewer.setInput(new String[] { IecTypes.GenericTypes.ANY.getName() });
-			} else {
-				tableViewer
-						.setInput(new String[] { ((ConfigurableMoveFB) configurableObject).getDataType().getName() });
-			}
-			resizeTextField();
-		}
-
-		disableOpenEditorForAnyType();
-		tableViewer.setCellEditors(createCellEditors());
+		tableViewer.setCellEditors(new CellEditor[] {
+				new DataTypeDropdown(this::getTypeLibrary, contentProvider, treeContentProvider, tableViewer) });
 	}
 
 	public void refresh() {
-		if (configurableObject instanceof final VarDeclaration varDecl) {
-			tableViewer.setInput(new String[] { InterfaceElementAnnotations.getFullTypeName(varDecl) });
-		} else if (configurableObject instanceof final IInterfaceElement iel) {
-			tableViewer.setInput(new String[] { iel.getType().getName() });
-		}
+		tableViewer.setInput(new String[] { switch (configurableObject) {
+		case final ConfigurableFB configurableFB when configurableFB.getDataType() == null ->
+			IecTypes.GenericTypes.ANY.getName();
+		case final ConfigurableFB configurableFB ->
+			ImportHelper.deresolveImport(configurableFB.getDataType(), configurableFB);
+		case final ITypedElement typedElement -> typedElement.getFullTypeName();
+		default -> ""; //$NON-NLS-1$
+		} });
+		resizeTextField();
 		disableOpenEditorForAnyType();
-	}
-
-	private CellEditor[] createCellEditors() {
-		return new CellEditor[] {
-				new DataTypeDropdown(this::getTypeLibrary, contentProvider, treeContentProvider, tableViewer) };
 	}
 
 	private static TableViewer createTableViewer(final Composite parent) {

--- a/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/properties/SegmentSection.java
+++ b/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/properties/SegmentSection.java
@@ -98,16 +98,6 @@ public class SegmentSection extends AbstractDoubleColumnSection {
 	}
 
 	@Override
-	protected void setInputCode() {
-		// currently nothing to do here
-	}
-
-	@Override
-	protected void setInputInit() {
-		// currently nothing to do here
-	}
-
-	@Override
 	protected void performRefresh() {
 		nameText.setText(getType().getName());
 		commentText.setText(getType().getComment());


### PR DESCRIPTION
Clean-up init and refresh in property sheets:
- avoid duplicate refresh in `setInputInit()`,
- ensure refresh is performed in `performRefresh()`,
- remove empty `setInputInit()` and `setInputCode()`.