### PR TITLE
Improved visual representation of Mapping

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractBlockFBNElementEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractBlockFBNElementEditPart.java
@@ -163,7 +163,7 @@ public abstract class AbstractBlockFBNElementEditPart extends AbstractPositionab
 				super.notifyChanged(notification);
 				refreshToolTip(); // TODO add here checks that better define when the tooltip should be refreshed
 				if (notification.getFeature() == LibraryElementPackage.eINSTANCE.getFBNetworkElement_Mapping()) {
-					updateDeviceListener();
+					refreshChildren();
 				}
 			}
 

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractBlockFBNElementEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractBlockFBNElementEditPart.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
- *                          Johannes Kepler University Linz,
- *                          Primetals Technologies Germany GmbH,
- *                          Primetals Technologies Austria GmbH
+ * Copyright (c) 2008 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
+ *                    Johannes Kepler University Linz,
+ *                    Primetals Technologies Germany GmbH,
+ *                    Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -75,6 +75,7 @@ import org.eclipse.gef.editpolicies.DirectEditPolicy;
 import org.eclipse.gef.requests.DirectEditRequest;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.util.IPropertyChangeListener;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Display;
 
@@ -298,7 +299,7 @@ public abstract class AbstractBlockFBNElementEditPart extends AbstractPositionab
 				color.setBlue(dev.getColor().getBlue());
 			}
 		}
-		setColor(figure, color);
+		// setColor(figure, color);
 	}
 
 	protected ColorizableElement findDevice() {
@@ -317,8 +318,17 @@ public abstract class AbstractBlockFBNElementEditPart extends AbstractPositionab
 			getTargetFigure(interfaceEditPart).add(child, getInterfaceElementIndex(interfaceEditPart));
 		case final HiddenPinIndicatorEditPart hiddenPinIndicatorEditPart ->
 			addPinIndicatorFigure(hiddenPinIndicatorEditPart, child);
+		case final MappingEditPart mapping -> addMappingFigure(child);
 		default -> getFigure().add(child, new GridData(GridData.HORIZONTAL_ALIGN_CENTER), index);
 		}
+	}
+
+	protected void addMappingFigure(final IFigure child) {
+		final GridData gridData = new GridData();
+		gridData.horizontalSpan = 2;
+		gridData.grabExcessHorizontalSpace = true;
+		gridData.horizontalAlignment = SWT.FILL;
+		getFigure().getBottom().add(child, gridData, -1);
 	}
 
 	private void addPinIndicatorFigure(final HiddenPinIndicatorEditPart indicatorEditPart,
@@ -450,6 +460,7 @@ public abstract class AbstractBlockFBNElementEditPart extends AbstractPositionab
 		}
 		case final HiddenPinIndicatorEditPart hiddenPinIndicatorEditPart ->
 			removePinIndicatorFigure(hiddenPinIndicatorEditPart, child);
+		case final MappingEditPart mapping -> getFigure().getBottom().remove(child);
 		default -> super.removeChildVisual(childEditPart);
 		}
 	}
@@ -467,8 +478,12 @@ public abstract class AbstractBlockFBNElementEditPart extends AbstractPositionab
 	protected List<Object> getModelChildren() {
 		final List<Object> elements = new ArrayList<>();
 		elements.add(getInstanceName());
-		elements.addAll(getModel().getInterface().getAllInterfaceElements().filter(IInterfaceElement::isVisible).toList());
+		elements.addAll(
+				getModel().getInterface().getAllInterfaceElements().filter(IInterfaceElement::isVisible).toList());
 		addPinIndicators(elements);
+		if (getModel().isMapped()) {
+			elements.add(getModel().getMapping());
+		}
 		return elements;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractBlockFBNElementEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractBlockFBNElementEditPart.java
@@ -46,18 +46,14 @@ import org.eclipse.fordiac.ide.gef.listeners.DiagramFontChangeListener;
 import org.eclipse.fordiac.ide.gef.policies.DragHighlightEditPolicy;
 import org.eclipse.fordiac.ide.model.commands.change.UpdateFBTypeCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
-import org.eclipse.fordiac.ide.model.libraryElement.Color;
-import org.eclipse.fordiac.ide.model.libraryElement.ColorizableElement;
 import org.eclipse.fordiac.ide.model.libraryElement.ContainerVarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.ErrorMarkerInterface;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
-import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.libraryElement.PositionableElement;
-import org.eclipse.fordiac.ide.model.libraryElement.Resource;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
@@ -104,8 +100,6 @@ public abstract class AbstractBlockFBNElementEditPart extends AbstractPositionab
 		}
 	}
 
-	private ColorizableElement referencedDevice;
-
 	private DiagramFontChangeListener fontChangeListener;
 
 	protected AbstractBlockFBNElementEditPart() {
@@ -146,15 +140,6 @@ public abstract class AbstractBlockFBNElementEditPart extends AbstractPositionab
 		return (FBNetworkElementFigure) super.getFigure();
 	}
 
-	private final Adapter colorChangeListener = new AdapterImpl() {
-		@Override
-		public void notifyChanged(final Notification notification) {
-			if (notification.getFeature() == LibraryElementPackage.eINSTANCE.getColorizableElement_Color()) {
-				backgroundColorChanged(getFigure());
-			}
-		}
-	};
-
 	@Override
 	protected Adapter createContentAdapter() {
 		return new AdapterImpl() {
@@ -170,24 +155,9 @@ public abstract class AbstractBlockFBNElementEditPart extends AbstractPositionab
 		};
 	}
 
-	protected void updateDeviceListener() {
-		final ColorizableElement device = findDevice();
-		if (device != referencedDevice) {
-			if (referencedDevice != null) {
-				referencedDevice.eAdapters().remove(colorChangeListener);
-			}
-			referencedDevice = device;
-			if (referencedDevice != null) {
-				referencedDevice.eAdapters().add(colorChangeListener);
-			}
-			backgroundColorChanged(getFigure());
-		}
-	}
-
 	@Override
 	public void activate() {
 		super.activate();
-		updateDeviceListener();
 		JFaceResources.getFontRegistry().addListener(getFontChangeListener());
 		if (getColorChangeListener() != null) {
 			JFaceResources.getColorRegistry().addListener(getColorChangeListener());
@@ -200,9 +170,6 @@ public abstract class AbstractBlockFBNElementEditPart extends AbstractPositionab
 	@Override
 	public void deactivate() {
 		super.deactivate();
-		if (referencedDevice != null) {
-			referencedDevice.eAdapters().remove(colorChangeListener);
-		}
 		JFaceResources.getFontRegistry().removeListener(getFontChangeListener());
 		if (getColorChangeListener() != null) {
 			JFaceResources.getColorRegistry().removeListener(getColorChangeListener());
@@ -289,25 +256,7 @@ public abstract class AbstractBlockFBNElementEditPart extends AbstractPositionab
 
 	@Override
 	protected void backgroundColorChanged(final IFigure figure) {
-		Color color = null;
-		if (getModel() != null) {
-			final ColorizableElement dev = findDevice();
-			if (dev != null) {
-				color = LibraryElementFactory.eINSTANCE.createColor();
-				color.setRed(dev.getColor().getRed());
-				color.setGreen(dev.getColor().getGreen());
-				color.setBlue(dev.getColor().getBlue());
-			}
-		}
-		// setColor(figure, color);
-	}
-
-	protected ColorizableElement findDevice() {
-		Resource res = null;
-		if ((null != getModel()) && getModel().isMapped()) {
-			res = getModel().getResource();
-		}
-		return (null != res) ? res.getDevice() : null;
+		// don't do anything
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractBlockFBNElementEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractBlockFBNElementEditPart.java
@@ -18,6 +18,8 @@
  *                 direct editing of instance names
  *               - added separate colors for different data types
  *   Bianca Wiesmayr, Alois Zoitl - forward direct editing request to instance name
+ *   Alois Zoitl - reworked mapping representation
+ *               - reworked background color handling
  *******************************************************************************/
 package org.eclipse.fordiac.ide.application.editparts;
 
@@ -252,11 +254,6 @@ public abstract class AbstractBlockFBNElementEditPart extends AbstractPositionab
 			};
 		}
 		return listener;
-	}
-
-	@Override
-	protected void backgroundColorChanged(final IFigure figure) {
-		// don't do anything
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractStructManipulatorEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractStructManipulatorEditPart.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Johannes Kepler University Linz,
- *                          Primetals Technologies Austria GmbH
+ * Copyright (c) 2020 Johannes Kepler University Linz,
+ *                    Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -37,7 +37,7 @@ public abstract class AbstractStructManipulatorEditPart extends AbstractBlockFBN
 	}
 
 	@Override
-	protected IFigure createFigureForModel() {
+	protected IFigure createFigure() {
 		return new FBNetworkElementFigure(getModel(),
 				((AdvancedScrollingGraphicalViewer) getViewer()).getPreferencesCache().getMaxTypeLabelSize());
 	}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/CommentEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/CommentEditPart.java
@@ -202,7 +202,7 @@ public class CommentEditPart extends AbstractPositionableElementEditPart {
 	}
 
 	@Override
-	protected IFigure createFigureForModel() {
+	protected IFigure createFigure() {
 		final StickyNoteCommentFigure mainFigure = new StickyNoteCommentFigure();
 		mainFigure.setCommentText(getModel().getComment());
 		return mainFigure;

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/CommentEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/CommentEditPart.java
@@ -8,8 +8,10 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *   Alois Zoitl - initial API and implementation and/or initial documentation
+ *   Alois Zoitl     - initial API and implementation and/or initial documentation
  *   Prankur Agarwal - update the figure to look like a sticky note
+ *   Alois Zoitl     - improved and modernized comment figure drawing
+ *                   - reworked background color handling
  *******************************************************************************/
 package org.eclipse.fordiac.ide.application.editparts;
 
@@ -279,11 +281,6 @@ public class CommentEditPart extends AbstractPositionableElementEditPart {
 				}
 			}
 		};
-	}
-
-	@Override
-	protected void backgroundColorChanged(final IFigure figure) {
-		// we have a static background color don't change it.
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/CommunicationChannelEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/CommunicationChannelEditPart.java
@@ -14,24 +14,12 @@ package org.eclipse.fordiac.ide.application.editparts;
 
 import java.util.List;
 
-import org.eclipse.fordiac.ide.model.libraryElement.MappingTarget;
-import org.eclipse.fordiac.ide.model.libraryElement.Segment;
-
 public class CommunicationChannelEditPart extends FBEditPart {
 	@Override
 	protected List<Object> getModelChildren() {
 		final List<Object> elements = super.getModelChildren();
 		elements.remove(getInstanceName());
 		return elements;
-	}
-
-	@Override
-	protected Segment findDevice() {
-		MappingTarget tgt = null;
-		if ((null != getModel()) && getModel().isMapped()) {
-			tgt = (MappingTarget) getModel().getOpposite().eContainer();
-		}
-		return (null != tgt) ? (Segment) tgt.eContainer().eContainer() : null;
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/ElementEditPartFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/ElementEditPartFactory.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Profactor GmbH, fortiss GmbH, Johannes Kepler University,
- * 							Primetals Technologies Germany GmbH
+ * Copyright (c) 2008 Profactor GmbH, fortiss GmbH, Johannes Kepler University,
+ *                    Primetals Technologies Germany GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -34,6 +34,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.Group;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
+import org.eclipse.fordiac.ide.model.libraryElement.Mapping;
 import org.eclipse.fordiac.ide.model.libraryElement.Multiplexer;
 import org.eclipse.fordiac.ide.model.libraryElement.StructManipulator;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
@@ -56,52 +57,28 @@ public class ElementEditPartFactory extends Abstract4diacEditPartFactory {
 	 */
 	@Override
 	protected EditPart getPartForElement(final EditPart context, final Object modelElement) {
-		if (modelElement instanceof GroupContentNetwork) {
-			return new GroupContentEditPart();
-		}
-		if (modelElement instanceof final FBNetwork network) {
+		return switch (modelElement) {
+		case final GroupContentNetwork gcn -> new GroupContentEditPart();
+		case final FBNetwork network -> {
 			if (context instanceof SubAppForFBNetworkEditPart) {
-				return new UnfoldedSubappContentEditPart();
+				yield new UnfoldedSubappContentEditPart();
 			}
-			return getPartForFBNetwork(network);
+			yield getPartForFBNetwork(network);
 		}
-		if (modelElement instanceof final FBNetworkElement fbnel) {
-			return getPartForFBNetworkElement(context, fbnel);
-		}
-		if (modelElement instanceof StructuredType) {
-			return new StructuredTypeEditPart();
-		}
-		if (modelElement instanceof ErrorDataType) {
-			return new ErrorDataTypeEditPart();
-		}
-		if (modelElement instanceof InstanceName) {
-			return new InstanceNameEditPart();
-		}
-		if (modelElement instanceof InstanceComment) {
-			return new InstanceCommentEditPart();
-		}
-		if (modelElement instanceof InstanceContract) {
-			return new InstanceContractEditPart();
-		}
-		if (modelElement instanceof Connection) {
-			return new ConnectionEditPart();
-		}
-		if (modelElement instanceof IInterfaceElement) {
-			return createInterfaceEditPart(modelElement);
-		}
-		if (modelElement instanceof Value) {
-			return new FBNValueEditPart();
-		}
-		if (modelElement instanceof HiddenPinIndicator) {
-			return new HiddenPinIndicatorEditPart();
-		}
-
-		if (modelElement instanceof TargetInterfaceElement) {
-			return new TargetInterfaceElementEditPart();
-		}
-
-		throw createEditpartCreationException(context, modelElement);
-
+		case final FBNetworkElement fbnel -> getPartForFBNetworkElement(context, fbnel);
+		case final StructuredType structType -> new StructuredTypeEditPart();
+		case final ErrorDataType errorDT -> new ErrorDataTypeEditPart();
+		case final InstanceName in -> new InstanceNameEditPart();
+		case final InstanceComment ic -> new InstanceCommentEditPart();
+		case final InstanceContract instContract -> new InstanceContractEditPart();
+		case final Connection conn -> new ConnectionEditPart();
+		case final IInterfaceElement ie -> createInterfaceEditPart(modelElement);
+		case final Value value -> new FBNValueEditPart();
+		case final HiddenPinIndicator hpi -> new HiddenPinIndicatorEditPart();
+		case final TargetInterfaceElement tie -> new TargetInterfaceElementEditPart();
+		case final Mapping mapping -> new MappingEditPart();
+		default -> throw createEditpartCreationException(context, modelElement);
+		};
 	}
 
 	private static EditPart getPartForFBNetworkElement(final EditPart context, final FBNetworkElement element) {

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/ErrorMarkerFBNEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/ErrorMarkerFBNEditPart.java
@@ -30,7 +30,7 @@ public class ErrorMarkerFBNEditPart extends AbstractBlockFBNElementEditPart {
 	}
 
 	@Override
-	protected IFigure createFigureForModel() {
+	protected IFigure createFigure() {
 		errorMarkerFBNeworkElementFigure = new ErrorMarkerFBNeworkElementFigure(getModel(),
 				((AdvancedScrollingGraphicalViewer) getViewer()).getPreferencesCache().getMaxTypeLabelSize());
 		updateErrorText();

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/FBEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/FBEditPart.java
@@ -38,7 +38,7 @@ public class FBEditPart extends AbstractBlockFBNElementEditPart {
 	 * @return IFigure The figure for the model
 	 */
 	@Override
-	protected IFigure createFigureForModel() {
+	protected IFigure createFigure() {
 		// extend this if FunctionBlock gets extended!
 		FBNetworkElementFigure f = null;
 		if (getModel() == null) {

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/GroupEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/GroupEditPart.java
@@ -170,7 +170,7 @@ public class GroupEditPart extends AbstractPositionableElementEditPart
 	}
 
 	@Override
-	protected IFigure createFigureForModel() {
+	protected IFigure createFigure() {
 		final GroupFigure groupFigure = new GroupFigure();
 		groupFigure.getCommentFigure().setText(getModel().getComment());
 

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/MappingEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/MappingEditPart.java
@@ -16,12 +16,35 @@ import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.MarginBorder;
 import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.emf.common.notify.Adapter;
+import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.common.notify.impl.AdapterImpl;
 import org.eclipse.fordiac.ide.model.libraryElement.Color;
+import org.eclipse.fordiac.ide.model.libraryElement.ColorizableElement;
+import org.eclipse.fordiac.ide.model.libraryElement.CommunicationMappingTarget;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.libraryElement.Mapping;
+import org.eclipse.fordiac.ide.model.libraryElement.Segment;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.editparts.AbstractGraphicalEditPart;
 
 public class MappingEditPart extends AbstractGraphicalEditPart {
+
+	private final Adapter colorChangeListener = new AdapterImpl() {
+		@Override
+		public void notifyChanged(final Notification notification) {
+			if (notification.getFeature() == LibraryElementPackage.eINSTANCE.getColorizableElement_Color()
+					&& notification.getNewValue() instanceof final Color col) {
+				setColor(getFigure(), col);
+			}
+		}
+	};
+
+	@Override
+	public void activate() {
+		getColorizeableElement().eAdapters().add(colorChangeListener);
+		super.activate();
+	}
 
 	@Override
 	protected IFigure createFigure() {
@@ -38,13 +61,26 @@ public class MappingEditPart extends AbstractGraphicalEditPart {
 		fig.setPreferredSize(new Dimension(-1, 7));
 		fig.setBorder(new MarginBorder(0, 0, -1, 0));
 
-		setColor(fig, getModel().getTo().getResource().getDevice().getColor());
+		setColor(fig, getColorizeableElement().getColor());
 		return fig;
 	}
 
 	@Override
 	protected void createEditPolicies() {
 		// no edit interaction should be done with mapping elements
+	}
+
+	@Override
+	public void deactivate() {
+		getColorizeableElement().eAdapters().remove(colorChangeListener);
+		super.deactivate();
+	}
+
+	private ColorizableElement getColorizeableElement() {
+		if (getModel().getTo().eContainer() instanceof final CommunicationMappingTarget commTarget) {
+			return (Segment) commTarget.eContainer().eContainer();
+		}
+		return getModel().getTo().getResource().getDevice();
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/MappingEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/MappingEditPart.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Johannes Kepler University Linz
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Alois Zoitl - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.application.editparts;
+
+import org.eclipse.draw2d.Figure;
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.MarginBorder;
+import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.fordiac.ide.model.libraryElement.Color;
+import org.eclipse.fordiac.ide.model.libraryElement.Mapping;
+import org.eclipse.gef.EditPolicy;
+import org.eclipse.gef.editparts.AbstractGraphicalEditPart;
+
+public class MappingEditPart extends AbstractGraphicalEditPart {
+
+	@Override
+	protected IFigure createFigure() {
+
+		final IFigure fig = new Figure() {
+			@Override
+			protected void paintFigure(final org.eclipse.draw2d.Graphics graphics) {
+				// super paint figure first to draw the border
+				super.paintFigure(graphics);
+				graphics.fillRoundRectangle(getBounds(), 3, 3);
+			}
+
+		};
+		fig.setPreferredSize(new Dimension(-1, 7));
+		fig.setBorder(new MarginBorder(0, 0, -1, 0));
+
+		setColor(fig, getModel().getTo().getResource().getDevice().getColor());
+		return fig;
+	}
+
+	@Override
+	protected void createEditPolicies() {
+		// no edit interaction should be done with mapping elements
+	}
+
+	@Override
+	public Mapping getModel() {
+		return (Mapping) super.getModel();
+	}
+
+	@Override
+	public void installEditPolicy(final Object key, final EditPolicy editPolicy) {
+		if (key == EditPolicy.PRIMARY_DRAG_ROLE) {
+			// we do not want to be selectable and dragable
+			return;
+		}
+
+		super.installEditPolicy(key, editPolicy);
+	}
+
+	private static void setColor(final IFigure figure, final Color fordiacColor) {
+		org.eclipse.swt.graphics.Color newColor;
+		if (fordiacColor != null) {
+			newColor = new org.eclipse.swt.graphics.Color(fordiacColor.getRed(), fordiacColor.getGreen(),
+					fordiacColor.getBlue());
+		} else {
+			newColor = null;
+		}
+		figure.setBackgroundColor(newColor);
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/SubAppForFBNetworkEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/SubAppForFBNetworkEditPart.java
@@ -119,7 +119,7 @@ public class SubAppForFBNetworkEditPart extends AbstractBlockFBNElementEditPart 
 			}
 			refreshToolTip();
 			if (notification.getFeature() == LibraryElementPackage.eINSTANCE.getFBNetworkElement_Mapping()) {
-				updateDeviceListener();
+				refreshChildren();
 			}
 		}
 

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/SubAppForFBNetworkEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/SubAppForFBNetworkEditPart.java
@@ -244,7 +244,7 @@ public class SubAppForFBNetworkEditPart extends AbstractBlockFBNElementEditPart 
 	}
 
 	@Override
-	protected IFigure createFigureForModel() {
+	protected IFigure createFigure() {
 		final var prefCache = ((AdvancedScrollingGraphicalViewer) getViewer()).getPreferencesCache();
 		return new SubAppForFbNetworkFigure(getModel(), this, prefCache.getMinInterfaceBarSize(),
 				prefCache.getMaxTypeLabelSize());

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/SubAppForFBNetworkEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/SubAppForFBNetworkEditPart.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Profactor GmbH, AIT, fortiss GmbH,
- *                          Johannes Kepler University Linz,
- *                          Primetals Technologies Germany GmbH,
- *                          Primetals Technologies Austria GmbH
+ * Copyright (c) 2008 Profactor GmbH, AIT, fortiss GmbH,
+ *                    Johannes Kepler University Linz,
+ *                    Primetals Technologies Germany GmbH,
+ *                    Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -372,6 +372,19 @@ public class SubAppForFBNetworkEditPart extends AbstractBlockFBNElementEditPart 
 	}
 
 	@Override
+	protected void addMappingFigure(final IFigure child) {
+		if (getModel().isUnfolded()) {
+			final GridData gridData = new GridData();
+			gridData.horizontalSpan = 3;
+			gridData.grabExcessHorizontalSpace = true;
+			gridData.horizontalAlignment = SWT.FILL;
+			getFigure().getExpandedMainFigure().add(child, gridData, -1);
+		} else {
+			super.addMappingFigure(child);
+		}
+	}
+
+	@Override
 	protected void removeChildVisual(final EditPart childEditPart) {
 		switch (childEditPart) {
 		case final UnfoldedSubappContentEditPart unfoldedSubappContentEP when getFigure()
@@ -384,6 +397,8 @@ public class SubAppForFBNetworkEditPart extends AbstractBlockFBNElementEditPart 
 				getFigure().getExpandedOutputFigure().remove(interfaceEditPart.getFigure());
 			}
 		}
+		case final MappingEditPart mapping when getModel().isUnfolded() ->
+			getFigure().getExpandedMainFigure().remove(mapping.getFigure());
 		default -> super.removeChildVisual(childEditPart);
 		}
 	}

--- a/plugins/org.eclipse.fordiac.ide.gef/plugin.properties
+++ b/plugins/org.eclipse.fordiac.ide.gef/plugin.properties
@@ -18,7 +18,6 @@
 AbstractAttributeSection_CreateAttribute=create attribute
 AbstractAttributeSection_DeleteSelectedAttribute=delete selected attribute
 AdjustConnectionCommand_WrongConnectionSegmentIndex=Wrong connection segment index ({0}) provided to AdjustConnectionCommand!
-AbstractViewEditPart_ERROR_createFigure=Error in createFigure()
 AppearancePropertySection_LABEL_Color=Background Color
 AppearancePropertySection_LABEL_BackgroundColor=Background Color...
 AppearancePropertySection_ChangeBackgroundColor=Change Background Color

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/Messages.java
@@ -27,7 +27,6 @@ public final class Messages extends NLS {
 	public static String AbstractAttributeSection_CreateAttribute;
 	public static String AbstractAttributeSection_DeleteSelectedAttribute;
 	public static String AdjustConnectionCommand_WrongConnectionSegmentIndex;
-	public static String AbstractViewEditPart_ERROR_createFigure;
 	public static String AppearancePropertySection_ChangeBackgroundColor;
 	public static String AppearancePropertySection_LABEL_BackgroundColor;
 	public static String AppearancePropertySection_LABEL_ChooseColor;

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/AbstractViewEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/AbstractViewEditPart.java
@@ -24,21 +24,18 @@ import org.eclipse.emf.common.notify.Adapter;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.Notifier;
 import org.eclipse.emf.common.notify.impl.AdapterImpl;
-import org.eclipse.fordiac.ide.gef.Messages;
 import org.eclipse.fordiac.ide.gef.draw2d.ITransparencyFigure;
 import org.eclipse.fordiac.ide.gef.policies.AbstractViewRenameEditPolicy;
 import org.eclipse.fordiac.ide.gef.policies.EmptyXYLayoutEditPolicy;
 import org.eclipse.fordiac.ide.model.libraryElement.Color;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
-import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
 import org.eclipse.gef.tools.DirectEditManager;
 
 public abstract class AbstractViewEditPart extends AbstractConnectableEditPart {
-	private static final String ERROR_IN_CREATE_FIGURE = Messages.AbstractViewEditPart_ERROR_createFigure;
 
 	private Adapter adapter;
 
@@ -120,27 +117,6 @@ public abstract class AbstractViewEditPart extends AbstractConnectableEditPart {
 			}
 			((Notifier) getModel()).eAdapters().remove(getContentAdapter());
 		}
-	}
-
-	protected abstract IFigure createFigureForModel();
-
-	/**
-	 * Creates the <code>Figure</code> to be used as this part's <i>visuals</i>.
-	 *
-	 * @return a figure
-	 *
-	 * @see org.eclipse.gef.editparts.AbstractGraphicalEditPart#createFigure()
-	 * @see #createFigureForModel()
-	 */
-	@Override
-	protected IFigure createFigure() {
-		IFigure f = null;
-		try {
-			f = createFigureForModel();
-		} catch (final IllegalArgumentException e) {
-			FordiacLogHelper.logError(ERROR_IN_CREATE_FIGURE, e);
-		}
-		return f;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/AbstractViewEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/AbstractViewEditPart.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008 - 2017  Profactor GbmH, TU Wien ACIN, AIT, fortiss GmbH
- * 				 2019 Johannes Kepler University Linz
+ * Copyright (c) 2008 Profactor GbmH, TU Wien ACIN, AIT, fortiss GmbH,
+ *                    Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -10,9 +10,10 @@
  *
  * Contributors:
  *   Gerhard Ebenhofer, Alois Zoitl, Filip Andren, Monika Wenger
- *     - initial API and implementation and/or initial documentation
+ *               - initial API and implementation and/or initial documentation
  *   Alois Zoitl - separated FBNetworkElement from instance name for better
  *                 direct editing of instance names
+ *   Alois Zoitl - reworked background color handling
  *******************************************************************************/
 package org.eclipse.fordiac.ide.gef.editparts;
 
@@ -31,12 +32,10 @@ import org.eclipse.fordiac.ide.model.libraryElement.Color;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
-import org.eclipse.fordiac.ide.util.ColorManager;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
 import org.eclipse.gef.tools.DirectEditManager;
-import org.eclipse.swt.graphics.RGB;
 
 public abstract class AbstractViewEditPart extends AbstractConnectableEditPart {
 	private static final String ERROR_IN_CREATE_FIGURE = Messages.AbstractViewEditPart_ERROR_createFigure;
@@ -69,16 +68,11 @@ public abstract class AbstractViewEditPart extends AbstractConnectableEditPart {
 		}
 	};
 
-	protected void backgroundColorChanged(final IFigure figure) {
-		setColor(figure, null);
-	}
-
-	@SuppressWarnings("static-method")
-	protected void setColor(final IFigure figure, final Color fordiacColor) {
+	protected static void setColor(final IFigure figure, final Color fordiacColor) {
 		org.eclipse.swt.graphics.Color newColor;
 		if (fordiacColor != null) {
-			newColor = ColorManager
-					.getColor(new RGB(fordiacColor.getRed(), fordiacColor.getGreen(), fordiacColor.getBlue()));
+			newColor = new org.eclipse.swt.graphics.Color(fordiacColor.getRed(), fordiacColor.getGreen(),
+					fordiacColor.getBlue());
 		} else {
 			newColor = null;
 		}
@@ -143,9 +137,6 @@ public abstract class AbstractViewEditPart extends AbstractConnectableEditPart {
 		IFigure f = null;
 		try {
 			f = createFigureForModel();
-			if (f != null) {
-				backgroundColorChanged(f);
-			}
 		} catch (final IllegalArgumentException e) {
 			FordiacLogHelper.logError(ERROR_IN_CREATE_FIGURE, e);
 		}

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/figures/FBShape.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/figures/FBShape.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
- *                          Johannes Kepler University Linz,
- *                          Primetals Technologies Germany GmbH
+ * Copyright (c) 2008 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
+ *                    Johannes Kepler University Linz,
+ *                    Primetals Technologies Germany GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -195,7 +195,7 @@ public class FBShape extends Figure implements IFontUpdateListener, ITransparenc
 		return middle;
 	}
 
-	protected RoundedRectangle getBottom() {
+	public RoundedRectangle getBottom() {
 		return bottom;
 	}
 
@@ -256,7 +256,10 @@ public class FBShape extends Figure implements IFontUpdateListener, ITransparenc
 		bottom = new RoundedRectangle();
 		bottom.setOutline(false);
 		bottom.setCornerDimensions(new Dimension(cornerDim, cornerDim));
-		bottom.setLayoutManager(createTopBottomLayout());
+		final GridLayout bottomLayout = createTopBottomLayout();
+		bottomLayout.marginHeight = 0;
+		bottom.setLayoutManager(bottomLayout);
+		bottom.setBorder(new MarginBorder(1, 0, 0, 0));
 		addBottom();
 		setBottomIOs();
 		setPinIndicators();

--- a/plugins/org.eclipse.fordiac.ide.resourceediting/src/org/eclipse/fordiac/ide/resourceediting/editparts/VirtualInOutputEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.resourceediting/src/org/eclipse/fordiac/ide/resourceediting/editparts/VirtualInOutputEditPart.java
@@ -255,7 +255,7 @@ public class VirtualInOutputEditPart extends AbstractViewEditPart implements Nod
 	}
 
 	@Override
-	protected IFigure createFigureForModel() {
+	protected IFigure createFigure() {
 		return new VirtualInputOutputFigure();
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/editparts/DeviceEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/editparts/DeviceEditPart.java
@@ -192,7 +192,7 @@ public class DeviceEditPart extends AbstractPositionableElementEditPart implemen
 	}
 
 	@Override
-	protected IFigure createFigureForModel() {
+	protected IFigure createFigure() {
 		final DeviceFigure deviceFigure = new DeviceFigure();
 		setColor(deviceFigure, getModel().getColor());
 		return deviceFigure;

--- a/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/editparts/DeviceEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/editparts/DeviceEditPart.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008 - 2017 Profactor GbmH, TU Wien ACIN, fortiss GmbH,
- * 				 2018 - 2019 Johannes Kepler University Linz
+ * Copyright (c) 2008 Profactor GbmH, TU Wien ACIN, fortiss GmbH,
+ *                    Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,8 +12,9 @@
  *   Gerhard Ebenhofer, Alois Zoitl, Monika Wenger
  *     - initial API and implementation and/or initial documentation
  *   Alois Zoitl - added diagram font preference
- *     - changed section border to a simple line removing issues on Linux and
- *       modernizing the look
+ *               - changed section border to a simple line removing issues on
+ *                 Linux and modernizing the look
+ *               - reworked background color handling
  *******************************************************************************/
 package org.eclipse.fordiac.ide.systemconfiguration.editparts;
 
@@ -41,6 +42,7 @@ import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.impl.AdapterImpl;
 import org.eclipse.fordiac.ide.gef.draw2d.AdvancedLineBorder;
 import org.eclipse.fordiac.ide.gef.editparts.AbstractPositionableElementEditPart;
+import org.eclipse.fordiac.ide.gef.editparts.AbstractViewEditPart;
 import org.eclipse.fordiac.ide.gef.figures.BorderedRoundedRectangle;
 import org.eclipse.fordiac.ide.gef.figures.InteractionStyleFigure;
 import org.eclipse.fordiac.ide.gef.listeners.DiagramFontChangeListener;
@@ -104,8 +106,9 @@ public class DeviceEditPart extends AbstractPositionableElementEditPart implemen
 			@Override
 			public void notifyChanged(final Notification notification) {
 				final Object feature = notification.getFeature();
-				if (LibraryElementPackage.eINSTANCE.getColorizableElement_Color().equals(feature)) {
-					backgroundColorChanged(getFigure());
+				if (LibraryElementPackage.eINSTANCE.getColorizableElement_Color().equals(feature) && notification
+						.getNewValue() instanceof final org.eclipse.fordiac.ide.model.libraryElement.Color col) {
+					AbstractViewEditPart.setColor(getFigure(), col);
 				} else {
 					super.notifyChanged(notification);
 					refreshChildren();
@@ -190,18 +193,9 @@ public class DeviceEditPart extends AbstractPositionableElementEditPart implemen
 
 	@Override
 	protected IFigure createFigureForModel() {
-		return new DeviceFigure();
-	}
-
-	@Override
-	protected void backgroundColorChanged(final IFigure figure) {
-		// TODO model refactoring - default value for colors if not persisted
-		org.eclipse.fordiac.ide.model.libraryElement.Color fordiacColor = getModel().getColor();
-		if (fordiacColor == null) {
-			fordiacColor = ColorHelper.createRandomColor();
-			getModel().setColor(fordiacColor);
-		}
-		setColor(figure, fordiacColor);
+		final DeviceFigure deviceFigure = new DeviceFigure();
+		setColor(deviceFigure, getModel().getColor());
+		return deviceFigure;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/editparts/ResourceEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/editparts/ResourceEditPart.java
@@ -119,7 +119,7 @@ public class ResourceEditPart extends AbstractViewEditPart {
 	}
 
 	@Override
-	protected IFigure createFigureForModel() {
+	protected IFigure createFigure() {
 		return new ResourceFigure();
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/editparts/ResourceEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/editparts/ResourceEditPart.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2011 - 2016 Profactor GbmH, TU Wien ACIN, fortiss GmbH
- * 				 2019 Johannes Kepler University Linz
+ * Copyright (c) 2008 Profactor GbmH, TU Wien ACIN, fortiss GmbH
+ *                    Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,6 +13,7 @@
  *     - initial API and implementation and/or initial documentation
  *   Alois Zoitl - moved openEditor helper function to EditorUtils
  *   Alois Zoitl - added diagram font preference
+ *   Alois Zoitl - reworked background color handling
  *******************************************************************************/
 package org.eclipse.fordiac.ide.systemconfiguration.editparts;
 
@@ -166,11 +167,6 @@ public class ResourceEditPart extends AbstractViewEditPart {
 	@Override
 	public Label getNameLabel() {
 		return getFigure().getInstanceName();
-	}
-
-	@Override
-	protected void backgroundColorChanged(final IFigure figure) {
-		// currently nothing to be done here
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/editparts/SegmentEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/editparts/SegmentEditPart.java
@@ -85,7 +85,7 @@ public class SegmentEditPart extends AbstractViewEditPart implements NodeEditPar
 	}
 
 	@Override
-	protected IFigure createFigureForModel() {
+	protected IFigure createFigure() {
 		final SegmentFigure segmentFigure = new SegmentFigure();
 		setColor(segmentFigure, getModel().getColor());
 		return segmentFigure;

--- a/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/editparts/SegmentEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/editparts/SegmentEditPart.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2011 - 2017 Profactor GbmH, TU Wien ACIN, fortiss GmbH,
- * 				 2018 - 2020 Johannes Kepler University
+ * Copyright (c) 2008 Profactor GbmH, TU Wien ACIN, fortiss GmbH,
+ *                    Johannes Kepler University
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -11,8 +11,9 @@
  * Contributors:
  *   Gerhard Ebenhofer, Alois Zoitl, Monika Wenger
  *     - initial API and implementation and/or initial documentation
- *   Alois Zoitl - added diagram font preference
+ *   Alois Zoitl     - added diagram font preference
  *   Bianca Wiesmayr - removed gradient
+ *   Alois Zoitl     - reworked background color handling
  *******************************************************************************/
 package org.eclipse.fordiac.ide.systemconfiguration.editparts;
 
@@ -48,7 +49,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.Segment;
 import org.eclipse.fordiac.ide.systemconfiguration.policies.DeleteSegmentEditPolicy;
 import org.eclipse.fordiac.ide.systemconfiguration.policies.SegmentNodeEditPolicy;
 import org.eclipse.fordiac.ide.ui.preferences.UIPreferenceConstants;
-import org.eclipse.fordiac.ide.util.ColorHelper;
 import org.eclipse.gef.ConnectionEditPart;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.GraphicalEditPart;
@@ -86,7 +86,9 @@ public class SegmentEditPart extends AbstractViewEditPart implements NodeEditPar
 
 	@Override
 	protected IFigure createFigureForModel() {
-		return new SegmentFigure();
+		final SegmentFigure segmentFigure = new SegmentFigure();
+		setColor(segmentFigure, getModel().getColor());
+		return segmentFigure;
 	}
 
 	@Override
@@ -100,8 +102,9 @@ public class SegmentEditPart extends AbstractViewEditPart implements NodeEditPar
 			@Override
 			public void notifyChanged(final Notification notification) {
 				final Object feature = notification.getFeature();
-				if (LibraryElementPackage.eINSTANCE.getColorizableElement_Color().equals(feature)) {
-					backgroundColorChanged(getFigure());
+				if (LibraryElementPackage.eINSTANCE.getColorizableElement_Color().equals(feature) && notification
+						.getNewValue() instanceof final org.eclipse.fordiac.ide.model.libraryElement.Color col) {
+					AbstractViewEditPart.setColor(getFigure(), col);
 				}
 				if (LibraryElementPackage.eINSTANCE.getPositionableElement_Position().equals(feature)
 						|| LibraryElementPackage.eINSTANCE.getSegment_Width().equals(feature)) {
@@ -124,24 +127,9 @@ public class SegmentEditPart extends AbstractViewEditPart implements NodeEditPar
 		return getModel();
 	}
 
-	private SegmentFigure getCastedFigure() {
-		return getFigure();
-	}
-
-	@Override
-	protected void backgroundColorChanged(final IFigure figure) {
-		// TODO model refactoring - default value for colors if not persisted
-		org.eclipse.fordiac.ide.model.libraryElement.Color fordiacColor = getModel().getColor();
-		if (fordiacColor == null) {
-			fordiacColor = ColorHelper.createRandomColor();
-			getModel().setColor(fordiacColor);
-		}
-		setColor(figure, fordiacColor);
-	}
-
 	@Override
 	public Label getNameLabel() {
-		return getCastedFigure().getName();
+		return getFigure().getName();
 	}
 
 	@Override


### PR DESCRIPTION
Filling the whole FB with the device color was original a very good concept. However it has several issues: readability depends on the device color, it is hard to show mapping status of subapps with FBs mapped to different devices (panned feature) and most important not mapped FBs are very flat and the diagrams sometimes hard to read.

In order to improve this I came up with a concept where we show the mapping status at the bottom of the FB. This first PR migrates the existing mapping features to that concept. The result for a simple dummy app looks as follows. Curios what you think:
<img width="1115" height="642" alt="image" src="https://github.com/user-attachments/assets/fd0814a1-23d1-442a-87df-7feeab3b542a" />
