### PR TITLE
Fix EC state placement under zoom in ECC editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 **/.META-INF_MANIFEST.MF
 **/.tycho-consumer-pom.xml
 **/pom.tycho
+features/.project

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/actions/NewStateAction.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/actions/NewStateAction.java
@@ -19,9 +19,10 @@ import org.eclipse.fordiac.ide.fbtypeeditor.ecc.Messages;
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.commands.CreateECStateCommand;
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.editors.ECCEditor;
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.editors.StateCreationFactory;
+import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.libraryElement.ECState;
+import org.eclipse.fordiac.ide.model.libraryElement.Position;
 import org.eclipse.fordiac.ide.ui.imageprovider.FordiacImage;
-import org.eclipse.gef.editparts.ZoomManager;
 import org.eclipse.gef.ui.actions.WorkbenchPartAction;
 import org.eclipse.ui.IWorkbenchPart;
 
@@ -36,7 +37,6 @@ public class NewStateAction extends WorkbenchPartAction {
 	private static StateCreationFactory stateFactory = new StateCreationFactory();
 	private FigureCanvas viewerControl;
 	private org.eclipse.swt.graphics.Point pos = new org.eclipse.swt.graphics.Point(0, 0);
-	private ZoomManager zoomManager;
 
 	public NewStateAction(final IWorkbenchPart part) {
 		super(part);
@@ -52,10 +52,6 @@ public class NewStateAction extends WorkbenchPartAction {
 		}
 	}
 
-	public void setZoomManager(final ZoomManager zoomManager) {
-		this.zoomManager = zoomManager;
-	}
-
 	@Override
 	protected boolean calculateEnabled() {
 		return true; // we can always be enabled
@@ -67,10 +63,12 @@ public class NewStateAction extends WorkbenchPartAction {
 
 		final Point location = viewerControl.getViewport().getViewLocation();
 		final Point realPos = new Point(pos.x + location.x, pos.y + location.y);
-		realPos.scale(1.0 / zoomManager.getZoom());
+		viewerControl.getViewport().getContents().translateToRelative(realPos);
 
 		final ECState model = (ECState) stateFactory.getNewObject();
-		execute(new CreateECStateCommand(model, realPos, editor.getModel()));
+		final Position posModel = CoordinateConverter.INSTANCE.createPosFromScreenCoordinates(realPos.x, realPos.y);
+
+		execute(new CreateECStateCommand(model, posModel, editor.getModel()));
 
 		editor.outlineSelectionChanged(model);
 	}

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editors/ECCEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editors/ECCEditor.java
@@ -126,7 +126,6 @@ public class ECCEditor extends DiagramEditorWithFlyoutPalette implements IFBTEdi
 		// position for state creation
 		final IAction action = getActionRegistry().getAction(NewStateAction.CREATE_STATE);
 		((NewStateAction) action).setViewerControl((FigureCanvas) viewer.getControl());
-		((NewStateAction) action).setZoomManager(getZoomManger());
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editors/ECCEditorEditDomain.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editors/ECCEditorEditDomain.java
@@ -21,12 +21,13 @@ import org.eclipse.fordiac.ide.fbtypeeditor.ecc.editparts.ECActionOutputEventEdi
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.editparts.ECStateEditPart;
 import org.eclipse.fordiac.ide.gef.editparts.ConnCreateDirectEditDragTrackerProxy;
 import org.eclipse.fordiac.ide.gef.tools.AdvancedPanningSelectionTool;
+import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.libraryElement.ECC;
 import org.eclipse.fordiac.ide.model.libraryElement.ECState;
+import org.eclipse.fordiac.ide.model.libraryElement.Position;
 import org.eclipse.gef.DefaultEditDomain;
 import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.SharedCursors;
-import org.eclipse.gef.commands.CompoundCommand;
 import org.eclipse.gef.editparts.FreeformGraphicalRootEditPart;
 import org.eclipse.gef.requests.LocationRequest;
 import org.eclipse.gef.tools.CreationTool;
@@ -104,17 +105,31 @@ final class ECCEditorEditDomain extends DefaultEditDomain {
 			handleMove();
 		}
 
-		public void performCreation() {
+		public void performCreation(final org.eclipse.gef.EditPartViewer viewer) {
+			if (viewer == null || point == null || sourceState == null) {
+				return;
+			}
+			if (!(viewer.getRootEditPart() instanceof final org.eclipse.gef.editparts.ScalableFreeformRootEditPart root)) {
+				return;
+			}
+
 			final ECState destState = (ECState) getFactory().getNewObject();
-			final CreateECStateCommand createStateCommand = new CreateECStateCommand(destState, point, getECC());
+			final Point translated = point.getCopy();
+			root.getContentPane().translateToRelative(translated);
+
+			final Position pos = CoordinateConverter.INSTANCE.createPosFromScreenCoordinates(translated.x,
+					translated.y);
+
+			final CreateECStateCommand createStateCommand = new CreateECStateCommand(destState, pos, getECC());
 			final CreateTransitionCommand createTransitionCommand = new CreateTransitionCommand(sourceState, destState,
 					null);
 			createTransitionCommand.setDestinationLocation(point);
-			final CompoundCommand compCom = new CompoundCommand();
+
+			final org.eclipse.gef.commands.CompoundCommand compCom = new org.eclipse.gef.commands.CompoundCommand();
 			compCom.add(createStateCommand);
 			compCom.add(createTransitionCommand);
-			setCurrentCommand(compCom);
-			performCreation(1);
+
+			viewer.getEditDomain().getCommandStack().execute(compCom);
 		}
 
 		private ECC getECC() {
@@ -178,9 +193,7 @@ final class ECCEditorEditDomain extends DefaultEditDomain {
 					.getTargetEditPart() instanceof FreeformGraphicalRootEditPart) {
 				transitionStateCreationTool
 						.setLocationActivation(((ECCPanningSelectionTool) getDefaultTool()).getLastLocation());
-				setActiveTool(transitionStateCreationTool);
-				transitionStateCreationTool.performCreation();
-				setActiveTool(getDefaultTool());
+				transitionStateCreationTool.performCreation(viewer); // viewer parameter pass kiya
 				createTransitionAndState = false;
 			}
 			transition = false;

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/policies/ECCXYLayoutEditPolicy.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/policies/ECCXYLayoutEditPolicy.java
@@ -74,7 +74,10 @@ public class ECCXYLayoutEditPolicy extends XYLayoutEditPolicy {
 		if (request.getNewObjectType().equals(ECState.class) && getHost().getModel() instanceof final ECC ecc) {
 			final Point point = request.getLocation().getCopy();
 			getHostFigure().translateToRelative(point);
-			return new CreateECStateCommand((ECState) request.getNewObject(), point, ecc);
+
+			final Position pos = CoordinateConverter.INSTANCE.createPosFromScreenCoordinates(point.x, point.y);
+
+			return new CreateECStateCommand((ECState) request.getNewObject(), pos, ecc);
 		}
 		return null;
 	}


### PR DESCRIPTION
### Problem
When creating a new EC state in the ECC editor while zoomed in or out, 
the state was placed at an incorrect position.

### Cause
The mouse location was used without compensating for the current zoom level, 
which resulted in incorrect coordinate calculations.

### Solution
Adjusted the coordinate calculation to account for the current zoom factor 
before creating the EC state.

### Testing
- Tested state creation at 100% zoom
- Tested state creation at zoom in (150%+)
- Tested state creation at zoom out (<100%)
- Verified transitions still work correctly
