### PR TITLE
Insert Adapter Proxy refactoring: generate proxy FB type and rewire adapter connections

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.typemanagement/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/plugin.xml
@@ -135,6 +135,12 @@
            id="org.eclipse.fordiac.ide.typemanagement.connectionstostruct"
            name="%command.ConnectionsToStruct">
      </command>
+      <command
+      id="org.eclipse.fordiac.ide.typemanagement.insertAdapterProxy"
+      name="Insert Adapter Proxy"/>
+        <command
+      id="org.eclipse.fordiac.ide.typemanagement.refactoring.adapter.replaceConnectionWithAdapter"
+      name="Replace Connection with Adapter"/>
      <command
            id="org.eclipse.fordiac.ide.typemanagement.repairbrokenconnection"
            name="%command.RepairBrokenConnection">
@@ -187,6 +193,40 @@
                  </test>
            </with></enabledWhen>
      </handler>
+     <handler
+           class="org.eclipse.fordiac.ide.typemanagement.refactoring.adapter.IntroduceAdapterProxyOnConnectionHandler"
+           commandId="org.eclipse.fordiac.ide.typemanagement.insertAdapterProxy">
+           <enabledWhen>
+           <with
+                 variable="selection">
+                 <test
+                       property="org.eclipse.fordiac.ide.typemanagement.insertAdapterProxy">
+                 </test>
+           </with></enabledWhen>
+ 	</handler>
+	<handler
+	      class="org.eclipse.fordiac.ide.typemanagement.refactoring.adapter.IntroduceAdapterProxyHandler"
+	      commandId="org.eclipse.fordiac.refactoring.insertAdapterProxy">
+	    <activeWhen>
+	      <with variable="activePartId">
+	        <equals value="org.eclipse.fordiac.ide.systemmanagement.ui.systemexplorer"/>
+	      </with>
+	    </activeWhen>
+	
+	    <enabledWhen>
+	      <with variable="activeMenuSelection">
+	        <count value="1"/>
+	        <iterate>
+	          <or>
+	            <adapt type="org.eclipse.core.resources.IFile">
+	              <test property="org.eclipse.core.resources.extension" value="adp"/>
+	            </adapt>
+	            <instanceof value="org.eclipse.fordiac.ide.model.typelibrary.AdapterTypeEntry"/>
+	          </or>
+	        </iterate>
+	      </with>
+	    </enabledWhen>
+	 </handler>
      <handler
            class="org.eclipse.fordiac.ide.typemanagement.refactoring.handler.RepairBrokenConnectionHandler"
            commandId="org.eclipse.fordiac.ide.typemanagement.repairbrokenconnection">
@@ -542,6 +582,13 @@
             properties="ConnectionsToStructSupported"
             type="java.lang.Object">
       </propertyTester>
+       <propertyTester
+            class="org.eclipse.fordiac.ide.typemanagement.refactoring.adapter.InsertAdapterProxyPropertyTester"
+            id="org.eclipse.fordiac.ide.typemanagement.insertAdapterProxyTester"
+            namespace="org.eclipse.fordiac.ide.typemanagement"
+            properties="insertAdapterProxy"
+            type="java.lang.Object">
+      </propertyTester>
    </extension>  
 
    
@@ -630,6 +677,24 @@
                      checkEnabled="true">
                </visibleWhen>
             </command>
+              <command
+                  commandId="org.eclipse.fordiac.ide.typemanagement.insertAdapterProxy"
+                  label="Insert Adapter Proxy"
+                  style="push">
+               <visibleWhen
+                     checkEnabled="true">
+               </visibleWhen>
+            </command>
+       <command
+          commandId="org.eclipse.fordiac.ide.typemanagement.refactoring.adapter.replaceConnectionWithAdapter"
+          label="Replace Connection with Adapter"
+          style="push">
+        <!-- Show only when selection passes the tester (prevents a greyed entry) -->
+         <visibleWhen
+                     checkEnabled="true">
+         </visibleWhen>
+      </command>
+            
             <command
                   commandId="org.eclipse.fordiac.ide.typemanagement.repairbrokenconnection"
                   label="Repair broken Connection"
@@ -727,5 +792,30 @@
 				</or>
 	     	</adapt>
     	</definition>
-   </extension>   
+   </extension>
+
+<extension point="org.eclipse.ui.menus">
+  <menuContribution
+      locationURI="popup:org.eclipse.fordiac.ide.systemmanagement.ui.systemexplorer?after=group.search">
+    <command
+        commandId="org.eclipse.fordiac.refactoring.insertAdapterProxy"
+        label="Insert Adapter Proxy"
+        style="push">
+      <visibleWhen checkEnabled="true">
+        <with variable="selection">
+          <count value="1"/>
+          <iterate>
+            <or>
+              <adapt type="org.eclipse.core.resources.IFile">
+                <test property="org.eclipse.core.resources.extension" value="adp"/>
+              </adapt>
+              <instanceof value="org.eclipse.fordiac.ide.model.typelibrary.AdapterTypeEntry"/>
+            </or>
+          </iterate>
+        </with>
+      </visibleWhen>
+    </command>
+  </menuContribution>
+</extension>
+      
 </plugin>

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/adapter/CreateAdapterProxyTypeChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/adapter/CreateAdapterProxyTypeChange.java
@@ -1,0 +1,312 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Michael Oberlehner - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.refactoring.adapter;
+
+import java.util.List;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.fordiac.ide.model.commands.create.AbstractConnectionCreateCommand;
+import org.eclipse.fordiac.ide.model.commands.create.CreateInterfaceElementCommand;
+import org.eclipse.fordiac.ide.model.data.EventType;
+import org.eclipse.fordiac.ide.model.libraryElement.AdapterDeclaration;
+import org.eclipse.fordiac.ide.model.libraryElement.AdapterFB;
+import org.eclipse.fordiac.ide.model.libraryElement.AdapterType;
+import org.eclipse.fordiac.ide.model.libraryElement.CompositeFBType;
+import org.eclipse.fordiac.ide.model.libraryElement.Event;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
+import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
+import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.typelibrary.AdapterTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.EventTypeLibrary;
+import org.eclipse.fordiac.ide.model.typelibrary.FBTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
+import org.eclipse.fordiac.ide.typemanagement.preferences.TypeManagementPreferencesHelper;
+import org.eclipse.gef.commands.CompoundCommand;
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+import org.eclipse.ltk.core.refactoring.resource.DeleteResourceChange;
+
+public class CreateAdapterProxyTypeChange extends Change {
+
+	public static final String PLUG1 = "PLUG1"; //$NON-NLS-1$
+	public static final String SOCKET1 = "SOCKET1"; //$NON-NLS-1$
+	public static final String SOCKET_PREFIX = "SOCKET_"; //$NON-NLS-1$
+	public static final String PLUG_PREFIX = "PLUG_"; //$NON-NLS-1$
+	private final IFolder libFolder;
+	private final String typeName;
+	private final String adapterTypeName;
+
+	private IFile createdFile;
+
+	public CreateAdapterProxyTypeChange(final IFolder libFolder, final String typeName, final String adapterTypeName) {
+		this.libFolder = libFolder;
+		this.typeName = typeName;
+		this.adapterTypeName = adapterTypeName;
+	}
+
+	@Override
+	public String getName() {
+		return "Create Adapter Proxy Type: " + typeName; //$NON-NLS-1$
+	}
+
+	@Override
+	public void initializeValidationData(final IProgressMonitor pm) {
+	}
+
+	@Override
+	public RefactoringStatus isValid(final IProgressMonitor pm) {
+		return new RefactoringStatus();
+	}
+
+	@Override
+	public Change perform(final IProgressMonitor pm) throws CoreException {
+		if (!libFolder.exists()) {
+			libFolder.create(true, true, pm);
+		}
+		createdFile = libFolder.getFile(typeName + TypeLibraryTags.FB_TYPE_FILE_ENDING_WITH_DOT);
+
+		final TypeLibrary tl = TypeLibraryManager.INSTANCE.getTypeLibrary(libFolder.getProject());
+		final FBTypeEntry fbEntry = (FBTypeEntry) tl.createTypeEntry(createdFile);
+
+		final AdapterTypeEntry adapterTypeEntry = tl.getAdapterTypeEntry(adapterTypeName);
+		final CompositeFBType proxy = buildProxy(adapterTypeEntry, typeName);
+		fbEntry.save(proxy, pm);
+
+		return new DeleteResourceChange(fbEntry.getFile().getFullPath(), true);
+	}
+
+	@Override
+	public Object getModifiedElement() {
+		return createdFile;
+	}
+
+	private static CompositeFBType buildProxy(final AdapterTypeEntry typeEntry, final String typeName) {
+		final var f = LibraryElementFactory.eINSTANCE;
+		final AdapterType adapterType = typeEntry.getType();
+		final CompositeFBType cfbType = f.createCompositeFBType();
+		cfbType.setName(typeName);
+
+		TypeManagementPreferencesHelper.setupIdentification(cfbType, typeEntry.getFile().getProject());
+		TypeManagementPreferencesHelper.setupVersionInfo(cfbType, typeEntry.getFile().getProject());
+
+		final var svc = f.createService();
+		svc.setLeftInterface(f.createServiceInterface());
+		svc.setRightInterface(f.createServiceInterface());
+		final var seq = f.createServiceSequence();
+		seq.setName("SEQ"); //$NON-NLS-1$
+		svc.getServiceSequence().add(seq);
+		cfbType.setService(svc);
+
+		cfbType.setInterfaceList(f.createInterfaceList());
+		final InterfaceList il = cfbType.getInterfaceList();
+		final FBNetwork fbNetwork = f.createFBNetwork();
+		cfbType.setFBNetwork(fbNetwork);
+
+		final var cmdSock = new CreateInterfaceElementCommand(adapterType, SOCKET1, il, true, -1);
+		cmdSock.execute();
+		final AdapterDeclaration socketDecl = (AdapterDeclaration) cmdSock.getCreatedElement();
+
+		final var cmdPlug = new CreateInterfaceElementCommand(adapterType, PLUG1, il, false, -1);
+		cmdPlug.execute();
+		final AdapterDeclaration plugDecl = (AdapterDeclaration) cmdPlug.getCreatedElement();
+
+		final AdapterFB socketFB = socketDecl.getAdapterFB();
+		final AdapterFB plugFB = plugDecl.getAdapterFB();
+		if (socketFB != null && socketFB.eContainer() == null) {
+			fbNetwork.getNetworkElements().add(socketFB);
+		}
+		if (plugFB != null && plugFB.eContainer() == null) {
+			fbNetwork.getNetworkElements().add(plugFB);
+		}
+
+		if (socketFB != null) {
+			final var p = f.createPosition();
+			p.setX(40);
+			p.setY(40);
+			socketFB.setPosition(p);
+		}
+		if (plugFB != null) {
+			final var p = f.createPosition();
+			p.setX(380);
+			p.setY(80);
+			plugFB.setPosition(p);
+		}
+
+		mirrorAdapterInterfaceBidirectional(adapterType, f, il);
+
+		final var connectionCreateCommands = createConnectionCommands(il, fbNetwork, socketFB, plugFB);
+
+		if (connectionCreateCommands.canExecute()) {
+			connectionCreateCommands.execute();
+		}
+		return cfbType;
+	}
+
+	protected static CompoundCommand createConnectionCommands(final InterfaceList proxyIL, final FBNetwork fbNetwork,
+			final AdapterFB socketFB, final AdapterFB plugFB) {
+
+		final var cc = new CompoundCommand("Adapter Proxy Wiring"); //$NON-NLS-1$
+		if (socketFB == null || plugFB == null) {
+			return cc;
+		}
+
+		final InterfaceList socketFBInterface = socketFB.getInterface();
+		final InterfaceList plugFBInterface = plugFB.getInterface();
+
+		for (final Event proxyIn : proxyIL.getEventInputs()) {
+			final String name = proxyIn.getName();
+
+			if (name.startsWith(SOCKET_PREFIX)) {
+				final String base = name.substring(SOCKET_PREFIX.length());
+				final IInterfaceElement dst = socketFBInterface.getInput(List.of(base));
+				if (dst != null) {
+					addConnection(cc, fbNetwork, proxyIn, dst);
+				}
+			} else if (name.startsWith(PLUG_PREFIX)) {
+				final String base = name.substring(PLUG_PREFIX.length());
+				final IInterfaceElement dst = plugFBInterface.getInput(List.of(base));
+				if (dst != null) {
+					addConnection(cc, fbNetwork, proxyIn, dst);
+				}
+			}
+		}
+		bridgeAllOutputs(cc, fbNetwork, socketFBInterface, plugFBInterface, proxyIL, SOCKET_PREFIX);
+
+		bridgeAllOutputs(cc, fbNetwork, plugFBInterface, socketFBInterface, proxyIL, PLUG_PREFIX);
+
+		return cc;
+	}
+
+	private static void bridgeAllOutputs(final CompoundCommand cc, final FBNetwork fbNetwork,
+			final InterfaceList fromIF, final InterfaceList toIF, final InterfaceList proxyIL,
+			final String proxyPrefix) {
+
+		fromIF.getAllOutputs().forEach(out -> {
+			final String base = out.getName();
+
+			final IInterfaceElement toIn = toIF.getInput(List.of(base));
+			if (toIn != null) {
+				addConnection(cc, fbNetwork, out, toIn);
+			}
+
+			final IInterfaceElement proxyOut = proxyIL.getOutput(List.of(proxyPrefix + base));
+			if (proxyOut != null) {
+				addConnection(cc, fbNetwork, out, proxyOut);
+			}
+		});
+	}
+
+	private static void addConnection(final CompoundCommand cc, final FBNetwork fbNetwork, final IInterfaceElement src,
+			final IInterfaceElement dst) {
+
+		if (src == null || dst == null) {
+			return;
+		}
+
+		var cmd = AbstractConnectionCreateCommand.createCommand(fbNetwork, src, dst);
+		if (cmd instanceof final AbstractConnectionCreateCommand acc) {
+			acc.setSource(src);
+			acc.setDestination(dst);
+		}
+		if (cmd != null && cmd.canExecute()) {
+			cc.add(cmd);
+			return;
+		}
+
+		cmd = AbstractConnectionCreateCommand.createCommand(fbNetwork, dst, src);
+		if (cmd instanceof final AbstractConnectionCreateCommand acc2) {
+			acc2.setSource(dst);
+			acc2.setDestination(src);
+		}
+		if (cmd != null && cmd.canExecute()) {
+			cc.add(cmd);
+		}
+	}
+
+	protected static void mirrorAdapterInterfaceBidirectional(final AdapterType at, final LibraryElementFactory f,
+			final InterfaceList cfbInterfaceList) {
+
+		final InterfaceList adapterInterfaceList = at.getInterfaceList();
+
+		for (final VarDeclaration v : adapterInterfaceList.getOutputVars()) {
+			new CreateInterfaceElementCommand(v.getType(), SOCKET_PREFIX + v.getName(), cfbInterfaceList, false, -1)
+					.execute();
+		}
+
+		for (final VarDeclaration v : adapterInterfaceList.getInputVars()) {
+			new CreateInterfaceElementCommand(v.getType(), PLUG_PREFIX + v.getName(), cfbInterfaceList, false, -1)
+					.execute();
+		}
+
+		createMirroredEvents(adapterInterfaceList.getEventInputs(), cfbInterfaceList, true, SOCKET_PREFIX,
+				cfbInterfaceList.getInputVars(), f);
+		createMirroredEvents(adapterInterfaceList.getEventOutputs(), cfbInterfaceList, false, SOCKET_PREFIX,
+				cfbInterfaceList.getOutputVars(), f);
+
+		createMirroredEvents(adapterInterfaceList.getEventOutputs(), cfbInterfaceList, true, PLUG_PREFIX,
+				cfbInterfaceList.getInputVars(), f);
+		createMirroredEvents(adapterInterfaceList.getEventInputs(), cfbInterfaceList, false, PLUG_PREFIX,
+				cfbInterfaceList.getOutputVars(), f);
+
+	}
+
+	private static EventType resolveEventType(final Event e) {
+		final String typeName = e.getTypeName();
+		final String resolved = (typeName != null && !typeName.isBlank()) ? typeName : "Event"; //$NON-NLS-1$
+		return EventTypeLibrary.getInstance().getType(resolved);
+	}
+
+	private static void createMirroredEvents(final Iterable<? extends Event> srcEvents, final InterfaceList targetIL,
+			final boolean createAsInput, final String prefix, final Iterable<? extends VarDeclaration> withVarPool,
+			final LibraryElementFactory f) {
+
+		for (final Event src : srcEvents) {
+			final var et = resolveEventType(src);
+
+			final var cmd = new CreateInterfaceElementCommand(et, prefix + src.getName(), targetIL, createAsInput, -1);
+			cmd.execute();
+			final Event created = (Event) cmd.getCreatedElement();
+
+			for (final var w : src.getWith()) {
+				if (w.getVariables() == null) {
+					continue;
+				}
+
+				final String withName = prefix + w.getVariables().getName();
+				final VarDeclaration varDecl = findVarByName(withVarPool, withName);
+				if (varDecl != null) {
+					final var nw = f.createWith();
+					nw.setVariables(varDecl);
+					created.getWith().add(nw);
+				}
+			}
+		}
+	}
+
+	private static VarDeclaration findVarByName(final Iterable<? extends VarDeclaration> vars, final String name) {
+		for (final VarDeclaration v : vars) {
+			if (name.equals(v.getName())) {
+				return v;
+			}
+		}
+		return null;
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/adapter/InsertAdapterProxyPropertyTester.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/adapter/InsertAdapterProxyPropertyTester.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Michael Oberlehner - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.refactoring.adapter;
+
+import org.eclipse.core.expressions.PropertyTester;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.fordiac.ide.model.libraryElement.AdapterConnection;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
+import org.eclipse.gef.ConnectionEditPart;
+import org.eclipse.jface.viewers.StructuredSelection;
+
+public class InsertAdapterProxyPropertyTester extends PropertyTester {
+
+	@Override
+	public boolean test(final Object receiver, final String property, final Object[] args, final Object expectedValue) {
+		if (receiver == null) {
+			return false;
+		}
+
+		if (receiver instanceof final StructuredSelection sel) {
+			final Object firstElement = sel.getFirstElement();
+
+			if (firstElement instanceof final ConnectionEditPart conEditPart) {
+				final Object model = conEditPart.getModel();
+				if (model instanceof AdapterConnection) {
+					return true;
+				}
+			}
+			if (firstElement instanceof final IFile file) {
+				return TypeLibraryTags.ADAPTER_TYPE_FILE_ENDING.equalsIgnoreCase(file.getFileExtension());
+			}
+		}
+
+		return false;
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/adapter/IntroduceAdapterProxyHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/adapter/IntroduceAdapterProxyHandler.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Michael Oberlehner - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.refactoring.adapter;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.fordiac.ide.model.typelibrary.AdapterTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.ltk.core.refactoring.PerformChangeOperation;
+import org.eclipse.ui.handlers.HandlerUtil;
+
+public class IntroduceAdapterProxyHandler extends AbstractHandler {
+
+	@Override
+	public Object execute(final ExecutionEvent event) throws ExecutionException {
+		final ISelection sel = HandlerUtil.getCurrentSelection(event);
+
+		final AdapterTypeEntry atEntry = resolveAdapterTypeEntry(sel);
+		if (atEntry == null) {
+			return null;
+		}
+
+		final String adapterName = atEntry.getTypeName();
+		final String proxyName = adapterName + "_Proxy";
+
+		final IFile adpFile = atEntry.getFile();
+		final IProject project = adpFile.getProject();
+
+		// prefer same folder as the .adp
+		final IFolder targetFolder = (adpFile.getParent() instanceof IFolder) ? (IFolder) adpFile.getParent()
+				: project.getFolder("Type Library");
+
+		final CreateAdapterProxyTypeChange change = new CreateAdapterProxyTypeChange(targetFolder, proxyName,
+				adapterName);
+
+		try {
+			new PerformChangeOperation(change).run(null);
+
+		} catch (final CoreException e) {
+			throw new ExecutionException("Insert Adapter Proxy failed", e); //$NON-NLS-1$
+		}
+
+		return null;
+	}
+
+	private static AdapterTypeEntry resolveAdapterTypeEntry(final ISelection selection) throws ExecutionException {
+		if (!(selection instanceof final IStructuredSelection iss) || iss.isEmpty()) {
+			return null;
+		}
+		final Object first = iss.getFirstElement();
+
+		if (first instanceof final AdapterTypeEntry f) {
+			return f;
+		}
+
+		if (first instanceof final IFile f
+				&& TypeLibraryTags.ADAPTER_TYPE_FILE_ENDING.equalsIgnoreCase(f.getFileExtension())) {
+			final TypeEntry te = TypeLibraryManager.INSTANCE.getTypeEntryForFile(f);
+			if (te instanceof final AdapterTypeEntry at) {
+				return at;
+			}
+		}
+		return null;
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/adapter/IntroduceAdapterProxyOnConnectionHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/adapter/IntroduceAdapterProxyOnConnectionHandler.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Michael Oberlehner - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.refactoring.adapter;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.fordiac.ide.model.libraryElement.AdapterConnection;
+import org.eclipse.fordiac.ide.model.libraryElement.AdapterType;
+import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
+import org.eclipse.gef.ConnectionEditPart;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.ltk.core.refactoring.CreateChangeOperation;
+import org.eclipse.ltk.core.refactoring.PerformChangeOperation;
+import org.eclipse.ltk.core.refactoring.Refactoring;
+import org.eclipse.ui.handlers.HandlerUtil;
+
+public class IntroduceAdapterProxyOnConnectionHandler extends AbstractHandler {
+
+	@Override
+	public Object execute(final ExecutionEvent event) throws ExecutionException {
+		final ISelection sel = HandlerUtil.getActiveMenuSelection(event);
+		if (!(sel instanceof final IStructuredSelection s) || s.isEmpty()) {
+			return null;
+		}
+
+		final Object first = s.getFirstElement();
+		final AdapterConnection ac = unwrapAdapterConnection(first);
+		if (ac == null) {
+			return null;
+		}
+
+		final String adapterTypeName = getAdapterTypeName(ac);
+		final String proxyTypeName = adapterTypeName + "_Proxy";
+		final LibraryElement elem = (LibraryElement) EcoreUtil.getRootContainer(ac);
+		final URI connURI = EcoreUtil.getURI(ac);
+		final IFile file = elem.getTypeEntry().getFile();
+		final IFolder folder = file.getProject().getFolder("Type Library");
+
+		final Refactoring refactoring = new IntroduceAdapterRefactoring(connURI, proxyTypeName, folder,
+				adapterTypeName);
+
+		final CreateChangeOperation create = new CreateChangeOperation(refactoring);
+		final PerformChangeOperation perform = new PerformChangeOperation(create);
+
+		try {
+			ResourcesPlugin.getWorkspace()
+					.run(monitor -> perform.run(monitor != null ? monitor : new NullProgressMonitor()), null);
+		} catch (final Exception e) {
+			throw new ExecutionException("Failed to perform refactoring", e); //$NON-NLS-1$
+		}
+		return null;
+	}
+
+	private static AdapterConnection unwrapAdapterConnection(final Object element) {
+		if (element instanceof final ConnectionEditPart cep && cep.getModel() instanceof final AdapterConnection ac) {
+			return ac;
+		}
+		if (element instanceof final AdapterConnection adapterConnection) {
+			return adapterConnection;
+		}
+		return null;
+	}
+
+	private static String getAdapterTypeName(final AdapterConnection ac) {
+		final IInterfaceElement src = ac.getSource();
+		final IInterfaceElement dst = ac.getDestination();
+		final AdapterType at = (src != null && src.getType() instanceof AdapterType) ? (AdapterType) src.getType()
+				: (dst != null && dst.getType() instanceof AdapterType ? (AdapterType) dst.getType() : null);
+		return (at != null) ? at.getName() : null;
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/adapter/IntroduceAdapterRefactoring.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/adapter/IntroduceAdapterRefactoring.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Michael Oberlehner - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.refactoring.adapter;
+
+import java.util.List;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.fordiac.ide.typemanagement.refactoring.ModelEditChange;
+import org.eclipse.fordiac.ide.typemanagement.refactoring.adapter.edits.InsertAdapterProxyOnConnectionEdit;
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.CompositeChange;
+import org.eclipse.ltk.core.refactoring.Refactoring;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+
+public class IntroduceAdapterRefactoring extends Refactoring {
+
+	private final URI connectionURI;
+	private final String proxyTypeName;
+	private final IFolder folder;
+	private final String adapterName;
+
+	public IntroduceAdapterRefactoring(final URI connectionURI, final String proxyTypeName, final IFolder folder,
+			final String adapterName) {
+		this.connectionURI = connectionURI;
+		this.proxyTypeName = proxyTypeName;
+		this.folder = folder;
+		this.adapterName = adapterName;
+	}
+
+	@Override
+	public String getName() {
+		return "Insert Adapter Proxy"; //$NON-NLS-1$
+	}
+
+	@Override
+	public RefactoringStatus checkInitialConditions(final IProgressMonitor pm) {
+		return new RefactoringStatus();
+	}
+
+	@Override
+	public RefactoringStatus checkFinalConditions(final IProgressMonitor pm) {
+		return new RefactoringStatus();
+	}
+
+	@Override
+	public Change createChange(final IProgressMonitor pm) {
+		InsertAdapterProxyOnConnectionEdit edit = null;
+		if (connectionURI != null) {
+			edit = new InsertAdapterProxyOnConnectionEdit(connectionURI);
+		}
+
+		final CompositeChange cc = new CompositeChange("Insert Adapter Proxy"); //$NON-NLS-1$
+
+		final IFile proxyFile = folder.getFile(proxyTypeName + ".fbt"); //$NON-NLS-1$
+
+		if (!proxyFile.exists()) {
+			cc.add(new CreateAdapterProxyTypeChange(folder, proxyTypeName, adapterName));
+		}
+		if (edit != null) {
+			cc.add(ModelEditChange.fromModelEdits("Replace Connection with Adapter Proxy", List.of(edit))); //$NON-NLS-1$
+		}
+
+		return cc;
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/adapter/edits/InsertAdapterProxyOnConnectionEdit.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/adapter/edits/InsertAdapterProxyOnConnectionEdit.java
@@ -1,0 +1,257 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Michael Oberlehner - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.refactoring.adapter.edits;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.fordiac.ide.model.commands.create.AbstractConnectionCreateCommand;
+import org.eclipse.fordiac.ide.model.commands.create.FBCreateCommand;
+import org.eclipse.fordiac.ide.model.commands.delete.DeleteConnectionCommand;
+import org.eclipse.fordiac.ide.model.libraryElement.AdapterConnection;
+import org.eclipse.fordiac.ide.model.libraryElement.AdapterDeclaration;
+import org.eclipse.fordiac.ide.model.libraryElement.AdapterType;
+import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
+import org.eclipse.fordiac.ide.model.libraryElement.Position;
+import org.eclipse.fordiac.ide.model.typelibrary.FBTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
+import org.eclipse.fordiac.ide.typemanagement.refactoring.ModelEdit;
+import org.eclipse.fordiac.ide.typemanagement.refactoring.adapter.CreateAdapterProxyTypeChange;
+import org.eclipse.gef.commands.Command;
+import org.eclipse.gef.commands.CompoundCommand;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+
+public class InsertAdapterProxyOnConnectionEdit extends ModelEdit<AdapterConnection> {
+
+	public InsertAdapterProxyOnConnectionEdit(final URI connectionURI) {
+		super("Insert Adapter Proxy", connectionURI, AdapterConnection.class); //$NON-NLS-1$
+	}
+
+	@Override
+	public void initializeValidationData(final AdapterConnection element, final IProgressMonitor pm) {
+
+	}
+
+	@Override
+	public RefactoringStatus isValid(final AdapterConnection element, final IProgressMonitor pm) throws CoreException {
+		final RefactoringStatus rs = new RefactoringStatus();
+
+		final AdapterConnection ac = element;
+		if (ac == null) {
+			rs.addFatalError("Selected adapter connection no longer exists."); //$NON-NLS-1$
+			return rs;
+		}
+
+		final AdapterType at = inferAdapterType(ac);
+		if (at == null || at.getName() == null || at.getName().isBlank()) {
+			rs.addFatalError("Cannot determine adapter type from the selected connection."); //$NON-NLS-1$
+			return rs;
+		}
+
+		final FBTypeEntry proxy = findProxyEntry(ac, at.getName() + "_Proxy"); //$NON-NLS-1$
+		if (proxy == null) {
+			rs.addWarning("Proxy type '" + at.getName() + "_Proxy.fbt' not found in project. " //$NON-NLS-2$
+					+ "The operation will fail at execution."); //$NON-NLS-1$
+		}
+		return rs;
+	}
+
+	@Override
+	protected Command createCommand(final AdapterConnection net) {
+		final AdapterConnection original = net;
+		if (original == null) {
+			return null;
+		}
+
+		final AdapterDeclaration src = safeCastAdapterDecl(original.getSource());
+		final AdapterDeclaration dst = safeCastAdapterDecl(original.getDestination());
+		if (src == null || dst == null) {
+			return null;
+		}
+
+		final AdapterType at = inferAdapterType(original);
+		if (at == null || at.getName() == null || at.getName().isBlank()) {
+			return null;
+		}
+
+		final FBTypeEntry proxyEntry = findProxyEntry(original, at.getName() + "_Proxy"); //$NON-NLS-1$
+		if (proxyEntry == null) {
+			return null;
+		}
+
+		final FBNetworkElement srcFB = src.getBlockFBNetworkElement();
+		final FBNetworkElement dstFB = dst.getBlockFBNetworkElement();
+		final int midX = avg(xOf(srcFB), xOf(dstFB));
+		final int midY = avg(yOf(srcFB), yOf(dstFB));
+
+		final Position position = LibraryElementFactory.eINSTANCE.createPosition();
+		position.setX(midX);
+		position.setY(midY);
+
+		final FBCreateCommand createProxy = new FBCreateCommand(proxyEntry, srcFB.getFbNetwork(), position);
+
+		final CompoundCommand compound = new CompoundCommand("Insert Adapter Proxy"); //$NON-NLS-1$
+		compound.add(createProxy);
+		compound.add(new WireAroundProxyAndRemoveOriginal(original, createProxy));
+		return compound;
+	}
+
+	private static final class WireAroundProxyAndRemoveOriginal extends Command {
+		private final AdapterConnection original;
+		private final FBCreateCommand createdCmd;
+		private List<Command> executed = new ArrayList<>();
+
+		WireAroundProxyAndRemoveOriginal(final AdapterConnection original, final FBCreateCommand createdCmd) {
+
+			this.original = original;
+			this.createdCmd = createdCmd;
+		}
+
+		@Override
+		public void execute() {
+			executed = new ArrayList<>();
+
+			final FBNetwork net = original.getFBNetwork();
+			final IInterfaceElement src = original.getSource();
+			final IInterfaceElement dst = original.getDestination();
+			final boolean srcIsPlug = (src instanceof final AdapterDeclaration ad) && !ad.isIsInput();
+
+			final DeleteConnectionCommand del = new DeleteConnectionCommand(original);
+			if (del.canExecute()) {
+				del.execute();
+				executed.add(del);
+			}
+
+			final BlockFBNetworkElement proxy = createdCmd.getFB();
+			final AdapterDeclaration proxySock = proxy.getInterface().getSockets().stream()
+					.filter(a -> a.isIsInput() && CreateAdapterProxyTypeChange.SOCKET1.equals(a.getName())).findFirst()
+					.orElseThrow(() -> new IllegalStateException("Proxy SOCKET1 not found")); //$NON-NLS-1$
+			final AdapterDeclaration proxyPlug = proxy.getInterface().getPlugs().stream()
+					.filter(a -> !a.isIsInput() && CreateAdapterProxyTypeChange.PLUG1.equals(a.getName())).findFirst()
+					.orElseThrow(() -> new IllegalStateException("Proxy PLUG1 not found")); //$NON-NLS-1$
+
+			final IInterfaceElement origPlug = srcIsPlug ? src : dst;
+			final IInterfaceElement origSocket = srcIsPlug ? dst : src;
+
+			addAndExecuteConn(net, origPlug, proxySock);
+			addAndExecuteConn(net, proxyPlug, origSocket);
+		}
+
+		@Override
+		public void undo() {
+			for (int i = executed.size() - 1; i >= 0; --i) {
+				executed.get(i).undo();
+			}
+		}
+
+		private void addAndExecuteConn(final FBNetwork net, final IInterfaceElement src, final IInterfaceElement dst) {
+			if (src == null || dst == null) {
+				return;
+			}
+
+			Command c = AbstractConnectionCreateCommand.createCommand(net, src, dst);
+			if (c instanceof final AbstractConnectionCreateCommand acc) {
+				acc.setSource(src);
+				acc.setDestination(dst);
+			}
+			if (c != null && c.canExecute()) {
+				c.execute();
+				executed.add(c);
+				return;
+			}
+			c = AbstractConnectionCreateCommand.createCommand(net, dst, src);
+			if (c instanceof final AbstractConnectionCreateCommand acc2) {
+				acc2.setSource(dst);
+				acc2.setDestination(src);
+			}
+			if (c != null && c.canExecute()) {
+				c.execute();
+				executed.add(c);
+			}
+		}
+	}
+
+	private static AdapterDeclaration safeCastAdapterDecl(final IInterfaceElement ie) {
+		return (ie instanceof final AdapterDeclaration a) ? a : null;
+	}
+
+	private static AdapterType inferAdapterType(final AdapterConnection ac) {
+		if (ac.getSource() instanceof final AdapterDeclaration a && a.getType() != null) {
+			return a.getType();
+		}
+		if (ac.getDestination() instanceof final AdapterDeclaration a && a.getType() != null) {
+			return a.getType();
+		}
+		return null;
+	}
+
+	private static FBTypeEntry findProxyEntry(final AdapterConnection ac, final String proxyTypeName) {
+		final EObject rootContainer = EcoreUtil.getRootContainer(ac);
+
+		final IProject project = ((LibraryElement) rootContainer).getTypeEntry().getFile().getProject();
+
+		final TypeLibrary tl = TypeLibraryManager.INSTANCE.getTypeLibrary(project);
+
+		final TypeEntry te = tl.getFBTypeEntry(proxyTypeName);
+		if (te instanceof final FBTypeEntry fb) {
+			return fb;
+		}
+
+		final FBTypeEntry[] out = new FBTypeEntry[1];
+		try {
+			project.accept(r -> {
+				if (r instanceof final IFile file
+						&& TypeLibraryTags.FB_TYPE_FILE_ENDING.equalsIgnoreCase(file.getFileExtension())
+						&& file.getName().equals(proxyTypeName + TypeLibraryTags.FB_TYPE_FILE_ENDING_WITH_DOT)) {
+					final TypeEntry te2 = tl.createTypeEntry(file);
+					if (te2 instanceof final FBTypeEntry fb) {
+						out[0] = fb;
+						return false;
+					}
+				}
+				return true;
+			});
+		} catch (final Exception e) {
+			return null;
+		}
+		return out[0];
+	}
+
+	private static int xOf(final FBNetworkElement e) {
+		return (int) ((e != null && e.getPosition() != null) ? e.getPosition().getX() : 0);
+	}
+
+	private static int yOf(final FBNetworkElement e) {
+		return (int) ((e != null && e.getPosition() != null) ? e.getPosition().getY() : 0);
+	}
+
+	private static int avg(final int a, final int b) {
+		return a + ((b - a) / 2);
+	}
+
+}


### PR DESCRIPTION
This PR adds the first building block for the Replace Connection with Adapter workflow: automatic adapter-proxy generation + insertion to safely split adapter connections and preserve fan-out/fan-in use sites.

The adapter proxy is an auto-generated Composite FB type named <Adapter>_Proxy that contains exactly one socket (SOCKET1) and one plug (PLUG1) of the selected adapter type. It mirrors the adapter interface in both directions by creating prefixed events/vars (e.g., SOCKET_*, PLUG_*) and wiring them so signals are forwarded and re-exported consistently. When inserted on an adapter connection, it splits one direct connection into two hops via the proxy, preventing fan-in/fan-out issues while preserving existing connection semantics.

**How to test**

In an application editor: right-click an adapter connection → Insert Adapter Proxy → verify a proxy FB instance is inserted and the single connection becomes two adapter connections via the proxy.

In System Explorer: right-click an adapter type (.adp) → Insert Adapter Proxy → verify <Adapter>_Proxy.fbt is generated in the type library.