### PR TITLE
Deactivate Affected Type search on Type Save

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.typeeditor/src/org/eclipse/fordiac/ide/typeeditor/AbstractTypeEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.typeeditor/src/org/eclipse/fordiac/ide/typeeditor/AbstractTypeEditor.java
@@ -193,26 +193,26 @@ public abstract class AbstractTypeEditor extends AbstractCloseAbleFormEditor
 				doSaveAs();
 				return;
 			}
-			int result = DEFAULT_BUTTON_INDEX;
-			try {
-				if (dependencyAffectingTypeChange()) {
-					result = createTypeUpdateDialog().open();
-				}
-			} catch (final Exception e) {
-				FordiacLogHelper.logError(e.getMessage(), e);
-			}
-
-			switch (result) {
-			case DEFAULT_BUTTON_INDEX:
-				doSaveInternal(monitor);
-				break;
-			case CANCEL_BUTTON_INDEX:
-				MessageDialog.openInformation(null, Messages.TypeEditor_WarningDialog_Headline,
-						Messages.TypeEditor_WarningDialog_NotSaved);
-				break;
-			default:
-				break;
-			}
+//			int result = DEFAULT_BUTTON_INDEX;
+//			try {
+//				if (dependencyAffectingTypeChange()) {
+//					result = createTypeUpdateDialog().open();
+//				}
+//			} catch (final Exception e) {
+//				FordiacLogHelper.logError(e.getMessage(), e);
+//			}
+//
+//			switch (result) {
+//			case DEFAULT_BUTTON_INDEX:
+			doSaveInternal(monitor);
+//				break;
+//			case CANCEL_BUTTON_INDEX:
+//				MessageDialog.openInformation(null, Messages.TypeEditor_WarningDialog_Headline,
+//						Messages.TypeEditor_WarningDialog_NotSaved);
+//				break;
+//			default:
+//				break;
+//			}
 		}
 	}
 


### PR DESCRIPTION
As instance update is done automatically in the background this feature is more an information then a functional feature. As it costs a lot of performance and makes 4diac IDE feel clunky deactivating it to see what users think.