### PR TITLE
Fix follow/go-to pin handlers for expanded struct member pins by

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/AbstractGoToPinHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/AbstractGoToPinHandler.java
@@ -14,7 +14,6 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.application.handlers;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.core.commands.AbstractHandler;
@@ -22,7 +21,6 @@ import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
-import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.ui.editors.HandlerHelper;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.GraphicalViewer;
@@ -88,23 +86,11 @@ public abstract class AbstractGoToPinHandler extends AbstractHandler {
 	}
 
 	protected static List<IInterfaceElement> getAllInputs(final IInterfaceElement ie) {
-		final List<IInterfaceElement> inputList = new ArrayList<>();
-		final InterfaceList interfaceList = (InterfaceList) ie.eContainer();
-		inputList.addAll(interfaceList.getEventInputs().stream().filter(IInterfaceElement::isVisible).toList());
-		inputList.addAll(interfaceList.getInputVars().stream().filter(IInterfaceElement::isVisible).toList());
-		inputList.addAll(interfaceList.getInOutVars().stream().filter(IInterfaceElement::isVisible).toList());
-		inputList.addAll(interfaceList.getSockets().stream().filter(IInterfaceElement::isVisible).toList());
-		return inputList;
+		return ie.getInterfaceList().getAllInputs().filter(IInterfaceElement::isVisible).toList();
 	}
 
 	protected static List<IInterfaceElement> getAllOutputs(final IInterfaceElement ie) {
-		final List<IInterfaceElement> outputList = new ArrayList<>();
-		final InterfaceList interfaceList = (InterfaceList) ie.eContainer();
-		outputList.addAll(interfaceList.getEventOutputs().stream().filter(IInterfaceElement::isVisible).toList());
-		outputList.addAll(interfaceList.getOutputVars().stream().filter(IInterfaceElement::isVisible).toList());
-		outputList.addAll(interfaceList.getOutMappedInOutVars().stream().filter(IInterfaceElement::isVisible).toList());
-		outputList.addAll(interfaceList.getPlugs().stream().filter(IInterfaceElement::isVisible).toList());
-		return outputList;
+		return ie.getInterfaceList().getAllOutputs().filter(IInterfaceElement::isVisible).toList();
 	}
 
 	private IInterfaceElement getFollowingPin(final IInterfaceElement ie, final List<IInterfaceElement> interfaceList) {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/InterfaceElementAnnotations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/InterfaceElementAnnotations.java
@@ -95,7 +95,11 @@ public final class InterfaceElementAnnotations {
 	}
 
 	public static InterfaceList getInterfaceList(final IInterfaceElement element) {
-		return element.eContainer() instanceof final InterfaceList interfaceList ? interfaceList : null;
+		return switch (element.eContainer()) {
+		case final InterfaceList interfaceList -> interfaceList;
+		case final IInterfaceElement parent -> parent.getInterfaceList();
+		case null, default -> null;
+		};
 	}
 
 	public static boolean validateName(final IInterfaceElement element, final DiagnosticChain diagnostics,


### PR DESCRIPTION
resolving IInterfaceElement#getInterfaceList() recursively via parent pins