### PR TITLE
Prepare replay debugging to be used with the intepreter in the GUI

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/LaunchConfigurationTab.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/LaunchConfigurationTab.java
@@ -27,6 +27,7 @@ import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.ui.AbstractLaunchConfigurationTab;
+import org.eclipse.fordiac.ide.debug.replaydebugging.LaunchConfigurationDelegate;
 import org.eclipse.fordiac.ide.deployment.debug.DeploymentLaunchConfigurationAttributes;
 import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
 import org.eclipse.fordiac.ide.model.libraryElement.Device;
@@ -72,17 +73,23 @@ import org.eclipse.ui.model.WorkbenchLabelProvider;
  */
 public class LaunchConfigurationTab extends AbstractLaunchConfigurationTab {
 
-	public static final String ATTR_TRACE_PATH = "org.eclipse.fordiac.ide.debug.replaydebugging.ATTR_TRACE_PATH"; //$NON-NLS-1$
+	private static final String TRACE_PATH_SECTION_TEXT = "Trace Path"; //$NON-NLS-1$
+	private static final String SELECT_PATH_DIALOG_TEXT = "Select trace directory"; //$NON-NLS-1$
+	private static final String BROWSE_BUTTON_TEXT = "Browse Trace Path"; //$NON-NLS-1$
 
-	private static final String ATTR_TRACE_PATH_DEFAULT = ""; //$NON-NLS-1$
+	private static final String SIMULATOR_SECTION_TEXT = "Simulator Options"; //$NON-NLS-1$
+	private static final String REMOTE_TEXT = "Remote"; //$NON-NLS-1$
 
-	private static final String SELECT_PATH_DIALOG_TEXT = "Select trace directory";
-	private static final String BROWSE_BUTTON_TEXT = "Browse Trace Path";
+	private static final String COMPONENTS_SELECTION_SECTION_TEXT = "Select Components"; //$NON-NLS-1$
+	private static final String SYSTEM_SELECTION_BUTTON_TEXT = "Browse System"; //$NON-NLS-1$
 
-	private static final String GROUP_TEXT = "Select Components";
-	private static final String SYSTEM_SELECTION_BUTTON_TEXT = "Browse System";
+	private static final String LAUNCH_CONFIGURATION_TAB_NAME = "Replay Debugging"; //$NON-NLS-1$
 
 	private Text systemText;
+	private static final String SYSTEM_TEXT_DEFAULT = ""; //$NON-NLS-1$
+
+	private Button remoteCheckbox;
+
 	private CheckboxTreeViewer selectionTree;
 
 	private Composite component;
@@ -94,12 +101,36 @@ public class LaunchConfigurationTab extends AbstractLaunchConfigurationTab {
 		component = new Composite(parent, SWT.FILL);
 		component.setLayout(new GridLayout(1, false));
 
+		createSimulatorSection();
 		createPathSelectionComponent();
 		createSelectionComponent();
 	}
 
+	private void createSimulatorSection() {
+		final Group group = new Group(component, SWT.BORDER);
+		group.setLayout(new GridLayout(1, false));
+		GridDataFactory.fillDefaults().grab(true, false).applyTo(group);
+		group.setText(SIMULATOR_SECTION_TEXT);
+
+		// Checkbox to indicate if the replay should use the remote simulator (forte)
+		remoteCheckbox = new Button(group, SWT.CHECK);
+		remoteCheckbox.setText(REMOTE_TEXT);
+		GridDataFactory.fillDefaults().grab(true, false).applyTo(remoteCheckbox);
+		remoteCheckbox.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(final SelectionEvent e) {
+				updateLaunchConfigurationDialog();
+			}
+		});
+	}
+
 	private void createPathSelectionComponent() {
-		final Composite pathSelectionComposite = new Composite(component, SWT.FILL);
+		final Group group = new Group(component, SWT.BORDER);
+		group.setLayout(new GridLayout(1, false));
+		GridDataFactory.fillDefaults().grab(true, false).applyTo(group);
+		group.setText(TRACE_PATH_SECTION_TEXT);
+
+		final Composite pathSelectionComposite = new Composite(group, SWT.FILL);
 		pathSelectionComposite.setLayout(new GridLayout(3, false));
 		GridDataFactory.fillDefaults().grab(true, false).applyTo(pathSelectionComposite);
 
@@ -126,7 +157,7 @@ public class LaunchConfigurationTab extends AbstractLaunchConfigurationTab {
 		final Group group = new Group(component, SWT.BORDER);
 		group.setLayout(new GridLayout(1, false));
 		GridDataFactory.fillDefaults().grab(true, true).applyTo(group);
-		group.setText(GROUP_TEXT);
+		group.setText(COMPONENTS_SELECTION_SECTION_TEXT);
 
 		final Composite sytemSelectionComposite = new Composite(group, SWT.NONE);
 		sytemSelectionComposite.setLayout(new GridLayout(2, false));
@@ -152,38 +183,46 @@ public class LaunchConfigurationTab extends AbstractLaunchConfigurationTab {
 
 	@Override
 	public void setDefaults(final ILaunchConfigurationWorkingCopy configuration) {
-		configuration.setAttribute(ATTR_TRACE_PATH, ATTR_TRACE_PATH_DEFAULT);
+		configuration.setAttribute(LaunchConfigurationDelegate.ATTR_TRACE_PATH,
+				LaunchConfigurationDelegate.ATTR_TRACE_PATH_DEFAULT);
 		configuration.removeAttribute(DeploymentLaunchConfigurationAttributes.SYSTEM);
 		configuration.removeAttribute(DeploymentLaunchConfigurationAttributes.SELECTION);
+		configuration.setAttribute(LaunchConfigurationDelegate.ATTR_REMOTE,
+				LaunchConfigurationDelegate.ATTR_REMOTE_DEFAULT);
 	}
 
 	@Override
 	public void initializeFrom(final ILaunchConfiguration configuration) {
 		try {
-			tracerPathText.setText(configuration.getAttribute(ATTR_TRACE_PATH, ATTR_TRACE_PATH_DEFAULT));
-			systemText.setText(configuration.getAttribute(DeploymentLaunchConfigurationAttributes.SYSTEM, "")); //$NON-NLS-1$
+			tracerPathText.setText(configuration.getAttribute(LaunchConfigurationDelegate.ATTR_TRACE_PATH,
+					LaunchConfigurationDelegate.ATTR_TRACE_PATH_DEFAULT));
+			systemText.setText(
+					configuration.getAttribute(DeploymentLaunchConfigurationAttributes.SYSTEM, SYSTEM_TEXT_DEFAULT));
+			remoteCheckbox.setSelection(configuration.getAttribute(LaunchConfigurationDelegate.ATTR_REMOTE,
+					LaunchConfigurationDelegate.ATTR_REMOTE_DEFAULT));
 			final AutomationSystem system = DeploymentLaunchConfigurationAttributes.getSystem(configuration);
 			selectionTree.setInput(system);
 			selectionTree.setCheckedElements(
 					DeploymentLaunchConfigurationAttributes.getSelection(configuration, system).toArray());
 		} catch (final CoreException e) {
-			systemText.setText(""); //$NON-NLS-1$
+			systemText.setText(SYSTEM_TEXT_DEFAULT);
 		}
 	}
 
 	@Override
 	public void performApply(final ILaunchConfigurationWorkingCopy configuration) {
-		configuration.setAttribute(ATTR_TRACE_PATH, tracerPathText.getText());
+		configuration.setAttribute(LaunchConfigurationDelegate.ATTR_TRACE_PATH, tracerPathText.getText());
 		configuration.setAttribute(DeploymentLaunchConfigurationAttributes.SYSTEM, systemText.getText());
 		configuration.setAttribute(DeploymentLaunchConfigurationAttributes.SELECTION,
 				Stream.of(selectionTree.getCheckedElements()).filter(INamedElement.class::isInstance)
 						.map(INamedElement.class::cast).map(INamedElement::getQualifiedName)
 						.collect(Collectors.toSet()));
+		configuration.setAttribute(LaunchConfigurationDelegate.ATTR_REMOTE, remoteCheckbox.getSelection());
 	}
 
 	@Override
 	public String getName() {
-		return "Replay Debugging";
+		return LAUNCH_CONFIGURATION_TAB_NAME;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/ReplayDebuggingView.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/ReplayDebuggingView.java
@@ -16,9 +16,9 @@ package org.eclipse.fordiac.ide.debug.replaydebugging.ui;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.fordiac.ide.debug.replaydebugging.IReplayNavigatorRegistrationListener;
-import org.eclipse.fordiac.ide.debug.replaydebugging.ReplayNavigator;
-import org.eclipse.fordiac.ide.debug.replaydebugging.ReplayNavigatorManager;
+import org.eclipse.fordiac.ide.debug.replaydebugging.core.IReplayNavigatorRegistrationListener;
+import org.eclipse.fordiac.ide.debug.replaydebugging.core.ReplayNavigator;
+import org.eclipse.fordiac.ide.debug.replaydebugging.core.ReplayNavigatorManager;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.layout.GridData;

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/TimelineWidget.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/TimelineWidget.java
@@ -16,7 +16,7 @@ package org.eclipse.fordiac.ide.debug.replaydebugging.ui;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.fordiac.ide.debug.replaydebugging.ReplayNavigator;
+import org.eclipse.fordiac.ide.debug.replaydebugging.core.ReplayNavigator;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.KeyAdapter;
 import org.eclipse.swt.events.KeyEvent;

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/META-INF/MANIFEST.MF
@@ -17,4 +17,5 @@ Require-Bundle: org.eclipse.debug.core,
  org.eclipse.fordiac.ide.deployment,
  org.eclipse.fordiac.ide.model.eval,
  org.eclipse.fordiac.ide.ui,
- org.eclipse.tracecompass.ctf.core;bundle-version="5.0.0"
+ org.eclipse.tracecompass.ctf.core;bundle-version="5.0.0",
+ org.eclipse.fordiac.ide.fb.interpreter

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/META-INF/MANIFEST.MF
@@ -15,4 +15,5 @@ Require-Bundle: org.eclipse.debug.core,
  org.eclipse.core.runtime,
  org.eclipse.fordiac.ide.deployment,
  org.eclipse.fordiac.ide.model.eval,
- org.eclipse.fordiac.ide.ui
+ org.eclipse.fordiac.ide.ui,
+ org.eclipse.tracecompass.ctf.core;bundle-version="5.0.0"

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Bundle-Version: 3.0.100.qualifier
 Automatic-Module-Name: org.eclipse.fordiac.ide.debug.replaydebugging
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Export-Package: org.eclipse.fordiac.ide.debug.replaydebugging
+Export-Package: org.eclipse.fordiac.ide.debug.replaydebugging,
+ org.eclipse.fordiac.ide.debug.replaydebugging.core
 Require-Bundle: org.eclipse.debug.core,
  org.eclipse.equinox.common,
  org.eclipse.fordiac.ide.deployment.debug,

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/debug/replaydebugging/trace/SendOutputEvent.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/debug/replaydebugging/trace/SendOutputEvent.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Jose Cabral
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Jose Cabral
+ *     - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+package org.eclipse.fordiac.debug.replaydebugging.trace;
+
+import java.util.List;
+
+/**
+ * @brief Representation of a sendOutputEvent in the trace.
+ *
+ *        This record stores the type name, instance name, event ID, event
+ *        counter, and a list of outputs associated with the event.
+ */
+public final record SendOutputEvent(String typeName, String instanceName, int eventId, int eventCounter,
+		List<String> outputs) {
+
+	// for debugging purposes
+	@Override
+	public String toString() {
+		return "SendOutputEvent{" + "typeName='" + typeName + '\'' + ", instanceName='" + instanceName + '\''
+				+ ", eventId=" + eventId + ", eventCounter=" + eventCounter + ", outputs=" + outputs + '}';
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/debug/replaydebugging/trace/TracesReader.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/debug/replaydebugging/trace/TracesReader.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Jose Cabral
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Jose Cabral
+ *     - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+package org.eclipse.fordiac.debug.replaydebugging.trace;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.tracecompass.ctf.core.CTFException;
+import org.eclipse.tracecompass.ctf.core.event.IEventDefinition;
+import org.eclipse.tracecompass.ctf.core.event.types.AbstractArrayDefinition;
+import org.eclipse.tracecompass.ctf.core.event.types.ICompositeDefinition;
+import org.eclipse.tracecompass.ctf.core.event.types.IntegerDefinition;
+import org.eclipse.tracecompass.ctf.core.event.types.StringDefinition;
+import org.eclipse.tracecompass.ctf.core.trace.CTFTrace;
+import org.eclipse.tracecompass.ctf.core.trace.CTFTraceReader;
+
+public class TracesReader {
+
+	private final File path;
+
+	// Pattern to match trace filenames, e.g.,
+	// "trace_myResource_20240101_123456789.ctf"
+	private static final Pattern FILENAME_PATTERN = Pattern.compile("^trace_(.+)_\\d{8}_\\d{9}\\.ctf$"); //$NON-NLS-1$
+	private static final String TYPENAME_FIELD = "typeName"; // Field for type name //$NON-NLS-1$
+	private static final String INSTANCENAME_FIELD = "instanceName"; // Field for instance name //$NON-NLS-1$
+	private static final String EVENTID_FIELD = "eventId"; // Field for event ID //$NON-NLS-1$
+	private static final String EVENTCOUNTER_FIELD = "eventCounter"; // Field for event counter //$NON-NLS-1$
+	private static final String OUTPUTS_FIELD = "outputs"; // Field for outputs //$NON-NLS-1$
+	private static final String SEND_OUTPUT_EVENT = "sendOutputEvent"; // Event type name //$NON-NLS-1$
+
+	public TracesReader(final String path) {
+		this.path = new File(path); // Folder containing `metadata` + trace files
+	}
+
+	/**
+	 * Reads the trace files in the specified path and returns a map of resource
+	 * names to lists of SendOutputEvent objects.
+	 *
+	 * @return A map where keys are resource names and values are lists of
+	 *         SendOutputEvent objects.
+	 * @throws CTFException If there is an error reading the trace files.
+	 */
+	public Map<String, List<SendOutputEvent>> read() throws CTFException {
+
+		final Map<String, List<SendOutputEvent>> events = new java.util.HashMap<>();
+		final CTFTrace trace = new CTFTrace(path.getAbsolutePath());
+		try (final CTFTraceReader reader = new CTFTraceReader(trace)) {
+			while (reader.hasMoreEvents()) {
+				final IEventDefinition event = reader.getCurrentEventDef();
+				final String resourceName = getResourceName(reader.getTopStream().getFilename());
+				final List<SendOutputEvent> resourceEvents = events.computeIfAbsent(resourceName,
+						k -> new java.util.ArrayList<>());
+
+				reader.advance();
+
+				final String eventType = event.getDeclaration().getName();
+				if (!eventType.equals(SEND_OUTPUT_EVENT)) {
+					continue; // Skip events that are not sendOutputEvent
+				}
+
+				final ICompositeDefinition fields = event.getFields();
+
+				resourceEvents
+						.add(new SendOutputEvent(((StringDefinition) fields.getDefinition(TYPENAME_FIELD)).getValue(),
+								((StringDefinition) fields.getDefinition(INSTANCENAME_FIELD)).getValue(),
+								(int) ((IntegerDefinition) fields.getDefinition(EVENTID_FIELD)).getValue(),
+								(int) ((IntegerDefinition) fields.getDefinition(EVENTCOUNTER_FIELD)).getValue(),
+								((AbstractArrayDefinition) fields.getDefinition(OUTPUTS_FIELD)).getDefinitions()
+										.stream().map(StringDefinition.class::cast).map(StringDefinition::getValue)
+										.toList()));
+			}
+		}
+		return events;
+	}
+
+	private static String getResourceName(final String fileName) throws CTFException {
+		final Matcher match = FILENAME_PATTERN.matcher(fileName);
+
+		if (!match.find()) {
+			throw new CTFException("Filename does not match expected pattern: " + fileName); //$NON-NLS-1$
+		}
+		return match.group(1);
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/LaunchConfigurationDelegate.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/LaunchConfigurationDelegate.java
@@ -34,6 +34,10 @@ import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 public class LaunchConfigurationDelegate implements ILaunchConfigurationDelegate {
 
 	public static final String ATTR_TRACE_PATH = "org.eclipse.fordiac.ide.debug.replaydebugging.ATTR_TRACE_PATH"; //$NON-NLS-1$
+	public static final String ATTR_TRACE_PATH_DEFAULT = ""; //$NON-NLS-1$
+
+	public static final String ATTR_REMOTE = "org.eclipse.fordiac.ide.debug.replaydebugging.ATTR_REMOTE"; //$NON-NLS-1$
+	public static final boolean ATTR_REMOTE_DEFAULT = false;
 
 	@Override
 	public void launch(final ILaunchConfiguration configuration, final String mode, final ILaunch launch,
@@ -45,7 +49,7 @@ public class LaunchConfigurationDelegate implements ILaunchConfigurationDelegate
 			// To be able to handle several devices, this must be a list of paths, but also
 			// matched to the
 			// respective device
-			final String path = configuration.getAttribute(ATTR_TRACE_PATH, ""); //$NON-NLS-1$
+			final String path = configuration.getAttribute(ATTR_TRACE_PATH, ATTR_TRACE_PATH_DEFAULT);
 
 			final AutomationSystem system = DeploymentLaunchConfigurationAttributes.getSystem(configuration);
 			if (system == null) {
@@ -54,7 +58,10 @@ public class LaunchConfigurationDelegate implements ILaunchConfigurationDelegate
 			final Set<INamedElement> selection = DeploymentLaunchConfigurationAttributes.getSelection(configuration,
 					system);
 
-			final ReplayDebuggingTarget debugTarget = new ReplayDebuggingTarget(system, selection, launch, true, path);
+			final boolean remote = configuration.getAttribute(ATTR_REMOTE, ATTR_REMOTE_DEFAULT);
+
+			final ReplayDebuggingTarget debugTarget = new ReplayDebuggingTarget(system, selection, launch, true, path,
+					remote);
 			debugTarget.start();
 
 		} catch (final Exception e) {

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/ReplayDebuggingDevice.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/ReplayDebuggingDevice.java
@@ -27,7 +27,6 @@ import org.eclipse.fordiac.ide.debug.replaydebugging.core.DataPointChange;
 import org.eclipse.fordiac.ide.debug.replaydebugging.core.EventChange;
 import org.eclipse.fordiac.ide.debug.replaydebugging.core.ReplayNavigator;
 import org.eclipse.fordiac.ide.debug.replaydebugging.simulator.IDeviceSimulator;
-import org.eclipse.fordiac.ide.debug.replaydebugging.simulator.forte.DeviceSimulator;
 import org.eclipse.fordiac.ide.debug.replaydebugging.watch.WatchFactoryReplay;
 import org.eclipse.fordiac.ide.deployment.debug.DeploymentDebugDevice;
 import org.eclipse.fordiac.ide.deployment.debug.DeploymentDebugTarget;
@@ -65,10 +64,13 @@ public class ReplayDebuggingDevice extends DeploymentDebugDevice implements Repl
 	// they are shown with a different color
 	private final Map<String, IWatch> watches = new ConcurrentSkipListMap<>();
 
-	public ReplayDebuggingDevice(final Device device, final DeploymentDebugTarget debugTarget,
-			final String tracesPath) {
+	private final boolean remote;
+
+	public ReplayDebuggingDevice(final Device device, final DeploymentDebugTarget debugTarget, final String tracesPath,
+			final boolean remote) {
 		super(device, debugTarget, true, Duration.ZERO, List.of());
 		this.tracesPath = tracesPath;
+		this.remote = remote;
 	}
 
 	/**
@@ -100,7 +102,12 @@ public class ReplayDebuggingDevice extends DeploymentDebugDevice implements Repl
 	}
 
 	private IDeviceSimulator createSimulator() {
-		return new DeviceSimulator(getDeviceManagementExecutorService(), getDevice(), tracesPath);
+		if (remote) {
+			return new org.eclipse.fordiac.ide.debug.replaydebugging.simulator.forte.DeviceSimulator(
+					getDeviceManagementExecutorService(), getDevice(), tracesPath);
+		}
+		return new org.eclipse.fordiac.ide.debug.replaydebugging.simulator.interpreter.DeviceSimulator(getDevice(),
+				tracesPath);
 	}
 
 	// set the watches of the current changes to error so they are marked with a

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/ReplayDebuggingDevice.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/ReplayDebuggingDevice.java
@@ -23,6 +23,9 @@ import java.util.concurrent.ConcurrentSkipListMap;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.DebugException;
+import org.eclipse.fordiac.ide.debug.replaydebugging.core.DataPointChange;
+import org.eclipse.fordiac.ide.debug.replaydebugging.core.EventChange;
+import org.eclipse.fordiac.ide.debug.replaydebugging.core.ReplayNavigator;
 import org.eclipse.fordiac.ide.debug.replaydebugging.simulator.IDeviceSimulator;
 import org.eclipse.fordiac.ide.debug.replaydebugging.simulator.forte.DeviceSimulator;
 import org.eclipse.fordiac.ide.debug.replaydebugging.watch.WatchFactoryReplay;

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/ReplayDebuggingDevice.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/ReplayDebuggingDevice.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.debug.replaydebugging;
 
-import java.text.MessageFormat;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -20,23 +19,21 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListMap;
 
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.debug.core.DebugException;
+import org.eclipse.fordiac.ide.debug.replaydebugging.simulator.IDeviceSimulator;
+import org.eclipse.fordiac.ide.debug.replaydebugging.simulator.forte.DeviceSimulator;
 import org.eclipse.fordiac.ide.debug.replaydebugging.watch.WatchFactoryReplay;
 import org.eclipse.fordiac.ide.deployment.debug.DeploymentDebugDevice;
 import org.eclipse.fordiac.ide.deployment.debug.DeploymentDebugTarget;
 import org.eclipse.fordiac.ide.deployment.debug.DeploymentLaunchConfigurationAttributes.DeploymentLaunchWatchpoint;
-import org.eclipse.fordiac.ide.deployment.debug.Messages;
 import org.eclipse.fordiac.ide.deployment.debug.breakpoint.DeploymentWatchpoint;
 import org.eclipse.fordiac.ide.deployment.debug.watch.DeploymentDebugWatchData;
 import org.eclipse.fordiac.ide.deployment.debug.watch.IWatch;
 import org.eclipse.fordiac.ide.deployment.devResponse.DevResponseFactory;
 import org.eclipse.fordiac.ide.deployment.devResponse.Response;
-import org.eclipse.fordiac.ide.deployment.exceptions.DeploymentException;
 import org.eclipse.fordiac.ide.model.libraryElement.Device;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.Resource;
@@ -81,31 +78,26 @@ public class ReplayDebuggingDevice extends DeploymentDebugDevice implements Repl
 	 */
 	@Override
 	public void connect() throws DebugException {
-		try {
-			final Device device = getDevice();
-			getDeviceManagementExecutorService().connect();
-			getDeviceManagementExecutorService().readTraces(device, tracesPath);
 
-			final Map<String, Set<String>> allPortsByResource = Utils.collectAllPorts(device);
+		final IDeviceSimulator simulator = createSimulator();
+		simulator.start();
+		response.setWatches(DevResponseFactory.eINSTANCE.createWatches());
 
-			response.setWatches(DevResponseFactory.eINSTANCE.createWatches());
-
-			for (final Resource resource : device.getResource()) {
-				final ReplayDebuggingResource replayDebuggingResource = new ReplayDebuggingResource(resource,
-						allPortsByResource.get(resource.getName()),
-						new ReplayNavigator.Identifier(device.getAutomationSystem().getName(), device.getName(),
-								resource.getName()),
-						getDeviceManagementExecutorService(), this);
-				replayDebuggingResource.load();
-				replayDebuggingResources.add(replayDebuggingResource);
-				response.getWatches().getResources().add(replayDebuggingResource.getResourceResponse());
-			}
-
-			getDeviceManagementExecutorService().disconnect();
-		} catch (final DeploymentException e) {
-			throw new DebugException(Status.error(
-					MessageFormat.format(Messages.DeploymentDebugDevice_ConnectError, getDevice().getName()), e));
+		final Device device = getDevice();
+		for (final Resource resource : device.getResource()) {
+			final ReplayDebuggingResource replayDebuggingResource = new ReplayDebuggingResource(resource,
+					new ReplayNavigator.Identifier(device.getAutomationSystem().getName(), device.getName(),
+							resource.getName()),
+					simulator, this);
+			replayDebuggingResource.load();
+			replayDebuggingResources.add(replayDebuggingResource);
+			response.getWatches().getResources().add(replayDebuggingResource.getResourceResponse());
 		}
+		simulator.stop();
+	}
+
+	private IDeviceSimulator createSimulator() {
+		return new DeviceSimulator(getDeviceManagementExecutorService(), getDevice(), tracesPath);
 	}
 
 	// set the watches of the current changes to error so they are marked with a

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/ReplayDebuggingResource.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/ReplayDebuggingResource.java
@@ -199,7 +199,6 @@ public class ReplayDebuggingResource implements ReplayNavigator.StateListener {
 
 			String toLog = "\nEvent triggered " + lastEvent.get() + " with the following data changes:";
 			for (final DataPointChange change : dataPointChanges) {
-				FordiacLogHelper.logInfo("  " + change.datapoint() + ": " + change.newValue()); //$NON-NLS-1$ //$NON-NLS-2$
 				toLog += "  " + change.datapoint() + ": " + change.newValue();
 			}
 

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/ReplayDebuggingResource.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/ReplayDebuggingResource.java
@@ -19,6 +19,10 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.eclipse.emf.common.util.EList;
+import org.eclipse.fordiac.ide.debug.replaydebugging.core.DataPointChange;
+import org.eclipse.fordiac.ide.debug.replaydebugging.core.EventChange;
+import org.eclipse.fordiac.ide.debug.replaydebugging.core.ReplayNavigator;
+import org.eclipse.fordiac.ide.debug.replaydebugging.core.ReplayNavigatorManager;
 import org.eclipse.fordiac.ide.debug.replaydebugging.simulator.IDeviceSimulator;
 import org.eclipse.fordiac.ide.deployment.devResponse.DevResponseFactory;
 import org.eclipse.fordiac.ide.deployment.exceptions.DeploymentException;

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/ReplayDebuggingResource.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/ReplayDebuggingResource.java
@@ -17,15 +17,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.eclipse.emf.common.util.EList;
-import org.eclipse.fordiac.ide.deployment.debug.watch.DeploymentDebugWatchData;
-import org.eclipse.fordiac.ide.deployment.devResponse.Data;
+import org.eclipse.fordiac.ide.debug.replaydebugging.simulator.IDeviceSimulator;
 import org.eclipse.fordiac.ide.deployment.devResponse.DevResponseFactory;
 import org.eclipse.fordiac.ide.deployment.exceptions.DeploymentException;
-import org.eclipse.fordiac.ide.deployment.interactors.IDeviceManagementExecutorService;
 import org.eclipse.fordiac.ide.model.libraryElement.Resource;
 import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 
@@ -51,14 +47,11 @@ public class ReplayDebuggingResource implements ReplayNavigator.StateListener {
 
 	private final ReplayNavigator.Identifier replayNavigatorIdentifier;
 
-	private final IDeviceManagementExecutorService deviceManagementExecutorService;
-
 	private final Resource resource;
 
-	// port names beloging to the resource
-	private final Set<String> portNames;
-
 	private final UpdateListener updateListener;
+
+	private final IDeviceSimulator simulator;
 
 	// response data for the resources being replayed
 	org.eclipse.fordiac.ide.deployment.devResponse.Resource resourceResponse = DevResponseFactory.eINSTANCE
@@ -68,15 +61,12 @@ public class ReplayDebuggingResource implements ReplayNavigator.StateListener {
 	// in the response
 	private final Map<String, org.eclipse.fordiac.ide.deployment.devResponse.Data> dataValues = new HashMap<>();
 
-	public ReplayDebuggingResource(final Resource resource, final Set<String> portNames,
-			final ReplayNavigator.Identifier reaplayNavigatorIdentifier,
-			final IDeviceManagementExecutorService deviceManagementExecutorService,
-			final UpdateListener updateListener) {
+	public ReplayDebuggingResource(final Resource resource, final ReplayNavigator.Identifier reaplayNavigatorIdentifier,
+			final IDeviceSimulator simulator, final UpdateListener updateListener) {
 		this.replayNavigatorIdentifier = reaplayNavigatorIdentifier;
-		this.deviceManagementExecutorService = deviceManagementExecutorService;
 		this.resource = resource;
-		this.portNames = portNames;
 		this.updateListener = updateListener;
+		this.simulator = simulator;
 	}
 
 	public org.eclipse.fordiac.ide.deployment.devResponse.Resource getResourceResponse() {
@@ -87,7 +77,7 @@ public class ReplayDebuggingResource implements ReplayNavigator.StateListener {
 		return replayNavigator.getCurrentEventChange();
 	}
 
-	public void load() throws DeploymentException {
+	public void load() {
 		createReplayNavigator();
 	}
 
@@ -96,17 +86,8 @@ public class ReplayDebuggingResource implements ReplayNavigator.StateListener {
 		ReplayNavigatorManager.getDefault().unregisterNavigator(replayNavigator);
 	}
 
-	private void createReplayNavigator() throws DeploymentException {
-		for (final String portName : portNames) {
-			deviceManagementExecutorService.addWatch(resource, portName);
-		}
-
-		// Read initial state
-		DeploymentDebugWatchData watchData;
-		watchData = new DeploymentDebugWatchData(deviceManagementExecutorService.readWatches());
-
-		final ReplayNavigator.DatapointsState initialState = new ReplayNavigator.DatapointsState();
-		initialState.putAll(getWatchData(watchData, resource, portNames));
+	private void createReplayNavigator() {
+		final ReplayNavigator.DatapointsState initialState = simulator.getCurrentState(resource);
 
 		createResourceResponse(initialState);
 
@@ -114,28 +95,6 @@ public class ReplayDebuggingResource implements ReplayNavigator.StateListener {
 		replayNavigator = new ReplayNavigator(replayNavigatorIdentifier, initialState, eventChanges);
 		replayNavigator.addStateChangeListener(this);
 		ReplayNavigatorManager.getDefault().registerNavigator(replayNavigator);
-	}
-
-	/**
-	 * @brief It reads the data from a watchData response from the device
-	 *        (DeploymentDebugWatchData), gets the values of all datapoints in
-	 *        portNames and stores it in a map for the replay navigator.
-	 *
-	 * @return a map with the port names as keys and their values as values.
-	 */
-	private HashMap<String, String> getWatchData(final DeploymentDebugWatchData data, final Resource resource,
-			final Set<String> portNames) {
-		final HashMap<String, String> result = new HashMap<>();
-		for (final String portName : portNames) {
-			final Data portData = data.getLastData(resource, portName);
-			if (portData == null) {
-				// if there is no data for this port, we just skip it
-				// this means that the forte device could not add the watch
-				continue;
-			}
-			result.put(portName, portData.getValue());
-		}
-		return result;
 	}
 
 	/**
@@ -209,23 +168,21 @@ public class ReplayDebuggingResource implements ReplayNavigator.StateListener {
 	 *
 	 * @throws DeploymentException If an error occurs during the replay of events.
 	 */
-	private List<EventChange> iterateOverAllEvents(final ReplayNavigator.DatapointsState initialState)
-			throws DeploymentException {
+	private List<EventChange> iterateOverAllEvents(final ReplayNavigator.DatapointsState initialState) {
 		// simulate all events and gather all data
 		int eventCounter = 0;
 		final List<EventChange> eventChanges = new ArrayList<>();
 		Map<String, String> previousState = new HashMap<>(initialState);
 
-		for (Optional<String> lastEvent = deviceManagementExecutorService.replayNextEvent(resource); lastEvent
-				.isPresent(); lastEvent = deviceManagementExecutorService.replayNextEvent(resource)) {
-			final DeploymentDebugWatchData watchData = new DeploymentDebugWatchData(
-					deviceManagementExecutorService.readWatches());
-			final Map<String, String> currentState = getWatchData(watchData, resource,
-					initialState.keySet().stream().collect(Collectors.toSet()));
+		for (Optional<String> lastEvent = simulator.replayNextEvent(resource); lastEvent
+				.isPresent(); lastEvent = simulator.replayNextEvent(resource)) {
+
+			final Map<String, String> currentState = simulator.getCurrentState(resource);
 
 			// Process the value
 			final List<DataPointChange> dataPointChanges = new ArrayList<>();
 			for (final Map.Entry<String, String> entry : currentState.entrySet()) {
+//				System.out.println(entry.getKey() + " : " + entry.getValue());
 				final String key = entry.getKey();
 				final String currentStateValue = entry.getValue();
 				if (!previousState.get(key).equals(currentStateValue)) {
@@ -236,10 +193,13 @@ public class ReplayDebuggingResource implements ReplayNavigator.StateListener {
 			eventChanges.add(new EventChange(eventCounter, lastEvent.get(), dataPointChanges));
 			previousState = new HashMap<>(currentState);
 
-			FordiacLogHelper.logInfo("\nEvent triggered " + lastEvent.get() + " with the following data changes:");
+			String toLog = "\nEvent triggered " + lastEvent.get() + " with the following data changes:";
 			for (final DataPointChange change : dataPointChanges) {
 				FordiacLogHelper.logInfo("  " + change.datapoint() + ": " + change.newValue()); //$NON-NLS-1$ //$NON-NLS-2$
+				toLog += "  " + change.datapoint() + ": " + change.newValue();
 			}
+
+			FordiacLogHelper.logInfo(toLog);
 
 		}
 		return eventChanges;

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/ReplayDebuggingTarget.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/ReplayDebuggingTarget.java
@@ -36,11 +36,14 @@ import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 public class ReplayDebuggingTarget extends DeploymentDebugTarget {
 
 	private final Map<String, String> deviceNameToPath = new HashMap<>();
+	private final boolean remote;
 
 	public ReplayDebuggingTarget(final AutomationSystem system, final Set<INamedElement> selection,
-			final ILaunch launch, final boolean allowTerminate, final String tracesPath) throws DeploymentException {
-		super(system, selection, launch, allowTerminate, Duration.ofSeconds(30), List.of());
-
+			final ILaunch launch, final boolean allowTerminate, final String tracesPath, final boolean remote)
+			throws DeploymentException {
+		// pass empty list to deploy if not remote, as we do not want to deploy
+		super(system, remote ? selection : Set.of(), launch, allowTerminate, Duration.ofSeconds(30), List.of());
+		this.remote = remote;
 		for (final INamedElement element : selection) {
 			if (element instanceof final Device device) {
 				this.deviceNameToPath.put(device.getName(), tracesPath);
@@ -51,7 +54,7 @@ public class ReplayDebuggingTarget extends DeploymentDebugTarget {
 	@Override
 	protected void doConnect(final Device device) throws DebugException {
 		final ReplayDebuggingDevice replayDebuggingDevice = new ReplayDebuggingDevice(device, this,
-				deviceNameToPath.get(device.getName()));
+				deviceNameToPath.get(device.getName()), remote);
 
 		replayDebuggingDevice.connect();
 	}

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/core/DataPointChange.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/core/DataPointChange.java
@@ -11,7 +11,7 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-package org.eclipse.fordiac.ide.debug.replaydebugging;
+package org.eclipse.fordiac.ide.debug.replaydebugging.core;
 
 /**
  * @brief Representation of a change of a data point (event/variables,

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/core/EventChange.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/core/EventChange.java
@@ -11,7 +11,7 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-package org.eclipse.fordiac.ide.debug.replaydebugging;
+package org.eclipse.fordiac.ide.debug.replaydebugging.core;
 
 import java.util.List;
 

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/core/IReplayNavigatorRegistrationListener.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/core/IReplayNavigatorRegistrationListener.java
@@ -11,7 +11,7 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-package org.eclipse.fordiac.ide.debug.replaydebugging;
+package org.eclipse.fordiac.ide.debug.replaydebugging.core;
 
 public interface IReplayNavigatorRegistrationListener {
 

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/core/ReplayNavigator.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/core/ReplayNavigator.java
@@ -11,7 +11,7 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-package org.eclipse.fordiac.ide.debug.replaydebugging;
+package org.eclipse.fordiac.ide.debug.replaydebugging.core;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/core/ReplayNavigatorManager.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/core/ReplayNavigatorManager.java
@@ -11,7 +11,7 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-package org.eclipse.fordiac.ide.debug.replaydebugging;
+package org.eclipse.fordiac.ide.debug.replaydebugging.core;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/core/Utils.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/core/Utils.java
@@ -11,7 +11,7 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-package org.eclipse.fordiac.ide.debug.replaydebugging;
+package org.eclipse.fordiac.ide.debug.replaydebugging.core;
 
 import java.util.HashMap;
 import java.util.HashSet;

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/core/Utils.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/core/Utils.java
@@ -164,9 +164,9 @@ public class Utils {
 		final TreeIterator<EObject> it = network.eAllContents();
 		while (it.hasNext()) {
 			final EObject obj = it.next();
-			if (obj instanceof final IInterfaceElement varDecl) {
+			if (obj instanceof final IInterfaceElement varDecl
+					&& !(varDecl.getBlockFBNetworkElement() instanceof SubAppImpl)) {
 				result.get(varDecl.getBlockFBNetworkElement().getResource().getName()).add(varDecl);
-
 			}
 		}
 

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/core/Utils.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/core/Utils.java
@@ -18,14 +18,18 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.eclipse.fordiac.ide.model.libraryElement.Application;
+import org.eclipse.emf.common.util.TreeIterator;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.fordiac.ide.model.libraryElement.CFBInstance;
 import org.eclipse.fordiac.ide.model.libraryElement.Device;
-import org.eclipse.fordiac.ide.model.libraryElement.Event;
+import org.eclipse.fordiac.ide.model.libraryElement.FB;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
-import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
-import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.FBType;
+import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.Resource;
-import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.libraryElement.ServiceInterfaceFBType;
+import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
 import org.eclipse.fordiac.ide.model.libraryElement.impl.CFBInstanceImpl;
 import org.eclipse.fordiac.ide.model.libraryElement.impl.SubAppImpl;
 
@@ -33,6 +37,8 @@ public class Utils {
 
 	private Utils() {
 	}
+
+	private static final Set<String> SIFB_IN_FORTE_NOT_IN_IDE = Set.of("E_CYCLE");
 
 	/**
 	 * Collects all ports from the device and its resources, applications, and
@@ -42,67 +48,141 @@ public class Utils {
 	 * @return a map where keys are resource names and values are sets of port names
 	 *         (qualified names)
 	 */
-	public static Map<String, Set<String>> collectAllPorts(final Device device) {
-		final Map<String, Set<String>> result = new HashMap<>();
+	public static Map<String, Set<String>> collectAllValueHolders(final Device device) {
+		return transformToNames(collectAllValueHolderElements(device));
+	}
+
+	public static Map<String, Set<IInterfaceElement>> collectAllValueHolderElements(final Device device) {
+		final Map<String, Set<IInterfaceElement>> result = new HashMap<>();
 		for (final Resource resource : device.getResource()) {
 			result.put(resource.getName(), new HashSet<>());
-			collectAllPorts(resource, result);
-		}
-		for (final Application application : device.getAutomationSystem().getApplication()) {
-			collectAllPorts(application, result);
+			collectAllValueHolderElements(resource, result);
 		}
 
 		return result;
 	}
 
-	private static void collectAllPorts(final Resource resource, final Map<String, Set<String>> result) {
-		collectAllPorts(resource.getFBNetwork(), result);
+	public static Map<String, Set<String>> transformToNames(final Map<String, Set<IInterfaceElement>> elements) {
+		final Map<String, Set<String>> result = new HashMap<>();
+		for (final var entry : elements.entrySet()) {
+			final Set<String> names = new HashSet<>();
+			for (final IInterfaceElement interfaceElement : entry.getValue()) {
+				names.add(getWatchName(interfaceElement));
+			}
+			result.put(entry.getKey(), names);
+		}
+		return result;
 	}
 
-	private static void collectAllPorts(final Application application, final Map<String, Set<String>> result) {
-		collectAllPorts(application.getFBNetwork(), result);
+	public static String getWatchName(final IInterfaceElement interfaceElement) {
+		final String deviceName = interfaceElement.getBlockFBNetworkElement().getResource().getDevice().getName();
+		final String resourceName = interfaceElement.getBlockFBNetworkElement().getResource().getName();
+		final String prefix = deviceName + "." + resourceName + ".";
+		final String toAdd = interfaceElement.getQualifiedName();
+		if (toAdd.startsWith(prefix)) {
+			return toAdd.substring(prefix.length()); // remove the prefix if present
+		}
+		return toAdd;
 	}
 
-	private static void collectAllPorts(final FBNetwork network, final Map<String, Set<String>> result) {
+	public static boolean isSIFB(final FBType fbType) {
+		if (SIFB_IN_FORTE_NOT_IN_IDE.contains(fbType.getName())) {
+			return true;
+		}
+
+		return (fbType instanceof ServiceInterfaceFBType);
+	}
+
+	// returns the instance and its parent.
+	public static FB getInstanceFB(final Resource resource, final String fbName) {
+
+		// look in the resource first
+		final FB fb = resource.getFBNetwork().getFBNamed(fbName);
+		if (fb != null) {
+			return fb;
+		}
+		// then look in the applications
+		if (!fbName.contains(".")) { //$NON-NLS-1$
+			return null; // no point in looking further if there is no dot
+		}
+
+		final var prefix = fbName.substring(0, fbName.indexOf('.'));
+
+		// check if the prefix is an application
+		final var application = resource.getAutomationSystem().getApplication().stream()
+				.filter(app -> app.getName().equals(prefix)).findFirst();
+		if (!application.isPresent()) {
+			System.err.println("Application name " + prefix + " does not exist"); //$NON-NLS-1$
+			return null;
+		}
+
+		final var suffix = fbName.substring(fbName.indexOf('.') + 1);
+		return getInstanceFB(resource.getFBNetwork(), suffix);
+	}
+
+	private static FB getInstanceFB(final FBNetwork network, final String name) {
+		if (network == null) {
+			return null;
+		}
+		if (!name.contains(".")) {//$NON-NLS-1$
+			return network.getFBNamed(name);
+		}
+
+		final var prefix = name.substring(0, name.indexOf('.'));
+		final var suffix = name.substring(name.indexOf('.') + 1);
+
+		for (final var networkElement : network.getNetworkElements()) {
+			if (networkElement.getName().equals(prefix)) {
+				if (networkElement instanceof final CFBInstance cfb) {
+					return getInstanceFB(cfb.loadCFBNetwork(), suffix);
+				}
+				if (networkElement instanceof final SubApp subApp) {
+					var internalNetwork = subApp.loadSubAppNetwork();
+					if (internalNetwork == null) {
+						internalNetwork = ((SubApp) subApp.getOpposite()).loadSubAppNetwork();
+					}
+					return getInstanceFB(internalNetwork, suffix);
+				}
+				System.err.println("Element with name " + prefix + " has not internal network"); //$NON-NLS-1$
+			}
+		}
+		return null;
+	}
+
+	private static void collectAllValueHolderElements(final Resource resource,
+			final Map<String, Set<IInterfaceElement>> result) {
+		collectAllValueHolderElements(resource.getFBNetwork(), result);
+	}
+
+	private static void collectAllValueHolderElements(final FBNetwork network,
+			final Map<String, Set<IInterfaceElement>> result) {
 		if (network == null) {
 			return; // no network, nothing to collect
 		}
-		network.getBlockFBNetworkElements().forEach(networkElement -> {
-			collectAllPorts(networkElement.getInterface(), result);
-			if (networkElement instanceof final CFBInstanceImpl composite) {
-				collectAllPorts(composite.loadCFBNetwork(), result); // recursive call to collect ports from nested
-																		// networks
-			} else if (networkElement instanceof final SubAppImpl subApp) {
-				collectAllPorts(subApp.loadSubAppNetwork(), result); // recursive call to collect ports from sub-app
-																		// networks
+
+		// collect value holders from the current network
+		final TreeIterator<EObject> it = network.eAllContents();
+		while (it.hasNext()) {
+			final EObject obj = it.next();
+			if (obj instanceof final IInterfaceElement varDecl) {
+				result.get(varDecl.getBlockFBNetworkElement().getResource().getName()).add(varDecl);
+
 			}
-		});
+		}
+
+		// go deeper into network elements
+		for (final FBNetworkElement networkElement : network.getNetworkElements()) {
+			if (networkElement instanceof final CFBInstanceImpl composite) {
+				collectAllValueHolderElements(composite.loadCFBNetwork(), result); // recursive call to collect ports
+																					// from nested networks
+			} else if (networkElement instanceof final SubAppImpl subApp) {
+				var internalNetwork = subApp.loadSubAppNetwork();
+				if (internalNetwork == null) {
+					internalNetwork = ((SubApp) subApp.getOpposite()).loadSubAppNetwork();
+				}
+				collectAllValueHolderElements(internalNetwork, result); // recursive call to collect ports
+			}
+		}
 	}
 
-	private static void collectAllPorts(final InterfaceList interfaceList, final Map<String, Set<String>> result) {
-		final String deviceName = interfaceList.getBlockFBNetworkElement().getResource().getDevice().getName();
-		final String resourceName = interfaceList.getBlockFBNetworkElement().getResource().getName();
-		final String prefix = deviceName + "." + resourceName + "."; //$NON-NLS-1$ //$NON-NLS-2$
-		for (final Event event : interfaceList.getEventInputs()) {
-			addElementToResult(event, result.get(resourceName), prefix);
-		}
-		for (final Event event : interfaceList.getEventOutputs()) {
-			addElementToResult(event, result.get(resourceName), prefix);
-		}
-		for (final VarDeclaration variable : interfaceList.getInputVars()) {
-			addElementToResult(variable, result.get(resourceName), prefix);
-		}
-		for (final VarDeclaration variable : interfaceList.getOutputVars()) {
-			addElementToResult(variable, result.get(resourceName), prefix);
-		}
-		// check also adapters later
-	}
-
-	private static void addElementToResult(final INamedElement element, final Set<String> result, final String prefix) {
-		String toAdd = element.getQualifiedName();
-		if (toAdd.startsWith(prefix)) {
-			toAdd = toAdd.substring(prefix.length()); // remove the prefix if present
-		}
-		result.add(toAdd);
-	}
 }

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/simulator/IDeviceSimulator.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/simulator/IDeviceSimulator.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Jose Cabral
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Jose Cabral
+ *     - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+package org.eclipse.fordiac.ide.debug.replaydebugging.simulator;
+
+import java.util.Optional;
+
+import org.eclipse.fordiac.ide.debug.replaydebugging.ReplayNavigator;
+import org.eclipse.fordiac.ide.model.libraryElement.Resource;
+
+public interface IDeviceSimulator {
+
+	boolean start();
+
+	boolean stop();
+
+	Optional<String> replayNextEvent(final Resource resource);
+
+	ReplayNavigator.DatapointsState getCurrentState(final Resource resource);
+}

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/simulator/IDeviceSimulator.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/simulator/IDeviceSimulator.java
@@ -16,7 +16,7 @@ package org.eclipse.fordiac.ide.debug.replaydebugging.simulator;
 
 import java.util.Optional;
 
-import org.eclipse.fordiac.ide.debug.replaydebugging.ReplayNavigator;
+import org.eclipse.fordiac.ide.debug.replaydebugging.core.ReplayNavigator;
 import org.eclipse.fordiac.ide.model.libraryElement.Resource;
 
 public interface IDeviceSimulator {

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/simulator/forte/DeviceSimulator.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/simulator/forte/DeviceSimulator.java
@@ -19,8 +19,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import org.eclipse.fordiac.ide.debug.replaydebugging.ReplayNavigator;
-import org.eclipse.fordiac.ide.debug.replaydebugging.Utils;
+import org.eclipse.fordiac.ide.debug.replaydebugging.core.ReplayNavigator;
+import org.eclipse.fordiac.ide.debug.replaydebugging.core.Utils;
 import org.eclipse.fordiac.ide.debug.replaydebugging.simulator.IDeviceSimulator;
 import org.eclipse.fordiac.ide.deployment.debug.Messages;
 import org.eclipse.fordiac.ide.deployment.debug.watch.DeploymentDebugWatchData;

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/simulator/forte/DeviceSimulator.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/simulator/forte/DeviceSimulator.java
@@ -74,7 +74,7 @@ public class DeviceSimulator implements IDeviceSimulator {
 			executorService.connect();
 			executorService.readTraces(device, path);
 
-			allPortsByResource = Utils.collectAllPorts(device);
+			allPortsByResource = Utils.collectAllValueHolders(device);
 
 			for (final Resource resource : device.getResource()) {
 				for (final String portName : allPortsByResource.get(resource.getName())) {

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/simulator/forte/DeviceSimulator.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/simulator/forte/DeviceSimulator.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Jose Cabral
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Jose Cabral - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+package org.eclipse.fordiac.ide.debug.replaydebugging.simulator.forte;
+
+import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.eclipse.fordiac.ide.debug.replaydebugging.ReplayNavigator;
+import org.eclipse.fordiac.ide.debug.replaydebugging.Utils;
+import org.eclipse.fordiac.ide.debug.replaydebugging.simulator.IDeviceSimulator;
+import org.eclipse.fordiac.ide.deployment.debug.Messages;
+import org.eclipse.fordiac.ide.deployment.debug.watch.DeploymentDebugWatchData;
+import org.eclipse.fordiac.ide.deployment.devResponse.Data;
+import org.eclipse.fordiac.ide.deployment.exceptions.DeploymentException;
+import org.eclipse.fordiac.ide.deployment.interactors.IDeviceManagementExecutorService;
+import org.eclipse.fordiac.ide.model.libraryElement.Device;
+import org.eclipse.fordiac.ide.model.libraryElement.Resource;
+import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
+
+public class DeviceSimulator implements IDeviceSimulator {
+
+	private final Device device;
+	private final String path;
+	private final IDeviceManagementExecutorService executorService;
+	private Map<String, Set<String>> allPortsByResource = new HashMap<>();
+	private final Map<Resource, ReplayNavigator.DatapointsState> currentStates = new HashMap<>();
+
+	public DeviceSimulator(final IDeviceManagementExecutorService executorService, final Device device,
+			final String path) {
+		this.device = device;
+		this.path = path;
+		this.executorService = executorService;
+	}
+
+	@Override
+	public Optional<String> replayNextEvent(final Resource resource) {
+		try {
+			final var lastEvent = executorService.replayNextEvent(resource);
+
+			// read the current state after the event
+			final DeploymentDebugWatchData watchData = new DeploymentDebugWatchData(executorService.readWatches());
+			currentStates.put(resource, getWatchData(watchData, resource, allPortsByResource.get(resource.getName())));
+
+			return lastEvent;
+		} catch (final DeploymentException e) {
+			e.printStackTrace();
+			return Optional.empty();
+		}
+
+	}
+
+	@Override
+	public ReplayNavigator.DatapointsState getCurrentState(final Resource resource) {
+		return currentStates.get(resource);
+	}
+
+	@Override
+	public boolean start() {
+		try {
+			executorService.connect();
+			executorService.readTraces(device, path);
+
+			allPortsByResource = Utils.collectAllPorts(device);
+
+			for (final Resource resource : device.getResource()) {
+				for (final String portName : allPortsByResource.get(resource.getName())) {
+					executorService.addWatch(resource, portName);
+				}
+
+				// Read initial state
+				final DeploymentDebugWatchData watchData = new DeploymentDebugWatchData(executorService.readWatches());
+				currentStates.put(resource,
+						getWatchData(watchData, resource, allPortsByResource.get(resource.getName())));
+			}
+		} catch (final DeploymentException e) {
+			e.printStackTrace();
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public boolean stop() {
+		try {
+			executorService.disconnect();
+		} catch (final DeploymentException e) {
+			FordiacLogHelper
+					.logError(MessageFormat.format(Messages.DeploymentDebugDevice_ConnectError, device.getName()));
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * @brief It reads the data from a watchData response from the device
+	 *        (DeploymentDebugWatchData), gets the values of all datapoints in
+	 *        portNames and stores DatapointState.
+	 *
+	 * @return a map with the port names as keys and their values as values.
+	 */
+	private static ReplayNavigator.DatapointsState getWatchData(final DeploymentDebugWatchData data,
+			final Resource resource, final Set<String> portNames) {
+		final ReplayNavigator.DatapointsState result = new ReplayNavigator.DatapointsState();
+		for (final String portName : portNames) {
+			final Data portData = data.getLastData(resource, portName);
+			if (portData == null) {
+				// if there is no data for this port, we just skip it
+				// this means that the forte device could not add the watch
+				continue;
+			}
+			result.put(portName, portData.getValue());
+		}
+		return result;
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/simulator/interpreter/DeviceSimulator.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/simulator/interpreter/DeviceSimulator.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Jose Cabral
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Jose Cabral
+ *     - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+package org.eclipse.fordiac.ide.debug.replaydebugging.simulator.interpreter;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.eclipse.fordiac.debug.replaydebugging.trace.SendOutputEvent;
+import org.eclipse.fordiac.debug.replaydebugging.trace.TracesReader;
+import org.eclipse.fordiac.ide.debug.replaydebugging.core.ReplayNavigator;
+import org.eclipse.fordiac.ide.debug.replaydebugging.core.Utils;
+import org.eclipse.fordiac.ide.debug.replaydebugging.simulator.IDeviceSimulator;
+import org.eclipse.fordiac.ide.model.libraryElement.Device;
+import org.eclipse.fordiac.ide.model.libraryElement.Event;
+import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
+import org.eclipse.fordiac.ide.model.libraryElement.Resource;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
+import org.eclipse.tracecompass.ctf.core.CTFException;
+
+public class DeviceSimulator implements IDeviceSimulator {
+
+	private final String path;
+	private final Device device;
+	private Map<String, Set<IInterfaceElement>> allValueHolderElements = new HashMap<>();
+	private final Map<IInterfaceElement, Integer> eventMonitoringValues = new HashMap<>();
+	private final Map<Resource, ReplayNavigator.DatapointsState> currentStates = new HashMap<>();
+	private final Map<String, ResourceSimulator> resourceReplayers = new HashMap<>();
+
+	public DeviceSimulator(final Device device, final String path) {
+		this.path = path;
+		this.device = device;
+	}
+
+	@Override
+	public boolean start() {
+
+		// read traces
+		final TracesReader tracerReader = new TracesReader(path);
+
+		try {
+			final var externalEvents = tracerReader.read();
+
+			for (final var resource : device.getResource()) {
+				final var sifbEvents = externalEvents.getOrDefault(resource.getName(), List.of()).stream()
+						.map(externalEvent -> Map.entry(externalEvent,
+								Utils.getInstanceFB(resource, externalEvent.instanceName())))
+						.filter(entry -> Utils.isSIFB(entry.getValue().getType())).map(Map.Entry::getKey).toList();
+
+				resourceReplayers.put(resource.getName(), new ResourceSimulator(resource, sifbEvents));
+			}
+
+			for (final var entry : externalEvents.entrySet()) {
+				FordiacLogHelper.logInfo("Resource: " + entry.getKey()); //$NON-NLS-1$
+				for (final SendOutputEvent event : entry.getValue()) {
+					FordiacLogHelper.logInfo("  " + event); //$NON-NLS-1$
+				}
+			}
+		} catch (final CTFException e) {
+			FordiacLogHelper.logError("Error reading traces: " + e.getMessage()); //$NON-NLS-1$
+			return false;
+		}
+
+		// get reference to all value holders
+		allValueHolderElements = Utils.collectAllValueHolderElements(device);
+
+		// add monitoring counter for events
+		for (final var entry : allValueHolderElements.entrySet()) {
+			for (final IInterfaceElement element : entry.getValue()) {
+				System.out.println(
+						" Element: " + element.getQualifiedName() + " id: " + System.identityHashCode(element));
+				if (element instanceof Event) {
+					eventMonitoringValues.put(element, 0);
+				}
+			}
+		}
+
+		// set initial state
+		for (final var resource : device.getResource()) {
+			updateState(resource);
+		}
+
+		return true;
+	}
+
+	@Override
+	public boolean stop() {
+		// these aren't the droids you are looking for
+		return true;
+	}
+
+	@Override
+	public Optional<String> replayNextEvent(final Resource resource) {
+		final var resourceName = resource.getName();
+
+		final var resourceReplayer = resourceReplayers.get(resourceName);
+		if (null == resourceReplayer) {
+			return Optional.empty();
+		}
+		final var event = resourceReplayer.reproduceNextEvent();
+
+		if (event.isPresent()) {
+			final var currentCounter = eventMonitoringValues.get(event.get());
+			if (null == currentCounter) {
+				// should not happen
+			} else {
+				eventMonitoringValues.put(event.get(),
+						Integer.valueOf(eventMonitoringValues.get(event.get()).intValue() + 1));
+			}
+			for (final var outputEvent : resourceReplayer.getLastOutputEvents()) {
+				var val = eventMonitoringValues.get(outputEvent);
+				if (null == val) {
+					val = Integer.valueOf(0);
+					eventMonitoringValues.put(outputEvent, val);
+				}
+				eventMonitoringValues.put(outputEvent,
+						Integer.valueOf(eventMonitoringValues.get(outputEvent).intValue() + 1));
+			}
+			updateState(resource);
+			return Optional.of(event.get().getQualifiedName());
+		}
+		updateState(resource);
+		return Optional.empty();
+	}
+
+	@Override
+	public ReplayNavigator.DatapointsState getCurrentState(final Resource resource) {
+		return currentStates.get(resource);
+	}
+
+	private void updateState(final Resource resource) {
+		final var interfaceElements = allValueHolderElements.get(resource.getName());
+		final var result = new ReplayNavigator.DatapointsState();
+		for (final var interfaceElement : interfaceElements) {
+			if (interfaceElement instanceof Event) {
+				result.put(Utils.getWatchName(interfaceElement),
+						Integer.toString(eventMonitoringValues.get(interfaceElement)));
+			} else if (interfaceElement instanceof final VarDeclaration varDecl) {
+				final var value = varDecl.getValue();
+				if (value != null) {
+					result.put(Utils.getWatchName(varDecl), varDecl.getValue().getValue());
+				}
+			}
+		}
+		currentStates.put(resource, result);
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/simulator/interpreter/ResourceSimulator.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/simulator/interpreter/ResourceSimulator.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Jose Cabral
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Jose Cabral - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+package org.eclipse.fordiac.ide.debug.replaydebugging.simulator.interpreter;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import org.eclipse.fordiac.debug.replaydebugging.trace.SendOutputEvent;
+import org.eclipse.fordiac.ide.debug.replaydebugging.core.Utils;
+import org.eclipse.fordiac.ide.fb.interpreter.api.EventManagerFactory;
+import org.eclipse.fordiac.ide.fb.interpreter.mm.EventManagerProcessor;
+import org.eclipse.fordiac.ide.model.libraryElement.Event;
+import org.eclipse.fordiac.ide.model.libraryElement.Resource;
+
+public class ResourceSimulator {
+	private final Resource resource;
+	private final List<SendOutputEvent> externalEvents;
+	private int externalEventCounter = 0;
+
+	private final EventManagerProcessor eventManagerProcessor;
+
+	public ResourceSimulator(final Resource resource, final List<SendOutputEvent> externalEvents) {
+		this.resource = resource;
+		this.externalEvents = externalEvents;
+		eventManagerProcessor = new EventManagerProcessor(EventManagerFactory.createFrom(List.of()),
+				resource.getFBNetwork());
+	}
+
+	public List<Event> getLastOutputEvents() {
+		return eventManagerProcessor.getLastOutputEvents();
+	}
+
+	public Optional<Event> reproduceNextEvent() {
+
+		// check if we reached the end of the list of events
+		if (externalEvents.size() <= externalEventCounter) {
+			// keep processing internal events
+			return eventManagerProcessor.processOne(OptionalLong.empty());
+		}
+
+		final var externalEvent = externalEvents.get(externalEventCounter);
+		final int eventCounter = externalEvent.eventCounter();
+
+		if (eventManagerProcessor.getEventCounter() < eventCounter) {
+			return eventManagerProcessor.processOne(OptionalLong.empty());
+		}
+
+		externalEventCounter++;
+		final var instanceFB = Utils.getInstanceFB(resource, externalEvent.instanceName());
+		if (instanceFB == null) {
+			// could not find FB
+			return Optional.empty();
+		}
+		final var event = instanceFB.getInterface().getEventOutputs().get(externalEvent.eventId());
+
+		// set outputs
+		final List<String> outputValues = externalEvent.outputs();
+		final var fbDataOutput = instanceFB.getInterface().getOutputVars();
+		final var dataOutputValues = new HashMap<String, String>();
+		for (int i = 0; i < fbDataOutput.size(); i++) {
+			dataOutputValues.put(fbDataOutput.get(i).getName(), outputValues.get(i));
+		}
+
+		eventManagerProcessor.injectOutputEvent(instanceFB, event, dataOutputValues);
+		return eventManagerProcessor.processOne(OptionalLong.empty());
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/mm/EventManagerProcessor.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/mm/EventManagerProcessor.java
@@ -1,0 +1,226 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Jose Cabral
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Jose Cabral - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+package org.eclipse.fordiac.ide.fb.interpreter.mm;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.fordiac.ide.fb.interpreter.DefaultRunFBType;
+import org.eclipse.fordiac.ide.fb.interpreter.OpSem.CompositeFBTypeRuntime;
+import org.eclipse.fordiac.ide.fb.interpreter.OpSem.EventManager;
+import org.eclipse.fordiac.ide.fb.interpreter.OpSem.EventOccurrence;
+import org.eclipse.fordiac.ide.fb.interpreter.OpSem.FBNetworkRuntime;
+import org.eclipse.fordiac.ide.fb.interpreter.OpSem.FBRuntimeAbstract;
+import org.eclipse.fordiac.ide.fb.interpreter.OpSem.FBTransaction;
+import org.eclipse.fordiac.ide.fb.interpreter.api.EventOccFactory;
+import org.eclipse.fordiac.ide.fb.interpreter.api.RuntimeFactory;
+import org.eclipse.fordiac.ide.fb.interpreter.api.TransactionFactory;
+import org.eclipse.fordiac.ide.model.libraryElement.Connection;
+import org.eclipse.fordiac.ide.model.libraryElement.Event;
+import org.eclipse.fordiac.ide.model.libraryElement.FB;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.FBType;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
+import org.eclipse.fordiac.ide.model.libraryElement.Value;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
+
+public class EventManagerProcessor {
+
+	public enum ProcessMode {
+		INFINITE, EXISTING
+	}
+
+	private final EventManager eventManager;
+	private final FBNetworkRuntime networkRuntime;
+	private long time = 0;
+	private int eventCounter = 0;
+	private final List<Event> lastOutputEvents = new ArrayList<>();
+	private Event lastInjectedEvent = null;
+
+	public EventManagerProcessor(final EventManager eventManager, final FBNetwork network) {
+		this.eventManager = eventManager;
+		this.networkRuntime = RuntimeFactory.createFrom(network);
+		DefaultRunFBType.clearCaches();
+	}
+
+	public int getEventCounter() {
+		return eventCounter;
+	}
+
+	public List<Event> getLastOutputEvents() {
+		return lastOutputEvents;
+	}
+
+	public void process(final ProcessMode processMode) {
+		time = eventManager.getStartTime();
+		switch (processMode) {
+		case INFINITE:
+			Optional<Event> executedEvent;
+			do {
+				executedEvent = processOne(OptionalLong.of(time));
+			} while (executedEvent.isPresent());
+			break;
+		case EXISTING:
+			final int existingTransactions = eventManager.getTransactions().size();
+			for (int i = 0; i < existingTransactions; i++) {
+				processOne(OptionalLong.of(time));
+			}
+			break;
+		default:
+			throw new IllegalArgumentException("Unknown process mode: " + processMode); //$NON-NLS-1$
+		}
+	}
+
+	public Optional<Event> processOne(final OptionalLong startTime) {
+		lastOutputEvents.clear();
+
+		final var transactions = eventManager.getTransactions();
+		if (transactions.isEmpty()) {
+			return Optional.empty();
+		}
+
+		if (lastInjectedEvent != null) {
+			lastOutputEvents.add(lastInjectedEvent);
+			lastInjectedEvent = null;
+		}
+
+		final var transaction = transactions.get(0);
+		transactions.remove(0);
+
+		if (transaction instanceof final FBTransaction fbTransaction) {
+
+			var fbRuntime = getFBNetworkRuntime(networkRuntime, fbTransaction.getInputEventOccurrence().getParentFB(),
+					false);
+			if (fbRuntime == null) {
+				fbRuntime = getFBNetworkRuntime(networkRuntime,
+						fbTransaction.getInputEventOccurrence().getParentFB().getOuterFBNetworkElement(), true);
+				if (fbRuntime == null) {
+					fbRuntime = networkRuntime; // createMissingNetworkRuntimes(fbTransaction.getInputEventOccurrence().getParentFB());
+				} else if (fbRuntime instanceof final CompositeFBTypeRuntime compositeFBTypeRuntime) {
+					fbRuntime = compositeFBTypeRuntime.getNetworkRuntime();
+				}
+			}
+			final var copiedRT = EcoreUtil.copy(fbRuntime);
+			fbTransaction.getInputEventOccurrence().setFbRuntime(copiedRT);
+			final var transactionProcessor = new FBTransactionProcessor(fbTransaction);
+
+			transactionProcessor.process(startTime.isPresent() ? startTime.getAsLong() : 0);
+
+			((FBNetworkRuntime) fbRuntime).getTypeRuntimes().putAll(((FBNetworkRuntime) copiedRT).getTypeRuntimes());
+			((FBNetworkRuntime) fbRuntime).setFbnetwork((((FBNetworkRuntime) copiedRT).getFbnetwork()));
+
+			fbTransaction.getOutputEventOccurrences()
+					.forEach(outputEO -> eventManager.getTransactions().addAll(outputEO.getCreatedTransactions()));
+
+			for (final var outputEO : fbTransaction.getOutputEventOccurrences()) {
+				lastOutputEvents.add(outputEO.getEvent()); // TODO: this works only because in the default runtime
+															// runner, the mapped event from the network is assigned to
+															// the returned type event
+			}
+
+			eventCounter++;
+		}
+		time += transaction.getDuration();
+		return Optional.of(transaction.getInputEventOccurrence().getEvent());
+	}
+
+	private FBRuntimeAbstract getFBNetworkRuntime(final FBNetworkRuntime fbNetworkRuntime, final FBNetworkElement fb,
+			final boolean lookingForParent) {
+		if (fbNetworkRuntime.getTypeRuntimes().get(fb) != null) {
+			if (lookingForParent) {
+				return fbNetworkRuntime.getTypeRuntimes().get(fb);
+			}
+			return fbNetworkRuntime;
+		}
+
+		for (final var entry : fbNetworkRuntime.getTypeRuntimes()) {
+			if (entry.getValue() instanceof final FBNetworkRuntime fbNetwork) {
+				final var possibleRuntime = getFBNetworkRuntime(fbNetwork, fb, lookingForParent);
+				if (possibleRuntime != null) {
+					return possibleRuntime;
+				}
+			} else if (entry.getValue() instanceof final CompositeFBTypeRuntime compositeFBTypeRuntime) {
+				final var possibleRuntime = getFBNetworkRuntime(compositeFBTypeRuntime.getNetworkRuntime(), fb,
+						lookingForParent);
+				if (possibleRuntime != null) {
+					return possibleRuntime;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	public void injectOutputEvent(final FB fb, final Event event, final Map<String, String> outputValues) {
+		final String toLog = "\nEvent injected " + event.getQualifiedName();
+		FordiacLogHelper.logInfo(toLog);
+
+		// copy output values to the model.
+		for (final var output : fb.getInterface().getOutputVars()) {
+			final var value = LibraryElementFactory.eINSTANCE.createValue();
+			value.setValue(outputValues.get(output.getName()));
+			output.setValue(value);
+		}
+
+		final List<FBTransaction> generatedT = new ArrayList<>();
+		for (final Connection conn : event.getOutputConnections()) {
+			final var dest = (Event) conn.getDestination();
+			final EventOccurrence destinationEventOccurence = EventOccFactory.createFrom(dest, null);
+			destinationEventOccurence.setParentFB(dest.getBlockFBNetworkElement());
+			final FBTransaction transaction = TransactionFactory.createFrom(destinationEventOccurence);
+			generatedT.add(transaction);
+		}
+		lastInjectedEvent = event;
+		eventManager.getTransactions().addAll(generatedT);
+	}
+
+	private class FBTransactionProcessor {
+		private final FBTransaction transaction;
+
+		public FBTransactionProcessor(final FBTransaction transaction) {
+			this.transaction = transaction;
+		}
+
+		public void process(final long startTime) {
+			// set the input vars
+			for (final var inputVar : transaction.getInputVariables()) {
+				final var element = transaction.getInputEventOccurrence().getFbRuntime().getModel();
+				setInputVariable(inputVar, element);
+			}
+			transaction.getInputEventOccurrence().setStartTime(startTime);
+			final var result = transaction.getInputEventOccurrence().getFbRuntime().run();
+			transaction.getOutputEventOccurrences().addAll(result);
+		}
+
+		private static void setInputVariable(final VarDeclaration inputVar, final FBType type) {
+			if (null != inputVar) {
+				final var pin = type.getInterfaceList().getInterfaceElement(Arrays.asList(inputVar.getName()));
+				if ((pin instanceof final VarDeclaration datapin) && pin.isIsInput()) {
+					final Value sampledValue = LibraryElementFactory.eINSTANCE.createValue();
+					datapin.setValue(sampledValue);
+					sampledValue.setValue(inputVar.getValue().getValue());
+				}
+			}
+		}
+
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.product/org.eclipse.fordiac.ide.product.target
+++ b/plugins/org.eclipse.fordiac.ide.product/org.eclipse.fordiac.ide.product.target
@@ -29,7 +29,7 @@
 			<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.egit.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.ocl.all.sdk.feature.group" version="0.0.0"/>			
+			<unit id="org.eclipse.ocl.all.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.sirius.properties.feature.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.sirius.samples.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.sirius.specifier.feature.group" version="0.0.0"/>
@@ -49,6 +49,10 @@
       		<repository location="https://download.eclipse.org/technology/swtbot/releases/4.3.0/"/>
       		<unit id="org.eclipse.swtbot.nebula.nattable.finder" version="0.0.0"/>
     	</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/tracecompass/releases/11.0.0/repository/"/>
+			<unit id="org.eclipse.tracecompass.lttng2.ust.feature.group" version="11.0.0.202506130813"/>
+		</location>
 		<location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
 			<feature id="org.eclipse.fordiac.ide.milo" label="Milo Dependencies" provider-name="Eclipse 4diac" version="3.1.0.qualifier">
 				<description url="http://www.example.com/description">


### PR DESCRIPTION
As it's now, the replay debugging mechanism uses forte as a simulator to generate all the needed information.

This PR prepares it to be used with the local interpreter.

The major things done here are separated into commits:
1. Read traces directly in the GUI: before, forte read the traces. Now the tracecompass pluging allows us to have the traces loaded directly in the GUI and work from there
2. Separate the forte specfic part and the replay abstraction: The forte simulator needs connecting to forte and reading the watches. The local interpreter doesn't. This tries to create a common interface
3. Small refactoring to move the core of replay debugging (no simulator involved) into its own package
4. Add an interface to the local interpreter: This is mainly taking the functions already existing in the EventManagerUtils and encapsulating it into a class, with extra functions such as injectEvent and similar to what's already there in the FakeEcet in forte.
5. Add GUI stuff to let the user select the simulator.

Disclaimer: replay with the interpreter doesn't work yet. There are fixes still needed there, but I thought it would be better to let this be reviewed/merged and work on that in the meantime.  Also keeps the changes separated.