### PR TITLE
Provide the expected type for expressions during XMI export

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.export.xmi/model/xmiexport.ecore
+++ b/plugins/org.eclipse.fordiac.ide.export.xmi/model/xmiexport.ecore
@@ -6,7 +6,12 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="attributeValues" upperBound="-1"
         eType="#//XMIExportAttributeValue" containment="true"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="XMIExportAttributeValue">
+  <eClassifiers xsi:type="ecore:EClass" name="XMIExportAttributeValue" eSuperTypes="../../org.eclipse.fordiac.ide.structuredtextcore.model/model/STCore.ecore#//STExpectedTypeProvider">
+    <eOperations name="getExpectedType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="body" value="return attribute.getType();"/>
+      </eAnnotations>
+    </eOperations>
     <eStructuralFeatures xsi:type="ecore:EReference" name="attribute" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//Attribute"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="expression" eType="ecore:EClass ../../org.eclipse.fordiac.ide.structuredtextcore.model/model/STCore.ecore#//STInitializerExpression"
         containment="true"/>
@@ -16,7 +21,12 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="initialValues" upperBound="-1"
         eType="#//XMIExportInitialValue" containment="true"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="XMIExportInitialValue">
+  <eClassifiers xsi:type="ecore:EClass" name="XMIExportInitialValue" eSuperTypes="../../org.eclipse.fordiac.ide.structuredtextcore.model/model/STCore.ecore#//STExpectedTypeProvider">
+    <eOperations name="getExpectedType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="body" value="return org.eclipse.fordiac.ide.structuredtextcore.stcore.util.STCoreUtil.getFeatureType(variable);"/>
+      </eAnnotations>
+    </eOperations>
     <eStructuralFeatures xsi:type="ecore:EReference" name="variable" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//INamedElement"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="expression" eType="ecore:EClass ../../org.eclipse.fordiac.ide.structuredtextcore.model/model/STCore.ecore#//STInitializerExpression"
         containment="true"/>

--- a/plugins/org.eclipse.fordiac.ide.export.xmi/model/xmiexport.genmodel
+++ b/plugins/org.eclipse.fordiac.ide.export.xmi/model/xmiexport.genmodel
@@ -18,6 +18,8 @@
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference xmiexport.ecore#//XMIExportAttributeValue/attribute"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference xmiexport.ecore#//XMIExportAttributeValue/expression"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute xmiexport.ecore#//XMIExportAttributeValue/value"/>
+      <genOperations ecoreOperation="xmiexport.ecore#//XMIExportAttributeValue/getExpectedType"
+          body="return attribute.getType();"/>
     </genClasses>
     <genClasses ecoreClass="xmiexport.ecore#//XMIExportInitialValues">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference xmiexport.ecore#//XMIExportInitialValues/initialValues"/>
@@ -26,6 +28,8 @@
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference xmiexport.ecore#//XMIExportInitialValue/variable"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference xmiexport.ecore#//XMIExportInitialValue/expression"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute xmiexport.ecore#//XMIExportInitialValue/value"/>
+      <genOperations ecoreOperation="xmiexport.ecore#//XMIExportInitialValue/getExpectedType"
+          body="return org.eclipse.fordiac.ide.structuredtextcore.stcore.util.STCoreUtil.getFeatureType(variable);"/>
     </genClasses>
     <genClasses ecoreClass="xmiexport.ecore#//XMIExportTypeDeclarations">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference xmiexport.ecore#//XMIExportTypeDeclarations/typeDeclarations"/>

--- a/plugins/org.eclipse.fordiac.ide.export.xmi/src-gen/org/eclipse/fordiac/ide/xmiexport/xmiexport/XMIExportAttributeValue.java
+++ b/plugins/org.eclipse.fordiac.ide.export.xmi/src-gen/org/eclipse/fordiac/ide/xmiexport/xmiexport/XMIExportAttributeValue.java
@@ -15,10 +15,10 @@
  */
 package org.eclipse.fordiac.ide.xmiexport.xmiexport;
 
-import org.eclipse.emf.ecore.EObject;
-
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
 
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
+import org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpectedTypeProvider;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STInitializerExpression;
 
 /**
@@ -39,7 +39,7 @@ import org.eclipse.fordiac.ide.structuredtextcore.stcore.STInitializerExpression
  * @model
  * @generated
  */
-public interface XMIExportAttributeValue extends EObject {
+public interface XMIExportAttributeValue extends STExpectedTypeProvider {
 	/**
 	 * Returns the value of the '<em><b>Attribute</b></em>' reference.
 	 * <!-- begin-user-doc -->
@@ -105,5 +105,13 @@ public interface XMIExportAttributeValue extends EObject {
 	 * @generated
 	 */
 	void setValue(String value);
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @model kind="operation"
+	 * @generated
+	 */
+	LibraryElement getExpectedType();
 
 } // XMIExportAttributeValue

--- a/plugins/org.eclipse.fordiac.ide.export.xmi/src-gen/org/eclipse/fordiac/ide/xmiexport/xmiexport/XMIExportInitialValue.java
+++ b/plugins/org.eclipse.fordiac.ide.export.xmi/src-gen/org/eclipse/fordiac/ide/xmiexport/xmiexport/XMIExportInitialValue.java
@@ -15,9 +15,9 @@
  */
 package org.eclipse.fordiac.ide.xmiexport.xmiexport;
 
-import org.eclipse.emf.ecore.EObject;
-
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
+import org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpectedTypeProvider;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STInitializerExpression;
 
 /**
@@ -38,7 +38,7 @@ import org.eclipse.fordiac.ide.structuredtextcore.stcore.STInitializerExpression
  * @model
  * @generated
  */
-public interface XMIExportInitialValue extends EObject {
+public interface XMIExportInitialValue extends STExpectedTypeProvider {
 	/**
 	 * Returns the value of the '<em><b>Variable</b></em>' reference.
 	 * <!-- begin-user-doc -->
@@ -104,5 +104,13 @@ public interface XMIExportInitialValue extends EObject {
 	 * @generated
 	 */
 	void setValue(String value);
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @model kind="operation"
+	 * @generated
+	 */
+	LibraryElement getExpectedType();
 
 } // XMIExportInitialValue

--- a/plugins/org.eclipse.fordiac.ide.export.xmi/src-gen/org/eclipse/fordiac/ide/xmiexport/xmiexport/XMIExportPackage.java
+++ b/plugins/org.eclipse.fordiac.ide.export.xmi/src-gen/org/eclipse/fordiac/ide/xmiexport/xmiexport/XMIExportPackage.java
@@ -19,6 +19,7 @@ import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EReference;
+import org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage;
 
 /**
  * <!-- begin-user-doc -->
@@ -113,7 +114,7 @@ public interface XMIExportPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int XMI_EXPORT_ATTRIBUTE_VALUE__ATTRIBUTE = 0;
+	int XMI_EXPORT_ATTRIBUTE_VALUE__ATTRIBUTE = STCorePackage.ST_EXPECTED_TYPE_PROVIDER_FEATURE_COUNT + 0;
 
 	/**
 	 * The feature id for the '<em><b>Expression</b></em>' containment reference.
@@ -122,7 +123,7 @@ public interface XMIExportPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int XMI_EXPORT_ATTRIBUTE_VALUE__EXPRESSION = 1;
+	int XMI_EXPORT_ATTRIBUTE_VALUE__EXPRESSION = STCorePackage.ST_EXPECTED_TYPE_PROVIDER_FEATURE_COUNT + 1;
 
 	/**
 	 * The feature id for the '<em><b>Value</b></em>' attribute.
@@ -131,7 +132,7 @@ public interface XMIExportPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int XMI_EXPORT_ATTRIBUTE_VALUE__VALUE = 2;
+	int XMI_EXPORT_ATTRIBUTE_VALUE__VALUE = STCorePackage.ST_EXPECTED_TYPE_PROVIDER_FEATURE_COUNT + 2;
 
 	/**
 	 * The number of structural features of the '<em>Attribute Value</em>' class.
@@ -140,7 +141,7 @@ public interface XMIExportPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int XMI_EXPORT_ATTRIBUTE_VALUE_FEATURE_COUNT = 3;
+	int XMI_EXPORT_ATTRIBUTE_VALUE_FEATURE_COUNT = STCorePackage.ST_EXPECTED_TYPE_PROVIDER_FEATURE_COUNT + 3;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.xmiexport.xmiexport.impl.XMIExportInitialValuesImpl <em>Initial Values</em>}' class.
@@ -187,7 +188,7 @@ public interface XMIExportPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int XMI_EXPORT_INITIAL_VALUE__VARIABLE = 0;
+	int XMI_EXPORT_INITIAL_VALUE__VARIABLE = STCorePackage.ST_EXPECTED_TYPE_PROVIDER_FEATURE_COUNT + 0;
 
 	/**
 	 * The feature id for the '<em><b>Expression</b></em>' containment reference.
@@ -196,7 +197,7 @@ public interface XMIExportPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int XMI_EXPORT_INITIAL_VALUE__EXPRESSION = 1;
+	int XMI_EXPORT_INITIAL_VALUE__EXPRESSION = STCorePackage.ST_EXPECTED_TYPE_PROVIDER_FEATURE_COUNT + 1;
 
 	/**
 	 * The feature id for the '<em><b>Value</b></em>' attribute.
@@ -205,7 +206,7 @@ public interface XMIExportPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int XMI_EXPORT_INITIAL_VALUE__VALUE = 2;
+	int XMI_EXPORT_INITIAL_VALUE__VALUE = STCorePackage.ST_EXPECTED_TYPE_PROVIDER_FEATURE_COUNT + 2;
 
 	/**
 	 * The number of structural features of the '<em>Initial Value</em>' class.
@@ -214,7 +215,7 @@ public interface XMIExportPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int XMI_EXPORT_INITIAL_VALUE_FEATURE_COUNT = 3;
+	int XMI_EXPORT_INITIAL_VALUE_FEATURE_COUNT = STCorePackage.ST_EXPECTED_TYPE_PROVIDER_FEATURE_COUNT + 3;
 
 
 	/**

--- a/plugins/org.eclipse.fordiac.ide.export.xmi/src-gen/org/eclipse/fordiac/ide/xmiexport/xmiexport/impl/XMIExportAttributeValueImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.export.xmi/src-gen/org/eclipse/fordiac/ide/xmiexport/xmiexport/impl/XMIExportAttributeValueImpl.java
@@ -26,6 +26,7 @@ import org.eclipse.emf.ecore.impl.MinimalEObjectImpl;
 
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
 
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STInitializerExpression;
 
 import org.eclipse.fordiac.ide.xmiexport.xmiexport.XMIExportAttributeValue;
@@ -212,6 +213,16 @@ public class XMIExportAttributeValueImpl extends MinimalEObjectImpl.Container im
 		value = newValue;
 		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, XMIExportPackage.XMI_EXPORT_ATTRIBUTE_VALUE__VALUE, oldValue, value));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public LibraryElement getExpectedType() {
+		return attribute.getType();
 	}
 
 	/**

--- a/plugins/org.eclipse.fordiac.ide.export.xmi/src-gen/org/eclipse/fordiac/ide/xmiexport/xmiexport/impl/XMIExportInitialValueImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.export.xmi/src-gen/org/eclipse/fordiac/ide/xmiexport/xmiexport/impl/XMIExportInitialValueImpl.java
@@ -25,6 +25,7 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.impl.MinimalEObjectImpl;
 
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STInitializerExpression;
 
 import org.eclipse.fordiac.ide.xmiexport.xmiexport.XMIExportInitialValue;
@@ -211,6 +212,16 @@ public class XMIExportInitialValueImpl extends MinimalEObjectImpl.Container impl
 		value = newValue;
 		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, XMIExportPackage.XMI_EXPORT_INITIAL_VALUE__VALUE, oldValue, value));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public LibraryElement getExpectedType() {
+		return org.eclipse.fordiac.ide.structuredtextcore.stcore.util.STCoreUtil.getFeatureType(variable);
 	}
 
 	/**

--- a/plugins/org.eclipse.fordiac.ide.export.xmi/src-gen/org/eclipse/fordiac/ide/xmiexport/xmiexport/impl/XMIExportPackageImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.export.xmi/src-gen/org/eclipse/fordiac/ide/xmiexport/xmiexport/impl/XMIExportPackageImpl.java
@@ -481,14 +481,16 @@ public class XMIExportPackageImpl extends EPackageImpl implements XMIExportPacka
 		setNsURI(eNS_URI);
 
 		// Obtain other dependent packages
-		LibraryElementPackage theLibraryElementPackage = (LibraryElementPackage)EPackage.Registry.INSTANCE.getEPackage(LibraryElementPackage.eNS_URI);
 		STCorePackage theSTCorePackage = (STCorePackage)EPackage.Registry.INSTANCE.getEPackage(STCorePackage.eNS_URI);
+		LibraryElementPackage theLibraryElementPackage = (LibraryElementPackage)EPackage.Registry.INSTANCE.getEPackage(LibraryElementPackage.eNS_URI);
 
 		// Create type parameters
 
 		// Set bounds for type parameters
 
 		// Add supertypes to classes
+		xmiExportAttributeValueEClass.getESuperTypes().add(theSTCorePackage.getSTExpectedTypeProvider());
+		xmiExportInitialValueEClass.getESuperTypes().add(theSTCorePackage.getSTExpectedTypeProvider());
 
 		// Initialize classes and features; add operations and parameters
 		initEClass(xmiExportAttributeValuesEClass, XMIExportAttributeValues.class, "XMIExportAttributeValues", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
@@ -499,6 +501,8 @@ public class XMIExportPackageImpl extends EPackageImpl implements XMIExportPacka
 		initEReference(getXMIExportAttributeValue_Expression(), theSTCorePackage.getSTInitializerExpression(), null, "expression", null, 0, 1, XMIExportAttributeValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEAttribute(getXMIExportAttributeValue_Value(), ecorePackage.getEString(), "value", null, 0, 1, XMIExportAttributeValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
+		addEOperation(xmiExportAttributeValueEClass, theLibraryElementPackage.getLibraryElement(), "getExpectedType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+
 		initEClass(xmiExportInitialValuesEClass, XMIExportInitialValues.class, "XMIExportInitialValues", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getXMIExportInitialValues_InitialValues(), this.getXMIExportInitialValue(), null, "initialValues", null, 0, -1, XMIExportInitialValues.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
@@ -506,6 +510,8 @@ public class XMIExportPackageImpl extends EPackageImpl implements XMIExportPacka
 		initEReference(getXMIExportInitialValue_Variable(), theLibraryElementPackage.getINamedElement(), null, "variable", null, 0, 1, XMIExportInitialValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEReference(getXMIExportInitialValue_Expression(), theSTCorePackage.getSTInitializerExpression(), null, "expression", null, 0, 1, XMIExportInitialValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEAttribute(getXMIExportInitialValue_Value(), ecorePackage.getEString(), "value", null, 0, 1, XMIExportInitialValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
+
+		addEOperation(xmiExportInitialValueEClass, theLibraryElementPackage.getLibraryElement(), "getExpectedType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(xmiExportTypeDeclarationsEClass, XMIExportTypeDeclarations.class, "XMIExportTypeDeclarations", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getXMIExportTypeDeclarations_TypeDeclarations(), this.getXMIExportTypeDeclaration(), null, "typeDeclarations", null, 0, -1, XMIExportTypeDeclarations.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$

--- a/plugins/org.eclipse.fordiac.ide.export.xmi/src-gen/org/eclipse/fordiac/ide/xmiexport/xmiexport/util/XMIExportAdapterFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.export.xmi/src-gen/org/eclipse/fordiac/ide/xmiexport/xmiexport/util/XMIExportAdapterFactory.java
@@ -22,6 +22,7 @@ import org.eclipse.emf.common.notify.impl.AdapterFactoryImpl;
 
 import org.eclipse.emf.ecore.EObject;
 
+import org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpectedTypeProvider;
 import org.eclipse.fordiac.ide.xmiexport.xmiexport.*;
 
 /**
@@ -111,6 +112,10 @@ public class XMIExportAdapterFactory extends AdapterFactoryImpl {
 			@Override
 			public Adapter caseXMIExportLiteralType(XMIExportLiteralType object) {
 				return createXMIExportLiteralTypeAdapter();
+			}
+			@Override
+			public Adapter caseSTExpectedTypeProvider(STExpectedTypeProvider object) {
+				return createSTExpectedTypeProviderAdapter();
 			}
 			@Override
 			public Adapter defaultCase(EObject object) {
@@ -241,6 +246,20 @@ public class XMIExportAdapterFactory extends AdapterFactoryImpl {
 	 * @generated
 	 */
 	public Adapter createXMIExportLiteralTypeAdapter() {
+		return null;
+	}
+
+	/**
+	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpectedTypeProvider <em>ST Expected Type Provider</em>}'.
+	 * <!-- begin-user-doc -->
+	 * This default implementation returns null so that we can easily ignore cases;
+	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
+	 * <!-- end-user-doc -->
+	 * @return the new adapter.
+	 * @see org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpectedTypeProvider
+	 * @generated
+	 */
+	public Adapter createSTExpectedTypeProviderAdapter() {
 		return null;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.export.xmi/src-gen/org/eclipse/fordiac/ide/xmiexport/xmiexport/util/XMIExportSwitch.java
+++ b/plugins/org.eclipse.fordiac.ide.export.xmi/src-gen/org/eclipse/fordiac/ide/xmiexport/xmiexport/util/XMIExportSwitch.java
@@ -20,6 +20,7 @@ import org.eclipse.emf.ecore.EPackage;
 
 import org.eclipse.emf.ecore.util.Switch;
 
+import org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpectedTypeProvider;
 import org.eclipse.fordiac.ide.xmiexport.xmiexport.*;
 
 /**
@@ -88,6 +89,7 @@ public class XMIExportSwitch<T> extends Switch<T> {
 			case XMIExportPackage.XMI_EXPORT_ATTRIBUTE_VALUE: {
 				XMIExportAttributeValue xmiExportAttributeValue = (XMIExportAttributeValue)theEObject;
 				T result = caseXMIExportAttributeValue(xmiExportAttributeValue);
+				if (result == null) result = caseSTExpectedTypeProvider(xmiExportAttributeValue);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -100,6 +102,7 @@ public class XMIExportSwitch<T> extends Switch<T> {
 			case XMIExportPackage.XMI_EXPORT_INITIAL_VALUE: {
 				XMIExportInitialValue xmiExportInitialValue = (XMIExportInitialValue)theEObject;
 				T result = caseXMIExportInitialValue(xmiExportInitialValue);
+				if (result == null) result = caseSTExpectedTypeProvider(xmiExportInitialValue);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -248,6 +251,21 @@ public class XMIExportSwitch<T> extends Switch<T> {
 	 * @generated
 	 */
 	public T caseXMIExportLiteralType(XMIExportLiteralType object) {
+		return null;
+	}
+
+	/**
+	 * Returns the result of interpreting the object as an instance of '<em>ST Expected Type Provider</em>'.
+	 * <!-- begin-user-doc -->
+	 * This implementation returns null;
+	 * returning a non-null result will terminate the switch.
+	 * <!-- end-user-doc -->
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>ST Expected Type Provider</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
+	public T caseSTExpectedTypeProvider(STExpectedTypeProvider object) {
 		return null;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/model/STCore.ecore
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/model/STCore.ecore
@@ -661,6 +661,10 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="initializerExpression"
         eType="#//STInitializerExpression" containment="true"/>
   </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="STExpectedTypeProvider" abstract="true"
+      interface="true">
+    <eOperations name="getExpectedType" eType="ecore:EClass ../../org.eclipse.fordiac.ide.model/model/lib.ecore#//LibraryElement"/>
+  </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="STJavaMethod" instanceClassName="java.lang.reflect.Method"
       serializable="false"/>
 </ecore:EPackage>

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/model/STCore.genmodel
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/model/STCore.genmodel
@@ -393,5 +393,8 @@
     <genClasses ecoreClass="STCore.ecore#//STInitializerExpressionSource">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference STCore.ecore#//STInitializerExpressionSource/initializerExpression"/>
     </genClasses>
+    <genClasses image="false" ecoreClass="STCore.ecore#//STExpectedTypeProvider">
+      <genOperations ecoreOperation="STCore.ecore#//STExpectedTypeProvider/getExpectedType"/>
+    </genClasses>
   </genPackages>
 </genmodel:GenModel>

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STCorePackage.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STCorePackage.java
@@ -2283,6 +2283,25 @@ public interface STCorePackage extends EPackage {
 	int ST_INITIALIZER_EXPRESSION_SOURCE_FEATURE_COUNT = ST_SOURCE_FEATURE_COUNT + 1;
 
 	/**
+	 * The meta object id for the '{@link org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpectedTypeProvider <em>ST Expected Type Provider</em>}' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpectedTypeProvider
+	 * @see org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.STCorePackageImpl#getSTExpectedTypeProvider()
+	 * @generated
+	 */
+	int ST_EXPECTED_TYPE_PROVIDER = 58;
+
+	/**
+	 * The number of structural features of the '<em>ST Expected Type Provider</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int ST_EXPECTED_TYPE_PROVIDER_FEATURE_COUNT = 0;
+
+	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.structuredtextcore.stcore.STBinaryOperator <em>ST Binary Operator</em>}' enum.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -2290,7 +2309,7 @@ public interface STCorePackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.STCorePackageImpl#getSTBinaryOperator()
 	 * @generated
 	 */
-	int ST_BINARY_OPERATOR = 58;
+	int ST_BINARY_OPERATOR = 59;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.structuredtextcore.stcore.STUnaryOperator <em>ST Unary Operator</em>}' enum.
@@ -2300,7 +2319,7 @@ public interface STCorePackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.STCorePackageImpl#getSTUnaryOperator()
 	 * @generated
 	 */
-	int ST_UNARY_OPERATOR = 59;
+	int ST_UNARY_OPERATOR = 60;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.structuredtextcore.stcore.STMultiBitAccessSpecifier <em>ST Multi Bit Access Specifier</em>}' enum.
@@ -2310,7 +2329,7 @@ public interface STCorePackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.STCorePackageImpl#getSTMultiBitAccessSpecifier()
 	 * @generated
 	 */
-	int ST_MULTI_BIT_ACCESS_SPECIFIER = 60;
+	int ST_MULTI_BIT_ACCESS_SPECIFIER = 61;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.structuredtextcore.stcore.STBuiltinFeature <em>ST Builtin Feature</em>}' enum.
@@ -2320,7 +2339,7 @@ public interface STCorePackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.STCorePackageImpl#getSTBuiltinFeature()
 	 * @generated
 	 */
-	int ST_BUILTIN_FEATURE = 61;
+	int ST_BUILTIN_FEATURE = 62;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.structuredtextcore.stcore.STAccessSpecifier <em>ST Access Specifier</em>}' enum.
@@ -2330,7 +2349,7 @@ public interface STCorePackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.STCorePackageImpl#getSTAccessSpecifier()
 	 * @generated
 	 */
-	int ST_ACCESS_SPECIFIER = 62;
+	int ST_ACCESS_SPECIFIER = 63;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.structuredtextcore.stcore.STCommentPosition <em>ST Comment Position</em>}' enum.
@@ -2340,7 +2359,7 @@ public interface STCorePackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.STCorePackageImpl#getSTCommentPosition()
 	 * @generated
 	 */
-	int ST_COMMENT_POSITION = 63;
+	int ST_COMMENT_POSITION = 64;
 
 	/**
 	 * The meta object id for the '<em>ST Date</em>' data type.
@@ -2350,7 +2369,7 @@ public interface STCorePackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.STCorePackageImpl#getSTDate()
 	 * @generated
 	 */
-	int ST_DATE = 64;
+	int ST_DATE = 65;
 
 	/**
 	 * The meta object id for the '<em>ST Time</em>' data type.
@@ -2360,7 +2379,7 @@ public interface STCorePackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.STCorePackageImpl#getSTTime()
 	 * @generated
 	 */
-	int ST_TIME = 65;
+	int ST_TIME = 66;
 
 	/**
 	 * The meta object id for the '<em>ST Time Of Day</em>' data type.
@@ -2370,7 +2389,7 @@ public interface STCorePackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.STCorePackageImpl#getSTTimeOfDay()
 	 * @generated
 	 */
-	int ST_TIME_OF_DAY = 66;
+	int ST_TIME_OF_DAY = 67;
 
 	/**
 	 * The meta object id for the '<em>ST Date And Time</em>' data type.
@@ -2380,7 +2399,7 @@ public interface STCorePackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.STCorePackageImpl#getSTDateAndTime()
 	 * @generated
 	 */
-	int ST_DATE_AND_TIME = 67;
+	int ST_DATE_AND_TIME = 68;
 
 	/**
 	 * The meta object id for the '<em>ST String</em>' data type.
@@ -2390,7 +2409,7 @@ public interface STCorePackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.STCorePackageImpl#getSTString()
 	 * @generated
 	 */
-	int ST_STRING = 68;
+	int ST_STRING = 69;
 
 	/**
 	 * The meta object id for the '<em>ST Java Method</em>' data type.
@@ -2400,7 +2419,7 @@ public interface STCorePackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.STCorePackageImpl#getSTJavaMethod()
 	 * @generated
 	 */
-	int ST_JAVA_METHOD = 69;
+	int ST_JAVA_METHOD = 70;
 
 	/**
 	 * Returns the meta object for class '{@link org.eclipse.fordiac.ide.structuredtextcore.stcore.STSource <em>ST Source</em>}'.
@@ -4105,6 +4124,16 @@ public interface STCorePackage extends EPackage {
 	EReference getSTInitializerExpressionSource_InitializerExpression();
 
 	/**
+	 * Returns the meta object for class '{@link org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpectedTypeProvider <em>ST Expected Type Provider</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for class '<em>ST Expected Type Provider</em>'.
+	 * @see org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpectedTypeProvider
+	 * @generated
+	 */
+	EClass getSTExpectedTypeProvider();
+
+	/**
 	 * Returns the meta object for enum '{@link org.eclipse.fordiac.ide.structuredtextcore.stcore.STBinaryOperator <em>ST Binary Operator</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -5647,6 +5676,16 @@ public interface STCorePackage extends EPackage {
 		 * @generated
 		 */
 		EReference ST_INITIALIZER_EXPRESSION_SOURCE__INITIALIZER_EXPRESSION = eINSTANCE.getSTInitializerExpressionSource_InitializerExpression();
+
+		/**
+		 * The meta object literal for the '{@link org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpectedTypeProvider <em>ST Expected Type Provider</em>}' class.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @see org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpectedTypeProvider
+		 * @see org.eclipse.fordiac.ide.structuredtextcore.stcore.impl.STCorePackageImpl#getSTExpectedTypeProvider()
+		 * @generated
+		 */
+		EClass ST_EXPECTED_TYPE_PROVIDER = eINSTANCE.getSTExpectedTypeProvider();
 
 		/**
 		 * The meta object literal for the '{@link org.eclipse.fordiac.ide.structuredtextcore.stcore.STBinaryOperator <em>ST Binary Operator</em>}' enum.

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STExpectedTypeProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/STExpectedTypeProvider.java
@@ -1,0 +1,42 @@
+/**
+ * *******************************************************************************
+ * Copyright (c) 2022 Primetals Technologies GmbH,
+ *               2022 Martin Erich Jobst
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Martin Jobst, Martin Melik Merkumians
+ *      - initial API and implementation and/or initial documentation
+ * *******************************************************************************
+ */
+package org.eclipse.fordiac.ide.structuredtextcore.stcore;
+
+import org.eclipse.emf.ecore.EObject;
+
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the model object '<em><b>ST Expected Type Provider</b></em>'.
+ * <!-- end-user-doc -->
+ *
+ *
+ * @see org.eclipse.fordiac.ide.structuredtextcore.stcore.STCorePackage#getSTExpectedTypeProvider()
+ * @model interface="true" abstract="true"
+ * @generated
+ */
+public interface STExpectedTypeProvider extends EObject {
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @model kind="operation"
+	 * @generated
+	 */
+	LibraryElement getExpectedType();
+
+} // STExpectedTypeProvider

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STCorePackageImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/STCorePackageImpl.java
@@ -67,6 +67,7 @@ import org.eclipse.fordiac.ide.structuredtextcore.stcore.STElseIfPart;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STElsePart;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STEnumLiteral;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STExit;
+import org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpectedTypeProvider;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpression;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpressionSource;
 import org.eclipse.fordiac.ide.structuredtextcore.stcore.STFeatureExpression;
@@ -518,6 +519,13 @@ public class STCorePackageImpl extends EPackageImpl implements STCorePackage {
 	 * @generated
 	 */
 	private EClass stInitializerExpressionSourceEClass = null;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private EClass stExpectedTypeProviderEClass = null;
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -2274,6 +2282,16 @@ public class STCorePackageImpl extends EPackageImpl implements STCorePackage {
 	 * @generated
 	 */
 	@Override
+	public EClass getSTExpectedTypeProvider() {
+		return stExpectedTypeProviderEClass;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public EEnum getSTBinaryOperator() {
 		return stBinaryOperatorEEnum;
 	}
@@ -2634,6 +2652,8 @@ public class STCorePackageImpl extends EPackageImpl implements STCorePackage {
 
 		stInitializerExpressionSourceEClass = createEClass(ST_INITIALIZER_EXPRESSION_SOURCE);
 		createEReference(stInitializerExpressionSourceEClass, ST_INITIALIZER_EXPRESSION_SOURCE__INITIALIZER_EXPRESSION);
+
+		stExpectedTypeProviderEClass = createEClass(ST_EXPECTED_TYPE_PROVIDER);
 
 		// Create enums
 		stBinaryOperatorEEnum = createEEnum(ST_BINARY_OPERATOR);
@@ -3113,6 +3133,10 @@ public class STCorePackageImpl extends EPackageImpl implements STCorePackage {
 
 		initEClass(stInitializerExpressionSourceEClass, STInitializerExpressionSource.class, "STInitializerExpressionSource", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getSTInitializerExpressionSource_InitializerExpression(), this.getSTInitializerExpression(), null, "initializerExpression", null, 0, 1, STInitializerExpressionSource.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
+
+		initEClass(stExpectedTypeProviderEClass, STExpectedTypeProvider.class, "STExpectedTypeProvider", IS_ABSTRACT, IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
+
+		addEOperation(stExpectedTypeProviderEClass, theLibraryElementPackage.getLibraryElement(), "getExpectedType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		// Initialize enums and add enum literals
 		initEEnum(stBinaryOperatorEEnum, STBinaryOperator.class, "STBinaryOperator"); //$NON-NLS-1$

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/util/STCoreAdapterFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/util/STCoreAdapterFactory.java
@@ -319,6 +319,10 @@ public class STCoreAdapterFactory extends AdapterFactoryImpl {
 				return createSTInitializerExpressionSourceAdapter();
 			}
 			@Override
+			public Adapter caseSTExpectedTypeProvider(STExpectedTypeProvider object) {
+				return createSTExpectedTypeProviderAdapter();
+			}
+			@Override
 			public Adapter caseImport(Import object) {
 				return createImportAdapter();
 			}
@@ -1163,6 +1167,20 @@ public class STCoreAdapterFactory extends AdapterFactoryImpl {
 	 * @generated
 	 */
 	public Adapter createSTInitializerExpressionSourceAdapter() {
+		return null;
+	}
+
+	/**
+	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpectedTypeProvider <em>ST Expected Type Provider</em>}'.
+	 * <!-- begin-user-doc -->
+	 * This default implementation returns null so that we can easily ignore cases;
+	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
+	 * <!-- end-user-doc -->
+	 * @return the new adapter.
+	 * @see org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpectedTypeProvider
+	 * @generated
+	 */
+	public Adapter createSTExpectedTypeProviderAdapter() {
 		return null;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/util/STCoreSwitch.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src-gen/org/eclipse/fordiac/ide/structuredtextcore/stcore/util/STCoreSwitch.java
@@ -494,6 +494,12 @@ public class STCoreSwitch<T> extends Switch<T> {
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
+			case STCorePackage.ST_EXPECTED_TYPE_PROVIDER: {
+				STExpectedTypeProvider stExpectedTypeProvider = (STExpectedTypeProvider)theEObject;
+				T result = caseSTExpectedTypeProvider(stExpectedTypeProvider);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
 			default: return defaultCase(theEObject);
 		}
 	}
@@ -1365,6 +1371,21 @@ public class STCoreSwitch<T> extends Switch<T> {
 	 * @generated
 	 */
 	public T caseSTInitializerExpressionSource(STInitializerExpressionSource object) {
+		return null;
+	}
+
+	/**
+	 * Returns the result of interpreting the object as an instance of '<em>ST Expected Type Provider</em>'.
+	 * <!-- begin-user-doc -->
+	 * This implementation returns null;
+	 * returning a non-null result will terminate the switch.
+	 * <!-- end-user-doc -->
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>ST Expected Type Provider</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
+	public T caseSTExpectedTypeProvider(STExpectedTypeProvider object) {
 		return null;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/util/STCoreUtil.xtend
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/util/STCoreUtil.xtend
@@ -116,6 +116,7 @@ import org.eclipse.fordiac.ide.structuredtextcore.stcore.STWhileStatement
 
 import static extension org.eclipse.emf.ecore.util.EcoreUtil.copy
 import static extension org.eclipse.fordiac.ide.model.eval.function.Functions.*
+import org.eclipse.fordiac.ide.structuredtextcore.stcore.STExpectedTypeProvider
 
 final class STCoreUtil {
 	static final LoadingCache<Pair<DataType, String>, DataType> TYPE_DECLARATION_CACHE = CacheBuilder.newBuilder.
@@ -383,6 +384,8 @@ final class STCoreUtil {
 				variable.featureType
 			STCallArgument:
 				computeExpectedType
+			STExpectedTypeProvider:
+				expectedType
 			STExpressionSource:
 				(eResource as STResource).expectedType
 		}
@@ -401,6 +404,8 @@ final class STCoreUtil {
 			STArrayInitializerExpression:
 				expectedType
 			STStructInitializerExpression:
+				expectedType
+			STExpectedTypeProvider:
 				expectedType
 			STInitializerExpressionSource:
 				(eResource as STResource).expectedType
@@ -516,7 +521,7 @@ final class STCoreUtil {
 				val type = switch (type: feature.type) {
 					AnyStringType case feature.maxLength instanceof STNumericLiteral:
 						type.newStringType(feature.maxLength.asConstantInt)
-					DataType:
+					default:
 						type
 				}
 				if (feature.array)
@@ -531,6 +536,8 @@ final class STCoreUtil {
 			}
 			AdapterDeclaration:
 				feature.adapterFB?.type
+			DirectlyDerivedType:
+				feature.baseType
 			ITypedElement:
 				feature.type
 			default:


### PR DESCRIPTION
This ensures that (initializer) expressions will have the correct expected type during XMI export.