### PR TITLE
Removed Interfacebar Border

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/EditorWithInterfaceEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/EditorWithInterfaceEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020, 2021 Profactor GmbH, TU Wien ACIN, fortiss GmbH, Johannes
+ * Copyright (c) 2008, 2026 Profactor GmbH, TU Wien ACIN, fortiss GmbH, Johannes
  *                          Kepler University Linz, Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
@@ -61,6 +61,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.libraryElement.SubAppType;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.ui.editors.AdvancedScrollingGraphicalViewer;
+import org.eclipse.fordiac.ide.ui.preferences.UIPreferenceConstants;
 import org.eclipse.gef.DragTracker;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPolicy;
@@ -70,12 +71,8 @@ import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
 import org.eclipse.gef.requests.SelectionRequest;
 import org.eclipse.swt.events.ControlListener;
-import org.eclipse.swt.graphics.Color;
 
 public abstract class EditorWithInterfaceEditPart extends AbstractFBNetworkEditPart {
-	public static final Color INTERFACE_BAR_BG_COLOR = new Color(235, 245, 255);
-	public static final Color INTERFACE_BAR_BORDER_COLOR = new Color(190, 199, 225);
-
 	private static final int TOP_BOTTOM_MARGIN = 1;
 	private static final int LEFT_RIGHT_MARGIN = 5;
 	private static final Insets RIGHT_LIST_BORDER_INSET = new Insets(TOP_BOTTOM_MARGIN, 0, TOP_BOTTOM_MARGIN,
@@ -314,8 +311,7 @@ public abstract class EditorWithInterfaceEditPart extends AbstractFBNetworkEditP
 		rootContainer.setLayoutManager(rootContLayout);
 		rootContainer.setOpaque(true);
 		rootContainer.setOutline(false);
-		rootContainer.setBackgroundColor(INTERFACE_BAR_BG_COLOR);
-		rootContainer.setBorder(new SingleLineBorder(INTERFACE_BAR_BORDER_COLOR));
+		rootContainer.setBackgroundColor(UIPreferenceConstants.getInterfaceBarColor());
 		parent.add(rootContainer, layoutConstraint);
 		return rootContainer;
 	}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/UntypedSubAppInterfaceElementEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/UntypedSubAppInterfaceElementEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 fortiss GmbH, Johannes Kepler University,
+ * Copyright (c) 2017, 2026 fortiss GmbH, Johannes Kepler University,
  *                          Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
@@ -20,7 +20,6 @@ package org.eclipse.fordiac.ide.application.editparts;
 import java.util.List;
 
 import org.eclipse.draw2d.Border;
-import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.CompoundBorder;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.GridData;
@@ -212,7 +211,8 @@ public class UntypedSubAppInterfaceElementEditPart extends InterfaceEditPartForF
 			@Override
 			protected void paintFigure(final Graphics graphics) {
 				if (!getChildren().isEmpty()) {
-					graphics.fillRoundRectangle(getBounds(), 8, 8);
+					graphics.setAlpha(150);
+					graphics.fillRectangle(getBounds());
 				}
 				super.paintFigure(graphics);
 			}
@@ -263,7 +263,7 @@ public class UntypedSubAppInterfaceElementEditPart extends InterfaceEditPartForF
 			tbLayout.verticalSpacing = 2;
 			tbLayout.horizontalSpacing = 0;
 			epFigure.setLayoutManager(tbLayout);
-			epFigure.setBackgroundColor(ColorConstants.white);
+			epFigure.setBackgroundColor(epFigure.getParent().getParent().getBackgroundColor());
 		}
 		final IFigure child = ((GraphicalEditPart) childEditPart).getFigure();
 		getContentPane().add(child, new GridData(SWT.FILL, SWT.BEGINNING, true, false), index);

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/SubAppForFbNetworkFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/SubAppForFbNetworkFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2022 Profactor GmbH, fortiss GmbH,
+ * Copyright (c) 2008, 2026 Profactor GmbH, fortiss GmbH,
  *                           Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
@@ -40,7 +40,6 @@ import org.eclipse.draw2d.ToolbarLayout;
 import org.eclipse.draw2d.Viewport;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
-import org.eclipse.fordiac.ide.application.editparts.EditorWithInterfaceEditPart;
 import org.eclipse.fordiac.ide.application.editparts.SubAppForFBNetworkEditPart;
 import org.eclipse.fordiac.ide.application.utilities.ExpandedInterfacePositionMap;
 import org.eclipse.fordiac.ide.gef.draw2d.AdvancedLineBorder;
@@ -52,6 +51,7 @@ import org.eclipse.fordiac.ide.gef.preferences.GefPreferenceConstants;
 import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
 import org.eclipse.fordiac.ide.ui.imageprovider.FordiacImage;
+import org.eclipse.fordiac.ide.ui.preferences.UIPreferenceConstants;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Display;
@@ -223,7 +223,7 @@ public class SubAppForFbNetworkFigure extends FBNetworkElementFigure {
 		};
 		interfaceBar.setMinimumSize(new Dimension(minExpandedInterfaceBarWidth, -1));
 		interfaceBar.setOutline(false);
-		interfaceBar.setBackgroundColor(EditorWithInterfaceEditPart.INTERFACE_BAR_BG_COLOR);
+		interfaceBar.setBackgroundColor(UIPreferenceConstants.getInterfaceBarColor());
 
 		interfaceBar.setLayoutManager(new ExpandedSubappInterfaceLayout(interfacePositions, isInput));
 

--- a/plugins/org.eclipse.fordiac.ide.ui/css/dark_fordiac_connections.css
+++ b/plugins/org.eclipse.fordiac.ide.ui/css/dark_fordiac_connections.css
@@ -20,4 +20,5 @@ IEclipsePreferences#org-eclipse-ui-workbench:org-eclipse-fordiac-ide-ui {
 		'org.eclipse.fordiac.ide.ui.AnyStringConnectionConnectorColor=200, 150, 110' 
 		'org.eclipse.fordiac.ide.ui.DataConnectionConnectorColor=102, 153, 255' 
 		'org.eclipse.fordiac.ide.ui.AdapterConnectionConnectorColor=132, 93, 175'
+		'org.eclipse.fordiac.ide.ui.InterfaceBarBackgroundColor=45, 65, 85'
 } 

--- a/plugins/org.eclipse.fordiac.ide.ui/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.ui/plugin.xml
@@ -186,6 +186,14 @@
              label="%FordiacPreferencePage_LABEL_DefaultAdapterConnectorColor"
              value="132, 93, 175">
        </colorDefinition>
+       <colorDefinition
+             categoryId="org.eclipse.fordiac.ide.themeCategory"
+             id="org.eclipse.fordiac.ide.ui.InterfaceBarBackgroundColor"
+             label="Interface Bar Background Color"
+             value="235, 245, 255"
+             isEditable="false"> 
+             <!-- the label does not need to be translatable --> 
+       </colorDefinition>
     </extension>
 	<extension
 		point="org.eclipse.e4.ui.css.swt.theme">

--- a/plugins/org.eclipse.fordiac.ide.ui/src/org/eclipse/fordiac/ide/ui/preferences/UIPreferenceConstants.java
+++ b/plugins/org.eclipse.fordiac.ide.ui/src/org/eclipse/fordiac/ide/ui/preferences/UIPreferenceConstants.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2009, 2011, 2015, 2017 Profactor GbmH, fortiss GmbH
- * 				 2019, 2020 Johannes Kepler University Linz
+ * Copyright (c) 2008, 2026 Profactor GbmH, fortiss GmbH,
+ *                          Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -38,6 +38,7 @@ public final class UIPreferenceConstants {
 	public static final String P_ANY_REAL_CONNECTOR_COLOR = "org.eclipse.fordiac.ide.ui.AnyRealConnectionConnectorColor"; //$NON-NLS-1$
 	public static final String P_ANY_STRING_CONNECTOR_COLOR = "org.eclipse.fordiac.ide.ui.AnyStringConnectionConnectorColor"; //$NON-NLS-1$
 	public static final String P_REMAINING_DATA_CONNECTOR_COLOR = "org.eclipse.fordiac.ide.ui.DataConnectionConnectorColor";//$NON-NLS-1$
+	private static final String P_INTERFACE_BAR_COLOR = "org.eclipse.fordiac.ide.ui.InterfaceBarBackgroundColor";//$NON-NLS-1$
 
 	/** The Constant P_ADAPTER_CONNECTOR_COLOR. */
 	public static final String P_ADAPTER_CONNECTOR_COLOR = "org.eclipse.fordiac.ide.ui.AdapterConnectionConnectorColor";//$NON-NLS-1$
@@ -114,5 +115,9 @@ public final class UIPreferenceConstants {
 
 	public static Color getAdapterConnectorColor() {
 		return JFaceResources.getColorRegistry().get(P_ADAPTER_CONNECTOR_COLOR);
+	}
+
+	public static Color getInterfaceBarColor() {
+		return JFaceResources.getColorRegistry().get(P_INTERFACE_BAR_COLOR);
 	}
 }


### PR DESCRIPTION
The border of subapp and cfb interface bars is removed. This results in a cleaner more modern look and is in line with the interface bar of expanded subapps.