### PR TITLE
Only Consider Negate and Retain Attributes for Type Hash

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/datatype/helper/InternalAttributeDeclarations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/datatype/helper/InternalAttributeDeclarations.java
@@ -14,6 +14,7 @@
 package org.eclipse.fordiac.ide.model.datatype.helper;
 
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -62,6 +63,8 @@ public final class InternalAttributeDeclarations {
 
 	private static final List<AttributeDeclaration> allAttributes = List.of(VAR_CONFIG, VISIBLE, INOUT_VISIBLE_OUT,
 			UNFOLDED, RETAIN, TARGET, NEGATED, INHERIT);
+
+	private static final Set<AttributeDeclaration> HASH_RELEVANT_ATRTRIBUTES = Set.of(RETAIN, NEGATED);
 
 	private static AttributeDeclaration createAttributeDeclaration(final String name, final DataType type) {
 		final AttributeDeclaration declaration = LibraryElementFactory.eINSTANCE.createAttributeDeclaration();
@@ -125,6 +128,13 @@ public final class InternalAttributeDeclarations {
 
 	public static boolean isInternalAttribute(final Attribute attribute) {
 		return getInternalAttributeByName(attribute.getName()) != null;
+	}
+
+	public static boolean isHashRelevantAttribute(final AttributeDeclaration declaration) {
+		if (declaration == null) {
+			return false;
+		}
+		return HASH_RELEVANT_ATRTRIBUTES.contains(declaration);
 	}
 
 	private InternalAttributeDeclarations() {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/util/LibraryElementHasher.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/util/LibraryElementHasher.java
@@ -30,7 +30,9 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecore.util.EcoreUtil.Copier;
+import org.eclipse.fordiac.ide.model.datatype.helper.InternalAttributeDeclarations;
 import org.eclipse.fordiac.ide.model.emf.HashMetaData;
+import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
 import org.eclipse.fordiac.ide.model.resource.FordiacTypeResource;
 
 public final class LibraryElementHasher {
@@ -115,6 +117,12 @@ public final class LibraryElementHasher {
 			if (eObject == null) {
 				return null;
 			}
+
+			if (eObject instanceof final Attribute attr
+					&& !InternalAttributeDeclarations.isHashRelevantAttribute(attr.getAttributeDeclaration())) {
+				return null;
+			}
+
 			if (!HashMetaData.isIgnored(eObject.eClass())) {
 				return super.copy(eObject);
 			}


### PR DESCRIPTION
All other attributes have no and shall not have an impact on the functionality and therefore are not considered for type hashing anymore.