### PR TITLE
feat: Custom plugins may be registered for the error reporting

### DIFF
--- a/plugins/org.eclipse.fordiac.ide/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide/plugin.xml
@@ -239,9 +239,9 @@
          point="org.eclipse.fordiac.ide.errorDialogFilters">
 		<plugin
         id="org.eclipse.ui"
-        issue_url="https://github.com/eclipse-4diac/4diac-ide/issues/new?title=%s&amp;labels=%s&amp;body=%s"/>
+        preference_qualifier="org.eclipse.fordiac.ide.issuereport"/>
 		<plugin
         id="org.eclipse.fordiac.ide"
-        issue_url="https://github.com/eclipse-4diac/4diac-ide/issues/new?title=%s&amp;labels=%s&amp;body=%s"/>
+        preference_qualifier="org.eclipse.fordiac.ide.issuereport"/>
    </extension>
 </plugin>

--- a/plugins/org.eclipse.fordiac.ide/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide/plugin.xml
@@ -237,7 +237,11 @@
    </extension>
    <extension
          point="org.eclipse.fordiac.ide.errorDialogFilters">
-		<plugin id="org.eclipse.ui"/>
-		<plugin id="org.eclipse.fordiac.ide"/>
+		<plugin
+        id="org.eclipse.ui"
+        issue_url="https://github.com/eclipse-4diac/4diac-ide/issues/new?title=%s&amp;labels=%s&amp;body=%s"/>
+		<plugin
+        id="org.eclipse.fordiac.ide"
+        issue_url="https://github.com/eclipse-4diac/4diac-ide/issues/new?title=%s&amp;labels=%s&amp;body=%s"/>
    </extension>
 </plugin>

--- a/plugins/org.eclipse.fordiac.ide/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide/plugin.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.2"?>
 <plugin>
+   <extension-point id="errorDialogFilters" name="Error Dialog Filters" schema="schema/errorDialogFilters.exsd"/>
    <extension
          point="org.eclipse.ui.perspectives">
       <perspective
@@ -233,5 +234,10 @@
             id="org.eclipse.fordiac.ide.issuereport.GitIssueReportingPage"
             name="Git Issue Reporting">
       </page>
+   </extension>
+   <extension
+         point="org.eclipse.fordiac.ide.errorDialogFilters">
+		<plugin id="org.eclipse.ui"/>
+		<plugin id="org.eclipse.fordiac.ide"/>
    </extension>
 </plugin>

--- a/plugins/org.eclipse.fordiac.ide/schema/errorDialogFilters.exsd
+++ b/plugins/org.eclipse.fordiac.ide/schema/errorDialogFilters.exsd
@@ -57,7 +57,14 @@ Usefull when you want to provide a error reporting dialog.
                </documentation>
             </annotation>
          </attribute>
-         <attribute name="issue_url" type="string">
+         <attribute name="issue_url" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="preference_qualifier" type="string" use="default" value="org.eclipse.fordiac.ide.issuereport">
             <annotation>
                <documentation>
                   
@@ -83,8 +90,8 @@ Usefull when you want to provide a error reporting dialog.
       <documentation>
          &lt;extension
          point=&quot;org.eclipse.fordiac.ide.errorDialogFilters&quot;&gt;
-  &lt;plugin id=&quot;org.eclipse.ui&quot;/&gt;
-  &lt;plugin id=&quot;org.eclipse.fordiac.ide&quot;/ issue_url=&quot;https://github.com/myuser/myrepo/&quot;&gt;
+  &lt;plugin id=&quot;org.eclipse.ui&quot;/ issue_url=&quot;https://github.com/myuser/myrepo1/&quot;&gt;
+  &lt;plugin id=&quot;org.eclipse.fordiac.ide&quot;/ issue_url=&quot;https://github.com/myuser/myrepo2/&quot;&gt;
 &lt;/extension&gt;
 
 This ensure that the plugin &quot;org.eclipse.ui&quot; and &quot;org.eclipse.fordiac.ide&quot; are registered for filtering.

--- a/plugins/org.eclipse.fordiac.ide/schema/errorDialogFilters.exsd
+++ b/plugins/org.eclipse.fordiac.ide/schema/errorDialogFilters.exsd
@@ -57,6 +57,13 @@ Usefull when you want to provide a error reporting dialog.
                </documentation>
             </annotation>
          </attribute>
+         <attribute name="issue_url" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
       </complexType>
    </element>
 
@@ -76,8 +83,8 @@ Usefull when you want to provide a error reporting dialog.
       <documentation>
          &lt;extension
          point=&quot;org.eclipse.fordiac.ide.errorDialogFilters&quot;&gt;
-		&lt;plugin id=&quot;org.eclipse.ui&quot;/&gt;
-		&lt;plugin id=&quot;org.eclipse.fordiac.ide&quot;/&gt;
+  &lt;plugin id=&quot;org.eclipse.ui&quot;/&gt;
+  &lt;plugin id=&quot;org.eclipse.fordiac.ide&quot;/ issue_url=&quot;https://github.com/myuser/myrepo/&quot;&gt;
 &lt;/extension&gt;
 
 This ensure that the plugin &quot;org.eclipse.ui&quot; and &quot;org.eclipse.fordiac.ide&quot; are registered for filtering.

--- a/plugins/org.eclipse.fordiac.ide/schema/errorDialogFilters.exsd
+++ b/plugins/org.eclipse.fordiac.ide/schema/errorDialogFilters.exsd
@@ -1,0 +1,125 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.eclipse.fordiac.ide" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appInfo>
+         <meta.schema plugin="org.eclipse.fordiac.ide" id="errorDialogFilters" name="Error Dialog Filters"/>
+      </appInfo>
+      <documentation>
+         This schema is used to define custom error dialog filter and to add them to the FordiacLogListener.
+Usefull when you want to provide a error reporting dialog.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appInfo>
+            <meta.element />
+         </appInfo>
+      </annotation>
+      <complexType>
+         <sequence>
+            <element ref="plugin" minOccurs="1" maxOccurs="unbounded"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute translatable="true"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="plugin">
+      <complexType>
+         <attribute name="id" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="since"/>
+      </appInfo>
+      <documentation>
+         3.1
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="examples"/>
+      </appInfo>
+      <documentation>
+         &lt;extension
+         point=&quot;org.eclipse.fordiac.ide.errorDialogFilters&quot;&gt;
+		&lt;plugin id=&quot;org.eclipse.ui&quot;/&gt;
+		&lt;plugin id=&quot;org.eclipse.fordiac.ide&quot;/&gt;
+&lt;/extension&gt;
+
+This ensure that the plugin &quot;org.eclipse.ui&quot; and &quot;org.eclipse.fordiac.ide&quot; are registered for filtering.
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="apiinfo"/>
+      </appInfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="implementation"/>
+      </appInfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="copyright"/>
+      </appInfo>
+      <documentation>
+         /*******************************************************************************
+ * Copyright (c) 2026 Malte Grave, github.com/gravemalte
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Malte Grave - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+      </documentation>
+   </annotation>
+
+</schema>

--- a/plugins/org.eclipse.fordiac.ide/schema/errorDialogFilters.exsd
+++ b/plugins/org.eclipse.fordiac.ide/schema/errorDialogFilters.exsd
@@ -57,14 +57,7 @@ Usefull when you want to provide a error reporting dialog.
                </documentation>
             </annotation>
          </attribute>
-         <attribute name="issue_url" type="string" use="required">
-            <annotation>
-               <documentation>
-                  
-               </documentation>
-            </annotation>
-         </attribute>
-         <attribute name="preference_qualifier" type="string" use="default" value="org.eclipse.fordiac.ide.issuereport">
+         <attribute name="preference_qualifier" type="string" use="required">
             <annotation>
                <documentation>
                   
@@ -90,8 +83,8 @@ Usefull when you want to provide a error reporting dialog.
       <documentation>
          &lt;extension
          point=&quot;org.eclipse.fordiac.ide.errorDialogFilters&quot;&gt;
-  &lt;plugin id=&quot;org.eclipse.ui&quot;/ issue_url=&quot;https://github.com/myuser/myrepo1/&quot;&gt;
-  &lt;plugin id=&quot;org.eclipse.fordiac.ide&quot;/ issue_url=&quot;https://github.com/myuser/myrepo2/&quot;&gt;
+  &lt;plugin id=&quot;org.eclipse.ui&quot;/&gt;
+  &lt;plugin id=&quot;org.eclipse.fordiac.ide&quot;/&gt;
 &lt;/extension&gt;
 
 This ensure that the plugin &quot;org.eclipse.ui&quot; and &quot;org.eclipse.fordiac.ide&quot; are registered for filtering.

--- a/plugins/org.eclipse.fordiac.ide/schema/errorDialogFilters.exsd
+++ b/plugins/org.eclipse.fordiac.ide/schema/errorDialogFilters.exsd
@@ -57,7 +57,7 @@ Usefull when you want to provide a error reporting dialog.
                </documentation>
             </annotation>
          </attribute>
-         <attribute name="preference_qualifier" type="string" use="required">
+         <attribute name="preference_qualifier" type="string" use="default" value="org.eclipse.fordiac.ide.issuereport">
             <annotation>
                <documentation>
                   
@@ -115,7 +115,7 @@ This ensure that the plugin &quot;org.eclipse.ui&quot; and &quot;org.eclipse.for
       </appInfo>
       <documentation>
          /*******************************************************************************
- * Copyright (c) 2026 Malte Grave, github.com/gravemalte
+ * Copyright (c) 2026 Johannes Kepler Universität
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/plugins/org.eclipse.fordiac.ide/src/org/eclipse/fordiac/ide/FordiacLogListener.java
+++ b/plugins/org.eclipse.fordiac.ide/src/org/eclipse/fordiac/ide/FordiacLogListener.java
@@ -143,7 +143,8 @@ public class FordiacLogListener implements ILogListener {
 			// Platform UI plug-in as noteworthy
 			// if a error dialog is already showing we will not show another one.
 			try {
-				showErrorDialog(createStatusWithStackTrace(status), PreferenceConstants.P_BUG_REPORT_PREFERENCE_ID);
+				showErrorDialog(createStatusWithStackTrace(status),
+						cachedFilters.floorEntry(status.getPlugin()).getValue());
 			} finally {
 				singleWindow.set(false);
 			}
@@ -156,10 +157,6 @@ public class FordiacLogListener implements ILogListener {
 		}
 		final Map.Entry<String, String> floor = cachedFilters.floorEntry(pluginID);
 		if (floor != null && pluginID.startsWith(floor.getKey())) {
-			// TODO: The issue reporting layer needs to be changed
-			// We have to put the correct issue URL of the filter extension into the
-			// GitIssueCreator, but currently the GitIssueCreator only supports one URL for
-			// all issues.
 			return true;
 		}
 		return false;
@@ -172,13 +169,14 @@ public class FordiacLogListener implements ILogListener {
 				.getConfigurationElementsFor("org.eclipse.fordiac.ide.errorDialogFilters"); //$NON-NLS-1$
 		for (final IConfigurationElement e : config) {
 			final String pluginID = e.getAttribute("id"); //$NON-NLS-1$
-			final String pluginIssueURL = e.getAttribute("issue_url"); //$NON-NLS-1$
-			if (pluginID.isBlank() || pluginIssueURL.isBlank()) {
-				FordiacLogHelper.logInfo("Invalid error dialog filter extension, missing id or issue_url attribute: " //$NON-NLS-1$
-						+ e.getContributor().getName());
+			final String pluginPreferenceQualifier = e.getAttribute("preference_qualifier"); //$NON-NLS-1$
+			if (pluginID.isBlank() || pluginPreferenceQualifier.isBlank()) {
+				FordiacLogHelper
+						.logInfo("Invalid error dialog filter extension, missing id or preference_qualifier attribute: " //$NON-NLS-1$
+								+ e.getContributor().getName());
 				continue;
 			}
-			cachedFilters.put(pluginID, pluginIssueURL);
+			cachedFilters.put(pluginID, pluginPreferenceQualifier);
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide/src/org/eclipse/fordiac/ide/FordiacLogListener.java
+++ b/plugins/org.eclipse.fordiac.ide/src/org/eclipse/fordiac/ide/FordiacLogListener.java
@@ -171,10 +171,9 @@ public class FordiacLogListener implements ILogListener {
 				.getConfigurationElementsFor("org.eclipse.fordiac.ide.errorDialogFilters"); //$NON-NLS-1$
 		for (final IConfigurationElement e : config) {
 			final String pluginID = e.getAttribute("id"); //$NON-NLS-1$
-			String pluginIssueURL = e.getAttribute("issue_url"); //$NON-NLS-1$
-			// If not plugin reporting URL is not specified, use the default 4diac issue URL
-			if (pluginIssueURL == null) {
-				pluginIssueURL = ""; //$NON-NLS-1$
+			final String pluginIssueURL = e.getAttribute("issue_url"); //$NON-NLS-1$
+			if (pluginID == null || pluginID.isBlank() || pluginIssueURL == null || pluginIssueURL.isBlank()) {
+				continue;
 			}
 			cachedFilters.put(pluginID, pluginIssueURL);
 		}

--- a/plugins/org.eclipse.fordiac.ide/src/org/eclipse/fordiac/ide/FordiacLogListener.java
+++ b/plugins/org.eclipse.fordiac.ide/src/org/eclipse/fordiac/ide/FordiacLogListener.java
@@ -18,7 +18,6 @@ package org.eclipse.fordiac.ide;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Arrays;
-import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -46,7 +45,7 @@ import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Shell;
 
 public class FordiacLogListener implements ILogListener {
-	private static TreeMap<String, String> cachedFilters = null;
+	private static final TreeMap<String, String> cachedFilters = loadFilterExtensions();
 
 	private static final class LogErrorDialog extends ErrorDialog {
 
@@ -153,18 +152,12 @@ public class FordiacLogListener implements ILogListener {
 	}
 
 	private static boolean isPluginInFilterMap(final String pluginID) {
-		if (cachedFilters == null) {
-			loadFilterExtensions();
-		}
-		final Map.Entry<String, String> floor = cachedFilters.floorEntry(pluginID);
-		if (floor != null && pluginID.startsWith(floor.getKey())) {
-			return true;
-		}
-		return false;
+		final String floor = cachedFilters.floorKey(pluginID);
+		return floor != null && pluginID.startsWith(floor);
 	}
 
-	private static void loadFilterExtensions() {
-		cachedFilters = new TreeMap<>();
+	private static TreeMap<String, String> loadFilterExtensions() {
+		final TreeMap<String, String> filters = new TreeMap<>();
 		final IExtensionRegistry registry = Platform.getExtensionRegistry();
 		final IConfigurationElement[] config = registry
 				.getConfigurationElementsFor("org.eclipse.fordiac.ide.errorDialogFilters"); //$NON-NLS-1$
@@ -177,8 +170,9 @@ public class FordiacLogListener implements ILogListener {
 								+ e.getContributor().getName());
 				continue;
 			}
-			cachedFilters.put(pluginID, pluginPreferenceQualifier);
+			filters.put(pluginID, pluginPreferenceQualifier);
 		}
+		return filters;
 	}
 
 	private static IStatus createStatusWithStackTrace(final IStatus status) {

--- a/plugins/org.eclipse.fordiac.ide/src/org/eclipse/fordiac/ide/FordiacLogListener.java
+++ b/plugins/org.eclipse.fordiac.ide/src/org/eclipse/fordiac/ide/FordiacLogListener.java
@@ -159,7 +159,7 @@ public class FordiacLogListener implements ILogListener {
 			// We have to put the correct issue URL of the filter extension into the
 			// GitIssueCreator, but currently the GitIssueCreator only supports one URL for
 			// all issues.
-			return floor.getValue() != null ? true : false;
+			return true;
 		}
 		return false;
 	}
@@ -174,7 +174,7 @@ public class FordiacLogListener implements ILogListener {
 			String pluginIssueURL = e.getAttribute("issue_url"); //$NON-NLS-1$
 			// If not plugin reporting URL is not specified, use the default 4diac issue URL
 			if (pluginIssueURL == null) {
-				pluginIssueURL = GitIssueCreator.FORDIAC_IDE_ISSUE_URL;
+				pluginIssueURL = ""; //$NON-NLS-1$
 			}
 			cachedFilters.put(pluginID, pluginIssueURL);
 		}

--- a/plugins/org.eclipse.fordiac.ide/src/org/eclipse/fordiac/ide/FordiacLogListener.java
+++ b/plugins/org.eclipse.fordiac.ide/src/org/eclipse/fordiac/ide/FordiacLogListener.java
@@ -31,6 +31,7 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.fordiac.ide.issuereport.GitIssueCreator;
 import org.eclipse.fordiac.ide.issuereport.PreferenceConstants;
+import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 import org.eclipse.jface.dialogs.ErrorDialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.swt.SWT;
@@ -172,7 +173,9 @@ public class FordiacLogListener implements ILogListener {
 		for (final IConfigurationElement e : config) {
 			final String pluginID = e.getAttribute("id"); //$NON-NLS-1$
 			final String pluginIssueURL = e.getAttribute("issue_url"); //$NON-NLS-1$
-			if (pluginID == null || pluginID.isBlank() || pluginIssueURL == null || pluginIssueURL.isBlank()) {
+			if (pluginID.isBlank() || pluginIssueURL.isBlank()) {
+				FordiacLogHelper.logInfo("Invalid error dialog filter extension, missing id or issue_url attribute: " //$NON-NLS-1$
+						+ e.getContributor().getName());
 				continue;
 			}
 			cachedFilters.put(pluginID, pluginIssueURL);

--- a/plugins/org.eclipse.fordiac.ide/src/org/eclipse/fordiac/ide/FordiacLogListener.java
+++ b/plugins/org.eclipse.fordiac.ide/src/org/eclipse/fordiac/ide/FordiacLogListener.java
@@ -17,8 +17,9 @@ package org.eclipse.fordiac.ide;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.core.runtime.IConfigurationElement;
@@ -43,7 +44,7 @@ import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Shell;
 
 public class FordiacLogListener implements ILogListener {
-	private static HashMap<String, String> cachedFilters = null;
+	private static TreeMap<String, String> cachedFilters = null;
 
 	private static final class LogErrorDialog extends ErrorDialog {
 
@@ -152,27 +153,30 @@ public class FordiacLogListener implements ILogListener {
 		if (cachedFilters == null) {
 			loadFilterExtensions();
 		}
-		final String idFilter = cachedFilters.get(pluginID);
-		if (idFilter != null) {
-			// Now check if the id of the rule starts with the plugin id, if so we will also
-			// show the error dialog
-			if (pluginID.startsWith(idFilter)) {
-				return true;
-			}
-			// The exact plugin id is in the filter
-			return true;
+		final Map.Entry<String, String> floor = cachedFilters.floorEntry(pluginID);
+		if (floor != null && pluginID.startsWith(floor.getKey())) {
+			// TODO: The issue reporting layer needs to be changed
+			// We have to put the correct issue URL of the filter extension into the
+			// GitIssueCreator, but currently the GitIssueCreator only supports one URL for
+			// all issues.
+			return floor.getValue() != null ? true : false;
 		}
 		return false;
 	}
 
 	private static void loadFilterExtensions() {
-		cachedFilters = new HashMap<>();
+		cachedFilters = new TreeMap<>();
 		final IExtensionRegistry registry = Platform.getExtensionRegistry();
 		final IConfigurationElement[] config = registry
 				.getConfigurationElementsFor("org.eclipse.fordiac.ide.errorDialogFilters"); //$NON-NLS-1$
 		for (final IConfigurationElement e : config) {
-			final String id = e.getAttribute("id"); //$NON-NLS-1$
-			cachedFilters.put(id, id);
+			final String pluginID = e.getAttribute("id"); //$NON-NLS-1$
+			String pluginIssueURL = e.getAttribute("issue_url"); //$NON-NLS-1$
+			// If not plugin reporting URL is not specified, use the default 4diac issue URL
+			if (pluginIssueURL == null) {
+				pluginIssueURL = GitIssueCreator.FORDIAC_IDE_ISSUE_URL;
+			}
+			cachedFilters.put(pluginID, pluginIssueURL);
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide/src/org/eclipse/fordiac/ide/FordiacLogListener.java
+++ b/plugins/org.eclipse.fordiac.ide/src/org/eclipse/fordiac/ide/FordiacLogListener.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2026 Johannes Kepler University Linz
+ * Copyright (c) 2020, 2026 Johannes Kepler University Linz, Martin Erich Jobst
+ * 							Malte Grave
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/plugins/org.eclipse.fordiac.ide/src/org/eclipse/fordiac/ide/FordiacLogListener.java
+++ b/plugins/org.eclipse.fordiac.ide/src/org/eclipse/fordiac/ide/FordiacLogListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Johannes Kepler University Linz, Martin Erich Jobst
+ * Copyright (c) 2020, 2026 Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -10,18 +10,23 @@
  * Contributors:
  *   Alois Zoitl - initial API and implementation and/or initial documentation
  *   Martin Erich Jobst - add preference qualifier and issue URL parameter
+ *   Malte Grave - added filters to show error dialog based on plugin id
  *******************************************************************************/
 package org.eclipse.fordiac.ide;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExtensionRegistry;
 import org.eclipse.core.runtime.ILogListener;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.fordiac.ide.issuereport.GitIssueCreator;
 import org.eclipse.fordiac.ide.issuereport.PreferenceConstants;
@@ -36,9 +41,9 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.ui.PlatformUI;
 
 public class FordiacLogListener implements ILogListener {
+	private static HashMap<String, String> cachedFilters = null;
 
 	private static final class LogErrorDialog extends ErrorDialog {
 
@@ -126,9 +131,8 @@ public class FordiacLogListener implements ILogListener {
 
 	@Override
 	public void logging(final IStatus status, final String plugin) {
-		if ((status.getSeverity() == IStatus.ERROR) && (null != status.getException())
-				&& (status.getPlugin().startsWith(Activator.PLUGIN_ID)
-						|| status.getPlugin().equals(PlatformUI.PLUGIN_ID))
+		if (status.getSeverity() == IStatus.ERROR && status.getException() != null
+				&& isPluginInFilterMap(status.getPlugin())
 				// checking/setting the flag must be last, so that we only set it when actually
 				// showing an error dialog and resetting the flag afterwards
 				&& !singleWindow.getAndSet(true)) {
@@ -141,6 +145,34 @@ public class FordiacLogListener implements ILogListener {
 			} finally {
 				singleWindow.set(false);
 			}
+		}
+	}
+
+	private static boolean isPluginInFilterMap(final String pluginID) {
+		if (cachedFilters == null) {
+			loadFilterExtensions();
+		}
+		final String idFilter = cachedFilters.get(pluginID);
+		if (idFilter != null) {
+			// Now check if the id of the rule starts with the plugin id, if so we will also
+			// show the error dialog
+			if (pluginID.startsWith(idFilter)) {
+				return true;
+			}
+			// The exact plugin id is in the filter
+			return true;
+		}
+		return false;
+	}
+
+	private static void loadFilterExtensions() {
+		cachedFilters = new HashMap<>();
+		final IExtensionRegistry registry = Platform.getExtensionRegistry();
+		final IConfigurationElement[] config = registry
+				.getConfigurationElementsFor("org.eclipse.fordiac.ide.errorDialogFilters"); //$NON-NLS-1$
+		for (final IConfigurationElement e : config) {
+			final String id = e.getAttribute("id"); //$NON-NLS-1$
+			cachedFilters.put(id, id);
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide/src/org/eclipse/fordiac/ide/issuereport/GitIssueCreator.java
+++ b/plugins/org.eclipse.fordiac.ide/src/org/eclipse/fordiac/ide/issuereport/GitIssueCreator.java
@@ -199,3 +199,4 @@ public class GitIssueCreator {
 		return url.substring(0, idx).concat(epilogue);
 	}
 }
+


### PR DESCRIPTION
This allows us to register custom plugins to the error reporting.

I'm unsure about the name I named the extension point now `errorDialogFilters` but open for suggestions. Also, should I document the whole schema?

I opened the PR to develop now, but I could retarget it to 3.1, or we cherry-pick, depends on what we want.
