### PR TITLE
Fix issues in OCL checks #1850

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.validation/constraints/ECC.ocl
+++ b/plugins/org.eclipse.fordiac.ide.validation/constraints/ECC.ocl
@@ -17,44 +17,44 @@ package libraryElement
 -- A self-cycle exists when there is a transition from an EC state back to itself. Self-cycles must be gated by events.
 -- Problem: The process that is executing the ECC may enter an infinite loop
 context ECTransition
-inv "WARNING;[SelfCycleMustBeGatedByEvent]": self.source = self.destination implies (not self.conditionEvent.oclIsUndefined())
+inv _'WARNING;[SelfCycleMustBeGatedByEvent]': self.source = self.destination implies (not self.conditionEvent.oclIsUndefined())
 
 -- Transitions with lower priority than the 1 transition condition will never be taken regardless they are with pure data-driven conditions or event conditions
 -- Problem: Dead transitions
 context ECTransition
-inv "ERROR;[TransitionLowerThanOne]": not self.conditionEvent.oclIsUndefined() or self.conditionExpression <> '1' implies (self.source.outTransitions->forAll(trans | trans.conditionExpression = '1' implies (trans.getPriority() > self.getPriority())))
+inv _'ERROR;[TransitionLowerThanOne]': not self.conditionEvent.oclIsUndefined() or self.conditionExpression <> '1' implies (self.source.outTransitions->forAll(trans | trans.conditionExpression = '1' implies (trans.getPriority() > self.getPriority())))
 
 -- Transitions with higher priority than the 1 transition condition can only be taken if they are with pure data-driven conditions
 -- Problem: Dead transitions
 context ECTransition
-inv "ERROR;[TransitionHigherThanOne]": self.conditionExpression <> '1' implies self.source.outTransitions->forAll(trans | (trans.conditionExpression = '1' and trans.getPriority() > self.getPriority()) implies (self.conditionEvent.oclIsUndefined()))
+inv _'ERROR;[TransitionHigherThanOne]': self.conditionExpression <> '1' implies self.source.outTransitions->forAll(trans | (trans.conditionExpression = '1' and trans.getPriority() > self.getPriority()) implies (self.conditionEvent.oclIsUndefined()))
 
 -- States (except start state) which do not have any input transitions
 -- Problem: Unreachable states
 context ECState
-inv "WARNING;[UnreachableState]": not self.isStartState() implies(self.inTransitions->size() > 0)
+inv _'WARNING;[UnreachableState]': not self.isStartState() implies(self.inTransitions->size() > 0)
 
 -- States which do not have any outgoing EC transitions
 -- Problem: Terminal states
 context ECState
-inv "ERROR;[TerminalState]": self.outTransitions->size() > 0
+inv _'ERROR;[TerminalState]': self.outTransitions->size() > 0
 
 -- States (except start state) to which a path cannot be found from the EC initial state by following the directed links
 -- Problem: Dead states
 context ECState
-inv "WARNING;[DeadState]" : not self.isStartState() implies (self->closure(inTransitions.source)->select(state : ECState | state.isStartState())->size() > 0)
+inv _'WARNING;[DeadState]' : not self.isStartState() implies (self->closure(inTransitions.source)->select(state : ECState | state.isStartState())->size() > 0)
 
 -- Event inputs of the FB type containing the ECC that are not used in any EC transitions
 context ECC
-inv "WARNING;[UnusedEventInput]": self.eCTransition.conditionEvent->includesAll(self.basicFBType.interfaceList.eventInputs->asSet())
+inv _'WARNING;[UnusedEventInput]': self.eCTransition.conditionEvent->includesAll(self.basicFBType.interfaceList.eventInputs->asSet())
 
 -- Event outputs of the FB type containing the ECC that are not used in any EC actions
 context ECC
-inv "WARNING;[UnusedEventOutput]": self.eCTransition.destination.eCAction.output->includesAll(self.basicFBType.interfaceList.eventOutputs->asSet())
+inv _'WARNING;[UnusedEventOutput]': self.eCTransition.destination.eCAction.output->includesAll(self.basicFBType.interfaceList.eventOutputs->asSet())
 
 -- Transition conditions as "None" without any condition (empty or spaces) are invalid transitions
 context ECTransition
-inv "ERROR;[NoneTransitionWithoutCondition]": self.conditionEvent.oclIsUndefined() implies(self.conditionExpression <> '' and Sequence{1..self.conditionExpression.size()}->select(i | self.conditionExpression.substring(i, i) = ' ')->size() <> self.conditionExpression.size() )
+inv _'ERROR;[NoneTransitionWithoutCondition]': self.conditionEvent.oclIsUndefined() implies(self.conditionExpression <> '' and Sequence{1..self.conditionExpression.size()}->select(i | self.conditionExpression.substring(i, i) = ' ')->size() <> self.conditionExpression.size() )
 
 -- A guard-only cycle is the general case of a self-cycle (SelfCycleMustBeGatedByEvent), where a path exists from an EC state, through other EC states and back to itself through a path consisting of transitions with guard-only conditions (i.e., transitions not containing an event).
 -- Problem: The process that is executing the ECC may enter an infinite loop

--- a/plugins/org.eclipse.fordiac.ide.validation/constraints/FB.ocl
+++ b/plugins/org.eclipse.fordiac.ide.validation/constraints/FB.ocl
@@ -19,32 +19,32 @@ package libraryElement
 -- FBs which do not have any input connections on event inputs
 -- Problem: Unreachable FB
 context FB
-inv "ERROR;[UnreachableFB]": self.interface.eventInputs.inputConnections->size() > 0
+inv _'ERROR;[UnreachableFB]': self.interface.eventInputs.inputConnections->size() > 0
 
 context FB
 -- FB comment field should have a value which is not empty and not spaces
 -- Problem: FB is not commented good enough
-inv "INFO;[FBCommentFieldMustHaveValue]": self.comment <> '' and Sequence{1..self.comment.size()}->select(i | self.comment.substring(i, i) = ' ')->size() <> self.comment.size()
+inv _'INFO;[FBCommentFieldMustHaveValue]': self.comment <> '' and Sequence{1..self.comment.size()}->select(i | self.comment.substring(i, i) = ' ')->size() <> self.comment.size()
 
 -- CFBs which do not have any input connections on event inputs
 -- Problem: Unreachable FB
 context CFBInstance
-inv "ERROR;[UnreachableCFB]": self.interface.eventInputs.inputConnections->size() > 0
+inv _'ERROR;[UnreachableCFB]': self.interface.eventInputs.inputConnections->size() > 0
 
 -- Subapps which do not have any input connections on event inputs
 -- Problem: Unreachable Subapp
 context SubApp
-inv "ERROR;[UnreachableSubApp]": self.interface.eventInputs.inputConnections->size() > 0
+inv _'ERROR;[UnreachableSubApp]': self.interface.eventInputs.inputConnections->size() > 0
 
 -- Subapplication with no content
 -- Problem: Empty Subapplication
-context SubApp
-inv "WARNING;[EmptySubApp]": self.subAppNetwork.networkElements->size() > 0
+context UntypedSubApp
+inv _'WARNING;[EmptySubApp]': self.subAppNetwork.networkElements->size() > 0
 
 -- Subapplication that has no internal connections and no internally set values
 -- Problem: Lazy Subapplication
-context SubApp
-inv "WARNING;[LazySubApp]":
+context UntypedSubApp
+inv _'WARNING;[LazySubApp]':
 	self.subAppNetwork.networkElements->forAll(
 		interface.inputVars->forAll(
 			value.value <> '' or 
@@ -78,22 +78,22 @@ inv "WARNING;[LazySubApp]":
 
 -- If data inputs does not have input connections it should have a value which is not empty and not spaces
 context VarDeclaration
-inv "INFO;[DataInputMustHaveValue]": self.isInput implies (self.inputConnections->size() = 0 implies (self.value.value <> '' and Sequence{1..self.value.value.size()}->select(i | self.value.value.substring(i, i) = ' ')->size() <> self.value.value.size()))
+inv _'INFO;[DataInputMustHaveValue]': self.isInput implies (self.inputConnections->size() = 0 implies (self.value.value <> '' and Sequence{1..self.value.value.size()}->select(i | self.value.value.substring(i, i) = ' ')->size() <> self.value.value.size()))
 
 -- If the particular input event is connected, then the associated data should be connected or configured
 context Event
-inv "INFO;[AssociatedDataMustBeConfigured]": self.inputConnections->size() > 0 implies (self.with.variables->forAll(variable | variable.inputConnections->size() > 0 or variable.value.value <> ''))
+inv _'INFO;[AssociatedDataMustBeConfigured]': self.inputConnections->size() > 0 implies (self.with.variables->forAll(variable | variable.inputConnections->size() > 0 or variable.value.value <> ''))
 
 context DataConnection
-inv "ERROR;[DuplicateDataConnection]":
+inv _'ERROR;[DuplicateDataConnection]':
 	self.getFBNetwork().dataConnections->forAll(connection | self <> connection implies self.source <> connection.source or self.destination <> connection.destination)
 
 context EventConnection
-inv "ERROR;[DuplicateEventConnection]":
+inv _'ERROR;[DuplicateEventConnection]':
 	self.getFBNetwork().eventConnections->forAll(connection | self <> connection implies self.source <> connection.source or self.destination <> connection.destination) 
 
 context SubApp
-inv "ERROR;[SubAppFeatureEnvy]":
+inv _'ERROR;[SubAppFeatureEnvy]':
 	let externalConnections : Real = self.interface.inputVars.inputConnections->collect(isInterfaceConnection())->count(true)+self.interface.outputVars.outputConnections->collect(isInterfaceConnection())->count(true) in
 	let internalConnections : Real = self.interface.inputVars.inputConnections->collect(isInterfaceConnection())->count(false)+self.interface.outputVars.outputConnections->collect(isInterfaceConnection())->count(false) in
 	if externalConnections.floor() = 0 then
@@ -103,7 +103,7 @@ inv "ERROR;[SubAppFeatureEnvy]":
 	endif
 	
 context FB
-inv "ERROR;[FBFeatureEnvy]":
+inv _'ERROR;[FBFeatureEnvy]':
 	let externalConnections : Real = self.interface.inputVars.inputConnections->collect(isInterfaceConnection())->count(true)+self.interface.outputVars.outputConnections->collect(isInterfaceConnection())->count(true) in
 	let internalConnections : Real = self.interface.inputVars.inputConnections->collect(isInterfaceConnection())->count(false)+self.interface.outputVars.outputConnections->collect(isInterfaceConnection())->count(false) in
 	if externalConnections.floor() = 0 then
@@ -113,7 +113,7 @@ inv "ERROR;[FBFeatureEnvy]":
 	endif
 
 context CFBInstance
-inv "ERROR;[CFBFeatureEnvy]":
+inv _'ERROR;[CFBFeatureEnvy]':
 	let externalConnections : Real = self.interface.inputVars.inputConnections->collect(isInterfaceConnection())->count(true)+self.interface.outputVars.outputConnections->collect(isInterfaceConnection())->count(true) in
 	let internalConnections : Real = self.interface.inputVars.inputConnections->collect(isInterfaceConnection())->count(false)+self.interface.outputVars.outputConnections->collect(isInterfaceConnection())->count(false) in
 	if externalConnections.floor() = 0 then


### PR DESCRIPTION
 - fix warnings about double quotes
 - repair subapp-invariants for TypedSubApps and UntypedSubapps

Fixes: #1850