### PR TITLE
Modernize and Harmonize ECC colors, provide dark mode colors

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/build.properties
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/build.properties
@@ -3,4 +3,5 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\
-               plugin.properties
+               plugin.properties,,\
+               css/

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/css/dark_ecc_colors.css
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/css/dark_ecc_colors.css
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Johannes Kepler University Linz
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Alois Zoitl - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+IEclipsePreferences#org-eclipse-ui-workbench:org-eclipse-fordiac-fbtypeeditor_ecc {
+	preferences:
+		'org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorStateColor=75,115,190'
+		'org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorStateTextColor=240, 245, 255'
+		'org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCStateSpineColor=120,160,230'
+		'org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorAlgorithmColor=48,54,60'
+		'org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorAlgorithmTextColor=220, 225, 235'
+		'org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorEventColor=120,170,85'
+		'org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorEventTextColor=20,35,20'
+		'org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorTransitionColor=150,160,175'
+		'org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorTransitionTextColor=205,215,230'
+}

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/plugin.properties
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/plugin.properties
@@ -1,6 +1,5 @@
  ###############################################################################
- # Copyright (c) 2008, 2009, 2011, 2015, 2016 Profactor GmbH, TU Wien ACIN, fortiss GmbH
- #				 2020						  Andrea Zoitl
+ # Copyright (c) 2008 Profactor GmbH, TU Wien ACIN, fortiss GmbH, Andrea Zoitl
  # 
  # This program and the accompanying materials are made available under the
  # terms of the Eclipse Public License 2.0 which is available at
@@ -38,13 +37,6 @@ ECCPaletteFactory_LABEL_STAlgorithm= ST Algorithm
 ECCPaletteFactory_LABEL_State=State
 ECStateSetPositionCommand_LABEL_Move=Move
 ECAlgorithmGroup_Title=Algorithm {0}
-FordiacECCPreferencePage_LABEL_ECCStateColor=State Background Color
-FordiacECCPreferencePage_LABEL_ECCStateTextColor=State Text Color
-FordiacECCPreferencePage_LABEL_ECCAlgorithmColor=Algorithm Background Color
-FordiacECCPreferencePage_LABEL_ECCAlgorithmTextColor=Algorithm Text Color
-FordiacECCPreferencePage_LABEL_ECCEventColor=Event Background Color
-FordiacECCPreferencePage_LABEL_ECCEventTextColor=Event Text Color
-FordiacECCPreferencePage_LABEL_ECCTransitionColor=Transition Color
 ReconnectTransitionCommand_ReconnectTransition=Reconnect Transition
 StateCreationFactory_LABEL_NewECState=State
 StateSection_Comment=Comment:

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/plugin.xml
@@ -94,44 +94,83 @@
       <colorDefinition
             categoryId="org.eclipse.fordiac.ide.themeCategory"
             id="org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorStateColor"
-            label="%FordiacECCPreferencePage_LABEL_ECCStateColor"
-            value="184, 182, 206">
+            label="State Background Color"
+            value="70, 120, 190"
+            isEditable="false">
+            <!-- the label does not need to be translatable -->
       </colorDefinition>
       <colorDefinition
             categoryId="org.eclipse.fordiac.ide.themeCategory"
             id="org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorStateTextColor"
-            label="%FordiacECCPreferencePage_LABEL_ECCStateTextColor"
-            value="21, 17, 72">
+            label="State Text Color"
+            value="255, 255, 255"
+            isEditable="false">
+            <!-- the label does not need to be translatable -->
+      </colorDefinition>
+      <colorDefinition
+            categoryId="org.eclipse.fordiac.ide.themeCategory"
+            id="org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCStateSpineColor"
+            label="State Spine Color"
+            value="95, 145, 210"
+            isEditable="false">
+            <!-- the label does not need to be translatable -->
       </colorDefinition>
       <colorDefinition
             categoryId="org.eclipse.fordiac.ide.themeCategory"
             id="org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorAlgorithmColor"
-            label="%FordiacECCPreferencePage_LABEL_ECCAlgorithmColor"
-            value="235, 242, 179">
+            label="Algorithm Background Color"
+            value="215, 225, 235"
+            isEditable="false">
+            <!-- the label does not need to be translatable -->
       </colorDefinition>
       <colorDefinition
             categoryId="org.eclipse.fordiac.ide.themeCategory"
             id="org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorAlgorithmTextColor"
-            label="%FordiacECCPreferencePage_LABEL_ECCAlgorithmTextColor"
-            value="91, 101, 11">
+            label="Algorithm Text Color"
+            value="50, 50, 60"
+            isEditable="false">
+            <!-- the label does not need to be translatable -->
       </colorDefinition>
       <colorDefinition
             categoryId="org.eclipse.fordiac.ide.themeCategory"
             id="org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorEventColor"
-            label="%FordiacECCPreferencePage_LABEL_ECCEventColor"
-            value="245, 181, 183">
+            label="Event Background Color"
+            value="215, 235, 195"
+            isEditable="false">
+            <!-- the label does not need to be translatable -->
       </colorDefinition>
       <colorDefinition
             categoryId="org.eclipse.fordiac.ide.themeCategory"
             id="org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorEventTextColor"
-            label="%FordiacECCPreferencePage_LABEL_ECCEventTextColor"
-            value="141, 45, 47">
+            label="Event Text Color"
+            value="45, 60, 35"
+            isEditable="false">
+            <!-- the label does not need to be translatable -->
       </colorDefinition>
       <colorDefinition
             categoryId="org.eclipse.fordiac.ide.themeCategory"
             id="org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorTransitionColor"
-            label="%FordiacECCPreferencePage_LABEL_ECCTransitionColor"
-            value="68, 64, 121">
+            label="Transition Color"
+            value="175, 185, 200"
+            isEditable="false">
+            <!-- the label does not need to be translatable -->
       </colorDefinition>
+      <colorDefinition
+            categoryId="org.eclipse.fordiac.ide.themeCategory"
+            id="org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorTransitionTextColor"
+            label="Transition Text Color"
+            value="70, 80, 100"
+            isEditable="false">
+            <!-- the label does not need to be translatable -->
+      </colorDefinition>
+   </extension>
+   <extension
+         point="org.eclipse.e4.ui.css.swt.theme">
+      <stylesheet
+            uri="css/dark_ecc_colors.css">
+         <themeid
+               refid="org.eclipse.e4.ui.css.theme.e4_dark">
+         </themeid>
+      </stylesheet>
    </extension>
 </plugin>

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/Messages.java
@@ -45,13 +45,6 @@ public final class Messages extends NLS {
 	public static String ECCPaletteFactory_TOOLTIP_State;
 	public static String ECCPaletteFactory_TOOLTIP_STAlgorithm;
 	public static String ECStateSetPositionCommand_LABEL_Move;
-	public static String FordiacECCPreferencePage_LABEL_ECCAlgorithmTextColor;
-	public static String FordiacECCPreferencePage_LABEL_ECCAlgorithmColor;
-	public static String FordiacECCPreferencePage_LABEL_ECCEventTextColor;
-	public static String FordiacECCPreferencePage_LABEL_ECCEventColor;
-	public static String FordiacECCPreferencePage_LABEL_ECCStateTextColor;
-	public static String FordiacECCPreferencePage_LABEL_ECCStateColor;
-	public static String FordiacECCPreferencePage_LABEL_ECCTransitionColor;
 	public static String ReconnectTransitionCommand_ReconnectTransition;
 	public static String StateCreationFactory_LABEL_NewECState;
 	public static String StateSection_Comment;

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editparts/ECActionAlgorithmEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editparts/ECActionAlgorithmEditPart.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2011 - 2020 TU Wien ACIN, Profactor GmbH, fortiss GmbH,
- * 								Johannes Kepler University Linz (JKU)
+ * Copyright (c) 2011 TU Wien ACIN, Profactor GmbH, fortiss GmbH,
+ *                    Johannes Kepler University Linz (JKU)
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,7 +12,8 @@
  *   Alois Zoitl, Gerhard Ebenhofer, Monika Wenger
  *     - initial API and implementation and/or initial documentation
  *   Bianca Wiesmayr
- *     -  consistent dropdown menu edit, redesign ECC
+ *               -  consistent dropdown menu edit, redesign ECC
+ *   Alois Zoitl - modernized and reworked ECC look
  *******************************************************************************/
 package org.eclipse.fordiac.ide.fbtypeeditor.ecc.editparts;
 
@@ -55,8 +56,6 @@ import org.eclipse.gef.editpolicies.DirectEditPolicy;
 import org.eclipse.gef.requests.CreateRequest;
 import org.eclipse.gef.requests.DirectEditRequest;
 import org.eclipse.gef.requests.GroupRequest;
-import org.eclipse.jface.resource.JFaceResources;
-import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.viewers.ComboBoxCellEditor;
 
 public class ECActionAlgorithmEditPart extends AbstractDirectEditableEditPart {
@@ -90,16 +89,6 @@ public class ECActionAlgorithmEditPart extends AbstractDirectEditableEditPart {
 		}
 	};
 
-	/** The property change listener. */
-	private final IPropertyChangeListener colorChangeListener = event -> {
-		if (event.getProperty().equals(FBTypeEditorPreferenceConstants.P_ECC_ALGORITHM_COLOR)) {
-			getFigure().setBackgroundColor(FBTypeEditorPreferenceConstants.getEccAlgorithmColor());
-		}
-		if (event.getProperty().equals(FBTypeEditorPreferenceConstants.P_ECC_ALGORITHM_TEXT_COLOR)) {
-			getFigure().setForegroundColor(FBTypeEditorPreferenceConstants.getEccAlgorithmTextColor());
-		}
-	};
-
 	/*
 	 * (non-Javadoc)
 	 *
@@ -117,7 +106,6 @@ public class ECActionAlgorithmEditPart extends AbstractDirectEditableEditPart {
 			}
 			// addapt to the fbtype so that we get informed on alg name changes
 			ECCContentAndLabelProvider.getFBType(getAction()).eAdapters().add(fbAdapter);
-			JFaceResources.getColorRegistry().addListener(colorChangeListener);
 		}
 	}
 
@@ -135,7 +123,6 @@ public class ECActionAlgorithmEditPart extends AbstractDirectEditableEditPart {
 			if (fbtype != null) {
 				fbtype.eAdapters().remove(fbAdapter);
 			}
-			JFaceResources.getColorRegistry().removeListener(colorChangeListener);
 		}
 	}
 
@@ -176,14 +163,9 @@ public class ECActionAlgorithmEditPart extends AbstractDirectEditableEditPart {
 		installEditPolicy(EditPolicy.LAYOUT_ROLE, new EmptyXYLayoutEditPolicy() {
 			@Override
 			protected Command getCreateCommand(final CreateRequest request) {
-				if ((request != null) && (null != request.getNewObject())) {
-					final Object object = request.getNewObject();
-					if (getHost() instanceof ECActionAlgorithmEditPart) {
-						final ECActionAlgorithmEditPart editPart = (ECActionAlgorithmEditPart) getHost();
-						if (object instanceof STAlgorithm) {
-							return new CreateAlgorithmCommand(editPart.getBFB(), editPart.getAction());
-						}
-					}
+				if (request != null && request.getNewObject() instanceof STAlgorithm
+						&& getHost() instanceof final ECActionAlgorithmEditPart ep) {
+					return new CreateAlgorithmCommand(ep.getBFB(), ep.getAction());
 				}
 				return null;
 			}

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editparts/ECActionOutputEventEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editparts/ECActionOutputEventEditPart.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 TU Wien ACIN, Profactor GmbH, fortiss GmbH,
- *                          Johannes Kepler University Linz
+ * Copyright (c) 2011 TU Wien ACIN, Profactor GmbH, fortiss GmbH,
+ *                    Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,6 +13,7 @@
  *     - initial API and implementation and/or initial documentation
  *   Bianca Wiesmayr -  consistent dropdown menu edit, redesign ECC
  *   Alois Zoitl     - updated for new adapter FB handling
+ *   Alois Zoitl     - modernized and reworked ECC look
  *******************************************************************************/
 package org.eclipse.fordiac.ide.fbtypeeditor.ecc.editparts;
 
@@ -52,8 +53,6 @@ import org.eclipse.gef.editpolicies.ComponentEditPolicy;
 import org.eclipse.gef.editpolicies.DirectEditPolicy;
 import org.eclipse.gef.requests.DirectEditRequest;
 import org.eclipse.gef.requests.GroupRequest;
-import org.eclipse.jface.resource.JFaceResources;
-import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.viewers.ComboBoxCellEditor;
 
 public class ECActionOutputEventEditPart extends AbstractDirectEditableEditPart {
@@ -116,15 +115,6 @@ public class ECActionOutputEventEditPart extends AbstractDirectEditableEditPart 
 		return false;
 	}
 
-	private final IPropertyChangeListener colorChangeListener = event -> {
-		if (event.getProperty().equals(FBTypeEditorPreferenceConstants.P_ECC_EVENT_COLOR)) {
-			getFigure().setBackgroundColor(FBTypeEditorPreferenceConstants.getEccEventColor());
-		}
-		if (event.getProperty().equals(FBTypeEditorPreferenceConstants.P_ECC_EVENT_TEXT_COLOR)) {
-			getFigure().setForegroundColor(FBTypeEditorPreferenceConstants.getEccEventTextColor());
-		}
-	};
-
 	@Override
 	public void activate() {
 		if (!isActive()) {
@@ -132,8 +122,6 @@ public class ECActionOutputEventEditPart extends AbstractDirectEditableEditPart 
 			getAction().eAdapters().add(adapter);
 			// Adapt to the fbtype so that we get informed on interface changes
 			ECCContentAndLabelProvider.getFBType(getAction()).getInterfaceList().eAdapters().add(interfaceAdapter);
-
-			JFaceResources.getColorRegistry().addListener(colorChangeListener);
 		}
 	}
 
@@ -146,7 +134,6 @@ public class ECActionOutputEventEditPart extends AbstractDirectEditableEditPart 
 			if (fbType != null) {
 				fbType.getInterfaceList().eAdapters().remove(interfaceAdapter);
 			}
-			JFaceResources.getColorRegistry().removeListener(colorChangeListener);
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editparts/ECStateEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editparts/ECStateEditPart.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008 - 2013 Profactor GmbH, TU Wien ACIN, fortiss GmbH
- * 				 2020        Johannes Kepler University Linz
+ * Copyright (c) 2008 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
+ *                    Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,6 +14,7 @@
  *   Virendra Ashiwal, Bianca Wiesmayr
  *     - added tooltip functionality at state
  *     - added refresh tooltip at state
+ *   Alois Zoitl - modernized and reworked ECC look
  *******************************************************************************/
 package org.eclipse.fordiac.ide.fbtypeeditor.ecc.editparts;
 
@@ -34,7 +35,6 @@ import org.eclipse.fordiac.ide.fbtypeeditor.ecc.figures.ECStateFigure;
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.policies.ECStateLayoutEditPolicy;
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.policies.ECStateSelectionPolicy;
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.policies.TransitionNodeEditPolicy;
-import org.eclipse.fordiac.ide.fbtypeeditor.ecc.preferences.FBTypeEditorPreferenceConstants;
 import org.eclipse.fordiac.ide.gef.FixedAnchor;
 import org.eclipse.fordiac.ide.gef.editparts.AbstractDirectEditableEditPart;
 import org.eclipse.fordiac.ide.model.libraryElement.ECAction;
@@ -51,8 +51,6 @@ import org.eclipse.gef.RequestConstants;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.editpolicies.ComponentEditPolicy;
 import org.eclipse.gef.requests.GroupRequest;
-import org.eclipse.jface.resource.JFaceResources;
-import org.eclipse.jface.util.IPropertyChangeListener;
 
 public class ECStateEditPart extends AbstractDirectEditableEditPart implements NodeEditPart {
 	private List<Object> stateChildren;
@@ -84,7 +82,6 @@ public class ECStateEditPart extends AbstractDirectEditableEditPart implements N
 		if (!isActive()) {
 			super.activate();
 			getModel().eAdapters().add(adapter);
-			JFaceResources.getColorRegistry().addListener(colorChangeListener);
 		}
 	}
 
@@ -93,7 +90,6 @@ public class ECStateEditPart extends AbstractDirectEditableEditPart implements N
 		if (isActive()) {
 			super.deactivate();
 			getModel().eAdapters().remove(adapter);
-			JFaceResources.getColorRegistry().removeListener(colorChangeListener);
 		}
 	}
 
@@ -214,17 +210,6 @@ public class ECStateEditPart extends AbstractDirectEditableEditPart implements N
 	public INamedElement getINamedElement() {
 		return getModel();
 	}
-
-	/** The property change listener. */
-	private final IPropertyChangeListener colorChangeListener = event -> {
-		if (event.getProperty().equals(FBTypeEditorPreferenceConstants.P_ECC_STATE_COLOR)) {
-			getNameLabel().setBackgroundColor(FBTypeEditorPreferenceConstants.getEccStateColor());
-		}
-		if (event.getProperty().equals(FBTypeEditorPreferenceConstants.P_ECC_STATE_TEXT_COLOR)) {
-			getNameLabel().setForegroundColor(FBTypeEditorPreferenceConstants.getEccStateTextColor());
-			getFigure().getLine().setForegroundColor(FBTypeEditorPreferenceConstants.getEccStateTextColor());
-		}
-	};
 
 	public void highlightTransitions(final boolean highlight) {
 		for (final Object obj : getSourceConnections()) {

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editparts/ECTransitionEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editparts/ECTransitionEditPart.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Profactor GmbH, TU Wien ACIN, fortiss GmbH
- * 				            Johannes Kepler University Linz
+ * Copyright (c) 2008 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
+ *                    Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,6 +15,7 @@
  *   Alois Zoitl - reworked transition and handle widths
  *   Bianca Wiesmayr, Ernst Blecha - added tooltip
  *   Lisa Sonnleitner - Inital implementation of DirectEdit
+ *   Alois Zoitl - modernized and reworked ECC look
  *******************************************************************************/
 package org.eclipse.fordiac.ide.fbtypeeditor.ecc.editparts;
 
@@ -34,7 +35,6 @@ import org.eclipse.fordiac.ide.fbtypeeditor.ecc.contentprovider.ECCContentAndLab
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.figures.ECTransitionFigure;
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.policies.ECTransitionFeedbackEditPolicy;
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.policies.TransitionBendPointEditPolicy;
-import org.eclipse.fordiac.ide.fbtypeeditor.ecc.preferences.FBTypeEditorPreferenceConstants;
 import org.eclipse.fordiac.ide.gef.annotation.AnnotableGraphicalEditPart;
 import org.eclipse.fordiac.ide.gef.annotation.GraphicalAnnotationStyles;
 import org.eclipse.fordiac.ide.gef.editparts.AbstractDirectEditableEditPart;
@@ -65,8 +65,6 @@ import org.eclipse.gef.requests.CreateRequest;
 import org.eclipse.gef.requests.DirectEditRequest;
 import org.eclipse.gef.requests.GroupRequest;
 import org.eclipse.gef.tools.DirectEditManager;
-import org.eclipse.jface.resource.JFaceResources;
-import org.eclipse.jface.util.IPropertyChangeListener;
 
 public class ECTransitionEditPart extends AbstractConnectionEditPart implements AnnotableGraphicalEditPart {
 
@@ -89,13 +87,6 @@ public class ECTransitionEditPart extends AbstractConnectionEditPart implements 
 				refreshTransitionTooltip();
 				refresh();
 			}
-		}
-	};
-
-	/** The property change listener. */
-	private final IPropertyChangeListener colorChangeListener = event -> {
-		if (event.getProperty().equals(FBTypeEditorPreferenceConstants.P_ECC_TRANSITION_COLOR)) {
-			getFigure().setForegroundColor(FBTypeEditorPreferenceConstants.getEccTransitionColor());
 		}
 	};
 
@@ -324,8 +315,6 @@ public class ECTransitionEditPart extends AbstractConnectionEditPart implements 
 
 			// Adapt to the fbtype so that we get informed on interface changes
 			getModel().getECC().getBasicFBType().getInterfaceList().eAdapters().add(interfaceAdapter);
-
-			JFaceResources.getColorRegistry().addListener(colorChangeListener);
 		}
 	}
 
@@ -336,8 +325,6 @@ public class ECTransitionEditPart extends AbstractConnectionEditPart implements 
 			getModel().eAdapters().remove(adapter);
 			getModel().getECC().eAdapters().remove(adapter);
 			getModel().getECC().getBasicFBType().getInterfaceList().eAdapters().remove(interfaceAdapter);
-
-			JFaceResources.getColorRegistry().removeListener(colorChangeListener);
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/figures/CompoundBackground.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/figures/CompoundBackground.java
@@ -1,0 +1,153 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Alois Zoitl     - copied from CompoundBorder and adjusted for the needs
+ *                       of an AbstractBackground
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.fbtypeeditor.ecc.figures;
+
+import org.eclipse.draw2d.AbstractBackground;
+import org.eclipse.draw2d.Border;
+import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.draw2d.geometry.Insets;
+
+/**
+ * CompoundBackground allows for the nesting of two borders. The nested borders
+ * are referred to as the <i>inner</i> and <i>outer</i> borders.
+ *
+ * This will be upstreamed to GEF Classic for the upcoming GEF Classic 2026-06
+ * release.
+ */
+public class CompoundBackground extends AbstractBackground {
+
+	/** The inner Border. */
+	protected Border inner;
+	/** The outer Border. */
+	protected Border outer;
+
+	/**
+	 * Constructs a default CompoundBackground with no borders under it.
+	 */
+	public CompoundBackground() {
+	}
+
+	/**
+	 * Constructs a CompoundBackground with the two borders specified as input.
+	 *
+	 * @param outer Border which is drawn on the outside
+	 * @param inner Border which is drawn inside the outer border
+	 *
+	 * @since 2.0
+	 */
+	public CompoundBackground(final Border outer, final Border inner) {
+		this.outer = outer;
+		this.inner = inner;
+	}
+
+	/**
+	 * Returns the inner border of this CompoundBackground.
+	 *
+	 * @return The inner border
+	 * @since 2.0
+	 */
+	public Border getInnerBorder() {
+		return inner;
+	}
+
+	/**
+	 * Returns the total insets required to hold both the inner and outer borders of
+	 * this CompoundBorder.
+	 *
+	 * @param figure Figure for which this is the border
+	 * @return The total insets for this border
+	 * @since 2.0
+	 */
+	@Override
+	public Insets getInsets(final IFigure figure) {
+		Insets insets = null;
+		if (inner != null) {
+			insets = inner.getInsets(figure);
+		} else {
+			insets = new Insets();
+		}
+		if (outer != null) {
+			final Insets moreInsets = outer.getInsets(figure);
+			insets = insets.getAdded(moreInsets);
+		}
+		return insets;
+	}
+
+	/**
+	 * @see org.eclipse.draw2d.Border#getPreferredSize(IFigure)
+	 */
+	@Override
+	public Dimension getPreferredSize(final IFigure fig) {
+		final Dimension prefSize = new Dimension(inner.getPreferredSize(fig));
+		final Insets outerInsets = outer.getInsets(fig);
+		prefSize.expand(outerInsets.getWidth(), outerInsets.getHeight());
+		prefSize.union(outer.getPreferredSize(fig));
+		return prefSize;
+	}
+
+	/**
+	 * Returns the outer border of this CompoundBorder.
+	 *
+	 * @return The outer border
+	 * @since 2.0
+	 */
+	public Border getOuterBorder() {
+		return outer;
+	}
+
+	/**
+	 * Returns <code>true</code> if this border is opaque. Return value is dependent
+	 * on the opaque state of both the borders it contains. Both borders have to be
+	 * opaque for this border to be opaque. In the absence of any of the borders,
+	 * this border is not opaque.
+	 *
+	 * @return <code>true</code> if this border is opaque
+	 */
+	@Override
+	public boolean isOpaque() {
+		return (inner != null && inner.isOpaque()) && (outer != null && outer.isOpaque());
+	}
+
+	@Override
+	public void paint(final IFigure figure, final Graphics g, Insets insets) {
+		if (outer != null) {
+			g.pushState();
+			outer.paint(figure, g, insets);
+			g.popState();
+
+			insets = insets.getAdded(outer.getInsets(figure));
+		}
+		if (inner != null) {
+			inner.paint(figure, g, insets);
+		}
+	}
+
+	@Override
+	public void paintBackground(final IFigure figure, final Graphics g, Insets insets) {
+		if (outer instanceof final AbstractBackground outerBg) {
+			g.pushState();
+			outerBg.paintBackground(figure, g, insets);
+			g.popState();
+		}
+		if (outer != null) {
+			insets = insets.getAdded(outer.getInsets(figure));
+		}
+		if (inner instanceof final AbstractBackground innerBg) {
+			innerBg.paintBackground(figure, g, insets);
+		}
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/figures/ECStateFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/figures/ECStateFigure.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008 - 2013 Profactor GmbH, TU Wien ACIN, fortiss GmbH
- * 				 2020        Johannes Kepler University Linz
+ * Copyright (c) 2008 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
+ *                    Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,6 +13,7 @@
  *     - initial API and implementation and/or initial documentation
  *   Bianca Wiesmayr, Alois Zoitl
  *     - redesigned ECC
+ *   Alois Zoitl - modernized and reworked ECC look
  *******************************************************************************/
 
 package org.eclipse.fordiac.ide.fbtypeeditor.ecc.figures;
@@ -20,21 +21,22 @@ package org.eclipse.fordiac.ide.fbtypeeditor.ecc.figures;
 import static org.eclipse.fordiac.ide.fbtypeeditor.ecc.preferences.FBTypeEditorPreferenceConstants.MARGIN_HORIZONTAL;
 import static org.eclipse.fordiac.ide.fbtypeeditor.ecc.preferences.FBTypeEditorPreferenceConstants.MARGIN_VERTICAL;
 
+import org.eclipse.draw2d.AbstractBackground;
+import org.eclipse.draw2d.CompoundBorder;
 import org.eclipse.draw2d.Figure;
-import org.eclipse.draw2d.FlowLayout;
+import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.GridData;
 import org.eclipse.draw2d.GridLayout;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.Label;
 import org.eclipse.draw2d.LineBorder;
-import org.eclipse.draw2d.OrderedLayout;
 import org.eclipse.draw2d.ToolbarLayout;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.draw2d.shadows.RectangleDropShadowBorder;
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.preferences.FBTypeEditorPreferenceConstants;
-import org.eclipse.fordiac.ide.gef.figures.HorizontalLineFigure;
 import org.eclipse.fordiac.ide.gef.figures.InteractionStyleFigure;
 import org.eclipse.fordiac.ide.model.libraryElement.ECState;
 import org.eclipse.swt.SWT;
@@ -42,12 +44,15 @@ import org.eclipse.swt.graphics.Color;
 
 public final class ECStateFigure extends Figure implements InteractionStyleFigure {
 
-	private static final int STATE_ACTION_CONNECTOR_LENGTH = 15;
+	private static final int ACTION_SEPERATION = 1;
+
+	private static final int SPINE_WIDTH = 4;
+
 	private static final Insets STATE_INSET = new Insets(MARGIN_VERTICAL, MARGIN_HORIZONTAL, MARGIN_VERTICAL,
 			MARGIN_HORIZONTAL);
 
-	private Label nameLabel;
-	private final Figure stateActionConnector = new HorizontalLineFigure(STATE_ACTION_CONNECTOR_LENGTH);
+	private ECStateNameLabel nameLabel;
+	private final Figure spine = new Figure();
 	private final Figure actionContainer = new Figure() {
 		@Override
 		public void add(final IFigure figure, final Object constraint, final int index) {
@@ -60,28 +65,12 @@ public final class ECStateFigure extends Figure implements InteractionStyleFigur
 		final ToolbarLayout tbLayout = new ToolbarLayout();
 		tbLayout.setStretchMinorAxis(false);
 		tbLayout.setHorizontal(true);
+		tbLayout.setSpacing(-SPINE_WIDTH / 2); // this makes state name label overlap the spine
 		setLayoutManager(tbLayout);
 
-		final Figure stateRect = createStateRectangle();
-		stateRect.add(createStateNameLabel(state));
-		stateActionConnector.setForegroundColor(FBTypeEditorPreferenceConstants.getEccStateTextColor());
-		stateRect.add(stateActionConnector);
-		add(stateRect);
-
-		createActionContainerFigure();
+		add(createStateNameLabel(state));
+		add(createActionContainerFigure());
 		createStateCommentToolTip();
-	}
-
-	private static Figure createStateRectangle() {
-		final Figure stateRect = new Figure();
-		final FlowLayout layout = new FlowLayout();
-		layout.setStretchMinorAxis(true);
-		layout.setMajorSpacing(0);
-		layout.setMinorSpacing(0);
-		layout.setHorizontal(true);
-		layout.setMinorAlignment(OrderedLayout.ALIGN_CENTER);
-		stateRect.setLayoutManager(layout);
-		return stateRect;
 	}
 
 	private void createStateCommentToolTip() {
@@ -90,44 +79,45 @@ public final class ECStateFigure extends Figure implements InteractionStyleFigur
 		setToolTip(stateTooltip);
 	}
 
-	private void createActionContainerFigure() {
-		add(actionContainer);
+	private IFigure createActionContainerFigure() {
+		final Figure actionRootFigure = new Figure();
 
-		final GridLayout gl = new GridLayout(2, false);
-		gl.horizontalSpacing = -1;
-		gl.verticalSpacing = 1;
+		final ToolbarLayout layout = new ToolbarLayout(true);
+		layout.setSpacing(0);
+		layout.setStretchMinorAxis(true);
+		actionRootFigure.setLayoutManager(layout);
+
+		spine.setPreferredSize(new Dimension(SPINE_WIDTH, -1));
+		spine.setOpaque(true);
+		spine.setBackgroundColor(FBTypeEditorPreferenceConstants.getEccStateSpineColor());
+		actionRootFigure.add(spine);
+
+		final GridLayout gl = new GridLayout(2, false); // two columns one for algorithms one for output events
+		gl.horizontalSpacing = ACTION_SEPERATION;
+		gl.verticalSpacing = ACTION_SEPERATION;
 		gl.marginWidth = 0;
 		gl.marginHeight = 0;
 
 		actionContainer.setLayoutManager(gl);
+		actionContainer.setOpaque(true);
+		actionContainer.setBackgroundColor(FBTypeEditorPreferenceConstants.getEccStateSpineColor());
+		actionRootFigure.add(actionContainer);
+		return actionRootFigure;
 	}
 
 	private Label createStateNameLabel(final ECState state) {
-		nameLabel = new Label() {
-			@Override
-			public Insets getInsets() {
-				if (getBorder() != null) {
-					return getBorder().getInsets(this);
-				}
-				return STATE_INSET;
-			}
-
-			@Override
-			public void setBackgroundColor(final Color bg) {
-				if (getBorder() instanceof final StartStateBorder startStateBorder) {
-					startStateBorder.setColor(bg);
-				} else {
-					super.setBackgroundColor(bg);
-				}
-			}
-		};
+		nameLabel = new ECStateNameLabel();
 		nameLabel.setText(state.getName());
-		nameLabel.setForegroundColor(FBTypeEditorPreferenceConstants.getEccStateTextColor());
 		nameLabel.setOpaque(true);
 		if (state.isStartState()) {
-			nameLabel.setBorder(new StartStateBorder(FBTypeEditorPreferenceConstants.getEccStateColor()));
+			nameLabel.setBorder(new CompoundBackground(new RectangleDropShadowBorder(),
+					new StartStateBorder(FBTypeEditorPreferenceConstants.getEccStateColor())));
+			nameLabel.setForegroundColor(FBTypeEditorPreferenceConstants.getEccAlgorithmTextColor());
+			nameLabel.setBackgroundColor(FBTypeEditorPreferenceConstants.getEccAlgorithmColor());
 		} else {
+			nameLabel.setBorder(new RectangleDropShadowBorder());
 			nameLabel.setBackgroundColor(FBTypeEditorPreferenceConstants.getEccStateColor());
+			nameLabel.setForegroundColor(FBTypeEditorPreferenceConstants.getEccStateTextColor());
 		}
 		return nameLabel;
 	}
@@ -138,7 +128,8 @@ public final class ECStateFigure extends Figure implements InteractionStyleFigur
 	}
 
 	public void setHasAction(final boolean hasAction) {
-		stateActionConnector.setVisible(hasAction);
+		spine.setVisible(hasAction);
+		actionContainer.setVisible(hasAction);
 	}
 
 	public Figure getContentPane() {
@@ -149,8 +140,11 @@ public final class ECStateFigure extends Figure implements InteractionStyleFigur
 		return nameLabel;
 	}
 
-	public Figure getLine() {
-		return stateActionConnector;
+	@Override
+	protected void paintChildren(final Graphics graphics) {
+		super.paintChildren(graphics);
+		// draw name label body last so that it partly covers the spine
+		nameLabel.paintBody(graphics);
 	}
 
 	@Override
@@ -164,6 +158,47 @@ public final class ECStateFigure extends Figure implements InteractionStyleFigur
 			return InteractionStyleFigure.REGION_CONNECTION; // connection
 		}
 		return InteractionStyleFigure.REGION_DRAG; // move/drag
+	}
+
+	private static final class ECStateNameLabel extends Label {
+		@Override
+		public Insets getInsets() {
+			if (getBorder() instanceof CompoundBorder) {
+				return getBorder().getInsets(this);
+			}
+			return STATE_INSET;
+		}
+
+		@Override
+		protected void paintFigure(final Graphics graphics) {
+			// draw only background border
+			if (getBorder() instanceof final AbstractBackground abstractBackground) {
+				abstractBackground.paintBackground(this, graphics, NO_INSETS);
+			}
+			if (getBorder() instanceof CompoundBackground) {
+				// if we are the start state the body has to be painted first to be covered by
+				// the start state border
+				doPaintBody(graphics);
+			}
+		}
+
+		public void paintBody(final Graphics graphics) {
+			if (!(getBorder() instanceof CompoundBackground)) {
+				// if we are not the start state we draw the body last to get the overlap with
+				// the spine
+				doPaintBody(graphics);
+			}
+		}
+
+		private void doPaintBody(final Graphics graphics) {
+			graphics.setForegroundColor(getForegroundColor());
+			graphics.setBackgroundColor(getBackgroundColor());
+			graphics.fillRectangle(getBounds());
+			final Point curTextLocation = getTextLocation();
+			final int tx = bounds.x + curTextLocation.x;
+			final int ty = bounds.y + curTextLocation.y;
+			graphics.drawText(getSubStringText(), tx, ty);
+		}
 	}
 
 	private static class StartStateBorder extends LineBorder {

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/figures/ECTransitionFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/figures/ECTransitionFigure.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008 - 2017 Profactor GmbH, TU Wien ACIN, fortiss GmbH
- * 				 2019 - 2020 Johannes Kepler University Linz
+ * Copyright (c) 2008 Profactor GmbH, TU Wien ACIN, fortiss GmbH
+ *                    Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,6 +13,7 @@
  *     - initial API and implementation and/or initial documentation
  *   Alois Zoitl - extracted TransitionFigure code and changed to cubic spline
  *   Bianca Wiesmayr, Ernst Blecha - added tooltip
+ *   Alois Zoitl - modernized and reworked ECC look
  *******************************************************************************/
 package org.eclipse.fordiac.ide.fbtypeeditor.ecc.figures;
 
@@ -22,15 +23,17 @@ import java.util.List;
 
 import org.eclipse.draw2d.AbsoluteBendpoint;
 import org.eclipse.draw2d.Bendpoint;
-import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.ConnectionLocator;
 import org.eclipse.draw2d.Ellipse;
 import org.eclipse.draw2d.Label;
 import org.eclipse.draw2d.MarginBorder;
 import org.eclipse.draw2d.PolygonDecoration;
+import org.eclipse.draw2d.PolylineConnection;
 import org.eclipse.draw2d.RotatableDecoration;
 import org.eclipse.draw2d.StackLayout;
+import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.PointList;
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.preferences.FBTypeEditorPreferenceConstants;
 import org.eclipse.fordiac.ide.gef.draw2d.SetableAlphaLabel;
 import org.eclipse.fordiac.ide.model.libraryElement.ECTransition;
@@ -56,7 +59,7 @@ public class ECTransitionFigure extends SplineConnection {
 
 			orderLabel = new Label();
 			orderLabel.setOpaque(false);
-			orderLabel.setForegroundColor(ColorConstants.white);
+			orderLabel.setForegroundColor(FBTypeEditorPreferenceConstants.getEccAlgorithmTextColor());
 			orderLabel.setFont(getOrderLabelFont());
 			add(orderLabel);
 		}
@@ -76,9 +79,25 @@ public class ECTransitionFigure extends SplineConnection {
 
 		@Override
 		public void setLocation(final Point p) {
+			final Dimension size = getSize();
 			// Position the decorator centered on the start of the transition
-			p.x -= getSize().width() / 2;
-			p.y -= getSize().height() / 2;
+			final int radius = size.width() / 2;
+			p.x -= radius;
+			p.y -= radius;
+
+			if (getParent() instanceof final PolylineConnection conn) {
+				final PointList points = conn.getPoints();
+
+				if (points.size() >= 2) {
+					final Point start = points.getFirstPoint();
+					final Point next = points.getPoint(1);
+					final double angle = Math.atan2((double) next.x - start.x, (double) next.y - start.y);
+
+					p.x += (int) Math.cos(angle) * radius;
+					p.y += (int) Math.sin(angle) * radius;
+				}
+			}
+
 			super.setLocation(p);
 		}
 
@@ -146,12 +165,13 @@ public class ECTransitionFigure extends SplineConnection {
 		condition = new Label(conditionText);
 		condition.setBorder(new MarginBorder(VERTICAL_MARGIN, HORIZONTAL_MARGIN, VERTICAL_MARGIN, HORIZONTAL_MARGIN));
 		condition.setOpaque(false);
+		condition.setForegroundColor(FBTypeEditorPreferenceConstants.getEccTransitionTextColor());
 
 		conditionBackground = new SetableAlphaLabel();
 		conditionBackground.setText(conditionText); // needed for correct size
 		conditionBackground
 				.setBorder(new MarginBorder(VERTICAL_MARGIN, HORIZONTAL_MARGIN, VERTICAL_MARGIN, HORIZONTAL_MARGIN));
-		conditionBackground.setAlpha(190);
+		conditionBackground.setAlpha(210);
 		conditionBackground.setOpaque(true);
 
 		add(conditionBackground, new ConnectionLocator(this, ConnectionLocator.MIDDLE));

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/preferences/FBTypeEditorPreferenceConstants.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/preferences/FBTypeEditorPreferenceConstants.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2011 Profactor GmbH, TU Wien ACIN
+ * Copyright (c) 2011 Profactor GmbH, TU Wien ACIN,
+ *                    Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -10,6 +11,7 @@
  * Contributors:
  *   Ingo Hegny, Gerhard Ebenhofer
  *     - initial API and implementation and/or initial documentation
+ *   Alois Zoitl - modernized and reworked ECC look
  *******************************************************************************/
 package org.eclipse.fordiac.ide.fbtypeeditor.ecc.preferences;
 
@@ -24,25 +26,30 @@ public final class FBTypeEditorPreferenceConstants {
 	public static final String FBTYPEEDITOR_ECC_PREFERENCES_ID = "org.eclipse.fordiac.ide.fbtypeeditor.ecc"; //$NON-NLS-1$
 
 	/** The Constant P_ECC_STATE_COLOR. */
-	public static final String P_ECC_STATE_COLOR = "org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorStateColor"; //$NON-NLS-1$
+	private static final String P_ECC_STATE_COLOR = "org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorStateColor"; //$NON-NLS-1$
 
 	/** The Constant P_ECC_STATE_BORDER_COLOR. */
-	public static final String P_ECC_STATE_TEXT_COLOR = "org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorStateTextColor"; //$NON-NLS-1$
+	private static final String P_ECC_STATE_TEXT_COLOR = "org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorStateTextColor"; //$NON-NLS-1$
+
+	private static final String P_ECC_STATE_SPINE_COLOR = "org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCStateSpineColor"; //$NON-NLS-1$
 
 	/** The Constant P_ECC_TRANSITION_COLOR. */
-	public static final String P_ECC_TRANSITION_COLOR = "org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorTransitionColor"; //$NON-NLS-1$
+	private static final String P_ECC_TRANSITION_COLOR = "org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorTransitionColor"; //$NON-NLS-1$
+
+	/** The Constant P_ECC_TRANSITION_COLOR. */
+	private static final String P_ECC_TRANSITION_TEXT_COLOR = "org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorTransitionTextColor"; //$NON-NLS-1$
 
 	/** The Constant P_ECC_ALGORITHM_COLOR. */
-	public static final String P_ECC_ALGORITHM_COLOR = "org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorAlgorithmColor"; //$NON-NLS-1$
+	private static final String P_ECC_ALGORITHM_COLOR = "org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorAlgorithmColor"; //$NON-NLS-1$
 
 	/** The Constant P_ECC_ALGORITHM_BORDER_COLOR. */
-	public static final String P_ECC_ALGORITHM_TEXT_COLOR = "org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorAlgorithmTextColor"; //$NON-NLS-1$
+	private static final String P_ECC_ALGORITHM_TEXT_COLOR = "org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorAlgorithmTextColor"; //$NON-NLS-1$
 
 	/** The Constant P_ECC_EVENT_COLOR. */
-	public static final String P_ECC_EVENT_COLOR = "org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorEventColor"; //$NON-NLS-1$
+	private static final String P_ECC_EVENT_COLOR = "org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorEventColor"; //$NON-NLS-1$
 
 	/** The Constant P_ECC_EVENT_BORDER_COLOR. */
-	public static final String P_ECC_EVENT_TEXT_COLOR = "org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorEventTextColor"; //$NON-NLS-1$
+	private static final String P_ECC_EVENT_TEXT_COLOR = "org.eclipse.fordiac.ide.fbtypeeditor.ecc.ECCEditorEventTextColor"; //$NON-NLS-1$
 
 	/** The margin of state/action labels to create rectangles */
 	public static final int MARGIN_VERTICAL = 3;
@@ -60,8 +67,16 @@ public final class FBTypeEditorPreferenceConstants {
 		return JFaceResources.getColorRegistry().get(P_ECC_STATE_TEXT_COLOR);
 	}
 
+	public static Color getEccStateSpineColor() {
+		return JFaceResources.getColorRegistry().get(P_ECC_STATE_SPINE_COLOR);
+	}
+
 	public static Color getEccTransitionColor() {
 		return JFaceResources.getColorRegistry().get(P_ECC_TRANSITION_COLOR);
+	}
+
+	public static Color getEccTransitionTextColor() {
+		return JFaceResources.getColorRegistry().get(P_ECC_TRANSITION_TEXT_COLOR);
 	}
 
 	public static Color getEccAlgorithmColor() {


### PR DESCRIPTION
As reference here screenshots of the new design in light and dark mode:

<img width="598" height="243" alt="Screenshot From 2026-02-26 14-37-48" src="https://github.com/user-attachments/assets/d0b68c90-7dbd-4739-aff0-2b99e11b4ac4" />


<img width="640" height="262" alt="image" src="https://github.com/user-attachments/assets/7f2e9870-497a-450c-b084-4a55befbada0" />
