### PR TITLE
Corrects byte assembly logic and adds byte splitting

### DIFF
--- a/data/typelibrary/utils-3.0.0/typelib/assembling/ASSEMBLE_DWORD_FROM_BYTES.fct
+++ b/data/typelibrary/utils-3.0.0/typelib/assembling/ASSEMBLE_DWORD_FROM_BYTES.fct
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Function Name="ASSEMBLE_DWORD_FROM_BYTES" Comment="this Function combines the 2 BYTES to a DWORD">
-	<Identification Standard="61499-1" Description="Copyright (c) 2024 HR Agrartechnik GmbH    &#10;    &#10;This program and the accompanying materials are made     &#10;available under the terms of the Eclipse Public License 2.0     &#10;which is available at https://www.eclipse.org/legal/epl-2.0/     &#10;     &#10;SPDX-License-Identifier: EPL-2.0">
+<Function Name="ASSEMBLE_DWORD_FROM_BYTES" Comment="this Function combines the 4 BYTES to a DWORD">
+	<Identification Standard="61499-1" Description="Copyright (c) 2024, 2025 HR Agrartechnik GmbH    &#10;    &#10;This program and the accompanying materials are made     &#10;available under the terms of the Eclipse Public License 2.0     &#10;which is available at https://www.eclipse.org/legal/epl-2.0/     &#10;     &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik" Version="3.0.1" Author="Franz Höpfinger" Date="2025-12-21" Remarks="fix 2 --&gt; 4">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="HR Agrartechnik" Version="1.1" Author="Moritz Ortmeier" Date="2024-07-28" Remarks="rename Function and change Input/Output Variables">
@@ -12,7 +14,7 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="REQ" Type="Event" Comment="">
+			<Event Name="REQ" Type="Event">
 				<With Var="BYTE_00"/>
 				<With Var="BYTE_01"/>
 				<With Var="BYTE_02"/>
@@ -20,22 +22,22 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="CNF" Type="Event" Comment="">
+			<Event Name="CNF" Type="Event">
 				<With Var=""/>
 			</Event>
 		</EventOutputs>
 		<InputVars>
-			<VarDeclaration Name="BYTE_00" Type="BYTE" Comment=""/>
-			<VarDeclaration Name="BYTE_01" Type="BYTE" Comment=""/>
-			<VarDeclaration Name="BYTE_02" Type="BYTE" Comment=""/>
-			<VarDeclaration Name="BYTE_03" Type="BYTE" Comment=""/>
+			<VarDeclaration Name="BYTE_00" Type="BYTE"/>
+			<VarDeclaration Name="BYTE_01" Type="BYTE"/>
+			<VarDeclaration Name="BYTE_02" Type="BYTE"/>
+			<VarDeclaration Name="BYTE_03" Type="BYTE"/>
 		</InputVars>
 		<OutputVars>
-			<VarDeclaration Name="" Type="DWORD" Comment=""/>
+			<VarDeclaration Name="" Type="DWORD"/>
 		</OutputVars>
 	</InterfaceList>
 	<FunctionBody>
-		<ST><![CDATA[(* this Function combines the 2 BYTES to a DWORD *)
+		<ST><![CDATA[(* this Function combines the 4 BYTES to a DWORD *)
 FUNCTION ASSEMBLE_DWORD_FROM_BYTES : DWORD
 
 VAR_INPUT

--- a/data/typelibrary/utils-3.0.0/typelib/splitting/SPLIT_DWORD_INTO_BYTES.fct
+++ b/data/typelibrary/utils-3.0.0/typelib/splitting/SPLIT_DWORD_INTO_BYTES.fct
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Function Name="SPLIT_DWORD_INTO_BYTES" Comment="this Function extracts the 4 BYTE from a dword">
+	<Identification Standard="61499-1" Description="Copyright (c) 2025 HR Agrartechnik GmbH    &#10;    &#10;This program and the accompanying materials are made     &#10;available under the terms of the Eclipse Public License 2.0     &#10;which is available at https://www.eclipse.org/legal/epl-2.0/     &#10;     &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik" Version="1.0" Author="Franz Höpfinger" Date="2025-12-21" Remarks="initial Version">
+	</VersionInfo>
+	<CompilerInfo packageName="eclipse4diac::utils::splitting">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="BYTE_00"/>
+				<With Var="BYTE_01"/>
+				<With Var="BYTE_02"/>
+				<With Var="BYTE_03"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="DWORD"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="BYTE_00" Type="BYTE"/>
+			<VarDeclaration Name="BYTE_01" Type="BYTE"/>
+			<VarDeclaration Name="BYTE_02" Type="BYTE"/>
+			<VarDeclaration Name="BYTE_03" Type="BYTE"/>
+		</OutputVars>
+	</InterfaceList>
+	<FunctionBody>
+		<ST><![CDATA[(* this Function extracts the 4 BYTE from a dword *)
+FUNCTION SPLIT_DWORD_INTO_BYTES
+
+VAR_INPUT
+	IN : DWORD;
+END_VAR
+
+VAR_OUTPUT
+	BYTE_00 : BYTE;
+	BYTE_01 : BYTE;
+	BYTE_02 : BYTE;
+	BYTE_03 : BYTE;
+END_VAR
+
+BYTE_00 := IN.%B0;
+BYTE_01 := IN.%B1;
+BYTE_02 := IN.%B2;
+BYTE_03 := IN.%B3;
+
+END_FUNCTION
+]]></ST>
+	</FunctionBody>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</Function>


### PR DESCRIPTION
Updates ASSEMBLE_DWORD_FROM_BYTES to correctly assemble 4 bytes into a DWORD instead of 2. Adds new SPLIT_DWORD_INTO_BYTES function to extract bytes from a DWORD, improving functionality for byte manipulation tasks.

Relates to feature/SPLIT_DWORD_INTO_BYTES
