### PR TITLE
Move interface and FB network elements into same name collision domain

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/FBNetworkElementAnnotations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/FBNetworkElementAnnotations.java
@@ -15,21 +15,22 @@ package org.eclipse.fordiac.ide.model.libraryElement.impl;
 import java.util.Map;
 
 import org.eclipse.emf.common.util.DiagnosticChain;
+import org.eclipse.fordiac.ide.model.libraryElement.AdapterFB;
 import org.eclipse.fordiac.ide.model.libraryElement.Comment;
 import org.eclipse.fordiac.ide.model.libraryElement.ErrorMarkerFBNElement;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 
 public final class FBNetworkElementAnnotations {
-	private static final String NAMED_ELEMENTS_KEY = FBNetworkElementAnnotations.class.getName() + ".NAMED_ELEMENTS"; //$NON-NLS-1$
-
 	public static boolean validateName(final FBNetworkElement element, final DiagnosticChain diagnostics,
 			final Map<Object, Object> context) {
-		if (isErrorMarkerOrComment(element) || isMappedFromApplication(element)) {
-			return true; // do not check error markers, comments, or mapped elements in resource network
+		// do not check error markers, comments, mapped elements in resource network, or
+		// adapter FBs
+		if (isErrorMarkerOrComment(element) || isMappedFromApplication(element) || element instanceof AdapterFB) {
+			return true;
 		}
 		return NamedElementAnnotations.validateName(element, diagnostics, context)
-				&& NamedElementAnnotations.validateDuplicateName(element, diagnostics, context, NAMED_ELEMENTS_KEY);
+				&& NamedElementAnnotations.validateDuplicateName(element, diagnostics, context);
 	}
 
 	public static boolean validateType(final FBNetworkElement element, final DiagnosticChain diagnostics,

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/InterfaceElementAnnotations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/InterfaceElementAnnotations.java
@@ -111,7 +111,7 @@ public final class InterfaceElementAnnotations {
 			return false;
 		}
 		if (!isOutMappedInOutVar(element)
-				&& !NamedElementAnnotations.validateDuplicateName(element, diagnostics, context, NAMED_ELEMENTS_KEY)) {
+				&& !NamedElementAnnotations.validateDuplicateName(element, diagnostics, context)) {
 			return false;
 		}
 		if (!FordiacKeywords.DT.equals(element.getName()) // allow "DT" for IEC 61499 standard blocks

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/NamedElementAnnotations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/NamedElementAnnotations.java
@@ -38,6 +38,8 @@ import org.eclipse.fordiac.ide.model.libraryElement.util.LibraryElementValidator
 public final class NamedElementAnnotations {
 	static final String QUALIFIED_NAME_DELIMITER = "."; //$NON-NLS-1$
 
+	static final String DEFAULT_NAMED_ELEMENTS_KEY = NamedElementAnnotations.class.getName() + ".NAMED_ELEMENTS"; //$NON-NLS-1$
+
 	/**
 	 * @apiNote Do not call directly, use {@link INamedElement#getQualifiedName()}
 	 *          instead.
@@ -165,6 +167,26 @@ public final class NamedElementAnnotations {
 			}
 		}
 		return true;
+	}
+
+	/**
+	 * Validate duplicate names
+	 *
+	 * @param element     The element to validate
+	 * @param diagnostics The diagnostic chain
+	 * @param context     The diagnostic context
+	 * @return true on success, false if a duplicate was found
+	 *
+	 * @apiNote This is intended to be called only from an annotation for a specific
+	 *          subclass of {@link INamedElement}.
+	 * @implNote Do not add validations for a specific subclass to this generic
+	 *           implementation. If you need specific behavior for a subclass,
+	 *           override the invariant for the subclass in the model and create a
+	 *           separate annotation.
+	 */
+	public static boolean validateDuplicateName(final INamedElement element, final DiagnosticChain diagnostics,
+			final Map<Object, Object> context) {
+		return validateDuplicateName(element, diagnostics, context, DEFAULT_NAMED_ELEMENTS_KEY);
 	}
 
 	/**


### PR DESCRIPTION
An interface element and an internal FB network element may not have the same name, so they are moved into the same collision domain/key.