### PR TITLE
Fix discard and dirty in bulk editor

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.bulkeditor/src/org/eclipse/fordiac/ide/bulkeditor/editors/BulkEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.bulkeditor/src/org/eclipse/fordiac/ide/bulkeditor/editors/BulkEditor.java
@@ -270,6 +270,8 @@ public class BulkEditor extends EditorPart implements CommandExecutor, CommandSt
 			changedSearchParameter = false;
 			searchInformation.setText(""); //$NON-NLS-1$
 			commandStack.flush();
+			disconnectEditorInputs();
+			firePropertyChange(PROP_DIRTY);
 		});
 
 		advancedButton = WidgetFactory.button(SWT.TOGGLE).text(Messages.Advanced).onSelect(event -> {
@@ -715,6 +717,7 @@ public class BulkEditor extends EditorPart implements CommandExecutor, CommandSt
 		changedSearchParameter = false;
 		searchInformation.setText(""); //$NON-NLS-1$
 		commandStack.flush();
+		firePropertyChange(PROP_DIRTY);
 		return true;
 	}
 


### PR DESCRIPTION
The discard option in the bulk editor did not always actually discard the changes and the dirty state was not updated.