### PR TITLE
[ECC] Fix zoom-aware coordinate translation in NewStateAction

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/actions/NewStateAction.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/actions/NewStateAction.java
@@ -17,13 +17,14 @@ import org.eclipse.draw2d.FigureCanvas;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.Messages;
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.commands.CreateECStateCommand;
-import org.eclipse.fordiac.ide.fbtypeeditor.ecc.editors.ECCEditor;
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.editors.StateCreationFactory;
 import org.eclipse.fordiac.ide.model.CoordinateConverter;
+import org.eclipse.fordiac.ide.model.libraryElement.ECC;
 import org.eclipse.fordiac.ide.model.libraryElement.ECState;
 import org.eclipse.fordiac.ide.model.libraryElement.Position;
 import org.eclipse.fordiac.ide.ui.imageprovider.FordiacImage;
-import org.eclipse.gef.editparts.ZoomManager;
+import org.eclipse.gef.GraphicalEditPart;
+import org.eclipse.gef.GraphicalViewer;
 import org.eclipse.gef.ui.actions.WorkbenchPartAction;
 import org.eclipse.ui.IWorkbenchPart;
 
@@ -38,7 +39,6 @@ public class NewStateAction extends WorkbenchPartAction {
 	private static StateCreationFactory stateFactory = new StateCreationFactory();
 	private FigureCanvas viewerControl;
 	private org.eclipse.swt.graphics.Point pos = new org.eclipse.swt.graphics.Point(0, 0);
-	private ZoomManager zoomManager;
 
 	public NewStateAction(final IWorkbenchPart part) {
 		super(part);
@@ -54,10 +54,6 @@ public class NewStateAction extends WorkbenchPartAction {
 		}
 	}
 
-	public void setZoomManager(final ZoomManager zoomManager) {
-		this.zoomManager = zoomManager;
-	}
-
 	@Override
 	protected boolean calculateEnabled() {
 		return true; // we can always be enabled
@@ -65,18 +61,19 @@ public class NewStateAction extends WorkbenchPartAction {
 
 	@Override
 	public void run() {
-		final ECCEditor editor = (ECCEditor) getWorkbenchPart();
+		final GraphicalViewer viewer = getWorkbenchPart().getAdapter(GraphicalViewer.class);
+		final ECC ecc = getWorkbenchPart().getAdapter(ECC.class);
+		final Point clickPos = new Point(pos.x, pos.y);
 
-		final Point location = viewerControl.getViewport().getViewLocation();
-		final Point realPos = new Point(pos.x + location.x, pos.y + location.y);
-		realPos.scale(1.0 / zoomManager.getZoom());
+		if (viewer != null && ecc != null) {
+			final Object eccEditPart = viewer.getEditPartRegistry().get(ecc);
+			if (eccEditPart instanceof final GraphicalEditPart gep) {
+				gep.getFigure().translateToRelative(clickPos);
+			}
+		}
 
 		final ECState model = (ECState) stateFactory.getNewObject();
-
-		final Position posModel = CoordinateConverter.INSTANCE.createPosFromScreenCoordinates(realPos.x, realPos.y);
-
-		execute(new CreateECStateCommand(model, posModel, editor.getModel()));
-
-		editor.outlineSelectionChanged(model);
+		final Position posModel = CoordinateConverter.INSTANCE.createPosFromScreenCoordinates(clickPos.x, clickPos.y);
+		execute(new CreateECStateCommand(model, posModel, ecc));
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editors/ECCEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editors/ECCEditor.java
@@ -126,7 +126,6 @@ public class ECCEditor extends DiagramEditorWithFlyoutPalette implements IFBTEdi
 		// position for state creation
 		final IAction action = getActionRegistry().getAction(NewStateAction.CREATE_STATE);
 		((NewStateAction) action).setViewerControl((FigureCanvas) viewer.getControl());
-		((NewStateAction) action).setZoomManager(getZoomManger());
 	}
 
 	@Override


### PR DESCRIPTION
Fix coordinate translation when creating ECC states via right-click context menu with zoom enabled.

Previously, the code manually calculated diagram coordinates using viewport 
offset and zoom factor (getViewLocation() + scale(1/zoom)). This caused newly 
created states to appear at incorrect positions when the canvas was zoomed.

The fix uses GEF's built-in translateToRelative() method on the ECC EditPart's 
figure, which correctly handles zoom, viewport offset, and scrolling. The ECC 
EditPart is looked up from the viewer's edit part registry via the IAdaptable 
interface, avoiding any direct dependency on editor internals.

Affected: NewStateAction.run()