### PR TITLE
Use recursive constructor for replay debugging

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/simulator/interpreter/ResourceExecutor.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/simulator/interpreter/ResourceExecutor.java
@@ -45,7 +45,7 @@ public class ResourceExecutor {
 
 	public ResourceExecutor(final Resource resource) {
 
-		final FBNetworkRuntime networkRuntime = RuntimeFactory.createFrom(resource.getFBNetwork());
+		final FBNetworkRuntime networkRuntime = RuntimeFactory.createRecursiveFrom(resource.getFBNetwork());
 		networkRuntimeInspector = new NetworkRuntimeInspector(networkRuntime, Utils.getDeviceResourcePrefix(resource));
 
 		eventManagerProcessor = new EventManagerProcessor(EventManagerFactory.createFrom(List.of()), networkRuntime);


### PR DESCRIPTION
The replay debugging mechanism expect all the runtimes to exist when starting