### PR TITLE
Reworked SetPositionCommand to correctly handle screen resolution #1978

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/FBNetworkXYLayoutEditPolicy.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/FBNetworkXYLayoutEditPolicy.java
@@ -89,19 +89,20 @@ public class FBNetworkXYLayoutEditPolicy extends XYLayoutEditPolicy {
 			final Object constraint) {
 		if ((child.getModel() instanceof Group || child.getModel() instanceof SubApp
 				|| child.getModel() instanceof Comment) && RequestUtil.isResizeRequest(request)) {
-			return createChangeSizeCommand((FBNetworkElement) child.getModel(), request);
+			return createChangeSizeCommand((FBNetworkElement) child.getModel(), request, (Rectangle) constraint);
 		}
 		if ((child.getModel() instanceof final PositionableElement pe) && (RequestUtil.isMoveRequest(request))) {
-			return createMoveCommand(pe, request, constraint);
+			return createMoveCommand(pe, (Rectangle) constraint);
 		}
 		return null;
 	}
 
-	private Command createChangeSizeCommand(final FBNetworkElement container, final ChangeBoundsRequest request) {
+	private Command createChangeSizeCommand(final FBNetworkElement container, final ChangeBoundsRequest request,
+			final Rectangle constraint) {
 		final Dimension sizeDelta = getScaledSizeDelta(request);
 		if (sizeDelta.width == 0 && sizeDelta.height == 0) {
 			// we hit the min size and we are just moving, return a set position command
-			return createMoveCommand(container, request, null);
+			return createMoveCommand(container, constraint);
 		}
 		final Point moveDelta = getScaledMoveDelta(request);
 		return createChangeBoundsCommand(container, sizeDelta, moveDelta);
@@ -241,25 +242,12 @@ public class FBNetworkXYLayoutEditPolicy extends XYLayoutEditPolicy {
 		return (getHost().getModel() instanceof final FBNetwork fbNetwork) ? fbNetwork : null;
 	}
 
-	private Command createMoveCommand(final PositionableElement model, final ChangeBoundsRequest request,
-			final Object constraint) {
-		final Point moveDelta = (RequestUtil.isAlignmentRequest(request)) ? getAlignmentDelta(model, constraint)
-				: getScaledMoveDelta(request);
+	private static Command createMoveCommand(final PositionableElement model, final Rectangle constraint) {
+		final Position newPos = CoordinateConverter.INSTANCE.createPosFromScreenCoordinates(constraint.x, constraint.y);
 		if (model instanceof final FBNetworkElement fbnEl) {
-			return new FBNetworkElementSetPositionCommand(fbnEl, moveDelta.x, moveDelta.y);
+			return new FBNetworkElementSetPositionCommand(fbnEl, newPos);
 		}
-		return new SetPositionCommand(model, moveDelta.x, moveDelta.y);
-	}
-
-	private static Point getAlignmentDelta(final PositionableElement model, final Object constraint) {
-		if (constraint instanceof final Rectangle rect) {
-			final Position newPos = CoordinateConverter.INSTANCE.createPosFromScreenCoordinates(rect.x, rect.y);
-			newPos.setX(newPos.getX() - model.getPosition().getX());
-			newPos.setY(newPos.getY() - model.getPosition().getY());
-			return newPos.toScreenPoint();
-		}
-		// we don't have new positions keep the old one
-		return model.getPosition().toScreenPoint();
+		return new SetPositionCommand(model, newPos);
 	}
 
 	protected Dimension getScaledSizeDelta(final ChangeBoundsRequest request) {

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/policies/ECCXYLayoutEditPolicy.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/policies/ECCXYLayoutEditPolicy.java
@@ -47,24 +47,12 @@ public class ECCXYLayoutEditPolicy extends XYLayoutEditPolicy {
 	protected Command createChangeConstraintCommand(final ChangeBoundsRequest request, final EditPart child,
 			final Object constraint) {
 		if ((child.getModel() instanceof final ECState state) && RequestUtil.isMoveRequest(request)) {
-			final Point moveDelta;
-			if (constraint instanceof final Rectangle rect && RequestUtil.isAlignmentRequest(request)) {
-				moveDelta = getMoveDelta(rect, state);
-			} else {
-				moveDelta = request.getMoveDelta().getScaled(1.0 / getZoomManager().getZoom());
-			}
-
-			return new SetPositionCommand(state, moveDelta.x, moveDelta.y);
+			final Rectangle rectConstraint = (Rectangle) constraint;
+			final Position newPos = CoordinateConverter.INSTANCE.createPosFromScreenCoordinates(rectConstraint.x,
+					rectConstraint.y);
+			return new SetPositionCommand(state, newPos);
 		}
 		return null;
-	}
-
-	private static Point getMoveDelta(final Rectangle rect, final ECState state) {
-		final Position newPos = CoordinateConverter.INSTANCE.createPosFromScreenCoordinates(rect.x, rect.y);
-		final Position oldPos = state.getPosition();
-		newPos.setX(Math.floor((newPos.getX() - oldPos.getX()) / 2));
-		newPos.setY(Math.floor((newPos.getY() - oldPos.getY()) / 2));
-		return newPos.toScreenPoint();
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/draw2d/SetableAlphaLabel.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/draw2d/SetableAlphaLabel.java
@@ -17,6 +17,7 @@ import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.Label;
+import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
 
 public class SetableAlphaLabel extends Label implements ITransparencyFigure {
@@ -90,7 +91,14 @@ public class SetableAlphaLabel extends Label implements ITransparencyFigure {
 			graphics.drawText(getSubStringText(), tx + 1, ty + 1);
 			graphics.setForegroundColor(ColorConstants.buttonDarker);
 		}
-		graphics.drawText(getSubStringText(), tx, ty);
+
+		final Dimension subStringTextSize = getSubStringTextSize();
+		if ((subStringTextSize.height * graphics.getAbsoluteScale()) < 3) {
+			graphics.setBackgroundColor(getForegroundColor());
+			graphics.fillRectangle(tx, ty, subStringTextSize.width, subStringTextSize.height);
+		} else {
+			graphics.drawText(getSubStringText(), tx, ty);
+		}
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/FBNetworkElementSetPositionCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/FBNetworkElementSetPositionCommand.java
@@ -28,8 +28,8 @@ public class FBNetworkElementSetPositionCommand extends SetPositionCommand imple
 	private static final Consumer<IInterfaceElement> OUTPUT_CONSUMER = ie -> ie.getOutputConnections()
 			.forEach(con -> con.getRoutingData().setNeedsValidation(true));
 
-	public FBNetworkElementSetPositionCommand(final FBNetworkElement fbe, final int dx, final int dy) {
-		super(fbe, dx, dy);
+	public FBNetworkElementSetPositionCommand(final FBNetworkElement fbe, final Position newPos) {
+		super(fbe, newPos);
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/SetPositionCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/SetPositionCommand.java
@@ -1,6 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 fortiss GmbH
- * 				 2019 Johannes Keppler University Linz
+ * Copyright (c) 2016, 2025 fortiss GmbH, Johannes Keppler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -24,8 +23,6 @@ import org.eclipse.gef.commands.Command;
 
 public class SetPositionCommand extends Command {
 	private final PositionableElement positionableElement;
-//	private final double dx;
-//	private final double dy;
 	private Position oldPos;
 	private Position newPos;
 
@@ -36,20 +33,25 @@ public class SetPositionCommand extends Command {
 	private SetPositionCommand(final PositionableElement positionableElement) {
 		this.positionableElement = positionableElement;
 		setLabel(Messages.ViewSetPositionCommand_LABEL_Move);
-	}
-
-	public SetPositionCommand(final PositionableElement positionableElement, final double dx, final double dy) {
-		this(positionableElement);
 		if (positionableElement != null) {
 			oldPos = getPositionableElement().getPosition();
-			newPos = createNewPosition(oldPos, dx, dy);
 		}
 	}
 
+	public SetPositionCommand(final PositionableElement positionableElement, final Position newPos) {
+		this(positionableElement);
+		setLabel(Messages.ViewSetPositionCommand_LABEL_Move);
+		this.newPos = newPos;
+	}
+
+	public SetPositionCommand(final PositionableElement positionableElement, final double dx, final double dy) {
+		this(positionableElement, createNewPosition(positionableElement.getPosition(), dx, dy));
+	}
+
+	@Deprecated
 	public SetPositionCommand(final PositionableElement positionableElement, final int dx, final int dy) {
 		this(positionableElement);
 		if (positionableElement != null) {
-			oldPos = getPositionableElement().getPosition();
 			newPos = createNewPosition(oldPos, dx, dy);
 		}
 	}

--- a/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/policies/SystemConfXYLayoutEditPolicy.java
+++ b/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/policies/SystemConfXYLayoutEditPolicy.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2012, 2014, 2016, 2017 Profactor GbmH, TU Wien ACIN, fortiss GmbH,
- * 				 2018 Johannes Kepler University
+ * Copyright (c) 2008, 2025 Profactor GbmH, TU Wien ACIN, fortiss GmbH,
+ *                          Johannes Kepler University
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,12 +19,13 @@ import java.util.List;
 
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Insets;
-import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.fordiac.ide.gef.policies.ModifiedMoveHandle;
 import org.eclipse.fordiac.ide.gef.policies.ModifiedNonResizeableEditPolicy;
 import org.eclipse.fordiac.ide.gef.utilities.RequestUtil;
+import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.commands.change.SetPositionCommand;
+import org.eclipse.fordiac.ide.model.libraryElement.Position;
 import org.eclipse.fordiac.ide.model.libraryElement.PositionableElement;
 import org.eclipse.fordiac.ide.model.libraryElement.Segment;
 import org.eclipse.fordiac.ide.model.libraryElement.SystemConfiguration;
@@ -79,8 +80,8 @@ public class SystemConfXYLayoutEditPolicy extends XYLayoutEditPolicy {
 			}
 			// return a command that can move a "PositionableElement"
 			if (child.getModel() instanceof final PositionableElement posel && RequestUtil.isMoveRequest(request)) {
-				final Point moveDelta = request.getMoveDelta().getScaled(1.0 / getZoomManager().getZoom());
-				return new SetPositionCommand(posel, moveDelta.x, moveDelta.y);
+				final Position newPos = CoordinateConverter.INSTANCE.createPosFromScreenCoordinates(rec.x, rec.y);
+				return new SetPositionCommand(posel, newPos);
 			}
 		}
 		return null;


### PR DESCRIPTION
The position change commands didn't correctly accommodate the the requested position. It used the requests moveDelta and not the constraint object provided by GEF Classic that is already correctly translated for the target object.

As part of that change a first clean-up of the SetPositionCommand was performed.

Addresses: https://github.com/eclipse-4diac/4diac-ide/issues/1978