### PR TITLE
Fix Editor and Viewer Background

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.network/src/org/eclipse/fordiac/ide/fbtypeeditor/network/viewer/AbstractFbNetworkInstanceViewer.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.network/src/org/eclipse/fordiac/ide/fbtypeeditor/network/viewer/AbstractFbNetworkInstanceViewer.java
@@ -37,7 +37,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.ui.editors.EditorCloserAdapter;
-import org.eclipse.fordiac.ide.util.ColorHelper;
 import org.eclipse.gef.ContextMenuProvider;
 import org.eclipse.gef.GraphicalViewer;
 import org.eclipse.gef.editparts.ScalableFreeformRootEditPart;
@@ -188,8 +187,10 @@ public abstract class AbstractFbNetworkInstanceViewer extends DiagramEditor {
 				final IFigure viewPort = super.createFigure();
 				final IFigure backGround = viewPort.getChildren().get(0);
 				final IFigure drawingAreaContainer = backGround.getChildren().get(0);
+				// switch colors between background and editor to indicate that this is not
+				// editable
 				final Color backGroundColor = backGround.getBackgroundColor();
-				backGround.setBackgroundColor(ColorHelper.lighter(backGroundColor));
+				backGround.setBackgroundColor(drawingAreaContainer.getBackgroundColor());
 				drawingAreaContainer.setBackgroundColor(backGroundColor);
 				return viewPort;
 			}

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/figures/BackgroundFreeformFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/figures/BackgroundFreeformFigure.java
@@ -12,12 +12,11 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.gef.figures;
 
+import org.eclipse.draw2d.ColorProvider;
 import org.eclipse.draw2d.FigureCanvas;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.fordiac.ide.gef.editparts.ZoomScalableFreeformRootEditPart;
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.widgets.Display;
 
 public class BackgroundFreeformFigure extends AbstractFreeformFigure {
 
@@ -28,10 +27,7 @@ public class BackgroundFreeformFigure extends AbstractFreeformFigure {
 	public BackgroundFreeformFigure(final ZoomScalableFreeformRootEditPart zoomScalableFreeformRootEditPart) {
 		this.zoomScalableFreeformRootEditPart = zoomScalableFreeformRootEditPart;
 		setOpaque(true);
-		final Display display = Display.getCurrent();
-		if (null != display) {
-			setBackgroundColor(display.getSystemColor(SWT.COLOR_WIDGET_BACKGROUND));
-		}
+		setBackgroundColor(ColorProvider.SystemColorFactory.getColorProvider().getMenuBackground());
 	}
 
 	@Override


### PR DESCRIPTION
For the editor background now always the theme color is used this ensures that also in darkmode the editor background is always correct.

For the viewer the editor background and the editor color are swapped so that for all themes a clear differentiation between viewer and editor is possible.

Is this something for a maintenance release as it fixes also some viewer issues on windows?