### PR TITLE
Remove `javax.activation` from target platform

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.product/org.eclipse.fordiac.ide.product.target
+++ b/plugins/org.eclipse.fordiac.ide.product/org.eclipse.fordiac.ide.product.target
@@ -39,7 +39,6 @@
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/releases/2026-03"/>
-			<unit id="javax.activation" version="1.2.2.v20221203-1659"/>
 			<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.egit.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>


### PR DESCRIPTION
We do not use this (deprecated) bundle explicitly so it is better to remove it from the list of 3rd party.