### PR TITLE
Modernized Look of Page Border

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/EditorWithInterfaceEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/EditorWithInterfaceEditPart.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.eclipse.draw2d.Border;
 import org.eclipse.draw2d.BorderLayout;
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.FreeformLayer;
@@ -45,9 +44,9 @@ import org.eclipse.emf.common.notify.Adapter;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.impl.AdapterImpl;
 import org.eclipse.emf.ecore.util.EContentAdapter;
+import org.eclipse.fordiac.ide.application.figures.CommentContainer;
 import org.eclipse.fordiac.ide.application.policies.AbstractCreateInstanceDirectEditPolicy;
 import org.eclipse.fordiac.ide.application.policies.FBNetworkCreateInstanceDirectEditPolicy;
-import org.eclipse.fordiac.ide.gef.draw2d.SingleLineBorder;
 import org.eclipse.fordiac.ide.gef.editparts.AbstractFBNetworkEditPart;
 import org.eclipse.fordiac.ide.gef.editparts.InterfaceEditPart;
 import org.eclipse.fordiac.ide.model.CoordinateConverter;
@@ -342,22 +341,7 @@ public abstract class EditorWithInterfaceEditPart extends AbstractFBNetworkEditP
 	}
 
 	private void createCommentContainer(final IFigure mainFigure) {
-		commentContainer = new Figure();
-		final Border border = new SingleLineBorder() {
-			private final Insets insets = new Insets(5); // spacing
-
-			@Override
-			public Insets getInsets(final IFigure figure) {
-				return insets;
-			}
-		};
-		commentContainer.setBorder(border);
-		final ToolbarLayout layout = new ToolbarLayout();
-		layout.setMinorAlignment(OrderedLayout.ALIGN_CENTER);
-		layout.setStretchMinorAxis(false);
-		commentContainer.setOpaque(true);
-
-		commentContainer.setLayoutManager(layout);
+		commentContainer = new CommentContainer();
 		mainFigure.add(commentContainer, BorderLayout.TOP);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/FBNetworkEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/FBNetworkEditPart.java
@@ -19,25 +19,21 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.eclipse.draw2d.Border;
 import org.eclipse.draw2d.BorderLayout;
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.FreeformLayer;
 import org.eclipse.draw2d.FreeformLayout;
 import org.eclipse.draw2d.IFigure;
-import org.eclipse.draw2d.OrderedLayout;
-import org.eclipse.draw2d.ToolbarLayout;
 import org.eclipse.draw2d.geometry.Dimension;
-import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.emf.common.notify.Adapter;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.impl.AdapterImpl;
+import org.eclipse.fordiac.ide.application.figures.CommentContainer;
 import org.eclipse.fordiac.ide.application.policies.AbstractCreateInstanceDirectEditPolicy;
 import org.eclipse.fordiac.ide.application.policies.FBNetworkCreateInstanceDirectEditPolicy;
 import org.eclipse.fordiac.ide.application.policies.FBNetworkXYLayoutEditPolicy;
-import org.eclipse.fordiac.ide.gef.draw2d.SingleLineBorder;
 import org.eclipse.fordiac.ide.gef.editparts.AbstractFBNetworkEditPart;
 import org.eclipse.fordiac.ide.model.libraryElement.Application;
 import org.eclipse.gef.DragTracker;
@@ -243,24 +239,7 @@ public class FBNetworkEditPart extends AbstractFBNetworkEditPart {
 	}
 
 	private void createCommentContainer(final IFigure mainFigure) {
-		commentContainer = new Figure();
-		final Border border = new SingleLineBorder() {
-
-			private final Insets insets = new Insets(5); // spacing
-
-			@Override
-			public Insets getInsets(final IFigure figure) {
-				return insets;
-			}
-
-		};
-		commentContainer.setBorder(border);
-		final ToolbarLayout layout = new ToolbarLayout();
-		layout.setMinorAlignment(OrderedLayout.ALIGN_CENTER);
-		layout.setStretchMinorAxis(false);
-		commentContainer.setOpaque(true);
-
-		commentContainer.setLayoutManager(layout);
+		commentContainer = new CommentContainer();
 		mainFigure.add(commentContainer, BorderLayout.TOP);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/CommentContainer.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/CommentContainer.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2008 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
+ *                    Primetals Technologies Austria GmbH,
+ *                    Johannes Kepler University Linz
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Gerhard Ebenhofer, Alois Zoitl
+ *   - initial API and implementation and/or initial documentation
+ *   Fabio Gandolfi - added Comments for Applications
+ *   Alois Zoit     - extracted from FBNEtworkEditPart and adjust to new look
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.application.figures;
+
+import org.eclipse.draw2d.Figure;
+import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.MarginBorder;
+import org.eclipse.draw2d.OrderedLayout;
+import org.eclipse.draw2d.ToolbarLayout;
+import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.fordiac.ide.ui.preferences.UIPreferenceConstants;
+
+public final class CommentContainer extends Figure {
+
+	public CommentContainer() {
+		setBorder(new MarginBorder(5));
+		final ToolbarLayout layout = new ToolbarLayout();
+		layout.setMinorAlignment(OrderedLayout.ALIGN_CENTER);
+		layout.setStretchMinorAxis(false);
+		setOpaque(true);
+		setBackgroundColor(UIPreferenceConstants.getPageCommentColor());
+		setLayoutManager(layout);
+	}
+
+	@Override
+	protected void paintFigure(final Graphics graphics) {
+		super.paintFigure(graphics);
+		// draw a line separator at the bottom
+		final int alpha = graphics.getAlpha();
+		final Rectangle bounds = getBounds();
+		final int bottom = bounds.y + bounds.height - 1;
+		graphics.setAlpha(25);
+		graphics.drawLine(bounds.x, bottom, bounds.x + bounds.width, bottom);
+		graphics.setAlpha(alpha);
+
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/InstanceCommentFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/InstanceCommentFigure.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2019 Johannes Kepler University Linz
- * 				 2020 Primetals Technologies Germany GmbH
+ * Copyright (c) 2019 Johannes Kepler University Linz,
+ *                    Primetals Technologies Germany GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,16 +15,20 @@
 package org.eclipse.fordiac.ide.application.figures;
 
 import org.eclipse.draw2d.Figure;
+import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.StackLayout;
 import org.eclipse.draw2d.text.FlowPage;
 import org.eclipse.draw2d.text.ParagraphTextLayout;
 import org.eclipse.draw2d.text.TextFlow;
 import org.eclipse.fordiac.ide.application.Messages;
 import org.eclipse.fordiac.ide.gef.listeners.IFontUpdateListener;
+import org.eclipse.fordiac.ide.ui.preferences.UIPreferenceConstants;
+import org.eclipse.jface.resource.JFaceResources;
 
 public class InstanceCommentFigure extends Figure implements IFontUpdateListener {
 
 	public static final String EMPTY_COMMENT = "[" + Messages.InstanceCommentEditPart_EMPTY_COMMENT + "]"; //$NON-NLS-1$ //$NON-NLS-2$
+	private static final int EMPTY_COMMENT_ALPHA = 150;
 	private final TextFlow textFlow;
 
 	public InstanceCommentFigure() {
@@ -54,6 +58,15 @@ public class InstanceCommentFigure extends Figure implements IFontUpdateListener
 
 	public int getTextWidth() {
 		return textFlow.getSize().width();
+	}
+
+	@Override
+	protected void paintChildren(final Graphics graphics) {
+		if (EMPTY_COMMENT.equals(textFlow.getText())) {
+			graphics.setAlpha(EMPTY_COMMENT_ALPHA);
+			graphics.setFont(JFaceResources.getFontRegistry().getItalic(UIPreferenceConstants.DIAGRAM_FONT));
+		}
+		super.paintChildren(graphics);
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.ui/css/dark_fordiac_connections.css
+++ b/plugins/org.eclipse.fordiac.ide.ui/css/dark_fordiac_connections.css
@@ -21,4 +21,5 @@ IEclipsePreferences#org-eclipse-ui-workbench:org-eclipse-fordiac-ide-ui {
 		'org.eclipse.fordiac.ide.ui.DataConnectionConnectorColor=102, 153, 255' 
 		'org.eclipse.fordiac.ide.ui.AdapterConnectionConnectorColor=132, 93, 175'
 		'org.eclipse.fordiac.ide.ui.InterfaceBarBackgroundColor=45, 65, 85'
+		'org.eclipse.fordiac.ide.ui.PageCommentBackgroundColor=37, 38, 43'
 } 

--- a/plugins/org.eclipse.fordiac.ide.ui/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.ui/plugin.xml
@@ -194,6 +194,14 @@
              isEditable="false"> 
              <!-- the label does not need to be translatable --> 
        </colorDefinition>
+       <colorDefinition
+             categoryId="org.eclipse.fordiac.ide.themeCategory"
+             id="org.eclipse.fordiac.ide.ui.PageCommentBackgroundColor"
+             label="Page Comment Background Color"
+             value="248, 248, 252"
+             isEditable="false"> 
+             <!-- the label does not need to be translatable --> 
+       </colorDefinition>
     </extension>
 	<extension
 		point="org.eclipse.e4.ui.css.swt.theme">

--- a/plugins/org.eclipse.fordiac.ide.ui/src/org/eclipse/fordiac/ide/ui/preferences/UIPreferenceConstants.java
+++ b/plugins/org.eclipse.fordiac.ide.ui/src/org/eclipse/fordiac/ide/ui/preferences/UIPreferenceConstants.java
@@ -39,6 +39,7 @@ public final class UIPreferenceConstants {
 	public static final String P_ANY_STRING_CONNECTOR_COLOR = "org.eclipse.fordiac.ide.ui.AnyStringConnectionConnectorColor"; //$NON-NLS-1$
 	public static final String P_REMAINING_DATA_CONNECTOR_COLOR = "org.eclipse.fordiac.ide.ui.DataConnectionConnectorColor";//$NON-NLS-1$
 	private static final String P_INTERFACE_BAR_COLOR = "org.eclipse.fordiac.ide.ui.InterfaceBarBackgroundColor";//$NON-NLS-1$
+	private static final String P_PAGE_COMMENT_COLOR = "org.eclipse.fordiac.ide.ui.PageCommentBackgroundColor";//$NON-NLS-1$
 
 	/** The Constant P_ADAPTER_CONNECTOR_COLOR. */
 	public static final String P_ADAPTER_CONNECTOR_COLOR = "org.eclipse.fordiac.ide.ui.AdapterConnectionConnectorColor";//$NON-NLS-1$
@@ -119,5 +120,9 @@ public final class UIPreferenceConstants {
 
 	public static Color getInterfaceBarColor() {
 		return JFaceResources.getColorRegistry().get(P_INTERFACE_BAR_COLOR);
+	}
+
+	public static Color getPageCommentColor() {
+		return JFaceResources.getColorRegistry().get(P_PAGE_COMMENT_COLOR);
 	}
 }


### PR DESCRIPTION
With the new drop shadow and the new interface bar the page comments with there single line border didn't fit anymore. This commit removes the border and sets an off white background. Furthermore an empty comment is shown in italic and light grey.

For darkmode the changes are done accordingly.