### PR TITLE
Rename ECCRootEditPart to ECCEditPart

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editparts/ECCEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editparts/ECCEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 - 2013 Profactor GmbH, TU Wien ACIN, fortiss GmbH
+ * Copyright (c) 2008 Profactor GmbH, TU Wien ACIN, fortiss GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -27,10 +27,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.ECState;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.editpolicies.RootComponentEditPolicy;
 
-/**
- * The Class ECCRootEditPart.
- */
-public class ECCRootEditPart extends AbstractDiagramEditPart {
+public class ECCEditPart extends AbstractDiagramEditPart {
 
 	/** The adapter. */
 	private Adapter adapter;

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editparts/ECCEditPartFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editparts/ECCEditPartFactory.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Profactor GmbH, fortiss GmbH,
- *                          Primetals Technologies Austria GmbH
+ * Copyright (c) 2008 Profactor GmbH, fortiss GmbH,
+ *                    Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -32,25 +32,14 @@ public class ECCEditPartFactory extends Abstract4diacEditPartFactory {
 
 	@Override
 	protected EditPart getPartForElement(final EditPart context, final Object modelElement) {
-		if (modelElement instanceof ECC) {
-			return new ECCRootEditPart();
-		}
-		if (modelElement instanceof ECState) {
-			return new ECStateEditPart();
-		}
-		if (modelElement instanceof ECTransition) {
-			return new ECTransitionEditPart();
-		}
-
-		if (modelElement instanceof ECActionAlgorithm) {
-			return new ECActionAlgorithmEditPart();
-		}
-
-		if (modelElement instanceof ECActionOutputEvent) {
-			return new ECActionOutputEventEditPart();
-		}
-
-		throw createEditpartCreationException(context, modelElement);
+		return switch (modelElement) {
+		case final ECC ecc -> new ECCEditPart();
+		case final ECState state -> new ECStateEditPart();
+		case final ECTransition trans -> new ECTransitionEditPart();
+		case final ECActionAlgorithm alg -> new ECActionAlgorithmEditPart();
+		case final ECActionOutputEvent eo -> new ECActionOutputEventEditPart();
+		default -> throw createEditpartCreationException(context, modelElement);
+		};
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/properties/ECCFilter.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/properties/ECCFilter.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.fbtypeeditor.ecc.properties;
 
-import org.eclipse.fordiac.ide.fbtypeeditor.ecc.editparts.ECCRootEditPart;
+import org.eclipse.fordiac.ide.fbtypeeditor.ecc.editparts.ECCEditPart;
 import org.eclipse.fordiac.ide.model.libraryElement.ECC;
 import org.eclipse.jface.viewers.IFilter;
 
@@ -21,7 +21,7 @@ public class ECCFilter implements IFilter {
 
 	@Override
 	public boolean select(Object toTest) {
-		return ((toTest instanceof ECCRootEditPart) || (toTest instanceof ECC));
+		return ((toTest instanceof ECCEditPart) || (toTest instanceof ECC));
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/properties/ECCSection.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/properties/ECCSection.java
@@ -26,7 +26,7 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.editors.IAlgorithmEditorCreator;
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.editparts.ECActionAlgorithmEditPart;
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.editparts.ECActionOutputEventEditPart;
-import org.eclipse.fordiac.ide.fbtypeeditor.ecc.editparts.ECCRootEditPart;
+import org.eclipse.fordiac.ide.fbtypeeditor.ecc.editparts.ECCEditPart;
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.editparts.ECStateEditPart;
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.editparts.ECTransitionEditPart;
 import org.eclipse.fordiac.ide.model.libraryElement.ECAction;
@@ -38,7 +38,8 @@ public final class ECCSection {
 	public static List<String> getLanguages() {
 		final List<String> languages = new ArrayList<>();
 		final IExtensionRegistry registry = Platform.getExtensionRegistry();
-		final IExtensionPoint point = registry.getExtensionPoint("org.eclipse.fordiac.ide.fbtypeeditor.ecc.algorithmEditor"); //$NON-NLS-1$
+		final IExtensionPoint point = registry
+				.getExtensionPoint("org.eclipse.fordiac.ide.fbtypeeditor.ecc.algorithmEditor"); //$NON-NLS-1$
 		final IExtension[] extensions = point.getExtensions();
 		for (final IExtension extension : extensions) {
 			final IConfigurationElement[] elements = extension.getConfigurationElements();
@@ -58,28 +59,21 @@ public final class ECCSection {
 	}
 
 	public static Object getECCInputType(final Object input) {
-		if (input instanceof ECCRootEditPart) {
-			return ((ECCRootEditPart) input).getCastedECCModel().getBasicFBType();
-		}
-		if (input instanceof ECC) {
-			return ((ECC) input).getBasicFBType();
-		}
-		if (input instanceof ECActionAlgorithmEditPart) {
-			return ((ECActionAlgorithmEditPart) input).getAction().getECState().getECC().getBasicFBType();
-		}
-		if (input instanceof ECActionOutputEventEditPart) {
-			final ECAction action = ((ECActionOutputEventEditPart) input).getAction();
-			if ((null != action) && (null != action.getECState())) {
-				return action.getECState().getECC().getBasicFBType();
+		return switch (input) {
+		case final ECCEditPart eccEP -> eccEP.getCastedECCModel().getBasicFBType();
+		case final ECC ecc -> ecc.getBasicFBType();
+		case final ECActionAlgorithmEditPart algEP -> algEP.getBFB();
+		case final ECActionOutputEventEditPart eoEP -> {
+			final ECAction action = eoEP.getAction();
+			if (action != null && action.getECState() != null) {
+				yield action.getECState().getECC().getBasicFBType();
 			}
+			yield null;
 		}
-		if (input instanceof ECTransitionEditPart) {
-			return ((ECTransitionEditPart) input).getModel().getECC().getBasicFBType();
-		}
-		if (input instanceof ECStateEditPart) {
-			return ((ECStateEditPart) input).getModel().getECC().getBasicFBType();
-		}
-		return null;
+		case final ECTransitionEditPart transitionEP -> transitionEP.getModel().getECC().getBasicFBType();
+		case final ECStateEditPart stateEP -> stateEP.getModel().getECC().getBasicFBType();
+		default -> null;
+		};
 	}
 
 	private ECCSection() {


### PR DESCRIPTION
This was never the root editpart of this editor and regularly leads to confusion and recently even to a major bug.