### PR TITLE
Fix dependency updates in library element provider

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/AbstractLibraryElementProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/AbstractLibraryElementProvider.java
@@ -259,8 +259,7 @@ public abstract class AbstractLibraryElementProvider<T extends AbstractLibraryEl
 
 		protected LibraryElementInfo(final IEditorInput input, final LibraryElement libraryElement) {
 			this.input = input;
-			this.libraryElement = libraryElement;
-			undoContext = new ObjectUndoContext(libraryElement);
+			setLibraryElement(libraryElement);
 		}
 
 		protected IEditorInput getEditorInput() {


### PR DESCRIPTION
The dependency updater was not properly set up in the constructor of the library element info.