### PR TITLE
Reduce unused includes in forte_ng export

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/STFunctionSupport.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/STFunctionSupport.xtend
@@ -28,6 +28,7 @@ import org.eclipse.fordiac.ide.structuredtextfunctioneditor.stfunction.STFunctio
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
 
 import static extension org.eclipse.fordiac.ide.export.forte_ng.util.ForteNgExportUtil.*
+import static extension org.eclipse.fordiac.ide.structuredtextcore.stcore.util.STCoreUtil.getFeatureType
 
 @FinalFieldsConstructor
 class STFunctionSupport extends StructuredTextSupport {
@@ -118,7 +119,7 @@ class STFunctionSupport extends StructuredTextSupport {
 				varDeclarations.filter [
 					it instanceof STVarInputDeclarationBlock || it instanceof STVarOutputDeclarationBlock
 				]
-			].flatMap[varDeclarations].map[type as INamedElement]).toSet
+			].flatMap[varDeclarations].map[featureType as INamedElement]).toSet
 		else
 			source.containedDependencies
 	}

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/STMethodSupport.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/STMethodSupport.xtend
@@ -28,6 +28,7 @@ import org.eclipse.fordiac.ide.structuredtextcore.stcore.STVarTempDeclarationBlo
 import static extension org.eclipse.emf.ecore.util.EcoreUtil.*
 import static extension org.eclipse.fordiac.ide.export.forte_ng.util.ForteNgExportUtil.*
 import static extension org.eclipse.fordiac.ide.structuredtextalgorithm.util.StructuredTextParseUtil.*
+import static extension org.eclipse.fordiac.ide.structuredtextcore.stcore.util.STCoreUtil.getFeatureType
 
 class STMethodSupport extends StructuredTextSupport {
 	final org.eclipse.fordiac.ide.model.libraryElement.STMethod method
@@ -112,7 +113,7 @@ class STMethodSupport extends StructuredTextSupport {
 			if (options.get(ForteNgExportFilter.OPTION_HEADER) == Boolean.TRUE)
 				(#[parseResult.returnType].filterNull + parseResult.body.varDeclarations.filter [
 					it instanceof STVarInputDeclarationBlock || it instanceof STVarOutputDeclarationBlock
-				].flatMap[varDeclarations].map[type as INamedElement]).toSet
+				].flatMap[varDeclarations].map[featureType as INamedElement]).toSet
 			else
 				parseResult.containedDependencies
 		} else

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/StructuredTextSupport.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/StructuredTextSupport.xtend
@@ -50,9 +50,9 @@ import org.eclipse.fordiac.ide.model.libraryElement.Event
 import org.eclipse.fordiac.ide.model.libraryElement.FB
 import org.eclipse.fordiac.ide.model.libraryElement.FBType
 import org.eclipse.fordiac.ide.model.libraryElement.FunctionFBType
-import org.eclipse.fordiac.ide.model.libraryElement.ICallable
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement
 import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration
 import org.eclipse.fordiac.ide.structuredtextalgorithm.stalgorithm.STMethod
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STArrayAccessExpression
@@ -62,6 +62,7 @@ import org.eclipse.fordiac.ide.structuredtextcore.stcore.STBinaryExpression
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STBuiltinFeatureExpression
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCallArgument
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCallNamedOutputArgument
+import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCaseCases
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCaseStatement
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STContinue
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STDateAndTimeLiteral
@@ -567,6 +568,14 @@ abstract class StructuredTextSupport implements ILanguageSupport {
 			STStructInitializerExpression:
 				// need dependencies of default values generated in initializer
 				object.mappedStructInitElements.entrySet.filter[value === null].flatMap[key.defaultDependencies]
+			STCaseCases:
+				object.conditions.flatMap[caseConditionDependencies]
+			STForStatement:
+				#["forte_st_iterator".createDependencyPlaceholder]
+			STBinaryExpression:
+				object.binaryExpressionDependencies
+			STUnaryExpression:
+				object.unaryExpressionDependencies
 			STNumericLiteral:
 				#[object.resultType]
 			STStringLiteral:
@@ -579,13 +588,35 @@ abstract class StructuredTextSupport implements ILanguageSupport {
 				#[object.resultType]
 			STDateAndTimeLiteral:
 				#[object.resultType]
-			STFeatureExpression: // feature expressions may refer to definitions contained in other sources
+			STFeatureExpression case object.call:
+				object.feature.featureDependencies + object.callArgumentDependencies
+			STFeatureExpression:
 				object.feature.featureDependencies
 			STFunction:
 				object.returnType !== null ? #[object.returnType] : emptySet
 			default:
 				emptySet
 		}
+	}
+
+	def protected Iterable<INamedElement> getCaseConditionDependencies(STExpression expr) {
+		switch (expr) {
+			STBinaryExpression case expr.op.range: #["AND", "GE", "LE"]
+			default: #["EQ"]
+		}.map[createStandardFunctionDependencyPlaceholder]
+	}
+
+	def protected Iterable<INamedElement> getBinaryExpressionDependencies(STBinaryExpression expr) {
+		switch (expr.op) {
+			case RANGE: emptySet // ranges in CASE statements are handled separately
+			case AMPERSAND: #["AND"]
+			case POWER: #["EXPT"]
+			default: #[expr.op.getName]
+		}.map[createStandardFunctionDependencyPlaceholder]
+	}
+
+	def protected Iterable<INamedElement> getUnaryExpressionDependencies(STUnaryExpression expr) {
+		#[expr.op.getName.createStandardFunctionDependencyPlaceholder]
 	}
 
 	def protected Iterable<INamedElement> getFeatureDependencies(INamedElement feature) {
@@ -597,21 +628,51 @@ abstract class StructuredTextSupport implements ILanguageSupport {
 				#[feature]
 			STVarDeclaration:
 				#[feature.featureType]
-			STFunction:
-				#[feature] + feature.parameterDependencies
+			STFunction,
 			FunctionFBType:
-				#[feature] + feature.parameterDependencies
-			ICallable:
-				feature.parameterDependencies
+				#[feature]
+			STStandardFunction:
+				#[feature.name.createStandardFunctionDependencyPlaceholder]
 			default:
 				emptySet
 		}
 	}
 
-	def protected Iterable<INamedElement> getParameterDependencies(ICallable feature) {
-		(feature.inputParameters + feature.outputParameters + feature.inOutParameters).flatMap [
-			defaultDependencies // need dependencies of default values possibly generated in call
-		].reject[isAnyType] // cannot have default values of generic types anyhow
+	def protected Iterable<INamedElement> getCallArgumentDependencies(STFeatureExpression expr) {
+		try {
+			(expr.mappedInputArguments.entrySet + expr.mappedInOutArguments.entrySet +
+				expr.mappedOutputArguments.entrySet).flatMap[key.getCallArgumentDependencies(value)]
+		} catch (IndexOutOfBoundsException e) {
+			emptySet
+		} catch (ClassCastException e) {
+			emptySet
+		}
+	}
+
+	def protected Iterable<INamedElement> getCallArgumentDependencies(STBuiltinFeatureExpression expr) {
+		try {
+			(expr.mappedInputArguments.entrySet + expr.mappedInOutArguments.entrySet +
+				expr.mappedOutputArguments.entrySet).flatMap[key.getCallArgumentDependencies(value)]
+		} catch (IndexOutOfBoundsException e) {
+			emptyList
+		} catch (ClassCastException e) {
+			emptyList
+		}
+	}
+
+	def protected Iterable<INamedElement> getCallArgumentDependencies(ITypedElement parameter,
+		STCallArgument argument) {
+		switch (argument) {
+			case null:
+				// need dependencies of default values generated in call,
+				// except for generic types, since those have no default values
+				#["forte_st_util".createDependencyPlaceholder] + parameter.defaultDependencies.reject[isAnyType]
+			case (argument.argument instanceof STMemberAccessExpression) &&
+				(argument.argument as STMemberAccessExpression).member instanceof STMultibitPartialExpression:
+				#["forte_st_util".createDependencyPlaceholder]
+			default:
+				emptySet
+		}
 	}
 
 	def protected Iterable<INamedElement> getDefaultDependencies(INamedElement feature) {
@@ -624,6 +685,10 @@ abstract class StructuredTextSupport implements ILanguageSupport {
 			default:
 				emptySet
 		}
+	}
+
+	protected def LibraryElement createStandardFunctionDependencyPlaceholder(CharSequence name) {
+		createDependencyPlaceholder('''iec61131_functions/func_«name»''')
 	}
 
 	def protected generateLineDirective(EObject element) {

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/VarDeclarationSupport.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/VarDeclarationSupport.xtend
@@ -23,6 +23,7 @@ import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
 
 import static extension org.eclipse.fordiac.ide.export.forte_ng.util.ForteNgExportUtil.*
 import static extension org.eclipse.fordiac.ide.structuredtextalgorithm.util.StructuredTextParseUtil.*
+import static extension org.eclipse.fordiac.ide.structuredtextcore.stcore.util.STCoreUtil.getFeatureType
 import static extension org.eclipse.xtext.EcoreUtil2.*
 
 @FinalFieldsConstructor
@@ -90,7 +91,7 @@ class VarDeclarationSupport extends StructuredTextSupport {
 
 	override getDependencies(Map<?, ?> options) {
 		if (options.get(ForteNgExportFilter.OPTION_HEADER) == Boolean.TRUE) {
-			#{varDeclaration.type}
+			#{varDeclaration.featureType}
 		} else if (!varDeclaration.value?.value.nullOrEmpty) {
 			prepareInitialValue
 			parseResult?.containedDependencies ?: emptySet

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/VarGlobalConstantsSupport.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/VarGlobalConstantsSupport.xtend
@@ -25,6 +25,8 @@ import org.eclipse.fordiac.ide.model.libraryElement.INamedElement
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STVarDeclaration
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
 
+import static extension org.eclipse.fordiac.ide.structuredtextcore.stcore.util.STCoreUtil.getFeatureType
+
 @FinalFieldsConstructor
 class VarGlobalConstantsSupport extends StructuredTextSupport {
 	final STGlobalConstsSource source
@@ -85,7 +87,7 @@ class VarGlobalConstantsSupport extends StructuredTextSupport {
 		prepare()
 		if (options.get(ForteNgExportFilter.OPTION_HEADER) == Boolean.TRUE)
 			if (source.constants !== null)
-				source.constants.elements.flatMap[varDeclarations].map[type as INamedElement].toSet
+				source.constants.elements.flatMap[varDeclarations].map[featureType as INamedElement].toSet
 			else
 				emptySet
 		else

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteFBTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteFBTemplate.xtend
@@ -477,7 +477,9 @@ abstract class ForteFBTemplate<T extends FBType> extends ForteLibraryElementTemp
 	}
 
 	override Set<INamedElement> getDependencies(Map<?, ?> options) {
-		(super.getDependencies(options) + (type.interfaceList.sockets + type.interfaceList.plugs).map[getType]
-			).toSet
+		(super.getDependencies(options) + (type.interfaceList.sockets + type.interfaceList.plugs).map[getType] +
+			(type.interfaceList.eventInputs.exists[!outputParameters.empty] ? #[
+				"forte_st_util".createDependencyPlaceholder] : emptySet)
+		).toSet
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteNgExportTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/ForteNgExportTemplate.xtend
@@ -15,7 +15,6 @@ package org.eclipse.fordiac.ide.export.forte_ng
 import java.nio.file.Path
 import org.eclipse.fordiac.ide.export.ExportTemplate
 import org.eclipse.fordiac.ide.export.forte_ng.util.ForteNgExportOptions
-import org.eclipse.fordiac.ide.model.data.DataType
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement
 import org.osgi.framework.FrameworkUtil
 
@@ -30,21 +29,9 @@ abstract class ForteNgExportTemplate extends ExportTemplate {
 	}
 
 	def protected generateDependencyIncludes(Iterable<? extends INamedElement> dependencies) '''
-		«dependencies.filter(DataType).generateTypeIncludes»
-		«FOR include : dependencies.reject(DataType).map[generateDefiningInclude].toSet.sort»
+		«FOR include : dependencies.flatMap[generateDefiningIncludes].toSet.sort»
 			«include.generateDependencyInclude»
 		«ENDFOR»
-	'''
-
-	def protected generateTypeIncludes(Iterable<DataType> types) '''
-		«FOR include : types.map[generateDefiningInclude].toSet.sort»
-			«include.generateDependencyInclude»
-		«ENDFOR»
-		«generateDependencyInclude("forte/iec61131_functions.h")»
-		«generateDependencyInclude("forte/datatypes/forte_array_common.h")»
-		«generateDependencyInclude("forte/datatypes/forte_array.h")»
-		«generateDependencyInclude("forte/datatypes/forte_array_fixed.h")»
-		«generateDependencyInclude("forte/datatypes/forte_array_variable.h")»
 	'''
 
 	def protected generateDependencyInclude(String path) {

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/composite/CompositeFBImplTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/composite/CompositeFBImplTemplate.xtend
@@ -184,6 +184,9 @@ class CompositeFBImplTemplate extends ForteFBTemplate<CompositeFBType> {
 	override getDependencies(Map<?, ?> options) {
 		(super.getDependencies(options) + fbNetworkInitialVariableLanguageSupport.values.filterNull.flatMap [
 			getDependencies(options)
-		]).toSet
+		] + (type.interfaceList.eventOutputs.flatMap[with].map[withVariable].exists [
+			!inOutVar && !inputConnections.empty && inputConnections.first.negated
+		] ? #["iec61131_functions/func_NOT".createDependencyPlaceholder] : emptySet)
+		).toSet
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/language/LanguageImplTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/language/LanguageImplTemplate.xtend
@@ -49,7 +49,6 @@ class LanguageImplTemplate extends ForteNgExportTemplate {
 	def protected generateImplIncludes() '''
 		#include "«fileBasename».h"
 
-		«generateDependencyInclude("forte/iec61131_functions.h")»
 		«IF languageSupport !== null»«languageSupport.getDependencies(emptyMap).generateDependencyIncludes»«ENDIF»
 	'''
 

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/util/ForteNgExportUtil.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/util/ForteNgExportUtil.xtend
@@ -49,9 +49,12 @@ import org.eclipse.fordiac.ide.model.libraryElement.FunctionFBType
 import org.eclipse.fordiac.ide.model.libraryElement.GlobalConstants
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration
 import org.eclipse.fordiac.ide.model.value.StringValueConverter
+
+import static extension org.eclipse.fordiac.ide.model.helpers.PackageNameHelper.setFullTypeName
 
 final class ForteNgExportUtil {
 	public static final CharSequence CONNECTION_EXPORT_PREFIX = "conn_"
@@ -258,10 +261,14 @@ final class ForteNgExportUtil {
 		resource.contents.filter(LibraryElement)?.head?.generateTypeName
 	}
 
-	def static String generateDefiningInclude(EObject object) {
+	def static Iterable<String> generateDefiningIncludes(EObject object) {
 		switch (object) {
-			LibraryElement: object.generateTypeIncludePath
-			default: object.eResource?.generateDefiningInclude
+			ArrayType:
+				#[object.generateTypeIncludePath, object.baseType.generateTypeIncludePath]
+			LibraryElement:
+				#[object.generateTypeIncludePath]
+			default:
+				#[object.eResource?.generateDefiningInclude]
 		}
 	}
 
@@ -313,8 +320,11 @@ final class ForteNgExportUtil {
 				"forte_string"
 			WstringType:
 				"forte_wstring"
-			ArrayType:
-				type.baseType.generateTypeBasename
+			ArrayType case type.typeEntry === null:
+				if(type.subranges.exists[!setLowerLimit || !setUpperLimit])
+					"forte_array_variable"
+				else
+					"forte_array_fixed"
 			AdapterType:
 				type.name + "_adp"
 			AnyDerivedType:
@@ -338,8 +348,6 @@ final class ForteNgExportUtil {
 
 	def static Path generateTypePath(LibraryElement type) {
 		switch (type) {
-			ArrayType:
-				type.baseType.generateTypePath
 			AnyType case type.typeEntry === null:
 				Path.of("datatypes")
 			default:
@@ -393,6 +401,12 @@ final class ForteNgExportUtil {
 			default:
 				type.name
 		}
+	}
+
+	def static LibraryElement createDependencyPlaceholder(CharSequence path) {
+		LibraryElementFactory.eINSTANCE.createLibraryElement => [
+			setFullTypeName(path.toString.replace("/", "::"))
+		]
 	}
 
 	def static CharSequence getFORTEStringId(String s) '''"«s»"_STRID'''

--- a/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/forte_ng/ForteNgBasicFBTest.xtend
+++ b/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/forte_ng/ForteNgBasicFBTest.xtend
@@ -59,11 +59,6 @@ class ForteNgBasicFBTest extends ExporterTestBasicFBTypeBase {
 						#pragma once
 						
 						#include "forte/basicfb.h"
-						#include "forte/iec61131_functions.h"
-						#include "forte/datatypes/forte_array_common.h"
-						#include "forte/datatypes/forte_array.h"
-						#include "forte/datatypes/forte_array_fixed.h"
-						#include "forte/datatypes/forte_array_variable.h"
 						
 						namespace forte {
 						  class «EXPORTED_FUNCTIONBLOCK_NAME» final : public CBasicFB {
@@ -115,13 +110,9 @@ class ForteNgBasicFBTest extends ExporterTestBasicFBTypeBase {
 					
 					#include "forte/«ExporterTestBase.BASICFUNCTIONBLOCK_NAME»_fbt.h"
 					
+					#include "forte/datatypes/forte_array_fixed.h"
 					#include "forte/datatypes/forte_dword.h"
 					#include "forte/datatypes/forte_sint.h"
-					#include "forte/iec61131_functions.h"
-					#include "forte/datatypes/forte_array_common.h"
-					#include "forte/datatypes/forte_array.h"
-					#include "forte/datatypes/forte_array_fixed.h"
-					#include "forte/datatypes/forte_array_variable.h"
 					
 					using namespace std::literals;
 					using namespace forte::literals;

--- a/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/forte_ng/ForteNgTest.xtend
+++ b/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/forte_ng/ForteNgTest.xtend
@@ -249,11 +249,6 @@ class ForteNgTest extends ExporterTestBasicFBTypeBase {
 						#pragma once
 						
 						#include "forte/basicfb.h"
-						#include "forte/iec61131_functions.h"
-						#include "forte/datatypes/forte_array_common.h"
-						#include "forte/datatypes/forte_array.h"
-						#include "forte/datatypes/forte_array_fixed.h"
-						#include "forte/datatypes/forte_array_variable.h"
 						
 						namespace forte {
 						  class «EXPORTED_FUNCTIONBLOCK_NAME» final : public CBasicFB {
@@ -305,11 +300,6 @@ class ForteNgTest extends ExporterTestBasicFBTypeBase {
 					
 					#include "forte/«ExporterTestBase.BASICFUNCTIONBLOCK_NAME»_fbt.h"
 					
-					#include "forte/iec61131_functions.h"
-					#include "forte/datatypes/forte_array_common.h"
-					#include "forte/datatypes/forte_array.h"
-					#include "forte/datatypes/forte_array_fixed.h"
-					#include "forte/datatypes/forte_array_variable.h"
 					
 					using namespace std::literals;
 					using namespace forte::literals;


### PR DESCRIPTION
Reduce unused includes in forte_ng export by including ST standard functions and utils, as well as array datatypes, only as needed.