### PR TITLE
Fixed NPEs in Handlers invoked on Mapped untyped Subapps #2155

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/InterfaceEditPartForFBNetwork.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/InterfaceEditPartForFBNetwork.java
@@ -22,7 +22,6 @@ import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.emf.common.notify.Adapter;
-import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.application.policies.AdapterNodeEditPolicy;
 import org.eclipse.fordiac.ide.application.policies.EventNodeEditPolicy;
 import org.eclipse.fordiac.ide.application.policies.VariableNodeEditPolicy;
@@ -169,7 +168,7 @@ public class InterfaceEditPartForFBNetwork extends InterfaceEditPart {
 	private static boolean needsOppositeSubapp(final SubApp subapp) {
 		// if a subapp is mapped and we are at the resource side we would like to get
 		// the opposite subapp
-		return (subapp.isMapped() && EcoreUtil.isAncestor(subapp.getResource(), subapp));
+		return (subapp.isMapped() && subapp.getMapping().getTo() == subapp);
 	}
 
 	protected boolean isUnfoldedSubapp() {

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/ConvertToGroupHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/ConvertToGroupHandler.java
@@ -67,7 +67,8 @@ public class ConvertToGroupHandler extends AbstractHandler implements CommandSta
 	private static SubApp getSelectedSubApp(final Object selection) {
 		if (selection instanceof final IStructuredSelection structSel && !structSel.isEmpty()
 				&& structSel.size() == 1) {
-			return getSubApp(structSel.getFirstElement());
+			final SubApp subApp = getSubApp(structSel.getFirstElement());
+			return (subApp != null && subApp.isMapped()) ? (SubApp) subApp.getMapping().getFrom() : subApp;
 		}
 		return null;
 	}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/FlattenSubApplication.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/handlers/FlattenSubApplication.java
@@ -89,12 +89,13 @@ public class FlattenSubApplication extends AbstractHandler {
 	}
 
 	private static SubApp getSubApp(final Object currentElement) {
-		return switch (currentElement) {
-		case final SubApp subApp -> subApp;
+		final SubApp subApp = switch (currentElement) {
+		case final SubApp sub -> sub;
 		case final SubAppForFBNetworkEditPart subAppEP -> subAppEP.getModel();
 		case final UISubAppNetworkEditPart uiSubAppNWEP -> (SubApp) uiSubAppNWEP.getModel().eContainer();
 		default -> null;
 		};
+		return (subApp != null && subApp.isMapped()) ? (SubApp) subApp.getMapping().getFrom() : subApp;
 	}
 
 	private static SubApp getSelectedSubApp(final Object selection) {


### PR DESCRIPTION
These handlers need to use the mapping source when invoked on mapped untyped subapps in the resource.

Fixes: https://github.com/eclipse-4diac/4diac-ide/issues/2155