### PR TITLE
Reworked ChangeBounds commands to better handle Screen Scaling #1978

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/ResizeGroupOrSubappCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/ResizeGroupOrSubappCommand.java
@@ -30,6 +30,7 @@ import org.eclipse.fordiac.ide.application.editparts.SubAppForFBNetworkEditPart;
 import org.eclipse.fordiac.ide.application.editparts.UnfoldedSubappContentEditPart;
 import org.eclipse.fordiac.ide.application.figures.SubAppForFbNetworkFigure;
 import org.eclipse.fordiac.ide.application.policies.ContainerContentLayoutPolicy;
+import org.eclipse.fordiac.ide.application.policies.FBNetworkXYLayoutEditPolicy;
 import org.eclipse.fordiac.ide.model.ConnectionLayoutTagger;
 import org.eclipse.fordiac.ide.model.commands.QualNameAffectedCommand;
 import org.eclipse.fordiac.ide.model.commands.change.AbstractChangeContainerBoundsCommand;
@@ -165,7 +166,7 @@ public class ResizeGroupOrSubappCommand extends Command implements ConnectionLay
 				fbBounds.union(containerBounds);
 				final FBNetworkElement container = getContainer(containerEP);
 				if (container != null) {
-					return ContainerContentLayoutPolicy.createChangeBoundsCommand(container, containerBounds, fbBounds);
+					return FBNetworkXYLayoutEditPolicy.createChangeBoundsCommand(container, fbBounds);
 				}
 			}
 		}
@@ -186,7 +187,7 @@ public class ResizeGroupOrSubappCommand extends Command implements ConnectionLay
 					+ subappFigure.getInsets().right;
 			if (fullContainerBounds.width < newFig1.width) {
 				final FBNetworkElement container = getSubappContainer(fullContentGraphicalEditPart);
-				return ContainerContentLayoutPolicy.createChangeBoundsCommand(container, fullContainerBounds, newFig1);
+				return FBNetworkXYLayoutEditPolicy.createChangeBoundsCommand(container, newFig1);
 			}
 		}
 		return null;

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/ResizingSubappInterfaceCreationCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/ResizingSubappInterfaceCreationCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 Primetals Technologies Austria GmbH
+ * Copyright (c) 2022 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.application.commands;
 
-import org.eclipse.draw2d.geometry.Dimension;
-import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.fordiac.ide.application.editparts.SubAppForFBNetworkEditPart;
 import org.eclipse.fordiac.ide.application.policies.ContainerContentLayoutPolicy;
@@ -128,9 +126,9 @@ public final class ResizingSubappInterfaceCreationCommand extends CreationComman
 		final int expandedIOHeight = subAppEP.getFigure().getExpandedIOHeight();
 		final Rectangle containerBounds = ContainerContentLayoutPolicy.getContainerAreaBounds(subAppEP.getContentEP());
 		if (containerBounds.height < expandedIOHeight) {
-			final int heightDelta = expandedIOHeight - containerBounds.height;
+			containerBounds.height = expandedIOHeight;
 			changeSubappHeightCmd = FBNetworkXYLayoutEditPolicy.createChangeBoundsCommand(subAppEP.getModel(),
-					new Dimension(0, heightDelta), new Point());
+					containerBounds);
 			changeSubappHeightCmd.execute();
 		}
 	}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/ConvertToSubappHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/ConvertToSubappHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 Primetals Technologies Austria GmbH
+ * Copyright (c) 2022 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,7 +19,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.fordiac.ide.application.commands.ConvertGroupToSubappCommand;
 import org.eclipse.fordiac.ide.application.editparts.IContainerEditPart;
-import org.eclipse.fordiac.ide.application.policies.ContainerContentLayoutPolicy;
+import org.eclipse.fordiac.ide.application.policies.FBNetworkXYLayoutEditPolicy;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.Group;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
@@ -63,13 +63,12 @@ public class ConvertToSubappHandler extends AbstractHandler {
 		final IContainerEditPart containerEditPart = (IContainerEditPart) subappEP;
 		final GraphicalEditPart contentEP = containerEditPart.getContentEP();
 
-		final Rectangle contentContainerBounds = ContainerContentLayoutPolicy.getContainerAreaBounds(contentEP);
 		final Rectangle subappContentBounds = containerEditPart.getMinContentBounds();
 		subappContentBounds.setWidth(Math.max(subappContentBounds.width, contentEP.getFigure().getSize().width));
 		subappContentBounds.setHeight(Math.max(subappContentBounds.height, contentEP.getFigure().getSize().height));
 
-		final Command cmd = ContainerContentLayoutPolicy.createChangeBoundsCommand(
-				(FBNetworkElement) containerEditPart.getModel(), contentContainerBounds, subappContentBounds);
+		final Command cmd = FBNetworkXYLayoutEditPolicy
+				.createChangeBoundsCommand((FBNetworkElement) containerEditPart.getModel(), subappContentBounds);
 		if (cmd.canExecute()) {
 			cmdStack.execute(cmd);
 		}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/TrimHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/TrimHandler.java
@@ -26,7 +26,7 @@ import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.fordiac.ide.application.editparts.AbstractContainerContentEditPart;
 import org.eclipse.fordiac.ide.application.editparts.IContainerEditPart;
 import org.eclipse.fordiac.ide.application.editparts.UntypedSubAppInterfaceElementEditPart;
-import org.eclipse.fordiac.ide.application.policies.ContainerContentLayoutPolicy;
+import org.eclipse.fordiac.ide.application.policies.FBNetworkXYLayoutEditPolicy;
 import org.eclipse.fordiac.ide.gef.editparts.InterfaceEditPart;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
@@ -50,13 +50,12 @@ public class TrimHandler extends AbstractHandler {
 			final GraphicalEditPart contentEP = containerEditPart.getContentEP();
 
 			if (contentEP != null) {
-				final Rectangle contentContainerBounds = ContainerContentLayoutPolicy.getContainerAreaBounds(contentEP);
 				final Rectangle groupContentBounds = containerEditPart.getMinContentBounds();
 				final int adjustedCommentWidth = adjustCommentWidth(containerEditPart.getCommentWidth(),
 						containerEditPart.getChildren());
 				groupContentBounds.setWidth(Math.max(groupContentBounds.width, adjustedCommentWidth));
-				final Command cmd = ContainerContentLayoutPolicy.createChangeBoundsCommand(
-						(FBNetworkElement) containerEditPart.getModel(), contentContainerBounds, groupContentBounds);
+				final Command cmd = FBNetworkXYLayoutEditPolicy
+						.createChangeBoundsCommand((FBNetworkElement) containerEditPart.getModel(), groupContentBounds);
 				getCommandStack(editor).execute(cmd);
 			}
 		}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/ContainerContentLayoutPolicy.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/ContainerContentLayoutPolicy.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Primetals Technologies Germany GmbH,
- * 							Primetals Technologies Austria GmbH
+ * Copyright (c) 2020 Primetals Technologies Germany GmbH,
+ *                    Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,7 +18,6 @@
 package org.eclipse.fordiac.ide.application.policies;
 
 import org.eclipse.draw2d.Figure;
-import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -27,7 +26,6 @@ import org.eclipse.fordiac.ide.application.editparts.AbstractContainerContentEdi
 import org.eclipse.fordiac.ide.application.editparts.UnfoldedSubappContentEditPart;
 import org.eclipse.fordiac.ide.gef.policies.ModifiedMoveHandle;
 import org.eclipse.fordiac.ide.gef.preferences.GefPreferenceConstants;
-import org.eclipse.fordiac.ide.model.commands.change.AbstractChangeContainerBoundsCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.GraphicalEditPart;
@@ -83,15 +81,6 @@ public class ContainerContentLayoutPolicy extends FBNetworkXYLayoutEditPolicy {
 			contentBounds.height = containerBounds.height - dy - borderSize;
 		}
 		return contentBounds;
-	}
-
-	public static AbstractChangeContainerBoundsCommand createChangeBoundsCommand(final FBNetworkElement container,
-			final Rectangle contentContainerBounds, final Rectangle contentBounds) {
-		final Point moveDelta = new Point(contentBounds.x - contentContainerBounds.x,
-				contentBounds.y - contentContainerBounds.y);
-		final Dimension sizeDelta = new Dimension(contentBounds.width - contentContainerBounds.width,
-				contentBounds.height - contentContainerBounds.height);
-		return FBNetworkXYLayoutEditPolicy.createChangeBoundsCommand(container, sizeDelta, moveDelta);
 	}
 
 	protected static void translateToRelative(final GraphicalEditPart graphicalEditPart, final Point topLeft) {

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/FBNetworkXYLayoutEditPolicy.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/FBNetworkXYLayoutEditPolicy.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2026 Profactor GmbH, fortiss GmbH,
- *                          Primetals Technologies Austria GmbH
+ * Copyright (c) 2008 Profactor GmbH, fortiss GmbH,
+ *                    Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,7 +19,6 @@ import java.util.List;
 
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.PositionConstants;
-import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.PrecisionPoint;
 import org.eclipse.draw2d.geometry.PrecisionRectangle;
@@ -37,9 +36,6 @@ import org.eclipse.fordiac.ide.gef.policies.ModifiedResizeablePolicy;
 import org.eclipse.fordiac.ide.gef.utilities.RequestUtil;
 import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.commands.change.AbstractChangeContainerBoundsCommand;
-import org.eclipse.fordiac.ide.model.commands.change.ChangeCommentBoundsCommand;
-import org.eclipse.fordiac.ide.model.commands.change.ChangeGroupBoundsCommand;
-import org.eclipse.fordiac.ide.model.commands.change.ChangeSubAppBoundsCommand;
 import org.eclipse.fordiac.ide.model.commands.change.FBNetworkElementSetPositionCommand;
 import org.eclipse.fordiac.ide.model.commands.change.RemoveElementsFromGroup;
 import org.eclipse.fordiac.ide.model.commands.change.SetPositionCommand;
@@ -93,7 +89,7 @@ public class FBNetworkXYLayoutEditPolicy extends XYLayoutEditPolicy {
 			final Object constraint) {
 		if ((child.getModel() instanceof Group || child.getModel() instanceof SubApp
 				|| child.getModel() instanceof Comment) && RequestUtil.isResizeRequest(request)) {
-			return createChangeSizeCommand((FBNetworkElement) child.getModel(), request, (Rectangle) constraint);
+			return createChangeSizeCommand((GraphicalEditPart) child, (Rectangle) constraint, request);
 		}
 		if ((child.getModel() instanceof final PositionableElement pe) && (RequestUtil.isMoveRequest(request))) {
 			return createMoveCommand(pe, (Rectangle) constraint);
@@ -101,29 +97,31 @@ public class FBNetworkXYLayoutEditPolicy extends XYLayoutEditPolicy {
 		return null;
 	}
 
-	private Command createChangeSizeCommand(final FBNetworkElement container, final ChangeBoundsRequest request,
-			final Rectangle constraint) {
-		final Dimension sizeDelta = getScaledSizeDelta(request);
-		if (sizeDelta.width == 0 && sizeDelta.height == 0) {
+	private static Command createChangeSizeCommand(final GraphicalEditPart child, final Rectangle constraint,
+			final ChangeBoundsRequest request) {
+		final FBNetworkElement fbnEl = (FBNetworkElement) child.getModel();
+		final Rectangle origBounds = child.getFigure().getBounds();
+
+		if (constraint.width == origBounds.width && constraint.height == origBounds.height) {
 			// we hit the min size and we are just moving, return a set position command
-			return createMoveCommand(container, constraint);
+			return createMoveCommand(fbnEl, constraint);
 		}
-		final Point moveDelta = getScaledMoveDelta(request);
-		return createChangeBoundsCommand(container, sizeDelta, moveDelta);
+		// if we resize the snap to grid gives as a pixel to much
+		if (request.getMoveDelta().x == 0 && request.getSizeDelta().width != 0) {
+			constraint.width -= 1;
+		}
+		if (request.getMoveDelta().y == 0 && request.getSizeDelta().height != 0) {
+			constraint.height -= 1;
+		}
+		return createChangeBoundsCommand(fbnEl, constraint);
 	}
 
 	public static AbstractChangeContainerBoundsCommand createChangeBoundsCommand(final FBNetworkElement container,
-			final Dimension sizeDelta, final Point moveDelta) {
-		if (container instanceof final Group group) {
-			return new ChangeGroupBoundsCommand(group, moveDelta.x, moveDelta.y, sizeDelta.width, sizeDelta.height);
-		}
-		if (container instanceof final SubApp subApp) {
-			return new ChangeSubAppBoundsCommand(subApp, moveDelta.x, moveDelta.y, sizeDelta.width, sizeDelta.height);
-		}
-		if (container instanceof final Comment comment) {
-			return new ChangeCommentBoundsCommand(comment, moveDelta.x, moveDelta.y, sizeDelta.width, sizeDelta.height);
-		}
-		return null;
+			final Rectangle constraint) {
+		final Position newPos = CoordinateConverter.INSTANCE.createPosFromScreenCoordinates(constraint.x, constraint.y);
+		final double newWidth = CoordinateConverter.INSTANCE.screenToIEC61499(constraint.width);
+		final double newHeight = CoordinateConverter.INSTANCE.screenToIEC61499(constraint.height);
+		return AbstractChangeContainerBoundsCommand.getCommandFor(container, newPos, newWidth, newHeight);
 	}
 
 	@Override
@@ -291,10 +289,6 @@ public class FBNetworkXYLayoutEditPolicy extends XYLayoutEditPolicy {
 			return new FBNetworkElementSetPositionCommand(fbnEl, newPos);
 		}
 		return new SetPositionCommand(model, newPos);
-	}
-
-	protected Dimension getScaledSizeDelta(final ChangeBoundsRequest request) {
-		return request.getSizeDelta().getScaled(1.0 / getZoomManager().getZoom());
 	}
 
 	protected Point getScaledMoveDelta(final ChangeBoundsRequest request) {

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/GroupPropertySection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/GroupPropertySection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 Primetals Technologies Austria GmbH
+ * Copyright (c) 2022 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -115,15 +115,15 @@ public class GroupPropertySection extends AbstractDoubleColumnSection {
 		heightText.addVerifyListener(GroupPropertySection::ensureTextContainsOnlyDigits);
 		heightText.addModifyListener(e -> {
 			if (getType() != null) {
-				final int heightDiff;
+				final double newHeight;
 				try {
-					heightDiff = Integer.parseInt(heightText.getText())
-							- CoordinateConverter.INSTANCE.iec61499ToScreen(getType().getHeight());
+					newHeight = CoordinateConverter.INSTANCE.screenToIEC61499(Integer.parseInt(heightText.getText()));
 				} catch (final Exception exc) {
 					return;
 				}
 				removeContentAdapter();
-				executeCommand(new ChangeGroupBoundsCommand(getType(), 0, 0, 0, heightDiff));
+				executeCommand(new ChangeGroupBoundsCommand(getType(), getType().getPosition(), getType().getWidth(),
+						newHeight));
 				addContentAdapter();
 			}
 		});
@@ -136,15 +136,15 @@ public class GroupPropertySection extends AbstractDoubleColumnSection {
 		widthText.addVerifyListener(GroupPropertySection::ensureTextContainsOnlyDigits);
 		widthText.addModifyListener(e -> {
 			if (getType() != null) {
-				final int widthDiff;
+				final double newWidth;
 				try {
-					widthDiff = Integer.parseInt(widthText.getText())
-							- CoordinateConverter.INSTANCE.iec61499ToScreen(getType().getWidth());
+					newWidth = CoordinateConverter.INSTANCE.screenToIEC61499(Integer.parseInt(widthText.getText()));
 				} catch (final Exception exc) {
 					return;
 				}
 				removeContentAdapter();
-				executeCommand(new ChangeGroupBoundsCommand(getType(), 0, 0, widthDiff, 0));
+				executeCommand(new ChangeGroupBoundsCommand(getType(), getType().getPosition(), newWidth,
+						getType().getHeight()));
 				addContentAdapter();
 			}
 		});

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/SubAppPropertySection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/SubAppPropertySection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 Primetals Technologies Austria GmbH
+ * Copyright (c) 2023 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -70,16 +70,16 @@ public class SubAppPropertySection extends InstancePropertySection {
 		heightText.setTextLimit(TEXT_INPUT_MAX_LENGTH);
 		heightText.addModifyListener(e -> {
 			if (getType() != null) {
-				final int heightDelta;
+				final double newHeight;
 				try {
-					heightDelta = Integer.parseInt(heightText.getText())
-							- CoordinateConverter.INSTANCE.iec61499ToScreen(getType().getHeight());
+					newHeight = CoordinateConverter.INSTANCE.screenToIEC61499(Integer.parseInt(heightText.getText()));
 				} catch (final NumberFormatException exception) {
 					return;
 				}
 
 				removeContentAdapter();
-				executeCommand(new ChangeSubAppBoundsCommand(getType(), 0, 0, 0, heightDelta));
+				executeCommand(new ChangeSubAppBoundsCommand(getType(), getType().getPosition(), getType().getWidth(),
+						newHeight));
 				addContentAdapter();
 			}
 		});
@@ -91,17 +91,16 @@ public class SubAppPropertySection extends InstancePropertySection {
 		widthText.setTextLimit(TEXT_INPUT_MAX_LENGTH);
 		widthText.addModifyListener(e -> {
 			if (getType() != null) {
-
-				final int widthDelta;
+				final double newWidth;
 				try {
-					widthDelta = Integer.parseInt(widthText.getText())
-							- CoordinateConverter.INSTANCE.iec61499ToScreen(getType().getWidth());
+					newWidth = CoordinateConverter.INSTANCE.screenToIEC61499(Integer.parseInt(widthText.getText()));
 				} catch (final NumberFormatException exception) {
 					return;
 				}
 
 				removeContentAdapter();
-				executeCommand(new ChangeSubAppBoundsCommand(getType(), 0, 0, widthDelta, 0));
+				executeCommand(new ChangeSubAppBoundsCommand(getType(), getType().getPosition(), newWidth,
+						getType().getHeight()));
 				addContentAdapter();
 			}
 		});

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractChangeContainerBoundsCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractChangeContainerBoundsCommand.java
@@ -18,18 +18,20 @@ import java.util.Set;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.fordiac.ide.model.ConnectionLayoutTagger;
-import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.commands.ScopedCommand;
+import org.eclipse.fordiac.ide.model.libraryElement.Comment;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.Group;
+import org.eclipse.fordiac.ide.model.libraryElement.Position;
 import org.eclipse.fordiac.ide.model.libraryElement.PositionableElement;
+import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.commands.CompoundCommand;
 
 public abstract class AbstractChangeContainerBoundsCommand extends Command
 		implements ConnectionLayoutTagger, ScopedCommand {
 
-	private final int dx;
-	private final int dy;
+	private final Position newPos;
 	private final double oldWidth;
 	private final double oldHeight;
 	private final double newWidth;
@@ -37,29 +39,24 @@ public abstract class AbstractChangeContainerBoundsCommand extends Command
 	private final PositionableElement target;
 	private CompoundCommand updatePositions;
 
-	protected AbstractChangeContainerBoundsCommand(final PositionableElement target, final int dx, final int dy,
-			final int dw, final int dh, final double oldWidth, final double oldHeight) {
-		this.target = Objects.requireNonNull(target);
-		this.dx = dx;
-		this.dy = dy;
-		this.oldWidth = oldWidth;
-		this.oldHeight = oldHeight;
-		newWidth = calcNewSize(dx, dw, oldWidth);
-		newHeight = calcNewSize(dy, dh, oldHeight);
+	public static AbstractChangeContainerBoundsCommand getCommandFor(final FBNetworkElement container,
+			final Position newPos, final double newWidth, final double newHeight) {
+		return switch (container) {
+		case final Group group -> new ChangeGroupBoundsCommand(group, newPos, newWidth, newHeight);
+		case final SubApp subApp -> new ChangeSubAppBoundsCommand(subApp, newPos, newWidth, newHeight);
+		case final Comment comment -> new ChangeCommentBoundsCommand(comment, newPos, newWidth, newHeight);
+		default -> null;
+		};
 	}
 
-	private static double calcNewSize(final int deltaPos, int deltaSize, final double oldSize) {
-		if (deltaSize == 0) {
-			return oldSize;
-		}
-		if (deltaPos == 0) {
-			// snap to grid gives us always one pixel to much in size
-			deltaSize--;
-		}
-		// use screen coordinates for the new size calculation to reduce rounding
-		// artefact issues
-		return CoordinateConverter.INSTANCE
-				.screenToIEC61499(CoordinateConverter.INSTANCE.iec61499ToScreen(oldSize) + deltaSize);
+	protected AbstractChangeContainerBoundsCommand(final PositionableElement target, final Position newPos,
+			final double newWidth, final double newHeight, final double oldWidth, final double oldHeight) {
+		this.target = Objects.requireNonNull(target);
+		this.newPos = newPos;
+		this.newWidth = newWidth;
+		this.newHeight = newHeight;
+		this.oldWidth = oldWidth;
+		this.oldHeight = oldHeight;
 	}
 
 	@Override
@@ -92,9 +89,14 @@ public abstract class AbstractChangeContainerBoundsCommand extends Command
 	}
 
 	private CompoundCommand createSetPosCommand() {
+
+		final Position oldPos = target.getPosition();
+		final double dx = newPos.getX() - oldPos.getX();
+		final double dy = newPos.getY() - oldPos.getY();
+
 		if (dx != 0 || dy != 0) {
 			final CompoundCommand cmd = new CompoundCommand();
-			cmd.add(new SetPositionCommand(target, dx, dy));
+			cmd.add(new SetPositionCommand(target, newPos));
 			// Ensure that the children stay at their position when the group grows or
 			// shrinks on the left/top side. If the child is in a group we must only
 			// consider it if the group the child is contained in itself is changed.

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeCommentBoundsCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeCommentBoundsCommand.java
@@ -17,11 +17,13 @@ import java.util.List;
 
 import org.eclipse.fordiac.ide.model.libraryElement.Comment;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.Position;
 
 public class ChangeCommentBoundsCommand extends AbstractChangeContainerBoundsCommand {
 
-	public ChangeCommentBoundsCommand(final Comment comment, final int dx, final int dy, final int dw, final int dh) {
-		super(comment, dx, dy, dw, dh, comment.getWidth(), comment.getHeight());
+	public ChangeCommentBoundsCommand(final Comment comment, final Position newPos, final double newWidth,
+			final double newHeight) {
+		super(comment, newPos, newWidth, newHeight, comment.getWidth(), comment.getHeight());
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeGroupBoundsCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeGroupBoundsCommand.java
@@ -16,11 +16,13 @@ import java.util.List;
 
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.Group;
+import org.eclipse.fordiac.ide.model.libraryElement.Position;
 
 public class ChangeGroupBoundsCommand extends AbstractChangeContainerBoundsCommand {
 
-	public ChangeGroupBoundsCommand(final Group group, final int dx, final int dy, final int dw, final int dh) {
-		super(group, dx, dy, dw, dh, group.getWidth(), group.getHeight());
+	public ChangeGroupBoundsCommand(final Group group, final Position newPos, final double newWidth,
+			final double newHeight) {
+		super(group, newPos, newWidth, newHeight, group.getWidth(), group.getHeight());
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeSubAppBoundsCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeSubAppBoundsCommand.java
@@ -15,12 +15,14 @@ package org.eclipse.fordiac.ide.model.commands.change;
 import java.util.List;
 
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.Position;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
 
 public class ChangeSubAppBoundsCommand extends AbstractChangeContainerBoundsCommand {
 
-	public ChangeSubAppBoundsCommand(final SubApp group, final int dx, final int dy, final int dw, final int dh) {
-		super(group, dx, dy, dw, dh, group.getWidth(), group.getHeight());
+	public ChangeSubAppBoundsCommand(final SubApp group, final Position newPos, final double newWidth,
+			final double newHeight) {
+		super(group, newPos, newWidth, newHeight, group.getWidth(), group.getHeight());
 	}
 
 	@Override


### PR DESCRIPTION
All change bound commands worked on size deltas. The better and more GEF way is to work on the new position and size. This also make the command more independent from the exact drawing and scaling and more reusable.

Addresses: #978