### PR TITLE
Use LibraryElementProvider for LiveSearch and AbstractModelChange

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/AbstractLiveSearchContext.java
+++ b/plugins/org.eclipse.fordiac.ide.model.search/src/org/eclipse/fordiac/ide/model/search/AbstractLiveSearchContext.java
@@ -21,16 +21,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
-import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
-import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.IEditorInput;
-import org.eclipse.ui.IEditorPart;
-import org.eclipse.ui.IEditorReference;
-import org.eclipse.ui.IWorkbench;
-import org.eclipse.ui.IWorkbenchPage;
-import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.PartInitException;
-import org.eclipse.ui.PlatformUI;
+import org.eclipse.fordiac.ide.model.ui.editors.LibraryElementProvider;
 import org.eclipse.ui.part.FileEditorInput;
 
 public abstract class AbstractLiveSearchContext implements ISearchContext {
@@ -63,54 +54,10 @@ public abstract class AbstractLiveSearchContext implements ISearchContext {
 	 * @return
 	 */
 	private static LibraryElement getLiveType(final TypeEntry typeEntry) {
+		final LibraryElement libElement = LibraryElementProvider.INSTANCE
+				.getLibraryElement(new FileEditorInput(typeEntry.getFile()));
 
-		final IEditorPart editor = getEditor(typeEntry);
-
-		if (editor == null) {
-			return typeEntry.getType();
-		}
-
-		final LibraryElement libElement = editor.getAdapter(LibraryElement.class);
-
-		if (libElement != null) {
-			return libElement;
-		}
-
-		// this should never happen
-		FordiacLogHelper
-				.logError("It was not possible to find a type for the typeEntry: " + typeEntry.getFullTypeName()); //$NON-NLS-1$
-		return null;
-
-	}
-
-	private static IEditorPart getEditor(final TypeEntry typeEntry) {
-		final IWorkbench workbench = PlatformUI.getWorkbench();
-
-		return Display.getDefault().syncCall(() -> {
-			final IWorkbenchWindow activeWorkbenchWindow = workbench.getActiveWorkbenchWindow();
-
-			if (activeWorkbenchWindow == null) {
-				final IWorkbenchWindow[] workbenchWindows = workbench.getWorkbenchWindows();
-				if (workbench.getWorkbenchWindows().length > 0 && workbenchWindows[0].getActivePage() != null) {
-					final IWorkbenchPage activePage = workbenchWindows[0].getActivePage();
-					for (final IEditorReference ref : activePage.getEditorReferences()) {
-						try {
-							final IEditorInput editorInput = ref.getEditorInput();
-							if (editorInput instanceof final FileEditorInput fileInput
-									&& fileInput.getFile().equals(typeEntry.getFile())) {
-								return ref.getEditor(true);
-							}
-						} catch (final PartInitException e) {
-							FordiacLogHelper.logWarning("Could not open Editor for type entry in search", e); //$NON-NLS-1$
-						}
-					}
-				}
-
-				return null;
-			}
-
-			return activeWorkbenchWindow.getActivePage().findEditor(new FileEditorInput(typeEntry.getFile()));
-		});
+		return (libElement != null) ? libElement : typeEntry.getType();
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/AbstractCommandChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/AbstractCommandChange.java
@@ -14,11 +14,9 @@ package org.eclipse.fordiac.ide.typemanagement.refactoring;
 
 import java.text.MessageFormat;
 import java.util.Objects;
-import java.util.stream.Stream;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
@@ -37,9 +35,7 @@ import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.CompositeChange;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.IEditorInput;
-import org.eclipse.ui.IEditorPart;
-import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.part.FileEditorInput;
 
 /**
@@ -57,7 +53,7 @@ public abstract class AbstractCommandChange<T extends EObject> extends Composite
 	private final Class<T> elementClass;
 	private final TypeEntry typeEntry;
 
-	private IEditorPart editor;
+	private boolean isOpenInEditor;
 
 	/**
 	 * Create an abstract command change with the last segment of the element URI as
@@ -204,8 +200,8 @@ public abstract class AbstractCommandChange<T extends EObject> extends Composite
 	 *           {@link CommandRedoChange}.
 	 */
 	protected LibraryElement acquireLibraryElement(final boolean editable) {
-		if (editor != null) {
-			return Adapters.adapt(editor, LibraryElement.class);
+		if (isOpenInEditor) {
+			return LibraryElementProvider.INSTANCE.getLibraryElement(getFileEditorInput());
 		}
 		if (typeEntry != null) {
 			return editable ? typeEntry.copyType() : typeEntry.getType();
@@ -222,8 +218,8 @@ public abstract class AbstractCommandChange<T extends EObject> extends Composite
 	 */
 	private void commit(final LibraryElement libraryElement, final IProgressMonitor pm) throws CoreException {
 		// save type entry
-		if (editor != null) {
-			LibraryElementProvider.INSTANCE.saveLibraryElement(editor.getEditorInput(), pm);
+		if (isOpenInEditor) {
+			LibraryElementProvider.INSTANCE.saveLibraryElement(getFileEditorInput(), pm);
 		} else if (typeEntry != null) {
 			typeEntry.save(libraryElement, pm);
 		}
@@ -292,15 +288,6 @@ public abstract class AbstractCommandChange<T extends EObject> extends Composite
 		return elementClass;
 	}
 
-	/**
-	 * Get the editor if open for the element URI
-	 *
-	 * @return The editor (may be null)
-	 */
-	public final IEditorPart getEditor() {
-		return editor;
-	}
-
 	private T getElement(final LibraryElement libraryElement) {
 		if (libraryElement != null && libraryElement.eResource() != null) {
 			final EObject element;
@@ -325,17 +312,14 @@ public abstract class AbstractCommandChange<T extends EObject> extends Composite
 	 *           corresponding file.
 	 */
 	protected boolean performInUIThread() {
-		return editor != null;
+		return isOpenInEditor;
 	}
 
 	private void initializeEditor() {
-		final IEditorInput editorInput = new FileEditorInput(getModifiedElement());
-		// need sync exec because IWorkbenchPage.findEditor(IEditorInput) may
-		// instantiate the editor if it is not loaded (e.g., open editor after a
-		// restart), which requires to be in the UI thread
-		Display.getDefault()
-				.syncExec(() -> editor = Stream.of(PlatformUI.getWorkbench().getWorkbenchWindows())
-						.flatMap(window -> Stream.of(window.getPages())).map(page -> page.findEditor(editorInput))
-						.filter(Objects::nonNull).findAny().orElse(null));
+		isOpenInEditor = LibraryElementProvider.INSTANCE.getLibraryElement(getFileEditorInput()) != null;
+	}
+
+	private IFileEditorInput getFileEditorInput() {
+		return new FileEditorInput(getModifiedElement());
 	}
 }


### PR DESCRIPTION
Both classes searched for the first editor that had the type file as editor input if the type file is open in a non 4diac IDE editor (e.g., xml text editor) search and refactoring didn't work.