### PR TITLE
Normalize paths before unzipping to prevent zip slip security issue

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/LibraryManager.java
+++ b/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/LibraryManager.java
@@ -347,9 +347,11 @@ public enum LibraryManager {
 	 * @throws IOException if an I/O error occurs
 	 */
 	private static Path newPath(final Path destinationDir, final ZipEntry zipEntry) throws IOException {
-		final Path destPath = destinationDir.resolve(zipEntry.getName());
+		final Path normalizedDestinationDir = destinationDir.toAbsolutePath().normalize();
+		final String entryName = zipEntry.getName().replace('\\', '/');
+		final Path destPath = normalizedDestinationDir.resolve(entryName).normalize();
 
-		if (!destPath.startsWith(destinationDir)) {
+		if (!destPath.startsWith(normalizedDestinationDir)) {
 			throw new IOException("Entry is outside of the target dir: " + zipEntry.getName()); //$NON-NLS-1$
 		}
 		return destPath;

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/wizard/ExampleCreationOperation.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/wizard/ExampleCreationOperation.java
@@ -120,12 +120,15 @@ public class ExampleCreationOperation extends WorkspaceModifyOperation {
 			throws IOException, InterruptedException {
 
 		final Enumeration<? extends ZipEntry> e = zipFile.entries();
+		final java.nio.file.Path targetDirPath = projectFolderFile.toPath().toRealPath();
 
 		while (e.hasMoreElements()) {
 			final ZipEntry zipEntry = e.nextElement();
-			final File file = new File(projectFolderFile, zipEntry.getName());
 
-			if (!zipEntry.isDirectory()) {
+			final File file = safeZipEntryDestination(targetDirPath, zipEntry);
+			if (zipEntry.isDirectory()) {
+				file.mkdirs();
+			} else {
 
 				// Copy files (and make sure parent directory exist)
 				final File parentFile = file.getParentFile();
@@ -144,6 +147,17 @@ public class ExampleCreationOperation extends WorkspaceModifyOperation {
 				throw new InterruptedException();
 			}
 		}
+	}
+
+	private static File safeZipEntryDestination(final java.nio.file.Path targetDir, final ZipEntry zipEntry)
+			throws IOException {
+		// Normalize separators to avoid Windows-style traversal (e.g. "..\\..\\evil")
+		final String entryName = zipEntry.getName().replace('\\', '/');
+		final java.nio.file.Path destPath = targetDir.resolve(entryName).normalize();
+		if (!destPath.startsWith(targetDir)) {
+			throw new IOException("Blocked zip entry outside target directory: " + entryName); //$NON-NLS-1$
+		}
+		return destPath.toFile();
 	}
 
 	private static void renameProject(final IProject project, final String projectName) throws CoreException {


### PR DESCRIPTION
This PR fixes the following security alerts:
https://github.com/eclipse-4diac/4diac-ide/security/code-scanning/1
https://github.com/eclipse-4diac/4diac-ide/security/code-scanning/2

