### PR TITLE
Change automatic event connection behavior

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/InsertFBIntoExecutionChainCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/InsertFBIntoExecutionChainCommand.java
@@ -122,7 +122,8 @@ public class InsertFBIntoExecutionChainCommand extends Command implements Scoped
 			return getExecutionChainEnd();
 		}
 		if (!predecessor.getInterface().getEventOutputs().isEmpty()) {
-			return predecessor.getInterface().getEventOutputs().getFirst();
+			return predecessor.getInterface().getEventOutputs().stream()
+					.filter(oe -> !oe.getOutputConnections().isEmpty()).findFirst().orElse(null);
 		}
 		return null;
 	}


### PR DESCRIPTION
Automatic event connection creation feature: When inserting a FB into a given execution chain, it is no longer assumed that the first output event  of the predecessor is used as connection source. Instead the first output event which has a connection will be used.