### PR TITLE
Check for end of string in array and struct value converters

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/plugin.properties
+++ b/plugins/org.eclipse.fordiac.ide.model/plugin.properties
@@ -19,6 +19,7 @@ pluginName = 4diac IDE Model Plug-in
 providerName = Eclipse 4diac
 
 ArrayValueConverter_IllegalElementValue=Illegal value for element at index {0}
+ArrayValueConverter_InvalidArrayLiteral=Invalid array literal
 ArrayValueConverter_InvalidRepeatSyntax=Invalid array repeat syntax
 CommonElementImporter_ERROR_DeclarationNotSet=Declaration not set
 CommonElementImporter_ERROR_MissingAuthorInfo=Author missing

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/Messages.java
@@ -25,6 +25,8 @@ public final class Messages extends NLS {
 
 	public static String ArrayValueConverter_IllegalElementValue;
 
+	public static String ArrayValueConverter_InvalidArrayLiteral;
+
 	public static String ArrayValueConverter_InvalidRepeatSyntax;
 
 	public static String CommonElementImporter_ERROR_DeclarationNotSet;

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/ArrayValueConverter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/ArrayValueConverter.java
@@ -42,7 +42,12 @@ public class ArrayValueConverter<T> implements ValueConverter<List<T>> {
 
 	@Override
 	public List<T> toValue(final String string) throws IllegalArgumentException {
-		return toValue(new Scanner(string));
+		final Scanner scanner = new Scanner(string);
+		final List<T> value = toValue(scanner);
+		if (scanner.hasNext()) { // ensure we parsed entire input
+			throw new IllegalArgumentException(Messages.ArrayValueConverter_InvalidArrayLiteral);
+		}
+		return value;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/StructValueConverter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/StructValueConverter.java
@@ -38,7 +38,12 @@ public class StructValueConverter implements ValueConverter<Map<String, Object>>
 
 	@Override
 	public Map<String, Object> toValue(final String string) throws IllegalArgumentException {
-		return toValue(new Scanner(string));
+		final Scanner scanner = new Scanner(string);
+		final Map<String, Object> value = toValue(scanner);
+		if (scanner.hasNext()) { // ensure we parsed entire input
+			throw new IllegalArgumentException(Messages.StructValueConverter_InvalidStructLiteral);
+		}
+		return value;
 	}
 
 	@Override

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/value/ValueConverterTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/value/ValueConverterTest.java
@@ -73,6 +73,8 @@ class ValueConverterTest {
 				arguments(NumericValueConverter.INSTANCE, IllegalArgumentException.class, "NoNumber"), //
 				arguments(NumericValueConverter.INSTANCE, IllegalArgumentException.class, "1__00"), //
 				arguments(NumericValueConverter.INSTANCE, IllegalArgumentException.class, "a1"), //
+				arguments(NumericValueConverter.INSTANCE, IllegalArgumentException.class, "trueerror"), //
+				arguments(NumericValueConverter.INSTANCE, IllegalArgumentException.class, "17error"), //
 				arguments(StringValueConverter.INSTANCE, "", "''"), //
 				arguments(StringValueConverter.INSTANCE, IllegalArgumentException.class, "\"\""), //
 				arguments(StringValueConverter.INSTANCE, IllegalArgumentException.class, ""), //
@@ -82,6 +84,7 @@ class ValueConverterTest {
 				arguments(StringValueConverter.INSTANCE, IllegalArgumentException.class, "'4diac'IDE'"), //
 				arguments(StringValueConverter.INSTANCE, IllegalArgumentException.class, "'4diac$''IDE'"), //
 				arguments(StringValueConverter.INSTANCE, IllegalArgumentException.class, "'4diac'$'IDE'"), //
+				arguments(StringValueConverter.INSTANCE, IllegalArgumentException.class, "'4diac IDE'error"), //
 				arguments(StringValueConverter.INSTANCE, "abc", "'abc'"), //
 				arguments(StringValueConverter.INSTANCE, NAME_ACUTE, "'4diac$'IDE'"), //
 				arguments(StringValueConverter.INSTANCE, NAME_BACKSLASH, "'4diac\"IDE'"), //
@@ -99,6 +102,7 @@ class ValueConverterTest {
 				arguments(WStringValueConverter.INSTANCE, IllegalArgumentException.class, "\"4diac\"IDE\""), //
 				arguments(WStringValueConverter.INSTANCE, IllegalArgumentException.class, "\"4diac\"$\"IDE\""), //
 				arguments(WStringValueConverter.INSTANCE, IllegalArgumentException.class, "\"4diac$\"\"IDE\""), //
+				arguments(WStringValueConverter.INSTANCE, IllegalArgumentException.class, "\"4diac IDE\"error"), //
 				arguments(WStringValueConverter.INSTANCE, "abc", "\"abc\""), //
 				arguments(WStringValueConverter.INSTANCE, NAME_ACUTE, "\"4diac'IDE\""), //
 				arguments(WStringValueConverter.INSTANCE, NAME_BACKSLASH, "\"4diac$\"IDE\""), //
@@ -134,6 +138,8 @@ class ValueConverterTest {
 						"[17,,]"), //
 				arguments(new ArrayValueConverter<>(NumericValueConverter.INSTANCE), IllegalArgumentException.class,
 						"[4"), //
+				arguments(new ArrayValueConverter<>(NumericValueConverter.INSTANCE), IllegalArgumentException.class,
+						"[17,4]error"), //
 				arguments(
 						named("StructValueConverter [NumericValueConverter]",
 								new StructValueConverter(unused -> NumericValueConverter.INSTANCE)),
@@ -160,7 +166,15 @@ class ValueConverterTest {
 				arguments(
 						named("StructValueConverter [NumericValueConverter]",
 								new StructValueConverter(unused -> NumericValueConverter.INSTANCE)),
-						IllegalArgumentException.class, "(a:=invalid,b:=4)") //
+						IllegalArgumentException.class, ""), //
+				arguments(
+						named("StructValueConverter [NumericValueConverter]",
+								new StructValueConverter(unused -> NumericValueConverter.INSTANCE)),
+						IllegalArgumentException.class, "(a:=invalid,b:=4)"), //
+				arguments(
+						named("StructValueConverter [NumericValueConverter]",
+								new StructValueConverter(unused -> NumericValueConverter.INSTANCE)),
+						IllegalArgumentException.class, "(a:=17,b:=4)error") //
 		);
 	}
 


### PR DESCRIPTION
The array and struct value converters did not check that they consumed the entire input string, which allowed an invalid suffix to be skipped.