### PR TITLE
Employ Eclipse Dash to control 3rd party dependencies #2251

### DIFF
--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -1,0 +1,36 @@
+###############################################################################
+# Copyright (c) 2023, 2026 Contributors to Eclipse Foundation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# https://www.eclipse.org/legal/epl-2.0/.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     see git history
+###############################################################################
+# This workflow will check for Maven projects if the licenses of all (transitive) dependencies are vetted.
+
+name: License vetting status check
+
+on:
+  push:
+    branches: 
+      - 'develop'
+  pull_request:
+    branches: 
+     - 'develop'
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  call-license-check:
+    uses: eclipse-dash/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
+    with:
+      projectId: iot.4diac
+    secrets:
+      gitlabAPIToken: ${{ secrets.GITLAB_API_TOKEN }}


### PR DESCRIPTION
Add GitHub CI action to check 3rd party with Eclipse Dash. 
"Automate IP team review requests" functionality requires API token to be asked via EF HelpDesk ticket by PL

Fixes https://github.com/eclipse-4diac/4diac-ide/issues/2251