### PR TITLE
Use relative name for params of member access pins

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.deployment/src/org/eclipse/fordiac/ide/deployment/data/ResourceDeploymentData.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src/org/eclipse/fordiac/ide/deployment/data/ResourceDeploymentData.java
@@ -148,7 +148,7 @@ public class ResourceDeploymentData {
 			final VarDeclaration input, final FB fb) throws DeploymentException {
 		final String value = findInitialValue(subAppHierarchy, input);
 		if (value != null) {
-			params.put(ensurePrefix(prefix, fb) + fb.getName() + "." + input.getName(), value); //$NON-NLS-1$
+			params.put(ensurePrefix(prefix, fb) + fb.getName() + "." + input.getRelativeName(fb), value); //$NON-NLS-1$
 		}
 		if (input instanceof final ContainerVarDeclaration container) {
 			for (final VarDeclaration member : container.getCachedMembers()) {


### PR DESCRIPTION
This resolves the deployment problem described in https://github.com/eclipse-4diac/4diac-ide/issues/2156.