### PR TITLE
[ECC] Remove UI dependency from CreateTransitionCommand

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/commands/CreateTransitionCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/commands/CreateTransitionCommand.java
@@ -17,33 +17,24 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.fbtypeeditor.ecc.commands;
 
-import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.fordiac.ide.model.libraryElement.ECC;
 import org.eclipse.fordiac.ide.model.libraryElement.ECState;
 import org.eclipse.fordiac.ide.model.libraryElement.ECTransition;
 import org.eclipse.fordiac.ide.model.libraryElement.Event;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
+import org.eclipse.fordiac.ide.model.libraryElement.Position;
 import org.eclipse.fordiac.ide.ui.providers.CreationCommand;
-import org.eclipse.gef.EditPart;
-import org.eclipse.gef.EditPartViewer;
 
 /**
  * The Class CreateTransitionCommand.
  */
 public class CreateTransitionCommand extends CreationCommand {
-	static final Point SELF_TRANS_OFFSET = new Point(10, 50);
 
 	/** The source. */
 	private ECState source;
 
 	/** The destination. */
 	private ECState destination;
-
-	/** The source location. */
-	private Point sourceLocation;
-
-	/** The dest location. */
-	private Point destLocation;
 
 	/** The parent. */
 	private ECC parent;
@@ -57,8 +48,11 @@ public class CreateTransitionCommand extends CreationCommand {
 	/** Transition condition event */
 	private Event conditionEvent;
 
-	/** the viewer which executed this command */
-	private EditPartViewer viewer;
+	/** Offset used for the X-coordinate of the bend point in a self-transition. */
+	private static final int SELF_TRANSITION_X_OFFSET = 10;
+
+	/** Offset used for the Y-coordinate of the bend point in a self-transition. */
+	private static final int SELF_TRANSITION_Y_OFFSET = 50;
 
 	public CreateTransitionCommand() {
 	}
@@ -76,11 +70,7 @@ public class CreateTransitionCommand extends CreationCommand {
 	 */
 	public CreateTransitionCommand(final ECState source, final ECState destination, final Event conditionEvent) {
 		this.source = source;
-		this.sourceLocation = source.getPosition().toScreenPoint();
 		this.destination = destination;
-		if (destination.getPosition() != null) {
-			this.destLocation = destination.getPosition().toScreenPoint();
-		}
 		this.conditionEvent = conditionEvent;
 	}
 
@@ -138,7 +128,7 @@ public class CreateTransitionCommand extends CreationCommand {
 
 	@Override
 	public boolean canExecute() {
-		return ((null != source) && (null != destination) && (null != source.getECC()) && (null != destLocation));
+		return ((null != source) && (null != destination) && (null != source.getECC()));
 	}
 
 	/*
@@ -157,7 +147,7 @@ public class CreateTransitionCommand extends CreationCommand {
 		// it is necessary to invoke the following code after adding the
 		// transition to the parent, otherwise ECTransitionEditPart will
 		// throw a NPE in the activate method!
-		transition.updatePositionFromScreenCoordinates(calcTransitionBendPoint());
+		transition.setPosition(calcTransitionBendPoint());
 		transition.setSource(source);
 		transition.setDestination(destination);
 		transition.setConditionEvent(conditionEvent);
@@ -167,21 +157,18 @@ public class CreateTransitionCommand extends CreationCommand {
 		} else if (conditionEvent == null) {
 			transition.setConditionExpression("1"); //$NON-NLS-1$
 		}
-		if (null != viewer) {
-			final EditPart ep = viewer.getEditPartForModel(transition);
-			if (ep != null) {
-				viewer.select(ep);
-			}
-		}
 	}
 
-	private Point calcTransitionBendPoint() {
-		final Point bendPoint = sourceLocation.getCopy();
-		bendPoint.translate(destLocation.getDifference(sourceLocation).scale(0.5)); // middle between source and dest
+	private Position calcTransitionBendPoint() {
+		final Position pos = LibraryElementFactory.eINSTANCE.createPosition();
 		if (source.equals(destination)) { // self transition
-			bendPoint.translate(SELF_TRANS_OFFSET);
+			pos.setX(source.getPosition().getX() + SELF_TRANSITION_X_OFFSET);
+			pos.setY(source.getPosition().getY() + SELF_TRANSITION_Y_OFFSET);
+		} else {
+			pos.setX((source.getPosition().getX() + destination.getPosition().getX()) / 2.0);
+			pos.setY((source.getPosition().getY() + destination.getPosition().getY()) / 2.0);
 		}
-		return bendPoint;
+		return pos;
 	}
 
 	@Override
@@ -204,29 +191,6 @@ public class CreateTransitionCommand extends CreationCommand {
 		parent.getECTransition().add(transition);
 		transition.setSource(source);
 		transition.setDestination(destination);
-	}
-
-	/**
-	 * Sets the source location.
-	 *
-	 * @param location the new source location
-	 */
-	public void setSourceLocation(final Point location) {
-		this.sourceLocation = location;
-	}
-
-	/**
-	 * Sets the destination location.
-	 *
-	 * @param location the new destination location
-	 */
-	public void setDestinationLocation(final Point location) {
-		this.destLocation = location;
-
-	}
-
-	public void setViewer(final EditPartViewer viewer) {
-		this.viewer = viewer;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/commands/ReconnectTransitionCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/commands/ReconnectTransitionCommand.java
@@ -85,9 +85,6 @@ public class ReconnectTransitionCommand extends Command {
 	protected void doReconnectSource(final ECTransition transition) {
 		dccc.setSource((ECState) request.getTarget().getModel());
 		dccc.setDestination(transition.getDestination());
-
-		dccc.setDestinationLocation(dccc.getDestination().getPosition().toScreenPoint());
-		dccc.setSourceLocation(request.getLocation());
 	}
 
 	/**
@@ -97,9 +94,6 @@ public class ReconnectTransitionCommand extends Command {
 	protected void doReconnectTarget(final ECTransition transition) {
 		dccc.setSource(transition.getSource());
 		dccc.setDestination((ECState) request.getTarget().getModel());
-
-		dccc.setDestinationLocation(request.getLocation());
-		dccc.setSourceLocation(dccc.getSource().getPosition().toScreenPoint());
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editors/ECCEditorEditDomain.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editors/ECCEditorEditDomain.java
@@ -121,7 +121,6 @@ final class ECCEditorEditDomain extends DefaultEditDomain {
 			final CreateECStateCommand createStateCommand = new CreateECStateCommand(destState, pos, getECC());
 			final CreateTransitionCommand createTransitionCommand = new CreateTransitionCommand(sourceState, destState,
 					null);
-			createTransitionCommand.setDestinationLocation(relativePoint);
 
 			final CompoundCommand compCom = new CompoundCommand();
 			compCom.add(createStateCommand);

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/policies/TransitionNodeEditPolicy.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/policies/TransitionNodeEditPolicy.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.fbtypeeditor.ecc.policies;
 
-import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.commands.CreateTransitionCommand;
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.commands.ReconnectTransitionCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.ECState;
@@ -31,13 +30,8 @@ public class TransitionNodeEditPolicy extends GraphicalNodeEditPolicy {
 	@Override
 	protected Command getConnectionCompleteCommand(final CreateConnectionRequest request) {
 		if (request.getStartCommand() instanceof CreateTransitionCommand) {
-			CreateTransitionCommand command = (CreateTransitionCommand) request.getStartCommand();
+			final CreateTransitionCommand command = (CreateTransitionCommand) request.getStartCommand();
 			if (getHost().getModel() instanceof ECState) {
-
-				Point destination = request.getLocation().getCopy();
-				getHostFigure().translateToRelative(destination);
-
-				command.setDestinationLocation(destination);
 				command.setDestination((ECState) getHost().getModel());
 				return command;
 			}
@@ -49,14 +43,9 @@ public class TransitionNodeEditPolicy extends GraphicalNodeEditPolicy {
 	@Override
 	protected Command getConnectionCreateCommand(final CreateConnectionRequest request) {
 
-		CreateTransitionCommand cmd = new CreateTransitionCommand();
+		final CreateTransitionCommand cmd = new CreateTransitionCommand();
 		if (getHost().getModel() instanceof ECState) {
-			Point source = request.getLocation().getCopy();
-			getHostFigure().translateToRelative(source);
-
 			cmd.setSource((ECState) getHost().getModel());
-			cmd.setSourceLocation(source);
-			cmd.setViewer(getHost().getViewer());
 		}
 		request.setStartCommand(cmd);
 		return cmd;
@@ -64,7 +53,7 @@ public class TransitionNodeEditPolicy extends GraphicalNodeEditPolicy {
 
 	@Override
 	protected Command getReconnectSourceCommand(final ReconnectRequest request) {
-		ECTransition transition = (ECTransition) request.getConnectionEditPart().getModel();
+		final ECTransition transition = (ECTransition) request.getConnectionEditPart().getModel();
 		// check if the source has changed
 		return (transition.getSource().equals(request.getTarget().getModel())) ? null
 				: new ReconnectTransitionCommand(request);
@@ -72,7 +61,7 @@ public class TransitionNodeEditPolicy extends GraphicalNodeEditPolicy {
 
 	@Override
 	protected Command getReconnectTargetCommand(final ReconnectRequest request) {
-		ECTransition transition = (ECTransition) request.getConnectionEditPart().getModel();
+		final ECTransition transition = (ECTransition) request.getConnectionEditPart().getModel();
 		// check if the source has changed
 		return (transition.getDestination().equals(request.getTarget().getModel())) ? null
 				: new ReconnectTransitionCommand(request);


### PR DESCRIPTION
@azoitl 

As discussed in #2228 
The CreateTransitionCommand was storing screen coordinates (sourceLocation and destLocation) which is wrong as commands should only work at the model level.

Changes that i made:
I have Removed sourceLocation, destLocation and viewer fields from CreateTransitionCommand. calcTransitionBendPoint() now directly uses source.getPosition() and destination.getPosition()

I have Removed setSourceLocation(), setDestinationLocation() and setViewer() methods as well which is also needed to be done and updated all callers in TransitionNodeEditPolicy, ReconnectTransitionCommand and ECCEditorEditDomain