### PR TITLE
Fix escaping of '&' in deployment

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.deployment.iec61499/src/org/eclipse/fordiac/ide/deployment/iec61499/executors/DeploymentExecutor.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.iec61499/src/org/eclipse/fordiac/ide/deployment/iec61499/executors/DeploymentExecutor.java
@@ -166,6 +166,9 @@ public class DeploymentExecutor extends AbstractDeviceManagementInteractor {
 
 	private static String encodeXMLChars(final String value) {
 		String retVal = value;
+		// replace '&' characters first
+		retVal = retVal.replace("&", "&amp;"); //$NON-NLS-1$ //$NON-NLS-2$
+		// replace remaining characters
 		retVal = retVal.replace("\"", "&quot;"); //$NON-NLS-1$ //$NON-NLS-2$
 		retVal = retVal.replace("'", "&apos;"); //$NON-NLS-1$ //$NON-NLS-2$
 		retVal = retVal.replace("<", "&lt;"); //$NON-NLS-1$ //$NON-NLS-2$


### PR DESCRIPTION
The '&' character was not escaped in XML requests sent during deployment.