### PR TITLE
Check if file exists before attempting to load from it in type entry

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractInterfaceTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractInterfaceTypeEntryImpl.java
@@ -120,7 +120,7 @@ public abstract class AbstractInterfaceTypeEntryImpl<T extends FBType> extends A
 			FBType type = null;
 			final long modificationStamp;
 			final IFile fileCached = getFile();
-			if (fileCached != null) {
+			if (fileCached != null && fileCached.exists()) {
 				// read modification stamp at the beginning to ensure the loaded interface is at
 				// least as recent as the read modification stamp
 				modificationStamp = fileCached.getModificationStamp();

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
@@ -265,7 +265,7 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 
 			final long modificationStamp;
 			final IFile fileCached = getFile();
-			if (fileCached != null) {
+			if (fileCached != null && fileCached.exists()) {
 				// read modification stamp at the beginning to ensure the loaded type is at
 				// least as recent as the read modification stamp
 				modificationStamp = fileCached.getModificationStamp();


### PR DESCRIPTION
This avoids flooding the log with load errors for files that do not exist.