### PR TITLE
FB insert position didn't correctly consider parent scaling #1978

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractBlockFBNElementEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractBlockFBNElementEditPart.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.core.runtime.Assert;
-import org.eclipse.draw2d.FigureCanvas;
 import org.eclipse.draw2d.GridData;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.Label;
@@ -44,7 +43,6 @@ import org.eclipse.fordiac.ide.gef.annotation.GraphicalAnnotationStyles;
 import org.eclipse.fordiac.ide.gef.editparts.AbstractPositionableElementEditPart;
 import org.eclipse.fordiac.ide.gef.editparts.AbstractViewEditPart;
 import org.eclipse.fordiac.ide.gef.editparts.InterfaceEditPart;
-import org.eclipse.fordiac.ide.gef.editparts.ZoomScalableFreeformRootEditPart;
 import org.eclipse.fordiac.ide.gef.listeners.DiagramFontChangeListener;
 import org.eclipse.fordiac.ide.gef.policies.DragHighlightEditPolicy;
 import org.eclipse.fordiac.ide.model.commands.change.UpdateFBTypeCommand;
@@ -71,7 +69,6 @@ import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
 import org.eclipse.gef.commands.Command;
-import org.eclipse.gef.editparts.ZoomManager;
 import org.eclipse.gef.editpolicies.DirectEditPolicy;
 import org.eclipse.gef.requests.DirectEditRequest;
 import org.eclipse.jface.resource.JFaceResources;
@@ -591,15 +588,9 @@ public abstract class AbstractBlockFBNElementEditPart extends AbstractPositionab
 	}
 
 	private Point getRefPoint() {
-		final org.eclipse.draw2d.geometry.Point typeLabelTopLeft = getFigure().getTypeLabel().getBounds().getTopLeft()
-				.scale(getZoomManager().getZoom());
-		final FigureCanvas viewerControl = (FigureCanvas) getViewer().getControl();
-		final org.eclipse.draw2d.geometry.Point location = viewerControl.getViewport().getViewLocation();
-		return new Point(typeLabelTopLeft.x - location.x, typeLabelTopLeft.y - location.y);
-	}
-
-	private ZoomManager getZoomManager() {
-		return ((ZoomScalableFreeformRootEditPart) getRoot()).getZoomManager();
+		final org.eclipse.draw2d.geometry.Point typeLabelTopLeft = getFigure().getTypeLabel().getBounds().getTopLeft();
+		getFigure().getTypeLabel().translateToAbsolute(typeLabelTopLeft);
+		return typeLabelTopLeft.getSWTPoint();
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/AbstractCreateInstanceDirectEditPolicy.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/AbstractCreateInstanceDirectEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 Primetals Technologies Austria GmbH
+ * Copyright (c) 2021, 2025 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.application.policies;
 
-import org.eclipse.draw2d.FigureCanvas;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.PrecisionPoint;
@@ -21,10 +20,8 @@ import org.eclipse.fordiac.ide.application.editors.NewInstanceDirectEditManager;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
-import org.eclipse.gef.RootEditPart;
 import org.eclipse.gef.SnapToHelper;
 import org.eclipse.gef.commands.Command;
-import org.eclipse.gef.editparts.ScalableFreeformRootEditPart;
 import org.eclipse.gef.editpolicies.DirectEditPolicy;
 import org.eclipse.gef.requests.DirectEditRequest;
 import org.eclipse.gef.requests.LocationRequest;
@@ -82,26 +79,15 @@ public abstract class AbstractCreateInstanceDirectEditPolicy extends DirectEditP
 		return refPoint;
 	}
 
-	private double getZoom() {
-		final RootEditPart root = getHost().getRoot();
-		if (root instanceof final ScalableFreeformRootEditPart scalableEditPart) {
-			return scalableEditPart.getZoomManager().getZoom();
-		}
-		return 1.0;
-	}
-
 	@Override
 	protected void showCurrentEditValue(final DirectEditRequest request) {
 		// we don't need to do anything here for creating new fb instances
 	}
 
 	public Point getInsertPos(final LocationRequest request) {
-		final Point location = request.getLocation();
-		final FigureCanvas figureCanvas = (FigureCanvas) getHost().getViewer().getControl();
-		final org.eclipse.draw2d.geometry.Point viewLocation = figureCanvas.getViewport().getViewLocation();
-		location.x += viewLocation.x;
-		location.y += viewLocation.y;
-		return new Point(location.x, location.y).scale(1.0 / getZoom());
+		final Point location = request.getLocation().getCopy();
+		getHost().getFigure().translateToRelative(location);
+		return location;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/FBNetworkXYLayoutEditPolicy.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/FBNetworkXYLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2022 Profactor GmbH, fortiss GmbH,
+ * Copyright (c) 2008, 2025 Profactor GmbH, fortiss GmbH,
  *                          Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
@@ -17,7 +17,6 @@ package org.eclipse.fordiac.ide.application.policies;
 
 import java.util.List;
 
-import org.eclipse.draw2d.FigureCanvas;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
@@ -187,10 +186,9 @@ public class FBNetworkXYLayoutEditPolicy extends XYLayoutEditPolicy {
 	}
 
 	protected Point getTranslatedAndZoomedPoint(final ChangeBoundsRequest request) {
-		final FigureCanvas viewerControl = (FigureCanvas) getTargetEditPart(request).getViewer().getControl();
-		final Point location = viewerControl.getViewport().getViewLocation();
-		return new Point(request.getLocation().x + location.x, request.getLocation().y + location.y)
-				.scale(1.0 / getZoomManager().getZoom());
+		final Point location = request.getLocation().getCopy();
+		getHost().getFigure().translateToRelative(location);
+		return location;
 	}
 
 	private static List<FBNetworkElement> collectDraggedFBs(final List<? extends EditPart> editParts,


### PR DESCRIPTION
This is for example a problem on windows with the new GEF Classic HDPI support.

Addresses: https://github.com/eclipse-4diac/4diac-ide/issues/1978