### PR TITLE
Fix invalid generic type for missing variable quickfix in ST editor

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/quickfix/STCoreQuickfixProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/quickfix/STCoreQuickfixProvider.java
@@ -561,7 +561,7 @@ public class STCoreQuickfixProvider extends DefaultQuickfixProvider {
 		if (element instanceof final STFeatureExpression expression) {
 			final ICallable callable = EcoreUtil2.getContainerOfType(expression, ICallable.class);
 			final String name = getFeatureText(expression);
-			final LibraryElement type = getExpectedFeatureType(expression);
+			final LibraryElement type = findNonGenericType(getExpectedFeatureType(expression));
 			if (callable != null && IdentifierVerifier.verifyIdentifier(name).isEmpty()
 					&& type instanceof final DataType dataType) {
 				createMissingVariable(callable, name, dataType, kind);
@@ -617,6 +617,14 @@ public class STCoreQuickfixProvider extends DefaultQuickfixProvider {
 			}
 		}
 		return ElementaryTypes.SINT;
+	}
+
+	protected static LibraryElement findNonGenericType(final LibraryElement type) {
+		if (type instanceof final DataType dataType && STCoreUtil.isAnyType(dataType)) {
+			return ElementaryTypes.getAllElementaryType().stream().filter(dataType::isAssignableFrom).findFirst()
+					.orElse(ElementaryTypes.SINT);
+		}
+		return type;
 	}
 
 	protected boolean hasSyntaxErrors(final Issue issue) {


### PR DESCRIPTION
The missing variable quickfix did attempt to create a variable with a generic type, which is not supported in ST code. This uses a matching non-generic type instead or falls back to `SINT`.