### PR TITLE
Avoid unnecessary notifications in type entry

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractInterfaceTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractInterfaceTypeEntryImpl.java
@@ -184,7 +184,9 @@ public abstract class AbstractInterfaceTypeEntryImpl<T extends FBType> extends A
 
 			NotificationChain notifications = null;
 			synchronized (this) {
-				notifications = basicSetInterface(null, notifications);
+				if (basicGetInterface() != null) {
+					notifications = basicSetInterface(null, notifications);
+				}
 			}
 
 			if (notifications != null) {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
@@ -366,7 +366,9 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 
 			NotificationChain notifications = null;
 			synchronized (this) {
-				notifications = basicSetType(null, notifications);
+				if (basicGetType() != null) {
+					notifications = basicSetType(null, notifications);
+				}
 			}
 			if (notifications != null) {
 				notifications.dispatch();


### PR DESCRIPTION
Avoid unnecessary notifications in type entry, resulting in unwanted noise or possibly infinite recursions.