### PR TITLE
Remove reload type from ChangeStructCommand

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/DiagramEditorWithFlyoutPalette.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/DiagramEditorWithFlyoutPalette.java
@@ -501,8 +501,11 @@ public abstract class DiagramEditorWithFlyoutPalette extends GraphicalEditorWith
 
 	@Override
 	public void selectionChanged(final IWorkbenchPart part, final ISelection selection) {
-		super.selectionChanged(part, selection);
-		updateActions(getSelectionActions());
+		// If not the active editor, ignore selection changed.
+		if (getSite() != null && getSite().getPage() != null && this.equals(getSite().getPage().getActiveEditor())) {
+			super.selectionChanged(part, selection);
+			updateActions(getSelectionActions());
+		}
 	}
 
 	/**

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeStructCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeStructCommand.java
@@ -24,7 +24,6 @@ import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes;
 import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableFB;
 import org.eclipse.fordiac.ide.model.libraryElement.Demultiplexer;
-import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.Multiplexer;
 import org.eclipse.fordiac.ide.model.libraryElement.StructManipulator;
@@ -35,7 +34,6 @@ public class ChangeStructCommand extends AbstractUpdateBlockFBNElementCommand {
 
 	private final TypeEntry newStructTypeEntry;
 	private final String newVisibleChildren;
-	private boolean reloadDatatype = true;
 
 	public ChangeStructCommand(final BlockFBNetworkElement fb, final DataType newStruct) {
 		super(fb);
@@ -50,17 +48,6 @@ public class ChangeStructCommand extends AbstractUpdateBlockFBNElementCommand {
 
 	public ChangeStructCommand(final StructManipulator mux, final DataType newStruct) {
 		this(mux, newStruct, getOldVisibleChildren(mux));
-	}
-
-	public ChangeStructCommand(final StructManipulator mux, final DataType newStruct, final String visibleChildren,
-			final boolean doNotReload) {
-		this(mux, newStruct, visibleChildren);
-		reloadDatatype = !doNotReload;
-	}
-
-	public ChangeStructCommand(final StructManipulator mux, final DataType newStruct, final boolean doNotReload) {
-		this(mux, newStruct, getOldVisibleChildren(mux));
-		reloadDatatype = !doNotReload;
 	}
 
 	public ChangeStructCommand(final Demultiplexer demux, final String newVisibleChildren) {
@@ -139,13 +126,6 @@ public class ChangeStructCommand extends AbstractUpdateBlockFBNElementCommand {
 			return IecTypes.GenericTypes.ANY_STRUCT;
 		}
 
-		final LibraryElement type;
-		if (reloadDatatype) {
-			type = newStructTypeEntry.getTypeLibrary().getDataTypeLibrary()
-					.getType(newStructTypeEntry.getFullTypeName());
-		} else {
-			type = newStructTypeEntry.getType();
-		}
-		return (type instanceof final DataType dt) ? dt : IecTypes.GenericTypes.ANY_STRUCT;
+		return (newStructTypeEntry.getType() instanceof final DataType dt) ? dt : IecTypes.GenericTypes.ANY_STRUCT;
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/DataTypeLibrary.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/DataTypeLibrary.java
@@ -138,13 +138,7 @@ public final class DataTypeLibrary {
 		if (null == name) {
 			return GenericTypes.ANY;
 		}
-		final String uppercaseName = name.toUpperCase();
-		DataType type = typeMap.get(uppercaseName);
-		if (type != null) {
-			return type;
-		}
-
-		type = getDerivedType(uppercaseName);
+		DataType type = getTypeIfExists(name);
 		if (type != null) {
 			return type;
 		}
@@ -163,7 +157,11 @@ public final class DataTypeLibrary {
 		if (dataType != null) {
 			return dataType;
 		}
-		return getDerivedType(uppercaseName);
+		final DataTypeEntry entry = derivedTypes.get(uppercaseName);
+		if (entry != null && !entry.hasError()) {
+			return entry.getType();
+		}
+		return null;
 	}
 
 	public List<StructuredType> getStructuredTypes() {
@@ -173,14 +171,6 @@ public final class DataTypeLibrary {
 
 	public List<StructuredType> getStructuredTypesSorted() {
 		return getStructuredTypes().stream().sorted(NamedElementComparator.INSTANCE).toList();
-	}
-
-	private DataType getDerivedType(final String uppercaseName) {
-		final DataTypeEntry entry = derivedTypes.get(uppercaseName);
-		if (null != entry) {
-			return entry.getType();
-		}
-		return null;
 	}
 
 	public DataTypeEntry getDerivedTypeEntry(final String name) {
@@ -228,7 +218,7 @@ public final class DataTypeLibrary {
 	}
 
 	public StructuredType getStructuredType(final String name) {
-		final DataType derivedType = getDerivedType(name.toUpperCase());
+		final DataType derivedType = getTypeIfExists(name);
 		if (derivedType instanceof final StructuredType structuredType) {
 			return structuredType;
 		}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/DataTypeLibrary.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/DataTypeLibrary.java
@@ -50,11 +50,13 @@ public final class DataTypeLibrary {
 	private static final Pattern STRING_MAX_LENGTH_PATTERN = Pattern.compile("(W?STRING)\\[(\\d+)\\]", //$NON-NLS-1$
 			Pattern.CASE_INSENSITIVE);
 
+	private final TypeLibrary typeLibrary;
 	private final Map<String, DataType> typeMap = new ConcurrentHashMap<>();
 	private final Map<String, DataTypeEntry> derivedTypes = new ConcurrentHashMap<>();
 
 	/** Instantiates a new data type library. */
-	public DataTypeLibrary() {
+	public DataTypeLibrary(final TypeLibrary typeLibrary) {
+		this.typeLibrary = typeLibrary;
 		initElementaryTypes();
 		initGenericTypes();
 	}
@@ -209,6 +211,7 @@ public final class DataTypeLibrary {
 			final DataType type = entry.getType();
 			PackageNameHelper.setFullTypeName(type, typeName);
 			entry.setType(type); // update type name in entry
+			entry.setTypeLibrary(typeLibrary);
 			return entry;
 		}).getType();
 	}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/TypeLibrary.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/TypeLibrary.java
@@ -80,7 +80,7 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 
 	private IProject project;
 	private Buildpath buildpath;
-	private final DataTypeLibrary dataTypeLib = new DataTypeLibrary();
+	private final DataTypeLibrary dataTypeLib = new DataTypeLibrary(this);
 	private final Map<String, AdapterTypeEntry> adapterTypes = new ConcurrentHashMap<>();
 	private final Map<String, AttributeTypeEntry> attributeTypes = new ConcurrentHashMap<>();
 	private final Map<String, DeviceTypeEntry> deviceTypes = new ConcurrentHashMap<>();

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.tests/src/org/eclipse/fordiac/ide/structuredtextalgorithm/tests/STAlgorithmValidatorTest.xtend
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.tests/src/org/eclipse/fordiac/ide/structuredtextalgorithm/tests/STAlgorithmValidatorTest.xtend
@@ -40,7 +40,7 @@ class STAlgorithmValidatorTest {
 
 	@BeforeAll
 	def static void setup() {
-		new DataTypeLibrary
+		new DataTypeLibrary(null)
 	}
 
 	@Test

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.tests/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/tests/STFunctionValidatorPartialAccessTest.xtend
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.tests/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/tests/STFunctionValidatorPartialAccessTest.xtend
@@ -37,7 +37,7 @@ class STFunctionValidatorPartialAccessTest {
 
 	@BeforeAll
 	def static void setup() {
-		new DataTypeLibrary
+		new DataTypeLibrary(null)
 	}
 
 	@Test

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.tests/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/tests/STFunctionValidatorTest.xtend
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.tests/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/tests/STFunctionValidatorTest.xtend
@@ -61,7 +61,7 @@ class STFunctionValidatorTest {
 
 	@BeforeAll
 	def static void setup() {
-		new DataTypeLibrary
+		new DataTypeLibrary(null)
 	}
 
 	@Test

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/UpdateManipulatorModelEdit.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/UpdateManipulatorModelEdit.java
@@ -55,6 +55,6 @@ public class UpdateManipulatorModelEdit extends ModelEdit<StructManipulator> {
 
 	@Override
 	protected Command createCommand(final StructManipulator manipulator) {
-		return new ChangeStructCommand(manipulator, IecTypes.GenericTypes.ANY, true);
+		return new ChangeStructCommand(manipulator, IecTypes.GenericTypes.ANY);
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/move/MoveTypeRefactoringParticipant.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/move/MoveTypeRefactoringParticipant.java
@@ -33,14 +33,10 @@ import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.model.IdentifierVerifier;
-import org.eclipse.fordiac.ide.model.commands.change.ChangeStructCommand;
-import org.eclipse.fordiac.ide.model.data.StructuredType;
 import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableFB;
-import org.eclipse.fordiac.ide.model.libraryElement.StructManipulator;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
-import org.eclipse.fordiac.ide.model.libraryElement.impl.ConfigurableFBManagement;
 import org.eclipse.fordiac.ide.model.search.types.BlockTypeInstanceSearch;
 import org.eclipse.fordiac.ide.model.search.types.DataTypeInstanceSearch;
 import org.eclipse.fordiac.ide.model.typelibrary.DataTypeEntry;
@@ -52,7 +48,6 @@ import org.eclipse.fordiac.ide.typemanagement.refactoring.ModelEdit;
 import org.eclipse.fordiac.ide.typemanagement.refactoring.ModelEditChange;
 import org.eclipse.fordiac.ide.typemanagement.refactoring.RefactoringUtil;
 import org.eclipse.fordiac.ide.typemanagement.refactoring.UpdateFBInstanceModelEdit;
-import org.eclipse.gef.commands.Command;
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.CompositeChange;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
@@ -150,7 +145,7 @@ public class MoveTypeRefactoringParticipant extends MoveParticipant {
 						EcoreUtil.getURI(eObject), PackageNameHelper.getFullTypeNameFromFile(newFile)));
 			}
 			if (eObject instanceof final BlockFBNetworkElement elem) {
-				modelEdits.add(new UpdateInstanceModelEdit(elem, dtEntry));
+				modelEdits.add(new UpdateFBInstanceModelEdit(elem, dtEntry));
 			}
 		}
 	}
@@ -163,27 +158,6 @@ public class MoveTypeRefactoringParticipant extends MoveParticipant {
 				modelEdits.add(new UpdateFBInstanceModelEdit(elem, typeEntry));
 			}
 		}
-	}
-
-	private static class UpdateInstanceModelEdit extends UpdateFBInstanceModelEdit {
-		final String visibleChildrenString;
-
-		public UpdateInstanceModelEdit(final BlockFBNetworkElement instance, final TypeEntry typeEntry) {
-			super(instance, typeEntry);
-			visibleChildrenString = (instance instanceof final StructManipulator structManipulator)
-					? ConfigurableFBManagement.buildVisibleChildrenString(structManipulator.getMemberVars())
-					: ""; //$NON-NLS-1$
-		}
-
-		@Override
-		protected Command createCommand(final BlockFBNetworkElement element) {
-			if (element instanceof final StructManipulator demux
-					&& typeEntry.getType() instanceof final StructuredType structuredType) {
-				return new ChangeStructCommand(demux, structuredType, visibleChildrenString, true);
-			}
-			return super.createCommand(element);
-		}
-
 	}
 
 }

--- a/tests/org.eclipse.fordiac.ide.test.deployment/src/org/eclipse/fordiac/ide/test/resourcedeployment/ResourceDeploymentTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.deployment/src/org/eclipse/fordiac/ide/test/resourcedeployment/ResourceDeploymentTest.java
@@ -103,7 +103,7 @@ class ResourceDeploymentTest {
 
 	@SuppressWarnings("unused")
 	private static void setup() {
-		new DataTypeLibrary();
+		new DataTypeLibrary(null);
 		GlobalConstantsStandaloneSetup.doSetup();
 		STFunctionStandaloneSetup.doSetup();
 		STAlgorithmStandaloneSetup.doSetup();

--- a/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/ExporterTestAdapterFBType.java
+++ b/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/ExporterTestAdapterFBType.java
@@ -53,7 +53,7 @@ public class ExporterTestAdapterFBType extends ExporterTestBase<AdapterType> {
 		functionBlock.getInterfaceList().getEventOutputs().add(adpOutputEvent);
 
 		final VarDeclaration adapterInputData = LibraryElementFactory.eINSTANCE.createVarDeclaration();
-		adapterInputData.setType(new DataTypeLibrary().getType(FordiacKeywords.INT));
+		adapterInputData.setType(new DataTypeLibrary(null).getType(FordiacKeywords.INT));
 		adapterInputData.setName(ADAPTER_DATA_INPUT_NAME);
 		adapterInputData.setIsInput(true);
 		final With withInput = LibraryElementFactory.eINSTANCE.createWith();
@@ -67,7 +67,7 @@ public class ExporterTestAdapterFBType extends ExporterTestBase<AdapterType> {
 		adpOutputEvent.getWith().add(withOutput);
 		withOutput.setVariables(adapterOutputData);
 		adapterOutputData.getWiths().add(withOutput);
-		adapterOutputData.setType(new DataTypeLibrary().getType(FordiacKeywords.INT));
+		adapterOutputData.setType(new DataTypeLibrary(null).getType(FordiacKeywords.INT));
 		adapterOutputData.setName(ADAPTER_DATA_OUTPUT_NAME);
 		functionBlock.getInterfaceList().getOutputVars().add(adapterOutputData);
 

--- a/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/ExporterTestBase.java
+++ b/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/ExporterTestBase.java
@@ -102,7 +102,7 @@ public abstract class ExporterTestBase<T extends FBType> {
 	protected static final int SIZE_BYTE = 8;
 	protected static final int SIZE_BOOL = 1;
 
-	private static final DataTypeLibrary dataTypeLib = new DataTypeLibrary();
+	private static DataTypeLibrary dataTypeLib;
 	protected T functionBlock;
 	protected Event inputEvent;
 	protected Event outputEvent;
@@ -113,7 +113,7 @@ public abstract class ExporterTestBase<T extends FBType> {
 	@SuppressWarnings("unused")
 	@BeforeAll
 	public static void setup() {
-		new DataTypeLibrary();
+		dataTypeLib = new DataTypeLibrary(null);
 		GlobalConstantsStandaloneSetup.doSetup();
 		STFunctionStandaloneSetup.doSetup();
 		STAlgorithmStandaloneSetup.doSetup();
@@ -452,11 +452,11 @@ public abstract class ExporterTestBase<T extends FBType> {
 		outputEvent.setType(EventTypeLibrary.getInstance().getType(EventTypeLibrary.EVENT));
 		functionBlock.getInterfaceList().getEventOutputs().add(outputEvent);
 		inputData = LibraryElementFactory.eINSTANCE.createVarDeclaration();
-		inputData.setType(new DataTypeLibrary().getType(FordiacKeywords.INT));
+		inputData.setType(dataTypeLib.getType(FordiacKeywords.INT));
 		inputData.setName(DATA_INPUT_NAME);
 		functionBlock.getInterfaceList().getInputVars().add(inputData);
 		outputData = LibraryElementFactory.eINSTANCE.createVarDeclaration();
-		outputData.setType(new DataTypeLibrary().getType(FordiacKeywords.INT));
+		outputData.setType(dataTypeLib.getType(FordiacKeywords.INT));
 		outputData.setName(DATA_OUTPUT_NAME);
 		functionBlock.getInterfaceList().getOutputVars().add(outputData);
 

--- a/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/forte_lua/st/ForteLuaStOperatorTest.xtend
+++ b/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/forte_lua/st/ForteLuaStOperatorTest.xtend
@@ -33,7 +33,7 @@ class ForteLuaStOperatorTest extends ExporterTestBasicFBTypeBase {
 
 	@BeforeAll
 	def static void setup() {
-		new DataTypeLibrary()
+		new DataTypeLibrary(null)
 		GlobalConstantsStandaloneSetup.doSetup()
 		STFunctionStandaloneSetup.doSetup()
 		STAlgorithmStandaloneSetup.doSetup()

--- a/tests/org.eclipse.fordiac.ide.test.model.commands/src/org/eclipse/fordiac/ide/model/commands/insert/InsertVariableCommandTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model.commands/src/org/eclipse/fordiac/ide/model/commands/insert/InsertVariableCommandTest.java
@@ -30,7 +30,7 @@ public class InsertVariableCommandTest extends InsertVariableCommandTestBase {
 	private static VarDeclaration createTestVarDec(final String name) {
 		final VarDeclaration varDec = LibraryElementFactory.eINSTANCE.createVarDeclaration();
 		varDec.setName(name);
-		varDec.setType(new DataTypeLibrary().getType(FordiacKeywords.BOOL));
+		varDec.setType(new DataTypeLibrary(null).getType(FordiacKeywords.BOOL));
 		return varDec;
 	}
 

--- a/tests/org.eclipse.fordiac.ide.test.model.commands/src/org/eclipse/fordiac/ide/model/commands/testinfra/CreateMemberVariableCommandTestBase.java
+++ b/tests/org.eclipse.fordiac.ide.test.model.commands/src/org/eclipse/fordiac/ide/model/commands/testinfra/CreateMemberVariableCommandTestBase.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.params.provider.Arguments;
 
 public abstract class CreateMemberVariableCommandTestBase
 		extends CommandTestBase<CreateMemberVariableCommandTestBase.State> {
-	protected static DataTypeLibrary datatypeLib = new DataTypeLibrary();
+	protected static DataTypeLibrary datatypeLib = new DataTypeLibrary(null);
 
 	// create a state description that holds the struct and the command
 	public static class State extends CommandTestBase.StateBase {
@@ -41,7 +41,7 @@ public abstract class CreateMemberVariableCommandTestBase
 			// TODO add user-defined datatypes to datatype library for testing
 		}
 
-		public State(State s) {
+		public State(final State s) {
 			struct = EcoreUtil.copy(s.struct);
 		}
 
@@ -51,22 +51,22 @@ public abstract class CreateMemberVariableCommandTestBase
 		}
 	}
 
-	protected static Collection<Arguments> describeCommand(String description, StateInitializer<?> initializer,
-			StateVerifier<?> initialVerifier, List<ExecutionDescription<?>> commands) {
+	protected static Collection<Arguments> describeCommand(final String description, final StateInitializer<?> initializer,
+			final StateVerifier<?> initialVerifier, final List<ExecutionDescription<?>> commands) {
 		return describeCommand(description, initializer, initialVerifier, commands, CommandTestBase::defaultUndoCommand,
 				CommandTestBase::defaultRedoCommand);
 	}
 
-	protected static void verifyDefaultInitialValues(State state, State oldState, TestFunction t) {
+	protected static void verifyDefaultInitialValues(final State state, final State oldState, final TestFunction t) {
 		t.test(state.getStructuredType());
 		t.test(state.getStructuredType().getMemberVariables().isEmpty());
 	}
 
 	// define here the list of test sequences
 	// multiple execution descriptions are possible -> define in test class
-	protected static Collection<Arguments> createCommands(List<ExecutionDescription<?>> autofilledExecutionDescriptions,
-			List<ExecutionDescription<?>> configuredExecutionDescriptions) {
-		Collection<Arguments> commands = new ArrayList<>();
+	protected static Collection<Arguments> createCommands(final List<ExecutionDescription<?>> autofilledExecutionDescriptions,
+			final List<ExecutionDescription<?>> configuredExecutionDescriptions) {
+		final Collection<Arguments> commands = new ArrayList<>();
 		// test series 1
 		commands.addAll(describeCommand("Autofilled Command", // //$NON-NLS-1$
 				State::new, //

--- a/tests/org.eclipse.fordiac.ide.test.model.commands/src/org/eclipse/fordiac/ide/model/commands/testinfra/DeleteMemberVariableCommandTestBase.java
+++ b/tests/org.eclipse.fordiac.ide.test.model.commands/src/org/eclipse/fordiac/ide/model/commands/testinfra/DeleteMemberVariableCommandTestBase.java
@@ -28,8 +28,8 @@ import org.eclipse.fordiac.ide.model.typelibrary.DataTypeLibrary;
 import org.junit.jupiter.params.provider.Arguments;
 
 public abstract class DeleteMemberVariableCommandTestBase
-extends CommandTestBase<DeleteMemberVariableCommandTestBase.State> {
-	protected static DataTypeLibrary datatypeLib = new DataTypeLibrary();
+		extends CommandTestBase<DeleteMemberVariableCommandTestBase.State> {
+	protected static DataTypeLibrary datatypeLib = new DataTypeLibrary(null);
 	protected static List<VarDeclaration> varList = new ArrayList<>();
 
 	// create a state description that holds the struct and the command
@@ -89,8 +89,9 @@ extends CommandTestBase<DeleteMemberVariableCommandTestBase.State> {
 		}
 	}
 
-	protected static Collection<Arguments> describeCommand(final String description, final StateInitializer<?> initializer,
-			final StateVerifier<?> initialVerifier, final List<ExecutionDescription<?>> commands) {
+	protected static Collection<Arguments> describeCommand(final String description,
+			final StateInitializer<?> initializer, final StateVerifier<?> initialVerifier,
+			final List<ExecutionDescription<?>> commands) {
 		return describeCommand(description, initializer, initialVerifier, commands, CommandTestBase::defaultUndoCommand,
 				CommandTestBase::defaultRedoCommand);
 	}
@@ -102,14 +103,15 @@ extends CommandTestBase<DeleteMemberVariableCommandTestBase.State> {
 
 	// define here the list of test sequences
 	// multiple execution descriptions are possible -> define in test class
-	protected static Collection<Arguments> createCommands(final List<ExecutionDescription<?>> deletionExecutionDescriptions) {
+	protected static Collection<Arguments> createCommands(
+			final List<ExecutionDescription<?>> deletionExecutionDescriptions) {
 		final Collection<Arguments> commands = new ArrayList<>();
 		// test series 1
 		commands.addAll(describeCommand("Autofilled Command", // //$NON-NLS-1$
 				State::new, //
 				(StateVerifier<State>) DeleteMemberVariableCommandTestBase::verifyDefaultInitialValues, //
 				deletionExecutionDescriptions //
-				));
+		));
 		return commands;
 	}
 

--- a/tests/org.eclipse.fordiac.ide.test.model.commands/src/org/eclipse/fordiac/ide/model/commands/testinfra/FBNetworkTestBase.java
+++ b/tests/org.eclipse.fordiac.ide.test.model.commands/src/org/eclipse/fordiac/ide/model/commands/testinfra/FBNetworkTestBase.java
@@ -52,7 +52,7 @@ import org.junit.jupiter.params.provider.Arguments;
 
 public abstract class FBNetworkTestBase extends CommandTestBase<FBNetworkTestBase.State> {
 
-	private static final DataTypeLibrary dataTypeLib = new DataTypeLibrary();
+	private static final DataTypeLibrary dataTypeLib = new DataTypeLibrary(null);
 
 	// create a state description that fits our purpose
 	public static class State extends CommandTestBase.StateBase {
@@ -342,7 +342,7 @@ public abstract class FBNetworkTestBase extends CommandTestBase<FBNetworkTestBas
 
 			@Override
 			public boolean exists() {
-				return true;  // needed that tests complete correctly
+				return true; // needed that tests complete correctly
 			}
 
 			@Override
@@ -605,8 +605,9 @@ public abstract class FBNetworkTestBase extends CommandTestBase<FBNetworkTestBas
 		}
 	}
 
-	protected static Collection<Arguments> describeCommand(final String description, final StateInitializer<?> initializer,
-			final StateVerifier<?> initialVerifier, final List<ExecutionDescription<?>> commands) {
+	protected static Collection<Arguments> describeCommand(final String description,
+			final StateInitializer<?> initializer, final StateVerifier<?> initialVerifier,
+			final List<ExecutionDescription<?>> commands) {
 		return describeCommand(description, initializer, initialVerifier, commands, CommandTestBase::defaultUndoCommand,
 				CommandTestBase::defaultRedoCommand);
 	}
@@ -625,7 +626,7 @@ public abstract class FBNetworkTestBase extends CommandTestBase<FBNetworkTestBas
 				State::new, //
 				(StateVerifier<State>) FBNetworkTestBase::verifyDefaultInitialValues, //
 				executionDescriptions //
-				));
+		));
 
 		return commands;
 	}

--- a/tests/org.eclipse.fordiac.ide.test.model.eval/src/org/eclipse/fordiac/ide/test/model/eval/function/StandardFunctionsTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model.eval/src/org/eclipse/fordiac/ide/test/model/eval/function/StandardFunctionsTest.java
@@ -116,7 +116,7 @@ class StandardFunctionsTest {
 	@BeforeAll
 	@SuppressWarnings("unused")
 	static void setupXtext() {
-		new DataTypeLibrary();
+		new DataTypeLibrary(null);
 		GlobalConstantsStandaloneSetup.doSetup();
 		STFunctionStandaloneSetup.doSetup();
 		STAlgorithmStandaloneSetup.doSetup();

--- a/tests/org.eclipse.fordiac.ide.test.model.eval/src/org/eclipse/fordiac/ide/test/model/eval/st/STFunctionEvaluatorTest.xtend
+++ b/tests/org.eclipse.fordiac.ide.test.model.eval/src/org/eclipse/fordiac/ide/test/model/eval/st/STFunctionEvaluatorTest.xtend
@@ -28,7 +28,7 @@ import static extension org.junit.jupiter.api.Assertions.*
 class STFunctionEvaluatorTest {
 	@BeforeAll
 	def static void setupXtext() {
-		new DataTypeLibrary
+		new DataTypeLibrary(null)
 		GlobalConstantsStandaloneSetup.doSetup
 		STFunctionStandaloneSetup.doSetup
 		StructuredTextEvaluatorFactory.register

--- a/tests/org.eclipse.fordiac.ide.test.model.eval/src/org/eclipse/fordiac/ide/test/model/eval/st/StructuredTextEvaluatorTest.xtend
+++ b/tests/org.eclipse.fordiac.ide.test.model.eval/src/org/eclipse/fordiac/ide/test/model/eval/st/StructuredTextEvaluatorTest.xtend
@@ -95,7 +95,7 @@ class StructuredTextEvaluatorTest {
 
 	@BeforeAll
 	def static void setupXtext() {
-		new DataTypeLibrary
+		new DataTypeLibrary(null)
 		GlobalConstantsStandaloneSetup.doSetup
 		STFunctionStandaloneSetup.doSetup
 		STAlgorithmStandaloneSetup.doSetup

--- a/tests/org.eclipse.fordiac.ide.test.model.eval/src/org/eclipse/fordiac/ide/test/model/eval/variable/ValueValidatorTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model.eval/src/org/eclipse/fordiac/ide/test/model/eval/variable/ValueValidatorTest.java
@@ -52,7 +52,7 @@ class ValueValidatorTest {
 	@BeforeAll
 	@SuppressWarnings("unused")
 	static void setupXtext() {
-		new DataTypeLibrary();
+		new DataTypeLibrary(null);
 		GlobalConstantsStandaloneSetup.doSetup();
 		STFunctionStandaloneSetup.doSetup();
 		STAlgorithmStandaloneSetup.doSetup();

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/model/typelibrary/DataTypeLibraryTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/model/typelibrary/DataTypeLibraryTest.java
@@ -33,7 +33,7 @@ class DataTypeLibraryTest {
 
 	@BeforeAll
 	static void setup() {
-		dataTypeLibrary = new DataTypeLibrary();
+		dataTypeLibrary = new DataTypeLibrary(null);
 	}
 
 	@Test


### PR DESCRIPTION
Since quite some time the TypeEntry is preserved therefore searching for a new one does not make sense and using TypeEntry.getType shall always deliver the latest type.