### PR TITLE
Gracefully Handle none Connection Create commands in Pin Policies #2100

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/InterfaceElementEditPolicy.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/InterfaceElementEditPolicy.java
@@ -54,18 +54,21 @@ public abstract class InterfaceElementEditPolicy extends GraphicalNodeEditPolicy
 
 	@Override
 	protected Command getConnectionCompleteCommand(final CreateConnectionRequest request) {
-		final AbstractConnectionCreateCommand command = (AbstractConnectionCreateCommand) request.getStartCommand();
-		command.setDestination(getHost().getModel());
+		if (!(request.getStartCommand() instanceof final AbstractConnectionCreateCommand connCreateCmd)) {
+			return null;
+		}
 
-		final FBNetwork newParent = checkConnectionParent(command.getSource(), command.getDestination(),
-				command.getParent());
+		connCreateCmd.setDestination(getHost().getModel());
+
+		final FBNetwork newParent = checkConnectionParent(connCreateCmd.getSource(), connCreateCmd.getDestination(),
+				connCreateCmd.getParent());
 		if (newParent != null) {
-			command.setParent(newParent);
-			return command;
+			connCreateCmd.setParent(newParent);
+			return connCreateCmd;
 		}
 		// if we are here it is not a direct connection try border crossing command
-		return CreateSubAppCrossingConnectionsCommand.createProcessBorderCrossingConnection(command.getSource(),
-				command.getDestination());
+		return CreateSubAppCrossingConnectionsCommand.createProcessBorderCrossingConnection(connCreateCmd.getSource(),
+				connCreateCmd.getDestination());
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/VariableNodeEditPolicy.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/VariableNodeEditPolicy.java
@@ -61,23 +61,27 @@ public class VariableNodeEditPolicy extends InterfaceElementEditPolicy {
 
 	@Override
 	protected Command getConnectionCompleteCommand(final CreateConnectionRequest request) {
-		final AbstractConnectionCreateCommand command = (AbstractConnectionCreateCommand) request.getStartCommand();
+		if (!(request.getStartCommand() instanceof final AbstractConnectionCreateCommand connCreateCmd)) {
+			return null;
+		}
+
 		final IInterfaceElement pin = getHost().getModel();
 
-		if (command instanceof StructDataConnectionCreateCommand) {
+		if (connCreateCmd instanceof StructDataConnectionCreateCommand) {
 			// if we drag from a struct manipulater but target is not a struct or
 			// configureable F_MOVE pin use normal
 			// data connection creation
 			if (!(pin.getType() instanceof StructuredType)
 					&& !(pin.eContainer().eContainer() instanceof ConfigurableMoveFB)) {
-				final DataConnectionCreateCommand structCmd = new DataConnectionCreateCommand(command.getParent());
-				structCmd.setSource(command.getSource());
+				final DataConnectionCreateCommand structCmd = new DataConnectionCreateCommand(
+						connCreateCmd.getParent());
+				structCmd.setSource(connCreateCmd.getSource());
 				request.setStartCommand(structCmd);
 			}
-		} else if (AbstractConnectionCreateCommand.shouldStructDataConnCreationBeUsed(pin, command.getSource())) {
+		} else if (AbstractConnectionCreateCommand.shouldStructDataConnCreationBeUsed(pin, connCreateCmd.getSource())) {
 			final StructDataConnectionCreateCommand structCmd = new StructDataConnectionCreateCommand(
-					command.getParent());
-			structCmd.setSource(command.getSource());
+					connCreateCmd.getParent());
+			structCmd.setSource(connCreateCmd.getSource());
 			request.setStartCommand(structCmd);
 		}
 		return super.getConnectionCompleteCommand(request);


### PR DESCRIPTION
The getConnecitonCompleteCommand method for pin edit policies may be called with no or the wrong start create connection command. This change handles that correctly

Fixes: #2100