### PR TITLE
Removed any access to systems from the System Manager

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/CheckSystem.java
+++ b/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/CheckSystem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Primetals Technologies Austria GmbH
+ * Copyright (c) 2021, 2026 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -46,8 +46,6 @@ public class CheckSystem extends Task {
 					systemPathString));
 		}
 
-		// load the system to get the error markers in place
-		SystemManager.INSTANCE.getSystem(systemFile);
 		Import4diacProject.runFullBuild(systemFile.getProject());
 		Import4diacProject.waitBuilderJobsComplete();
 

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/utilities/SubAppHierarchyDialog.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/utilities/SubAppHierarchyDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Primetals Technologies Austria GmbH
+ * Copyright (c) 2024, 2026 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -154,7 +154,7 @@ public class SubAppHierarchyDialog {
 	}
 
 	private List<TreeNode> buildNodeList(final TypeLibrary typeLib) {
-		final Stream<EObject> stream = Stream.concat(typeLib.getSystems().stream().map(SystemEntry::getSystem),
+		final Stream<EObject> stream = Stream.concat(typeLib.getSystems().stream().map(SystemEntry::getType),
 				typeLib.getSubAppTypes().stream().map(SubAppTypeEntry::getType));
 		return buildNodeList(stream, Collections.emptyList());
 	}

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/LaunchConfigurationTab.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/LaunchConfigurationTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Jose Cabral
+ * Copyright (c) 2025, 2026 Jose Cabral
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -302,7 +302,7 @@ public class LaunchConfigurationTab extends AbstractLaunchConfigurationTab {
 	public AutomationSystem getSystem() {
 		if (getSystemResource() instanceof final IFile systemFile && TypeLibraryManager.INSTANCE
 				.getTypeEntryForFile(systemFile) instanceof final SystemEntry systemEntry) {
-			return systemEntry.getSystem();
+			return systemEntry.getType();
 		}
 		return null;
 	}

--- a/plugins/org.eclipse.fordiac.ide.deployment.bootfile/src/org/eclipse/fordiac/ide/deployment/bootfile/wizard/CreateBootFilesWizardPage.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.bootfile/src/org/eclipse/fordiac/ide/deployment/bootfile/wizard/CreateBootFilesWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 fortiss GmbH, Johannes Kepler University Linz
+ * Copyright (c) 2014, 2026 fortiss GmbH, Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -116,7 +116,7 @@ public class CreateBootFilesWizardPage extends WizardExportResourcesPage {
 
 	private List<AutomationSystem> getSelectedSystems() {
 		return ((List<IFile>) getSelectedResources()).stream().map(TypeLibraryManager.INSTANCE::getTypeEntryForFile)
-				.filter(SystemEntry.class::isInstance).map(SystemEntry.class::cast).map(SystemEntry::getSystem)
+				.filter(SystemEntry.class::isInstance).map(SystemEntry.class::cast).map(SystemEntry::getType)
 				.filter(Objects::nonNull).toList();
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug.ui/src/org/eclipse/fordiac/ide/deployment/debug/ui/DeploymentLaunchConfigurationTab.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug.ui/src/org/eclipse/fordiac/ide/deployment/debug/ui/DeploymentLaunchConfigurationTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 Martin Erich Jobst
+ * Copyright (c) 2022, 2026 Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -286,7 +286,7 @@ public class DeploymentLaunchConfigurationTab extends AbstractLaunchConfiguratio
 	public AutomationSystem getSystem() {
 		if (getSystemResource() instanceof final IFile systemFile && TypeLibraryManager.INSTANCE
 				.getTypeEntryForFile(systemFile) instanceof final SystemEntry systemEntry) {
-			return systemEntry.getSystem();
+			return systemEntry.getType();
 		}
 		return null;
 	}

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug.ui/src/org/eclipse/fordiac/ide/deployment/debug/ui/DeploymentLaunchShortcut.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug.ui/src/org/eclipse/fordiac/ide/deployment/debug/ui/DeploymentLaunchShortcut.java
@@ -184,7 +184,7 @@ public class DeploymentLaunchShortcut implements ILaunchShortcut2 {
 			return collectDeployableObjects(TypeLibraryManager.INSTANCE.getTypeEntryForFile(file));
 		}
 		if (object instanceof final SystemEntry systemEntry) {
-			return collectDeployableObjects(systemEntry.getSystem());
+			return collectDeployableObjects(systemEntry.getType());
 		}
 		if (object instanceof final AutomationSystem automationSystem) {
 			return collectDeployableObjects(automationSystem.getSystemConfiguration());

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/DeploymentLaunchConfigurationAttributes.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/DeploymentLaunchConfigurationAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 Martin Erich Jobst
+ * Copyright (c) 2022, 2026 Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -76,7 +76,7 @@ public final class DeploymentLaunchConfigurationAttributes {
 	public static AutomationSystem getSystem(final ILaunchConfiguration configuration) throws CoreException {
 		final SystemEntry systemEntry = getSystemEntry(configuration);
 		if (systemEntry != null) {
-			return systemEntry.getSystem();
+			return systemEntry.getType();
 		}
 		return null;
 	}

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/breakpoint/DeploymentWatchpoint.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/breakpoint/DeploymentWatchpoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Martin Erich Jobst
+ * Copyright (c) 2024, 2026 Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -72,7 +72,7 @@ public class DeploymentWatchpoint extends Breakpoint {
 		if (marker != null && marker.getResource() instanceof final IFile file) {
 			final TypeEntry typeEntry = TypeLibraryManager.INSTANCE.getTypeEntryForFile(file);
 			if (typeEntry instanceof final SystemEntry systemEntry) {
-				final AutomationSystem system = systemEntry.getSystem();
+				final AutomationSystem system = systemEntry.getType();
 				if (system != null) {
 					return getTarget(system);
 				}

--- a/plugins/org.eclipse.fordiac.ide.elk/src/org/eclipse/fordiac/ide/elk/handlers/SystemLayoutHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.elk/src/org/eclipse/fordiac/ide/elk/handlers/SystemLayoutHandler.java
@@ -14,10 +14,10 @@
 package org.eclipse.fordiac.ide.elk.handlers;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
@@ -36,7 +36,6 @@ import org.eclipse.fordiac.ide.elk.Messages;
 import org.eclipse.fordiac.ide.gef.editparts.AbstractFBNetworkEditPart;
 import org.eclipse.fordiac.ide.model.helpers.ModelHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.Application;
-import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
 import org.eclipse.fordiac.ide.model.libraryElement.CompositeFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
@@ -45,6 +44,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
 import org.eclipse.fordiac.ide.model.libraryElement.SubAppType;
 import org.eclipse.fordiac.ide.model.libraryElement.UntypedSubApp;
+import org.eclipse.fordiac.ide.model.typelibrary.SystemEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
 import org.eclipse.fordiac.ide.model.ui.editors.AbstractBreadCrumbEditor;
@@ -92,11 +92,10 @@ public class SystemLayoutHandler extends AbstractHandler {
 			} else if (obj instanceof final IFile file) {
 				files.add(file);
 			} else if (obj instanceof final IProject project) {
-				final List<AutomationSystem> systems = SystemManager.INSTANCE.getProjectSystems(project);
-				systems.forEach(sys -> files.add(sys.getTypeEntry().getFile()));
 				final TypeLibrary typeLibrary = TypeLibraryManager.INSTANCE.getTypeLibrary(project);
-				typeLibrary.getCompositeFBTypes().forEach(typeEntry -> files.add(typeEntry.getFile()));
-				typeLibrary.getSubAppTypes().forEach(typeEntry -> files.add(typeEntry.getFile()));
+				Stream.of(typeLibrary.getSystems().stream(), typeLibrary.getCompositeFBTypes(),
+						typeLibrary.getSubAppTypes().stream()).flatMap(s -> s)
+						.forEach(typeEntry -> files.add(typeEntry.getFile()));
 			}
 		}
 
@@ -117,20 +116,17 @@ public class SystemLayoutHandler extends AbstractHandler {
 				collectElements(elements, List.of(subapp));
 			} else if (obj instanceof final IFile file) {
 				if (SystemManager.isSystemFile(file)) {
-					final var system = SystemManager.INSTANCE.getSystem(file);
-					collectElements(elements, system.getApplication());
+					if (TypeLibraryManager.INSTANCE.getTypeEntryForFile(file) instanceof final SystemEntry sysEntry) {
+						collectElements(elements, sysEntry.getType().getApplication());
+					}
 				} else {
 					// cfb and typed subapp
 					elements.add(file);
 				}
 			} else if (obj instanceof final IProject project) {
-				// @formatter:off
-				final var applications = SystemManager.INSTANCE.getProjectSystems(project).stream()
-					.map(AutomationSystem::getApplication)
-					.flatMap(Collection::stream).toList();
-				// @formatter:on
-				collectElements(elements, applications);
 				final TypeLibrary typeLibrary = TypeLibraryManager.INSTANCE.getTypeLibrary(project);
+				typeLibrary.getSystems().stream().map(SystemEntry::getType)
+						.forEach(sys -> collectElements(elements, sys.getApplication()));
 				typeLibrary.getCompositeFBTypes().forEach(typeEntry -> elements.add(typeEntry.getFile()));
 				typeLibrary.getSubAppTypes().forEach(typeEntry -> elements.add(typeEntry.getFile()));
 			}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/SystemEntry.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/SystemEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2022 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
+ * Copyright (c) 2008, 2026 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
  * 							Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
@@ -16,13 +16,11 @@
 package org.eclipse.fordiac.ide.model.typelibrary;
 
 import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
-import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 
 public interface SystemEntry extends TypeEntry {
 
-	AutomationSystem getSystem();
-
-	void setSystem(LibraryElement system);
+	@Override
+	AutomationSystem getType();
 
 	@Override
 	AutomationSystem copyType();

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/SystemEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/SystemEntryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
+ * Copyright (c) 2008, 2026 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
  * 							Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
@@ -21,7 +21,6 @@ import org.eclipse.fordiac.ide.model.dataexport.SystemExporter;
 import org.eclipse.fordiac.ide.model.dataimport.CommonElementImporter;
 import org.eclipse.fordiac.ide.model.dataimport.SystemImporter;
 import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
-import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.typelibrary.SystemEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
@@ -30,16 +29,6 @@ public class SystemEntryImpl extends AbstractCheckedTypeEntryImpl<AutomationSyst
 
 	public SystemEntryImpl() {
 		super(AutomationSystem.class);
-	}
-
-	@Override
-	public AutomationSystem getSystem() {
-		return getType();
-	}
-
-	@Override
-	public void setSystem(final LibraryElement system) {
-		setType(system);
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/linkhelpers/SystemExplorerLinkHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/linkhelpers/SystemExplorerLinkHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Primetals Technologies Austria GmbH
+ * Copyright (c) 2022, 2026 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -26,6 +26,9 @@ import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.Service;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
 import org.eclipse.fordiac.ide.model.libraryElement.SystemConfiguration;
+import org.eclipse.fordiac.ide.model.typelibrary.SystemEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
 import org.eclipse.fordiac.ide.model.ui.actions.OpenListener;
 import org.eclipse.fordiac.ide.model.ui.editors.AbstractBreadCrumbEditor;
 import org.eclipse.fordiac.ide.model.ui.editors.HandlerHelper;
@@ -116,7 +119,10 @@ public class SystemExplorerLinkHelper implements ILinkHelper {
 			LibraryElement libraryElement = LibraryElementProvider.INSTANCE
 					.getLibraryElement(new FileEditorInput(aFile));
 			if (libraryElement == null) {
-				libraryElement = SystemManager.INSTANCE.getSystem(aFile);
+				final TypeEntry typeEntry = TypeLibraryManager.INSTANCE.getTypeEntryForFile(aFile);
+				if (typeEntry instanceof final SystemEntry sysEntry) {
+					libraryElement = sysEntry.getType();
+				}
 			}
 			handleModelElementSelection(aPage, libraryElement);
 		}

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/SystemManager.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/SystemManager.java
@@ -1,9 +1,8 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 Profactor GmbH, TU Wien ACIN, AIT, fortiss GmbH,
- * 		            Johannes Kepler University Linz
- *                          Primetals Technologies Austria GmbH
+ * Copyright (c) 2008, 2026 Profactor GmbH, TU Wien ACIN, AIT, fortiss GmbH,
+ *                          Johannes Kepler University Linz,
+ *                          Primetals Technologies Austria GmbH,
  *                          Martin Erich Jobst
- *
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,13 +13,12 @@
  * Contributors:
  *   Gerhard Ebenhofer, Alois Zoitl, Matthias Plasch, Filip Andren,
  *   Waldemar Eisenmenger, Martin Melik Merkumians
- *     - initial API and implementation and/or initial documentation
- *   Alois Zoitl - Refactored class hierarchy of xml exporters
- *               - New Project Explorer layout
- *               - Added support for project renameing
- *   Martin Jobst
- *     - add Xtext nature and builder
- *     - migrate system handling to typelib
+ *                - initial API and implementation and/or initial documentation
+ *   Alois Zoitl  - Refactored class hierarchy of xml exporters
+ *                - New Project Explorer layout
+ *                - Added support for project renameing
+ *   Martin Jobst - add Xtext nature and builder
+ *                - migrate system handling to typelib
  *******************************************************************************/
 package org.eclipse.fordiac.ide.systemmanagement;
 
@@ -49,7 +47,6 @@ import org.eclipse.fordiac.ide.library.model.library.Required;
 import org.eclipse.fordiac.ide.library.model.util.ManifestHelper;
 import org.eclipse.fordiac.ide.model.dataimport.SystemImporter;
 import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
-import org.eclipse.fordiac.ide.model.typelibrary.SystemEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
@@ -139,36 +136,6 @@ public enum SystemManager {
 		system.setName(name);
 		typeLibrary.createTypeEntry(systemFile).save(system, monitor);
 		return system;
-	}
-
-	/**
-	 * Load system.
-	 *
-	 *
-	 * systemFile xml file for the system
-	 *
-	 * @return the system entry
-	 */
-	private static SystemEntry initSystem(final IFile systemFile) {
-		if (systemFile.exists()) {
-			return (SystemEntry) TypeLibraryManager.INSTANCE.getTypeLibrary(systemFile.getProject())
-					.createTypeEntry(systemFile);
-		}
-		return null;
-	}
-
-	public synchronized AutomationSystem getSystem(final IFile systemFile) {
-		final TypeLibrary typeLibrary = TypeLibraryManager.INSTANCE.getTypeLibrary(systemFile.getProject());
-		SystemEntry sysEntry = (SystemEntry) typeLibrary.getTypeEntry(systemFile);
-		if (sysEntry == null) {
-			sysEntry = initSystem(systemFile);
-		}
-		return sysEntry != null ? sysEntry.getSystem() : null;
-	}
-
-	public synchronized List<AutomationSystem> getProjectSystems(final IProject project) {
-		return TypeLibraryManager.INSTANCE.getTypeLibrary(project).getSystems().stream().map(SystemEntry::getSystem)
-				.toList();
 	}
 
 	public static String[] getNatureIDs() {


### PR DESCRIPTION
As any library element handling is now performed by the type library this functionality is not needed any more and leads only to issues.