### PR TITLE
Remove instantiation of runtimes outside of the functionality

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/FBNetworkDefaultInterpreter.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/FBNetworkDefaultInterpreter.java
@@ -42,23 +42,22 @@ public class FBNetworkDefaultInterpreter extends FBWithNetworkDefaultInterpreter
 			return switchNetwork(eventOccurrence.getEvent(), EcoreUtil.copy(fBNetworkRuntime));
 		}
 		if (eventOccurrence.getParentFB() instanceof final UntypedSubApp uSubApp) {
-			return new UntypedSubApplicationDefaultInterpreter(eventOccurrence).run(fBNetworkRuntime, uSubApp);
+			return new UntypedSubApplicationDefaultInterpreter(eventOccurrence, uSubApp).run(fBNetworkRuntime);
 		}
 
-		// run FB Type to get the output events for the instance in the network
-		FBRuntimeAbstract runtime = fBNetworkRuntime.getTypeRuntimes().get(eventOccurrence.getParentFB());
-		if (runtime == null) {
-			final FBType copiedType = EcoreUtil.copy(eventOccurrence.getParentFB().getType());
-			runtime = RuntimeFactory.createFrom(copiedType);
-			fBNetworkRuntime.getTypeRuntimes().put(eventOccurrence.getParentFB(), runtime);
-		}
+		final FBRuntimeAbstract runtime = RuntimeFactory.getOrCreateRuntime(fBNetworkRuntime,
+				eventOccurrence.getParentFB());
 
 		// sampling input & writing output is special for composite types
 		if (runtime instanceof final CompositeFBTypeRuntime compTypeRT) {
 			if (compTypeRT.getNetworkRuntime().getOuterNetworkRuntime() == null) {
+				// TODO: won't this move the fBNetworkRuntime from a possible
+				// composite/network parent runtime of it? or do we need to create a copy of it?
 				compTypeRT.getNetworkRuntime().setOuterNetworkRuntime(fBNetworkRuntime);
 				// put the composite runtime into the inner network, so we will find our way
 				// back to the outer network
+				// TODO: At this point compTypeRT is inside fBNetworkRuntime.getTypeRuntimes(),
+				// won't this move the compTypeRT from it?
 				compTypeRT.getNetworkRuntime().getTypeRuntimes().put(eventOccurrence.getParentFB(), compTypeRT);
 			}
 			return DefaultRunFBType.runFBType(runtime, eventOccurrence);
@@ -215,7 +214,7 @@ public class FBNetworkDefaultInterpreter extends FBWithNetworkDefaultInterpreter
 		if (!(dest instanceof Event)) {
 			throw new IllegalArgumentException("cannot trigger FB with pin " + dest.getName()); //$NON-NLS-1$
 		}
-		final EventOccurrence destEO = EventOccFactory.createFrom((Event) dest, null);
+		final EventOccurrence destEO = EventOccFactory.createFrom((Event) dest);
 
 		// if the destination EO does not have a parent, it might be the outgoing
 		// connection for the network inside a composite

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/FBNetworkDefaultInterpreter.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/FBNetworkDefaultInterpreter.java
@@ -51,13 +51,9 @@ public class FBNetworkDefaultInterpreter extends FBWithNetworkDefaultInterpreter
 		// sampling input & writing output is special for composite types
 		if (runtime instanceof final CompositeFBTypeRuntime compTypeRT) {
 			if (compTypeRT.getNetworkRuntime().getOuterNetworkRuntime() == null) {
-				// TODO: won't this move the fBNetworkRuntime from a possible
-				// composite/network parent runtime of it? or do we need to create a copy of it?
 				compTypeRT.getNetworkRuntime().setOuterNetworkRuntime(fBNetworkRuntime);
 				// put the composite runtime into the inner network, so we will find our way
 				// back to the outer network
-				// TODO: At this point compTypeRT is inside fBNetworkRuntime.getTypeRuntimes(),
-				// won't this move the compTypeRT from it?
 				compTypeRT.getNetworkRuntime().getTypeRuntimes().put(eventOccurrence.getParentFB(), compTypeRT);
 			}
 			return DefaultRunFBType.runFBType(runtime, eventOccurrence);

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/FBWithNetworkDefaultInterpreter.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/FBWithNetworkDefaultInterpreter.java
@@ -64,14 +64,15 @@ public class FBWithNetworkDefaultInterpreter {
 	}
 
 	protected static IInterfaceElement getEquivalentNetworkPin(final FBNetworkRuntime runtime,
-			final FBNetworkElement parentFB, final VarDeclaration pin) {
+			final FBNetworkElement parentFB, final IInterfaceElement pin) {
 		final var equivalentFb = runtime.getFbnetwork().getFBNamed(parentFB.getName());
 		return InterfacePinUtils.findPinInInterface(equivalentFb, pin);
 	}
 
 	protected EList<EventOccurrence> switchNetwork(final Event event, final FBNetworkRuntime runtime) {
 		final EList<Connection> outputs = ConnectionUtils.getOutputConnections(event);
-		final EventOccurrence outputEO = EventOccFactory.createFrom(eventOccurrence.getEvent(), runtime);
+		final EventOccurrence outputEO = EventOccFactory.createFrom(eventOccurrence.getEvent(),
+				EcoreUtil.copy(runtime));
 		for (final Connection conn : outputs) {
 			// add transactions
 			final EventConnection eventConn = (EventConnection) conn;

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/FBWithNetworkDefaultInterpreter.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/FBWithNetworkDefaultInterpreter.java
@@ -71,8 +71,7 @@ public class FBWithNetworkDefaultInterpreter {
 
 	protected EList<EventOccurrence> switchNetwork(final Event event, final FBNetworkRuntime runtime) {
 		final EList<Connection> outputs = ConnectionUtils.getOutputConnections(event);
-		final EventOccurrence outputEO = EventOccFactory.createFrom(eventOccurrence.getEvent(),
-				EcoreUtil.copy(runtime));
+		final EventOccurrence outputEO = EventOccFactory.createFrom(eventOccurrence.getEvent(), runtime);
 		for (final Connection conn : outputs) {
 			// add transactions
 			final EventConnection eventConn = (EventConnection) conn;

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/UntypedSubApplicationDefaultInterpreter.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/UntypedSubApplicationDefaultInterpreter.java
@@ -9,27 +9,23 @@ import org.eclipse.fordiac.ide.model.libraryElement.UntypedSubApp;
 
 public class UntypedSubApplicationDefaultInterpreter extends FBWithNetworkDefaultInterpreter {
 
-	public UntypedSubApplicationDefaultInterpreter(final EventOccurrence eventOccurrence) {
+	private final UntypedSubApp uSubApp;
+
+	public UntypedSubApplicationDefaultInterpreter(final EventOccurrence eventOccurrence, final UntypedSubApp uSubApp) {
 		super(eventOccurrence);
+		this.uSubApp = uSubApp;
 	}
 
-	public EList<EventOccurrence> run(final FBNetworkRuntime fBNetworkRuntime, final UntypedSubApp uSubApp) {
+	public EList<EventOccurrence> run(final FBNetworkRuntime fBNetworkRuntime) {
+
 		FBNetworkRuntime runtime;
+
 		if (InterfacePinUtils.isInput(eventOccurrence.getEvent())) { // we are entering the inner SubApp network
-			// try to get existing network runtime for this SubApp or create new
-			runtime = (FBNetworkRuntime) fBNetworkRuntime.getTypeRuntimes().get(uSubApp);
-			if (runtime == null) {
-				runtime = RuntimeFactory.createFrom(uSubApp.getSubAppNetwork());
-				runtime.setOuterNetworkRuntime(fBNetworkRuntime);
-				fBNetworkRuntime.getTypeRuntimes().put(uSubApp, runtime);
-			}
+			runtime = RuntimeFactory.getOrCreateNetworkRuntime(fBNetworkRuntime, uSubApp);
 		} else { // we are leaving the inner SubApp network
-			runtime = fBNetworkRuntime.getOuterNetworkRuntime();
-			// can still be null if we started the trace in the inner network
-			if (runtime == null) {
-				runtime = RuntimeFactory.createFrom(uSubApp.getFbNetwork());
-			}
+			runtime = RuntimeFactory.getOrCreateOuterNetworkRuntime(fBNetworkRuntime, uSubApp);
 		}
+
 		return switchNetwork(eventOccurrence.getEvent(), runtime);
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/api/RuntimeFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/api/RuntimeFactory.java
@@ -147,8 +147,6 @@ public final class RuntimeFactory {
 		}
 
 		runtime = RuntimeFactory.createFrom(uSubApp.getSubAppNetwork());
-		// TODO: won't this move the fBNetworkRuntime from a possible
-		// composite/network parent runtime of it? or do we need to create a copy of it?
 		runtime.setOuterNetworkRuntime(fBNetworkRuntime);
 		fBNetworkRuntime.getTypeRuntimes().put(uSubApp, runtime);
 		return runtime;

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/api/RuntimeFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/api/RuntimeFactory.java
@@ -124,6 +124,47 @@ public final class RuntimeFactory {
 		return networkRT;
 	}
 
+	public static FBRuntimeAbstract getOrCreateRuntime(final FBNetworkRuntime fBNetworkRuntime,
+			final FBNetworkElement element) {
+		FBRuntimeAbstract runtime = fBNetworkRuntime.getTypeRuntimes().get(element);
+		if (runtime != null) {
+			return runtime;
+		}
+
+		final FBType copiedType = EcoreUtil.copy(element.getType());
+		runtime = RuntimeFactory.createFrom(copiedType);
+		fBNetworkRuntime.getTypeRuntimes().put(element, runtime);
+
+		return runtime;
+	}
+
+	public static FBNetworkRuntime getOrCreateNetworkRuntime(final FBNetworkRuntime fBNetworkRuntime,
+			final UntypedSubApp uSubApp) {
+
+		FBNetworkRuntime runtime = (FBNetworkRuntime) fBNetworkRuntime.getTypeRuntimes().get(uSubApp);
+		if (runtime != null) {
+			return runtime;
+		}
+
+		runtime = RuntimeFactory.createFrom(uSubApp.getSubAppNetwork());
+		// TODO: won't this move the fBNetworkRuntime from a possible
+		// composite/network parent runtime of it? or do we need to create a copy of it?
+		runtime.setOuterNetworkRuntime(fBNetworkRuntime);
+		fBNetworkRuntime.getTypeRuntimes().put(uSubApp, runtime);
+		return runtime;
+	}
+
+	public static FBNetworkRuntime getOrCreateOuterNetworkRuntime(final FBNetworkRuntime fBNetworkRuntime,
+			final UntypedSubApp uSubApp) {
+
+		FBNetworkRuntime runtime = fBNetworkRuntime.getOuterNetworkRuntime();
+		// can still be null if we started the trace in the inner network
+		if (runtime == null) {
+			runtime = RuntimeFactory.createFrom(uSubApp.getFbNetwork());
+		}
+		return runtime;
+	}
+
 	private static void createInternalRuntimes(final FBNetworkRuntime containerRuntime) {
 		containerRuntime.getFbnetwork().getBlockFBNetworkElements().forEach(networkElement -> {
 


### PR DESCRIPTION
This PR started as runtimes were slipping away from my interpreter, so I moved the creation of runtimes out of the functionality into three functions:

`FBRuntimeAbstract getOrCreateRuntime(final FBNetworkRuntime fBNetworkRuntime, final FBNetworkElement element)`
`FBNetworkRuntime getOrCreateNetworkRuntime(final FBNetworkRuntime fBNetworkRuntime, final UntypedSubApp uSubApp)`
`FBNetworkRuntime getOrCreateOuterNetworkRuntime(final FBNetworkRuntime fBNetworkRuntime, final UntypedSubApp uSubApp) `

I let a comment on the only line that's actually changing the behaviour, where a copy of the runtime is assigned instead of the actual runtime.

I also left comments on places where I think runtimes will be moving out from network runtimes. The example I have is an application which has a SubAppliacation and inside the SubApplication there's a composite FB. So I have:
- Network runtime -> App
- Network Runtime -> SubApp
- Network Runtime -> CFB
- Other runtimes

Image this scenario when reading the TODO comments