### PR TITLE
fix: stabilize parameterized test names in ValueConverterTest

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/StringValueConverter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/StringValueConverter.java
@@ -127,6 +127,11 @@ public final class StringValueConverter implements ValueConverter<String> {
 		return result.toString();
 	}
 
+	@Override
+	public String toString() {
+		return getClass().getSimpleName();
+	}
+
 	private static void escape(final int value, final StringBuilder result) {
 		switch (value) {
 		case '$' -> result.append("$$"); //$NON-NLS-1$

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/WStringValueConverter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/value/WStringValueConverter.java
@@ -116,6 +116,11 @@ public final class WStringValueConverter implements ValueConverter<String> {
 		return result.toString();
 	}
 
+	@Override
+	public String toString() {
+		return getClass().getSimpleName();
+	}
+
 	protected static void escape(final int value, final StringBuilder result) {
 		switch (value) {
 		case '$' -> result.append("$$"); //$NON-NLS-1$

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/value/ValueConverterTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/value/ValueConverterTest.java
@@ -39,7 +39,6 @@ import org.eclipse.fordiac.ide.model.value.StructValueConverter;
 import org.eclipse.fordiac.ide.model.value.TypedValueConverter;
 import org.eclipse.fordiac.ide.model.value.ValueConverter;
 import org.eclipse.fordiac.ide.model.value.WStringValueConverter;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -192,7 +191,6 @@ class ValueConverterTest {
 		);
 	}
 
-	@ParameterizedTest(name = "[{index}] input=''{2}'', expected=''{1}''")
 	@MethodSource
 	void toValueTest(final ValueConverter<?> converter, final Object expected, final String string) {
 		if (expected instanceof final Class<?> expectedClass && Throwable.class.isAssignableFrom(expectedClass)) {
@@ -215,7 +213,6 @@ class ValueConverterTest {
 			assertEquals(expected, converter.toValue(new Scanner(string)));
 		}
 	}
-
 
 	static Stream<Arguments> toStringTest() {
 		return Stream.of(//
@@ -288,7 +285,6 @@ class ValueConverterTest {
 		);
 	}
 
-	@ParameterizedTest(name = "[{index}] input=''{2}'', expected=''{1}''")
 	@MethodSource
 	@SuppressWarnings("unchecked")
 	<T> void toStringTest(final ValueConverter<? super T> converter, final String expected, final T value) {

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/value/ValueConverterTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/value/ValueConverterTest.java
@@ -39,6 +39,7 @@ import org.eclipse.fordiac.ide.model.value.StructValueConverter;
 import org.eclipse.fordiac.ide.model.value.TypedValueConverter;
 import org.eclipse.fordiac.ide.model.value.ValueConverter;
 import org.eclipse.fordiac.ide.model.value.WStringValueConverter;
+import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -191,6 +192,7 @@ class ValueConverterTest {
 		);
 	}
 
+	@ParameterizedTest
 	@MethodSource
 	void toValueTest(final ValueConverter<?> converter, final Object expected, final String string) {
 		if (expected instanceof final Class<?> expectedClass && Throwable.class.isAssignableFrom(expectedClass)) {
@@ -285,6 +287,7 @@ class ValueConverterTest {
 		);
 	}
 
+	@ParameterizedTest
 	@MethodSource
 	@SuppressWarnings("unchecked")
 	<T> void toStringTest(final ValueConverter<? super T> converter, final String expected, final T value) {

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/value/ValueConverterTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/value/ValueConverterTest.java
@@ -192,7 +192,7 @@ class ValueConverterTest {
 		);
 	}
 
-	@ParameterizedTest
+	@ParameterizedTest(name = "[{index}] input=''{2}'', expected=''{1}''")
 	@MethodSource
 	void toValueTest(final ValueConverter<?> converter, final Object expected, final String string) {
 		if (expected instanceof final Class<?> expectedClass && Throwable.class.isAssignableFrom(expectedClass)) {
@@ -215,6 +215,7 @@ class ValueConverterTest {
 			assertEquals(expected, converter.toValue(new Scanner(string)));
 		}
 	}
+
 
 	static Stream<Arguments> toStringTest() {
 		return Stream.of(//
@@ -287,7 +288,7 @@ class ValueConverterTest {
 		);
 	}
 
-	@ParameterizedTest
+	@ParameterizedTest(name = "[{index}] input=''{2}'', expected=''{1}''")
 	@MethodSource
 	@SuppressWarnings("unchecked")
 	<T> void toStringTest(final ValueConverter<? super T> converter, final String expected, final T value) {


### PR DESCRIPTION
Prevents GitHub PR noise where renamed tests were reported as 73 additions and 73 deletions. This was caused by the default JUnit display name including the ValueConverter's memory address (hashcode).