### PR TITLE
Fix recursion during dependency updates

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/LibraryElementDependencyUpdater.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/LibraryElementDependencyUpdater.java
@@ -45,6 +45,7 @@ import org.eclipse.swt.widgets.Display;
 public class LibraryElementDependencyUpdater extends LibraryElementDependencyTracker {
 
 	private LibraryElement libraryElement;
+	private boolean updating;
 
 	@Override
 	public void notifyChanged(final Notification notification) {
@@ -65,14 +66,23 @@ public class LibraryElementDependencyUpdater extends LibraryElementDependencyTra
 	}
 
 	public void updateDependency(final TypeEntry dependency) {
-		switch (dependency) {
-		case final AttributeTypeEntry attributeTypeEntry -> updateAttributeDependency(attributeTypeEntry);
-		case final DataTypeEntry dataTypeEntry -> updateDataTypeDependency(dataTypeEntry);
-		case final AdapterTypeEntry adapterTypeEntry -> updateAdapterDependency(adapterTypeEntry);
-		case final InterfaceTypeEntry interfaceTypeEntry -> updateBlockDependency(interfaceTypeEntry);
-		case null, default -> {
-			// do nothing
+		if (updating) {
+			throw new IllegalStateException(
+					"Already updating dependencies for " + libraryElement.getTypeEntry().getFile()); //$NON-NLS-1$
 		}
+		try {
+			updating = true;
+			switch (dependency) {
+			case final AttributeTypeEntry attributeTypeEntry -> updateAttributeDependency(attributeTypeEntry);
+			case final DataTypeEntry dataTypeEntry -> updateDataTypeDependency(dataTypeEntry);
+			case final AdapterTypeEntry adapterTypeEntry -> updateAdapterDependency(adapterTypeEntry);
+			case final InterfaceTypeEntry interfaceTypeEntry -> updateBlockDependency(interfaceTypeEntry);
+			case null, default -> {
+				// do nothing
+			}
+			}
+		} finally {
+			updating = false;
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/LibraryElementDependencyUpdater.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/LibraryElementDependencyUpdater.java
@@ -59,10 +59,7 @@ public class LibraryElementDependencyUpdater extends LibraryElementDependencyTra
 	}
 
 	private static boolean isRelevant(final Notification notification) {
-		return ((notification.getFeature() == TypeEntry.TYPE_ENTRY_TYPE_FEATURE
-				&& !(notification.getNotifier() instanceof InterfaceTypeEntry))
-				|| notification.getFeature() == TypeEntry.TYPE_ENTRY_INTERFACE_FEATURE
-				|| notification.getFeature() == TypeEntry.TYPE_ENTRY_TYPE_LIBRARY_FEATURE);
+		return TypeEntry.TYPE_ENTRY_FILE_CONTENT_FEATURE.equals(notification.getFeature());
 	}
 
 	public void updateDependency(final TypeEntry dependency) {


### PR DESCRIPTION
There was a recursion when updating dependencies due to an incorrect filter for notifications from type entries. This both fixes the recursion and fails early if a recursion is detected.

Fixes https://github.com/eclipse-4diac/4diac-ide/issues/2128