### PR TITLE
Fix toggle mark occurrences only affecting fbt or fct editors

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/STAlgorithmUiModule.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/STAlgorithmUiModule.java
@@ -43,6 +43,7 @@ import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.quickfix.STCoreQuick
 import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.reconciler.STCoreDocumentReconcileStrategy;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.hovering.STCoreHoverDocumentationProvider;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.hovering.STCoreHoverProvider;
+import org.eclipse.fordiac.ide.structuredtextcore.ui.internal.StructuredtextcoreActivator;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.outline.FilterHeadingsContribution;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.outline.OutlineTreeContribution;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.outline.STCoreOutlinePage;
@@ -95,6 +96,7 @@ import org.eclipse.xtext.ui.editor.IURIEditorOpener;
 import org.eclipse.xtext.ui.editor.IXtextEditorCallback;
 import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.editor.XtextSourceViewer;
+import org.eclipse.xtext.ui.editor.actions.IActionContributor;
 import org.eclipse.xtext.ui.editor.contentassist.AbstractJavaBasedContentProposalProvider;
 import org.eclipse.xtext.ui.editor.contentassist.IContentProposalPriorities;
 import org.eclipse.xtext.ui.editor.contentassist.PrefixMatcher;
@@ -129,6 +131,7 @@ import org.eclipse.xtext.ui.validation.IResourceUIValidatorExtension;
 import org.eclipse.xtext.ui.validation.MarkerTypeProvider;
 
 import com.google.inject.Binder;
+import com.google.inject.Key;
 import com.google.inject.Provider;
 import com.google.inject.name.Names;
 
@@ -227,6 +230,14 @@ public class STAlgorithmUiModule extends AbstractSTAlgorithmUiModule {
 		if (PlatformUI.isWorkbenchRunning()) {
 			binder.bind(IURIEditorOpener.class).annotatedWith(LanguageSpecific.class).to(STCoreURIEditorOpener.class);
 		}
+	}
+
+	@Override
+	public void configureMarkOccurrencesAction(final Binder binder) {
+		binder.bind(IActionContributor.class).annotatedWith(Names.named("markOccurrences")) //$NON-NLS-1$
+				.toProvider(() -> StructuredtextcoreActivator.getInstance()
+						.getInjector(StructuredtextcoreActivator.ORG_ECLIPSE_FORDIAC_IDE_STRUCTUREDTEXTCORE_STCORE)
+						.getInstance(Key.get(IActionContributor.class, Names.named("markOccurrences")))); //$NON-NLS-1$
 	}
 
 	public Class<? extends IOccurrenceComputer> bindIOccurrenceComputer() {

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/ui/STFunctionUiModule.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/ui/STFunctionUiModule.java
@@ -35,6 +35,7 @@ import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.quickfix.STCoreQuick
 import org.eclipse.fordiac.ide.structuredtextcore.ui.editor.reconciler.STCoreDocumentReconcileStrategy;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.hovering.STCoreHoverDocumentationProvider;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.hovering.STCoreHoverProvider;
+import org.eclipse.fordiac.ide.structuredtextcore.ui.internal.StructuredtextcoreActivator;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.outline.FilterHeadingsContribution;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.outline.OutlineTreeContribution;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.outline.STCoreOutlinePage;
@@ -91,6 +92,7 @@ import org.eclipse.xtext.ui.editor.IURIEditorOpener;
 import org.eclipse.xtext.ui.editor.IXtextEditorCallback;
 import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.editor.XtextSourceViewer;
+import org.eclipse.xtext.ui.editor.actions.IActionContributor;
 import org.eclipse.xtext.ui.editor.contentassist.AbstractJavaBasedContentProposalProvider.ReferenceProposalCreator;
 import org.eclipse.xtext.ui.editor.contentassist.IContentProposalPriorities;
 import org.eclipse.xtext.ui.editor.contentassist.PrefixMatcher;
@@ -122,6 +124,7 @@ import org.eclipse.xtext.ui.validation.IResourceUIValidatorExtension;
 import org.eclipse.xtext.ui.validation.MarkerTypeProvider;
 
 import com.google.inject.Binder;
+import com.google.inject.Key;
 import com.google.inject.Provider;
 import com.google.inject.name.Names;
 
@@ -199,6 +202,14 @@ public class STFunctionUiModule extends AbstractSTFunctionUiModule {
 
 	public Class<? extends ISimilarityMatcher> bindISimilarityMatcher() {
 		return CaseInsensitiveSimilarityMatcher.class;
+	}
+
+	@Override
+	public void configureMarkOccurrencesAction(final Binder binder) {
+		binder.bind(IActionContributor.class).annotatedWith(Names.named("markOccurrences")) //$NON-NLS-1$
+				.toProvider(() -> StructuredtextcoreActivator.getInstance()
+						.getInjector(StructuredtextcoreActivator.ORG_ECLIPSE_FORDIAC_IDE_STRUCTUREDTEXTCORE_STCORE)
+						.getInstance(Key.get(IActionContributor.class, Names.named("markOccurrences")))); //$NON-NLS-1$
 	}
 
 	public Class<? extends IOccurrenceComputer> bindIOccurrenceComputer() {


### PR DESCRIPTION
There was a toggle mark occurrence action contribution per language, but there is only one toolbar manager for both fbt and fct type editors. This meant only the first language registered its contribution and thus only a subset of editors was updated on toggle.

This uses a common action contribution instance from ST core for both ST algorithm and function languages to avoid the problem.