### PR TITLE
LibraryElementDependencyUpdater used old name to search in typelib

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/LibraryElementDependencyUpdater.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/LibraryElementDependencyUpdater.java
@@ -64,7 +64,7 @@ public class LibraryElementDependencyUpdater extends LibraryElementDependencyTra
 				// react to TYPE_ENTRY_FULL_TYPE_NAME_FEATURE for renamed dependencies
 				if (TypeEntry.TYPE_ENTRY_FULL_TYPE_NAME_FEATURE.equals(notification.getFeature())) {
 					Display.getDefault()
-							.asyncExec(() -> updateDependency(dependency, notification.getOldStringValue()));
+							.asyncExec(() -> updateDependency(dependency, notification.getNewStringValue()));
 				}
 			}
 		} else {


### PR DESCRIPTION
@mx990 does the dependency updater even need to search the typelib again? As we maintain typeentries couldn't we just use type entries as I do in PR #2294?