### PR TITLE
ECC's AutoExposeHelper was attached to the wrong EditPart

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editors/ECCEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editors/ECCEditor.java
@@ -39,11 +39,13 @@ import org.eclipse.fordiac.ide.gef.figures.AbstractFreeformFigure;
 import org.eclipse.fordiac.ide.gef.figures.ModuloFreeformFigure;
 import org.eclipse.fordiac.ide.gef.tools.AdvancedMarqueeDragTracker;
 import org.eclipse.fordiac.ide.gef.tools.AdvancedPanningSelectionTool;
+import org.eclipse.fordiac.ide.gef.tools.FordiacViewportAutoexposeHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.BasicFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.ECAction;
 import org.eclipse.fordiac.ide.model.libraryElement.ECC;
 import org.eclipse.fordiac.ide.model.libraryElement.provider.ECCItemProvider;
 import org.eclipse.fordiac.ide.ui.imageprovider.FordiacImage;
+import org.eclipse.gef.AutoexposeHelper;
 import org.eclipse.gef.ContextMenuProvider;
 import org.eclipse.gef.DefaultEditDomain;
 import org.eclipse.gef.DragTracker;
@@ -102,6 +104,14 @@ public class ECCEditor extends DiagramEditorWithFlyoutPalette implements IFBTEdi
 				}
 
 			};
+		}
+
+		@Override
+		public <T> T getAdapter(final Class<T> key) {
+			if (key == AutoexposeHelper.class) {
+				return key.cast(new FordiacViewportAutoexposeHelper(this));
+			}
+			return super.getAdapter(key);
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editparts/ECCRootEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editparts/ECCRootEditPart.java
@@ -22,10 +22,8 @@ import org.eclipse.emf.common.notify.Notifier;
 import org.eclipse.emf.common.notify.impl.AdapterImpl;
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.policies.ECCXYLayoutEditPolicy;
 import org.eclipse.fordiac.ide.gef.editparts.AbstractDiagramEditPart;
-import org.eclipse.fordiac.ide.gef.tools.FordiacViewportAutoexposeHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.ECC;
 import org.eclipse.fordiac.ide.model.libraryElement.ECState;
-import org.eclipse.gef.AutoexposeHelper;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.editpolicies.RootComponentEditPolicy;
 
@@ -56,14 +54,6 @@ public class ECCRootEditPart extends AbstractDiagramEditPart {
 			super.deactivate();
 			((Notifier) getModel()).eAdapters().remove(getContentAdapter());
 		}
-	}
-
-	@Override
-	public <T> T getAdapter(final Class<T> key) {
-		if (key == AutoexposeHelper.class) {
-			return key.cast(new FordiacViewportAutoexposeHelper(this));
-		}
-		return super.getAdapter(key);
 	}
 
 	/**


### PR DESCRIPTION
The autoexposehelper needs to be attached to the editPart providing the viewport and not any child.

Fixes #2205