### PR TITLE
Fix modulo freeform figure for ECC

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/figures/ModuloFreeformFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/figures/ModuloFreeformFigure.java
@@ -73,7 +73,7 @@ public class ModuloFreeformFigure extends AbstractFreeformFigure {
 			final int baseUnit) {
 		final int startExtent = sourceExtent + PADDING + baseOrigin - newOrigin;
 
-		int newExtend = (startExtent / baseUnit) * baseUnit;
+		int newExtend = Math.ceilDiv(startExtent, baseUnit) * baseUnit;
 		if (newExtend < (3 * baseUnit)) {
 			newExtend = 3 * baseUnit;
 		}
@@ -81,11 +81,7 @@ public class ModuloFreeformFigure extends AbstractFreeformFigure {
 	}
 
 	private static int calcAxisOrigin(final int axisPos, final int baseUnit) {
-		if (axisPos < 0) {
-			// when negative we need to go one beyond to have the correct origin
-			return (axisPos / baseUnit) * baseUnit;
-		}
-		return (axisPos / baseUnit) * baseUnit;
+		return Math.floorDiv(axisPos, baseUnit) * baseUnit;
 	}
 
 }


### PR DESCRIPTION
Commit 82c6bd8 appears to have broken the growing background for the System Configuration and ECC diagrams.
This fixes it, although I am not happy with the hard-coded shrink size - maybe someone has a better idea there.