### PR TITLE
Remove reload type from ChangeStructCommand

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeStructCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeStructCommand.java
@@ -24,7 +24,6 @@ import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes;
 import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableFB;
 import org.eclipse.fordiac.ide.model.libraryElement.Demultiplexer;
-import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.Multiplexer;
 import org.eclipse.fordiac.ide.model.libraryElement.StructManipulator;
@@ -35,7 +34,6 @@ public class ChangeStructCommand extends AbstractUpdateBlockFBNElementCommand {
 
 	private final TypeEntry newStructTypeEntry;
 	private final String newVisibleChildren;
-	private boolean reloadDatatype = true;
 
 	public ChangeStructCommand(final BlockFBNetworkElement fb, final DataType newStruct) {
 		super(fb);
@@ -50,17 +48,6 @@ public class ChangeStructCommand extends AbstractUpdateBlockFBNElementCommand {
 
 	public ChangeStructCommand(final StructManipulator mux, final DataType newStruct) {
 		this(mux, newStruct, getOldVisibleChildren(mux));
-	}
-
-	public ChangeStructCommand(final StructManipulator mux, final DataType newStruct, final String visibleChildren,
-			final boolean doNotReload) {
-		this(mux, newStruct, visibleChildren);
-		reloadDatatype = !doNotReload;
-	}
-
-	public ChangeStructCommand(final StructManipulator mux, final DataType newStruct, final boolean doNotReload) {
-		this(mux, newStruct, getOldVisibleChildren(mux));
-		reloadDatatype = !doNotReload;
 	}
 
 	public ChangeStructCommand(final Demultiplexer demux, final String newVisibleChildren) {
@@ -139,13 +126,6 @@ public class ChangeStructCommand extends AbstractUpdateBlockFBNElementCommand {
 			return IecTypes.GenericTypes.ANY_STRUCT;
 		}
 
-		final LibraryElement type;
-		if (reloadDatatype) {
-			type = newStructTypeEntry.getTypeLibrary().getDataTypeLibrary()
-					.getType(newStructTypeEntry.getFullTypeName());
-		} else {
-			type = newStructTypeEntry.getType();
-		}
-		return (type instanceof final DataType dt) ? dt : IecTypes.GenericTypes.ANY_STRUCT;
+		return (newStructTypeEntry.getType() instanceof final DataType dt) ? dt : IecTypes.GenericTypes.ANY_STRUCT;
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/UpdateManipulatorModelEdit.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/UpdateManipulatorModelEdit.java
@@ -55,6 +55,6 @@ public class UpdateManipulatorModelEdit extends ModelEdit<StructManipulator> {
 
 	@Override
 	protected Command createCommand(final StructManipulator manipulator) {
-		return new ChangeStructCommand(manipulator, IecTypes.GenericTypes.ANY, true);
+		return new ChangeStructCommand(manipulator, IecTypes.GenericTypes.ANY);
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/move/MoveTypeRefactoringParticipant.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/move/MoveTypeRefactoringParticipant.java
@@ -33,14 +33,10 @@ import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.model.IdentifierVerifier;
-import org.eclipse.fordiac.ide.model.commands.change.ChangeStructCommand;
-import org.eclipse.fordiac.ide.model.data.StructuredType;
 import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableFB;
-import org.eclipse.fordiac.ide.model.libraryElement.StructManipulator;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
-import org.eclipse.fordiac.ide.model.libraryElement.impl.ConfigurableFBManagement;
 import org.eclipse.fordiac.ide.model.search.types.BlockTypeInstanceSearch;
 import org.eclipse.fordiac.ide.model.search.types.DataTypeInstanceSearch;
 import org.eclipse.fordiac.ide.model.typelibrary.DataTypeEntry;
@@ -52,7 +48,6 @@ import org.eclipse.fordiac.ide.typemanagement.refactoring.ModelEdit;
 import org.eclipse.fordiac.ide.typemanagement.refactoring.ModelEditChange;
 import org.eclipse.fordiac.ide.typemanagement.refactoring.RefactoringUtil;
 import org.eclipse.fordiac.ide.typemanagement.refactoring.UpdateFBInstanceModelEdit;
-import org.eclipse.gef.commands.Command;
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.CompositeChange;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
@@ -150,7 +145,7 @@ public class MoveTypeRefactoringParticipant extends MoveParticipant {
 						EcoreUtil.getURI(eObject), PackageNameHelper.getFullTypeNameFromFile(newFile)));
 			}
 			if (eObject instanceof final BlockFBNetworkElement elem) {
-				modelEdits.add(new UpdateInstanceModelEdit(elem, dtEntry));
+				modelEdits.add(new UpdateFBInstanceModelEdit(elem, dtEntry));
 			}
 		}
 	}
@@ -163,27 +158,6 @@ public class MoveTypeRefactoringParticipant extends MoveParticipant {
 				modelEdits.add(new UpdateFBInstanceModelEdit(elem, typeEntry));
 			}
 		}
-	}
-
-	private static class UpdateInstanceModelEdit extends UpdateFBInstanceModelEdit {
-		final String visibleChildrenString;
-
-		public UpdateInstanceModelEdit(final BlockFBNetworkElement instance, final TypeEntry typeEntry) {
-			super(instance, typeEntry);
-			visibleChildrenString = (instance instanceof final StructManipulator structManipulator)
-					? ConfigurableFBManagement.buildVisibleChildrenString(structManipulator.getMemberVars())
-					: ""; //$NON-NLS-1$
-		}
-
-		@Override
-		protected Command createCommand(final BlockFBNetworkElement element) {
-			if (element instanceof final StructManipulator demux
-					&& typeEntry.getType() instanceof final StructuredType structuredType) {
-				return new ChangeStructCommand(demux, structuredType, visibleChildrenString, true);
-			}
-			return super.createCommand(element);
-		}
-
 	}
 
 }


### PR DESCRIPTION
Since quite some time the TypeEntry is preserved therefore searching for a new one does not make sense and using TypeEntry.getType shall always deliver the latest type.