### PR TITLE
Fix Struct Creation Command Handling for Member Access Pins #2156

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/VariableNodeEditPolicy.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/VariableNodeEditPolicy.java
@@ -20,7 +20,6 @@ import org.eclipse.fordiac.ide.model.commands.change.ReconnectDataConnectionComm
 import org.eclipse.fordiac.ide.model.commands.create.AbstractConnectionCreateCommand;
 import org.eclipse.fordiac.ide.model.commands.create.DataConnectionCreateCommand;
 import org.eclipse.fordiac.ide.model.commands.create.StructDataConnectionCreateCommand;
-import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableMoveFB;
 import org.eclipse.fordiac.ide.model.libraryElement.Connection;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
@@ -71,7 +70,7 @@ public class VariableNodeEditPolicy extends InterfaceElementEditPolicy {
 			// configureable F_MOVE pin use normal
 			// data connection creation
 			if (!AbstractConnectionCreateCommand.isSimpleStructPin(pin)
-					&& !(pin.getBlockFBNetworkElement() instanceof ConfigurableMoveFB)) {
+					&& !AbstractConnectionCreateCommand.isStructManipulatorDefPin(pin)) {
 				final DataConnectionCreateCommand structCmd = new DataConnectionCreateCommand(
 						connCreateCmd.getParent());
 				structCmd.setSource(connCreateCmd.getSource());

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/AbstractConnectionCreateCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/create/AbstractConnectionCreateCommand.java
@@ -294,7 +294,7 @@ public abstract class AbstractConnectionCreateCommand extends Command implements
 	 * @return true if it is a struct defining pin of a struct manipulator.
 	 */
 	public static boolean isStructManipulatorDefPin(final IInterfaceElement pin) {
-		if (!(pin instanceof VarDeclaration)) {
+		if (!(pin instanceof VarDeclaration) || pin.eContainer() instanceof VarDeclaration) {
 			return false;
 		}
 		final FBNetworkElement fbNE = pin.getBlockFBNetworkElement();


### PR DESCRIPTION
Connections between configured and unconfigured F_MOVE blocks to struct member access pins where not correctly handled.

This fix now also correctly handles if the struct member to be connected to is a struct and the F_MOVE or struct manipulator shall be configured by the connection creation.

Addresses: https://github.com/eclipse-4diac/4diac-ide/issues/2156