### PR TITLE
Fix EC state placement under zoom updated

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editors/ECCEditorEditDomain.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editors/ECCEditorEditDomain.java
@@ -27,6 +27,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.ECState;
 import org.eclipse.fordiac.ide.model.libraryElement.Position;
 import org.eclipse.gef.DefaultEditDomain;
 import org.eclipse.gef.EditPartViewer;
+import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.SharedCursors;
 import org.eclipse.gef.commands.CompoundCommand;
 import org.eclipse.gef.editparts.FreeformGraphicalRootEditPart;
@@ -106,17 +107,21 @@ final class ECCEditorEditDomain extends DefaultEditDomain {
 			handleMove();
 		}
 
-		public void performCreation() {
+		public void performCreation(final EditPartViewer viewer) {
 			final ECState destState = (ECState) getFactory().getNewObject();
+			final Point relativePoint = point.getCopy();
 
-			final Position pos = CoordinateConverter.INSTANCE.createPosFromScreenCoordinates(point.x, point.y);
+			final Object eccEditPart = viewer.getEditPartRegistry().get(getECC());
+			if (eccEditPart instanceof final GraphicalEditPart gep) {
+				gep.getFigure().translateToRelative(relativePoint);
+			}
 
+			final Position pos = CoordinateConverter.INSTANCE.createPosFromScreenCoordinates(relativePoint.x,
+					relativePoint.y);
 			final CreateECStateCommand createStateCommand = new CreateECStateCommand(destState, pos, getECC());
-
 			final CreateTransitionCommand createTransitionCommand = new CreateTransitionCommand(sourceState, destState,
 					null);
-
-			createTransitionCommand.setDestinationLocation(point);
+			createTransitionCommand.setDestinationLocation(relativePoint);
 
 			final CompoundCommand compCom = new CompoundCommand();
 			compCom.add(createStateCommand);
@@ -188,7 +193,7 @@ final class ECCEditorEditDomain extends DefaultEditDomain {
 				transitionStateCreationTool
 						.setLocationActivation(((ECCPanningSelectionTool) getDefaultTool()).getLastLocation());
 				setActiveTool(transitionStateCreationTool);
-				transitionStateCreationTool.performCreation();
+				transitionStateCreationTool.performCreation(viewer);
 				setActiveTool(getDefaultTool());
 				createTransitionAndState = false;
 			}


### PR DESCRIPTION
Cause:
The mouse location was used without compensating for the current zoom level,
which resulted in incorrect coordinate calculations.

Solution:
Adjusted the coordinate calculation to account for the current zoom factor
before creating the EC state.

Testing:
- Tested state creation at 100% zoom
- Tested state creation at zoom in (150%+)
- Tested state creation at zoom out (<100%)
- Verified transitions still work correctly