### PR TITLE
Update dependencies and Plugin versions for 3.1 Release

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.ant/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.ant/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Ant
 Bundle-SymbolicName: org.eclipse.fordiac.ide.ant;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Automatic-Module-Name: org.eclipse.fordiac.ide.ant
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.resources,

--- a/plugins/org.eclipse.fordiac.ide.attributetypeeditor/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.attributetypeeditor/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 Bundle-Name: %AttributeTypeEditor.bundleName
 Bundle-SymbolicName: org.eclipse.fordiac.ide.attributetypeeditor;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.fordiac.ide.ui,

--- a/plugins/org.eclipse.fordiac.ide.contracts/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.contracts/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Contracts
 Bundle-SymbolicName: org.eclipse.fordiac.ide.contracts;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Vendor: Eclipse 4diac
 Automatic-Module-Name: org.eclipse.fordiac.ide.contracts
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/plugins/org.eclipse.fordiac.ide.contractspec.ide/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.contractspec.ide/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.fordiac.ide.contractspec.ide
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.fordiac.ide.contractspec.ide
 Bundle-Vendor: Eclipse 4diac
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-SymbolicName: org.eclipse.fordiac.ide.contractspec.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.fordiac.ide.contractspec,

--- a/plugins/org.eclipse.fordiac.ide.contractspec.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.contractspec.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.fordiac.ide.contractspec.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.fordiac.ide.contractspec.tests
 Bundle-Vendor: Eclipse 4diac
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-SymbolicName: org.eclipse.fordiac.ide.contractspec.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.fordiac.ide.contractspec,

--- a/plugins/org.eclipse.fordiac.ide.contractspec.ui.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.contractspec.ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.fordiac.ide.contractspec.ui.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.fordiac.ide.contractspec.ui.tests
 Bundle-Vendor: Eclipse 4diac
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-SymbolicName: org.eclipse.fordiac.ide.contractspec.ui.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.fordiac.ide.contractspec.ui,

--- a/plugins/org.eclipse.fordiac.ide.contractspec/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.contractspec/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.fordiac.ide.contractspec
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.fordiac.ide.contractspec
 Bundle-Vendor: Eclipse 4diac
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-SymbolicName: org.eclipse.fordiac.ide.contractspec; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/plugins/org.eclipse.fordiac.ide.datatypeeditor/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.datatypeeditor/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 Bundle-Name: %DataTypeEditor.bundleName
 Bundle-SymbolicName: org.eclipse.fordiac.ide.datatypeeditor;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.fordiac.ide.ui,

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Replay Debugging UI
 Bundle-SymbolicName: org.eclipse.fordiac.ide.debug.replaydebugging.ui;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Automatic-Module-Name: org.eclipse.fordiac.ide.debug.replaydebugging.ui
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Replay Debugging Core
 Bundle-SymbolicName: org.eclipse.fordiac.ide.debug.replaydebugging;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Automatic-Module-Name: org.eclipse.fordiac.ide.debug.replaydebugging
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/plugins/org.eclipse.fordiac.ide.debug.st/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.debug.st/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Debug ST
 Bundle-SymbolicName: org.eclipse.fordiac.ide.debug.st;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Vendor: Eclipse 4diac
 Automatic-Module-Name: org.eclipse.fordiac.ide.debug.st
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/plugins/org.eclipse.fordiac.ide.debug.ui.st/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.debug.ui.st/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Debug UI
 Bundle-SymbolicName: org.eclipse.fordiac.ide.debug.ui.st;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Vendor: Eclipse 4diac
 Automatic-Module-Name: org.eclipse.fordiac.ide.debug.ui.st
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/plugins/org.eclipse.fordiac.ide.debug/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.debug/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Debug
 Bundle-SymbolicName: org.eclipse.fordiac.ide.debug;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Vendor: Eclipse 4diac
 Automatic-Module-Name: org.eclipse.fordiac.ide.debug
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/plugins/org.eclipse.fordiac.ide.deployment.bootfile/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.deployment.bootfile/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Deployment Boot File
 Bundle-SymbolicName: org.eclipse.fordiac.ide.deployment.bootfile;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Export-Package: org.eclipse.fordiac.ide.deployment.bootfile,
  org.eclipse.fordiac.ide.deployment.bootfile.wizard
 Bundle-Vendor: Eclipse 4diac

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Deployment Debug
 Bundle-SymbolicName: org.eclipse.fordiac.ide.deployment.debug;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Vendor: Eclipse 4diac
 Automatic-Module-Name: org.eclipse.fordiac.ide.deployment.debug
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/plugins/org.eclipse.fordiac.ide.elk/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.elk/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.fordiac.ide.elk;singleton:=true
 Automatic-Module-Name: org.eclipse.fordiac.ide.elk
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Require-Bundle: org.eclipse.elk.core,
  org.eclipse.elk.graph,
  org.eclipse.elk.alg.common,

--- a/plugins/org.eclipse.fordiac.ide.export.compare/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.export.compare/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.fordiac.ide.ui
 Bundle-Vendor: Eclipse 4diac
 Bundle-ActivationPolicy: lazy
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Name: Compare exported FBs
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.fordiac.ide.export.compare;singleton:=true

--- a/plugins/org.eclipse.fordiac.ide.export.forte_lua.st/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_lua.st/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: FORTE Lua Export for FORTE V1.0.x New Generation ST Support
 Bundle-SymbolicName: org.eclipse.fordiac.ide.export.forte_lua.st;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Vendor: Eclipse 4diac
 Automatic-Module-Name: org.eclipse.fordiac.ide.export.forte_lua.st
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/plugins/org.eclipse.fordiac.ide.export.forte_lua/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_lua/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: FORTE Export for Lua
 Bundle-SymbolicName: org.eclipse.fordiac.ide.export.forte_lua;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,
  org.eclipse.xtend.lib,

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: FORTE Export for FORTE V1.0.x New Generation ST Support
 Bundle-SymbolicName: org.eclipse.fordiac.ide.export.forte_ng.st;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Vendor: Eclipse 4diac
 Automatic-Module-Name: org.eclipse.fordiac.ide.export.forte_ng.st
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: FORTE Export for FORTE V1.0.x New Generation
 Bundle-SymbolicName: org.eclipse.fordiac.ide.export.forte_ng;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Vendor: Eclipse 4diac
 Automatic-Module-Name: org.eclipse.fordiac.ide.export.forte_ng
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/plugins/org.eclipse.fordiac.ide.export.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.export.ui/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.fordiac.ide.export
 Bundle-Vendor: Eclipse 4diac
 Bundle-ActivationPolicy: lazy
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Name: Export UI
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.fordiac.ide.export.ui;singleton:=true

--- a/plugins/org.eclipse.fordiac.ide.export.xmi/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.export.xmi/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: XMI Export
 Bundle-SymbolicName: org.eclipse.fordiac.ide.export.xmi;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Vendor: Eclipse 4diac
 Automatic-Module-Name: org.eclipse.fordiac.ide.export.xmi
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/plugins/org.eclipse.fordiac.ide.export/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.export/META-INF/MANIFEST.MF
@@ -12,7 +12,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.fordiac.ide.util
 Bundle-Vendor: Eclipse 4diac
 Bundle-ActivationPolicy: lazy
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Name: Export Utils
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.fordiac.ide.export;singleton:=true

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter.design/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter.design/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.fordiac.ide.fb.interpreter.design;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Activator: org.eclipse.fordiac.ide.fb.interpreter.design.Activator
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter.edit/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter.edit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.fordiac.ide.fb.interpreter.edit;singleton:=true
 Automatic-Module-Name: org.eclipse.fordiac.ide.fb.interpreter.edit
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.fordiac.ide.fb.interpreter.provider.OperationalSemanticsEditPlugin$Implementation

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter.editor/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter.editor/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.fordiac.ide.fb.interpreter.editor;singleton:=true
 Automatic-Module-Name: org.eclipse.fordiac.ide.fb.interpreter.editor
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.fordiac.ide.fb.intepreter.presentation.OperationalSemanticsEditorPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/plugins/org.eclipse.fordiac.ide.fbrtlauncher/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.fbrtlauncher/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.fordiac.ide.ui
 Bundle-Vendor: Eclipse 4diac
 Bundle-ActivationPolicy: lazy
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Name: FBRT Launcher
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.fordiac.ide.fbrtlauncher;singleton:=true

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.doc/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.doc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Type Documentation Editor
 Bundle-SymbolicName: org.eclipse.fordiac.ide.fbtypeeditor.doc;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Automatic-Module-Name: org.eclipse.fordiac.ide.ftypeeditor.doc
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.ui,

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/META-INF/MANIFEST.MF
@@ -22,7 +22,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.fordiac.ide.typeeditor
 Bundle-Vendor: Eclipse 4diac
 Bundle-ActivationPolicy: lazy
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Name: ECC Editor
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.fordiac.ide.fbtypeeditor.ecc;singleton:=true

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.network/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.network/META-INF/MANIFEST.MF
@@ -19,7 +19,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.fordiac.ide.model.ui
 Bundle-Vendor: Eclipse 4diac
 Bundle-ActivationPolicy: lazy
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Name: Composite FB Network
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.fordiac.ide.fbtypeeditor.network;singleton:=true

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.st/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.st/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Structured Text FB Editor
 Bundle-SymbolicName: org.eclipse.fordiac.ide.fbtypeeditor.st;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.ui.views.properties.tabbed,

--- a/plugins/org.eclipse.fordiac.ide.fmu/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.fmu/META-INF/MANIFEST.MF
@@ -12,7 +12,7 @@ Require-Bundle: org.eclipse.ui.ide,
  org.eclipse.swt
 Bundle-Vendor: Eclipse 4diac
 Bundle-ActivationPolicy: lazy
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Name: FMU exporter
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.fordiac.ide.fmu;singleton:=true

--- a/plugins/org.eclipse.fordiac.ide.fortelauncher/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.fortelauncher/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.debug.ui
 Bundle-Vendor: Eclipse 4diac
 Bundle-ActivationPolicy: lazy
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Name: Forte Launcher
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.fordiac.ide.fortelauncher;singleton:=true

--- a/plugins/org.eclipse.fordiac.ide.gitlab/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.gitlab/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Gitlab
 Bundle-SymbolicName: org.eclipse.fordiac.ide.gitlab;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Import-Package: org.eclipse.ui.preferences
 Require-Bundle: org.eclipse.ui.ide,
  org.eclipse.core.resources,

--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ide/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ide/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.fordiac.ide.globalconstantseditor.ide
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.fordiac.ide.globalconstantseditor.ide
 Bundle-Vendor: Eclipse 4diac
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-SymbolicName: org.eclipse.fordiac.ide.globalconstantseditor.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.fordiac.ide.globalconstantseditor,

--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.fordiac.ide.globalconstantseditor.tests
 Bundle-Vendor: Eclipse 4diac
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-SymbolicName: org.eclipse.fordiac.ide.globalconstantseditor.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.fordiac.ide.globalconstantseditor.tests

--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.fordiac.ide.globalconstantseditor.ui.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.fordiac.ide.globalconstantseditor.ui.tests
 Bundle-Vendor: Eclipse 4diac
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-SymbolicName: org.eclipse.fordiac.ide.globalconstantseditor.ui.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.fordiac.ide.globalconstantseditor.ui,

--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.fordiac.ide.globalconstantseditor.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: %GlobalConstEditorUI.bundleName
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-SymbolicName: org.eclipse.fordiac.ide.globalconstantseditor.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin

--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.fordiac.ide.globalconstantseditor
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.fordiac.ide.globalconstantseditor
 Bundle-Vendor: Eclipse 4diac
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-SymbolicName: org.eclipse.fordiac.ide.globalconstantseditor; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/plugins/org.eclipse.fordiac.ide.hierarchymanager.build/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.hierarchymanager.build/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hierarchy Manager Build
 Bundle-SymbolicName: org.eclipse.fordiac.ide.hierarchymanager.build;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Export-Package: org.eclipse.fordiac.ide.hierarchymanager.build
 Require-Bundle: org.eclipse.core.resources,
  org.eclipse.core.runtime,

--- a/plugins/org.eclipse.fordiac.ide.hierarchymanager.model.edit/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.hierarchymanager.model.edit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.fordiac.ide.hierarchymanager.model.edit;singleton:=true
 Automatic-Module-Name: org.eclipse.fordiac.ide.hierarchymanager.model.edit
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.fordiac.ide.hierarchymanager.model.hierarchy.provider.HierarchyEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/plugins/org.eclipse.fordiac.ide.hierarchymanager.model/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.hierarchymanager.model/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.fordiac.ide.hierarchymanager.model;singleton:=true
 Automatic-Module-Name: org.eclipse.fordiac.ide.hierarchymanager.model
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/plugins/org.eclipse.fordiac.ide.hierarchymanager.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.hierarchymanager.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Hierarchy Manager UI
 Bundle-SymbolicName: org.eclipse.fordiac.ide.hierarchymanager.ui;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Require-Bundle: org.eclipse.core.resources,
  org.eclipse.core.runtime,
  org.eclipse.emf.edit,

--- a/plugins/org.eclipse.fordiac.ide.images/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.images/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Images
 Bundle-SymbolicName: org.eclipse.fordiac.ide.images
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Fragment-Host: org.eclipse.fordiac.ide.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: Eclipse 4diac

--- a/plugins/org.eclipse.fordiac.ide.library.model/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.library.model/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.fordiac.ide.library.model;singleton:=true
 Automatic-Module-Name: org.eclipse.fordiac.ide.library.model
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-ClassPath: .
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.fordiac.ide.library.model.library,

--- a/plugins/org.eclipse.fordiac.ide.library.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.fordiac.ide.library.ui;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Automatic-Module-Name: org.eclipse.fordiac.ide.library.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: %providerName

--- a/plugins/org.eclipse.fordiac.ide.library/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.library/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Library
 Bundle-SymbolicName: org.eclipse.fordiac.ide.library;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Automatic-Module-Name: org.eclipse.fordiac.ide.library
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/plugins/org.eclipse.fordiac.ide.model.eval.st/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.model.eval.st/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Evaluator
 Bundle-SymbolicName: org.eclipse.fordiac.ide.model.eval.st;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Vendor: Eclipse 4diac
 Automatic-Module-Name: org.eclipse.fordiac.ide.model.eval.st
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/plugins/org.eclipse.fordiac.ide.model.eval/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Evaluator
 Bundle-SymbolicName: org.eclipse.fordiac.ide.model.eval;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Vendor: Eclipse 4diac
 Automatic-Module-Name: org.eclipse.fordiac.ide.model.eval
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/plugins/org.eclipse.fordiac.ide.model.search.st/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.model.search.st/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Evaluator
 Bundle-SymbolicName: org.eclipse.fordiac.ide.model.search.st;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Vendor: Eclipse 4diac
 Automatic-Module-Name: org.eclipse.fordiac.ide.model.search.st
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/plugins/org.eclipse.fordiac.ide.model.search/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.model.search/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Search
 Bundle-SymbolicName: org.eclipse.fordiac.ide.model.search;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Vendor: Eclipse 4diac
 Bundle-Localization: plugin
 Automatic-Module-Name: org.eclipse.fordiac.ide.model.search

--- a/plugins/org.eclipse.fordiac.ide.model.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Model UI
 Bundle-ActivationPolicy: lazy
 Bundle-SymbolicName: org.eclipse.fordiac.ide.model.ui;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.emf.ecore.editor,
  org.eclipse.fordiac.ide.model,

--- a/plugins/org.eclipse.fordiac.ide.runtime/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.runtime/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Runtime
 Bundle-SymbolicName: org.eclipse.fordiac.ide.runtime;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Vendor: Eclipse 4diac
 Export-Package: org.eclipse.fordiac.ide.runtime
 Require-Bundle: org.eclipse.ui,

--- a/plugins/org.eclipse.fordiac.ide.structuredtext.mwe/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.structuredtext.mwe/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.fordiac.ide.structuredtext.mwe
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.fordiac.ide.structuredtext.mwe
 Bundle-Vendor: Eclipse 4diac
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-SymbolicName: org.eclipse.fordiac.ide.structuredtext.mwe; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ide/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ide/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.fordiac.ide.structuredtextalgorithm.ide
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.fordiac.ide.structuredtextalgorithm.ide
 Bundle-Vendor: Eclipse 4diac
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-SymbolicName: org.eclipse.fordiac.ide.structuredtextalgorithm.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.fordiac.ide.structuredtextalgorithm,

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.fordiac.ide.structuredtextalgorithm.tests
 Bundle-SymbolicName: org.eclipse.fordiac.ide.structuredtextalgorithm.tests;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.fordiac.ide.structuredtextalgorithm.tests;x-internal=true

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.fordiac.ide.structuredtextalgorithm.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-SymbolicName: org.eclipse.fordiac.ide.structuredtextalgorithm.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.fordiac.ide.structuredtextalgorithm,

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.fordiac.ide.structuredtextalgorithm
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.fordiac.ide.structuredtextalgorithm
 Bundle-Vendor: Eclipse 4diac
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-SymbolicName: org.eclipse.fordiac.ide.structuredtextalgorithm; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ide/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ide/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.fordiac.ide.structuredtextcore.ide
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.fordiac.ide.structuredtextcore.ide
 Bundle-Vendor: Eclipse 4diac
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-SymbolicName: org.eclipse.fordiac.ide.structuredtextcore.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.fordiac.ide.structuredtextcore,

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.fordiac.ide.structuredtextcore.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-SymbolicName: org.eclipse.fordiac.ide.structuredtextcore.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.fordiac.ide.model,

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.fordiac.ide.structuredtextcore
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.fordiac.ide.structuredtextcore
 Bundle-Vendor: Eclipse 4diac
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-SymbolicName: org.eclipse.fordiac.ide.structuredtextcore; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ide/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ide/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.fordiac.ide.structuredtextfunctioneditor.ide
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.fordiac.ide.structuredtextfunctioneditor.ide
 Bundle-Vendor: Eclipse 4diac
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-SymbolicName: org.eclipse.fordiac.ide.structuredtextfunctioneditor.ide;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.fordiac.ide.structuredtextfunctioneditor,

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.fordiac.ide.structuredtextfunctioneditor.test
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.fordiac.ide.structuredtextfunctioneditor.tests
 Bundle-Vendor: Eclipse 4diac
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-SymbolicName: org.eclipse.fordiac.ide.structuredtextfunctioneditor.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Import-Package: org.junit.jupiter.api;version="[5.1.0,6.0.0)",

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.t
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.tests
 Bundle-Vendor: Eclipse 4diac
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-SymbolicName: org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Import-Package: org.junit.jupiter.api;version="[5.1.0,6.0.0)",

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-SymbolicName: org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.fordiac.ide.structuredtextfunctioneditor,

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.fordiac.ide.structuredtextfunctioneditor
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.fordiac.ide.structuredtextfunctioneditor
 Bundle-Vendor: Eclipse 4diac
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-SymbolicName: org.eclipse.fordiac.ide.structuredtextfunctioneditor;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/plugins/org.eclipse.fordiac.ide.subapptypeeditor/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.subapptypeeditor/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: SubapplicationTypeEditor.bundleName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.fordiac.ide.subapptypeeditor;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.ui.views.properties.tabbed,

--- a/plugins/org.eclipse.fordiac.ide.systemconfiguration.segment/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.systemconfiguration.segment/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.fordiac.ide.systemconfiguration.segment;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/plugins/org.eclipse.fordiac.ide.systemconfiguration/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.systemconfiguration/META-INF/MANIFEST.MF
@@ -25,7 +25,7 @@ Require-Bundle: org.eclipse.ui.views.properties.tabbed,
  org.eclipse.fordiac.ide.model.eval
 Bundle-Vendor: Eclipse 4diac
 Bundle-ActivationPolicy: lazy
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Name: System Configuration
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.fordiac.ide.systemconfiguration;singleton:=true

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/META-INF/MANIFEST.MF
@@ -39,7 +39,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.fordiac.ide.typeeditor,
  org.eclipse.fordiac.ide.bulkeditor
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.fordiac.ide.systemmanagement.ui;singleton:=true
 Automatic-Module-Name: org.eclipse.fordiac.ide.systemmanagement.ui

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.fordiac.ide.library.model
 Bundle-Vendor: Eclipse 4diac
 Bundle-ActivationPolicy: lazy
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Name: System Management
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.fordiac.ide.systemmanagement;singleton:=true

--- a/plugins/org.eclipse.fordiac.ide.typeeditor/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.typeeditor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Type Editor
 Bundle-SymbolicName: org.eclipse.fordiac.ide.typeeditor;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Export-Package: org.eclipse.fordiac.ide.typeeditor
 Bundle-Vendor: Eclipse 4diac
 Automatic-Module-Name: org.eclipse.fordiac.ide.typeeditor

--- a/plugins/org.eclipse.fordiac.ide.ui.errormessages/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.ui.errormessages/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Error Messages
 Bundle-ActivationPolicy: lazy
 Bundle-SymbolicName: org.eclipse.fordiac.ide.ui.errormessages
 Bundle-Activator: org.eclipse.fordiac.ide.ui.errormessages.Activator
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: Eclipse 4diac
 Automatic-Module-Name: org.eclipse.fordiac.ui.errormessages

--- a/plugins/org.eclipse.fordiac.ide.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.ui/META-INF/MANIFEST.MF
@@ -30,7 +30,7 @@ Require-Bundle: org.eclipse.gef,
 Import-Package: org.osgi.service.event 
 Bundle-Vendor: Eclipse 4diac
 Bundle-ActivationPolicy: lazy
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Name: Common UI Controls
 Bundle-Activator: org.eclipse.fordiac.ide.ui.UIPlugin
 Bundle-ManifestVersion: 2

--- a/plugins/org.eclipse.fordiac.ide.util/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.util/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.fordiac.ide.systemmanagement
 Bundle-Vendor: Eclipse 4diac
 Bundle-ActivationPolicy: lazy
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Name: Utils
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.fordiac.ide.util;singleton:=true

--- a/plugins/org.eclipse.fordiac.ide.validation/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.validation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Validation
 Bundle-SymbolicName: org.eclipse.fordiac.ide.validation;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Activator: org.eclipse.fordiac.ide.validation.Activator
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime,

--- a/plugins/org.eclipse.fordiac.ide/pom.xml
+++ b/plugins/org.eclipse.fordiac.ide/pom.xml
@@ -16,7 +16,7 @@
   <properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>3.2.0</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>3.0.0</asciidoctorj.version>
+        <asciidoctorj.version>3.0.1</asciidoctorj.version>
 	</properties>
 	<build>
 		<defaultGoal>process-resources</defaultGoal>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
 		<maven.compiler.release/>
-		<tycho.version>5.0.2</tycho.version>
+		<tycho.version>5.0.2</tycho.version>  <!-- when updating this version also update .mvn/extensions.xml -->
 		<tycho-repo.url>https://download.eclipse.org/releases/2026-03</tycho-repo.url>
 		<sonar-maven-plugin.version>5.5.0.6356</sonar-maven-plugin.version>
 		<sonar.exclusions>**/src-gen/**/*,**/xtend-gen/**/*</sonar.exclusions>
@@ -27,10 +27,10 @@
 		<sonar.java.source>21</sonar.java.source>
 		<sonar.java.binaries>${project.build.outputDirectory}</sonar.java.binaries>
 		<sonar.organization>eclipse</sonar.organization>
-		<org.eclipse.justj.jre.repository>https://download.eclipse.org/justj/jres/25/updates/release/25.0.1</org.eclipse.justj.jre.repository>
-        <xtend-version>2.41.0</xtend-version>
+		<org.eclipse.justj.jre.repository>https://download.eclipse.org/justj/jres/25/updates/release/25.0.2</org.eclipse.justj.jre.repository>
+        <xtend-version>2.42.0</xtend-version>
         <xtend-java-version>21</xtend-java-version>
-        <eclipse.cbi.version>1.5.2</eclipse.cbi.version>
+        <eclipse.cbi.version>1.5.4</eclipse.cbi.version>
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
         <maven-resources-plugin-version>3.4.0</maven-resources-plugin-version>
 	</properties>
@@ -249,16 +249,6 @@
 	</build>
 
 	<dependencies>
-		<dependency>
-			<groupId>org.opentest4j</groupId>
-			<artifactId>opentest4j</artifactId>
-			<version>1.3.0</version>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter</artifactId>
-			<version>5.14.1</version>
-		</dependency>
 		<dependency>
 			<groupId>org.eclipse.xtend</groupId>
 			<artifactId>org.eclipse.xtend.lib</artifactId>

--- a/releng/check-changed-plugins.sh
+++ b/releng/check-changed-plugins.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# script to find all plugins and tests that changed till the last release
+# parameter: <feature freeze branch name> e.g., 3.1.x
+
+git diff --name-only release..$1 -- plugins/ | cut -d'/' -f2 | sort -u
+git diff --name-only release..$1 -- tests/ | cut -d'/' -f2 | sort -u

--- a/tests/org.eclipse.fordiac.ide.test.contracts/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.fordiac.ide.test.contracts/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Contracts Tests
 Bundle-SymbolicName: org.eclipse.fordiac.ide.test.contracts
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Fragment-Host: org.eclipse.fordiac.ide.contracts
 Automatic-Module-Name: org.eclipse.fordiac.ide.test.contracts
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/tests/org.eclipse.fordiac.ide.test.contracts/pom.xml
+++ b/tests/org.eclipse.fordiac.ide.test.contracts/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>org.eclipse.fordiac.ide.test.contracts</artifactId>
-  <version>3.0.100-SNAPSHOT</version>
+  <version>3.1.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
 </project> 

--- a/tests/org.eclipse.fordiac.ide.test.deployment/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.fordiac.ide.test.deployment/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Deployment Test
 Bundle-SymbolicName: org.eclipse.fordiac.ide.test.deployment
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Fragment-Host: org.eclipse.fordiac.ide.deployment
 Automatic-Module-Name: org.eclipse.fordiac.ide.test.deployment
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/tests/org.eclipse.fordiac.ide.test.export/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.fordiac.ide.test.export/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: forte_ng Tests
 Bundle-SymbolicName: org.eclipse.fordiac.ide.test.export
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Fragment-Host: org.eclipse.fordiac.ide.export.forte_ng
 Automatic-Module-Name: org.eclipse.fordiac.ide.test.export
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/tests/org.eclipse.fordiac.ide.test.library/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.fordiac.ide.test.library/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Library Tests
 Bundle-SymbolicName: org.eclipse.fordiac.ide.test.library;singleton:=true
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Automatic-Module-Name: org.eclipse.fordiac.ide.test.library
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: Eclipse 4diac

--- a/tests/org.eclipse.fordiac.ide.test.model.eval/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.fordiac.ide.test.model.eval/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Evaluator Tests
 Bundle-SymbolicName: org.eclipse.fordiac.ide.test.model.eval
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Fragment-Host: org.eclipse.fordiac.ide.model.eval
 Automatic-Module-Name: org.eclipse.fordiac.ide.test.model.eval
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/tests/org.eclipse.fordiac.ide.test.model.search/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.fordiac.ide.test.model.search/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Search Tests
 Bundle-SymbolicName: org.eclipse.fordiac.ide.test.model.search
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Fragment-Host: org.eclipse.fordiac.ide.model.search
 Automatic-Module-Name: org.eclipse.fordiac.ide.test.model.search
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/tests/org.eclipse.fordiac.ide.test.ui/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.fordiac.ide.test.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: 4diac IDE UI tests
 Bundle-SymbolicName: org.eclipse.fordiac.ide.test.ui
-Bundle-Version: 3.0.100.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-Vendor: Eclipse 4diac
 Automatic-Module-Name: org.eclipse.fordiac.ide.test.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-21


### PR DESCRIPTION
All Plugins with changes are updated to version 3.1. Furthermore all dependencies are updated to the latest version.