### PR TITLE
Suppress logging of core exceptions during load in type entry

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractInterfaceTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractInterfaceTypeEntryImpl.java
@@ -38,7 +38,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
-import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 
 public abstract class AbstractInterfaceTypeEntryImpl<T extends FBType> extends AbstractCheckedTypeEntryImpl<T>
 		implements InterfaceTypeEntry {
@@ -178,7 +177,7 @@ public abstract class AbstractInterfaceTypeEntryImpl<T extends FBType> extends A
 			updateInterfaceDependencies(importer.getDependencies());
 			return interfaceType;
 		} catch (final Exception e) {
-			FordiacLogHelper.logWarning("Error loading type " + getFile().getName() + ": " + e.getMessage(), e); //$NON-NLS-1$ //$NON-NLS-2$
+			handleLoadException(e);
 			return null;
 		}
 	}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
@@ -362,7 +362,7 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 			retval.setTypeEntry(this);
 			return retval;
 		} catch (final Exception e) {
-			FordiacLogHelper.logWarning("Error loading type " + getFile().getName() + ": " + e.getMessage(), e); //$NON-NLS-1$ //$NON-NLS-2$
+			handleLoadException(e);
 			return null;
 		} finally {
 			loading = false;
@@ -640,7 +640,7 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 						return foundTypeName;
 					}
 				} catch (final Exception e) {
-					FordiacLogHelper.logWarning(e.getMessage(), e);
+					handleLoadException(e);
 				}
 			}
 			return TypeEntry.getTypeNameFromFile(cachedFile);
@@ -656,10 +656,18 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 					return CommonElementImporter.fullyUnEscapeValue(scanner.match().group(1));
 				}
 			} catch (final Exception e) {
-				FordiacLogHelper.logWarning(e.getMessage(), e);
+				handleLoadException(e);
 			}
 		}
 		return ""; //$NON-NLS-1$
+	}
+
+	protected void handleLoadException(final Exception e) {
+		// suppress logging of core exceptions (e.g., resource not found)
+		if (e instanceof CoreException || e.getCause() instanceof CoreException) {
+			return;
+		}
+		FordiacLogHelper.logWarning("Error loading type " + getFile().getName() + ": " + e.getMessage(), e); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	protected static NotificationChain chainNotification(final NotificationChain notifications,


### PR DESCRIPTION
There may be core exceptions during type load due to a resource being inaccessible or out-of-sync with the filesystem. This prevents flooding the log with such exceptions.