### PR TITLE
Make adding InterfaceElement figures into FBs more robust

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractBlockFBNElementEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractBlockFBNElementEditPart.java
@@ -260,12 +260,21 @@ public abstract class AbstractBlockFBNElementEditPart extends AbstractPositionab
 	protected void addChildVisual(final EditPart childEditPart, final int index) {
 		final IFigure child = ((GraphicalEditPart) childEditPart).getFigure();
 		switch (childEditPart) {
-		case final InterfaceEditPart interfaceEditPart ->
-			getTargetFigure(interfaceEditPart).add(child, getInterfaceElementIndex(interfaceEditPart));
+		case final InterfaceEditPart interfaceEditPart -> addInterfaceElementFigure(child, interfaceEditPart);
 		case final HiddenPinIndicatorEditPart hiddenPinIndicatorEditPart ->
 			addPinIndicatorFigure(hiddenPinIndicatorEditPart, child);
 		case final MappingEditPart mapping -> addMappingFigure(child);
 		default -> getFigure().add(child, new GridData(GridData.HORIZONTAL_ALIGN_CENTER), index);
+		}
+	}
+
+	private void addInterfaceElementFigure(final IFigure child, final InterfaceEditPart interfaceEditPart) {
+		final int targetIndex = getInterfaceElementIndex(interfaceEditPart);
+		final IFigure targetFigure = getTargetFigure(interfaceEditPart);
+		if (targetIndex < targetFigure.getChildren().size()) {
+			targetFigure.add(child, targetIndex);
+		} else {
+			targetFigure.add(child);
 		}
 	}
 


### PR DESCRIPTION
In cases where we have mismatches between model and ui we gracefully add interface figures at the end of their list. This avoids exceptions and hopefully allows us to better find issues.