### PR TITLE
Fix StringIndexOutOfBoundsException when resizing expanded subapplications [Issue 2245] 

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/ContainerResizePolicy.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/ContainerResizePolicy.java
@@ -40,6 +40,7 @@ public class ContainerResizePolicy extends ModifiedResizeablePolicy {
 	@Override
 	protected IFigure createDragSourceFeedbackFigure() {
 		boundsHelper.updateMargins(getHost().getModel());
+		getHostFigure().validate();
 		ghostFigure = new GhostImageFigure(getHostFigure(), 2 * ModifiedMoveHandle.SELECTION_FILL_ALPHA, null);
 		addFeedback(ghostFigure);
 		return super.createDragSourceFeedbackFigure();

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/FBNetworkElementNonResizeableEP.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/FBNetworkElementNonResizeableEP.java
@@ -64,6 +64,7 @@ public class FBNetworkElementNonResizeableEP extends ModifiedNonResizeableEditPo
 	@Override
 	protected IFigure createDragSourceFeedbackFigure() {
 		boundsHelper.updateMargins(getHost().getModel());
+		getHostFigure().validate();
 		ghostFigure = new GhostImageFigure(getHostFigure(), 2 * ModifiedMoveHandle.SELECTION_FILL_ALPHA, null);
 		addFeedback(ghostFigure);
 		return super.createDragSourceFeedbackFigure();


### PR DESCRIPTION
## Description
This PR fixes a `StringIndexOutOfBoundsException` that occurred when resizing expanded subapplications in the 4diac IDE.

The issue was caused by the `GhostImageFigure` attempting to paint the figure hierarchy (specifically `TextFlow` elements used for subapplication comments) before they were properly validated and laid out. This led to inconsistent string index calculations in `org.eclipse.draw2d.text.TextFlow.getBidiSubstring`.

### Fix
The fix ensures that the host figure is valid before the ghost image is created. By calling `getHostFigure().validate()` in the [createDragSourceFeedbackFigure](cci:1://file:///d:/4diac-ide/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/ContainerResizePolicy.java:39:1-46:2) method of both [FBNetworkElementNonResizeableEP](cci:2://file:///d:/4diac-ide/develop_fb.java:26:0-96:1) and [ContainerResizePolicy](cci:2://file:///d:/4diac-ide/develop_container.java:29:0-130:1), This ensures that all child figures have been correctly laid out and are in a consistent state for painting.

Fixes #2245