### PR TITLE
Fix dependency update during move refactoring

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/LibraryElementDependencyUpdater.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/LibraryElementDependencyUpdater.java
@@ -73,6 +73,9 @@ public class LibraryElementDependencyUpdater extends LibraryElementDependencyTra
 	}
 
 	public void updateDependency(final TypeEntry dependency, final String fullTypeName) {
+		if (libraryElement == null) {
+			return;
+		}
 		final TypeLibrary typeLibrary = libraryElement.getTypeLibrary();
 		if (typeLibrary == null) {
 			return;

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/AbstractCommandChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/AbstractCommandChange.java
@@ -89,6 +89,9 @@ public abstract class AbstractCommandChange<T extends EObject> extends Composite
 	 */
 	@Override
 	public final void initializeValidationData(final IProgressMonitor pm) {
+		if (pm.isCanceled()) {
+			throw new OperationCanceledException();
+		}
 		initializeEditor();
 		final LibraryElement libraryElement = acquireLibraryElement(false);
 		final T element = getElement(libraryElement);
@@ -110,6 +113,9 @@ public abstract class AbstractCommandChange<T extends EObject> extends Composite
 	 */
 	@Override
 	public final RefactoringStatus isValid(final IProgressMonitor pm) throws CoreException, OperationCanceledException {
+		if (pm.isCanceled()) {
+			throw new OperationCanceledException();
+		}
 		final RefactoringStatus status = new RefactoringStatus();
 		final LibraryElement libraryElement = acquireLibraryElement(false);
 		final T element = getElement(libraryElement);
@@ -136,20 +142,19 @@ public abstract class AbstractCommandChange<T extends EObject> extends Composite
 	 */
 	@Override
 	public final Change perform(final IProgressMonitor pm) throws CoreException {
-		if (performInUIThread() && Display.getCurrent() == null) {
-			final Change[] change = new Change[1];
-			final CoreException[] coreException = new CoreException[1];
-			Display.getDefault().syncExec(() -> {
-				try {
-					change[0] = doPerform(pm);
-				} catch (final CoreException e) {
-					coreException[0] = e;
-				}
-			});
-			if (coreException[0] != null) {
-				throw coreException[0];
+		if (pm.isCanceled()) {
+			throw new OperationCanceledException();
+		}
+
+		if (performInUIThread()) {
+			if (Display.getCurrent() == null) {
+				return Display.getDefault().syncCall(() -> doPerform(pm));
 			}
-			return change[0];
+
+			// process outstanding UI/dependency updates if in UI thread
+			while (Display.getCurrent().readAndDispatch()) {
+				// read and dispatch events
+			}
 		}
 		return doPerform(pm);
 	}


### PR DESCRIPTION
There was a problem when refactorings were executed entirely within the UI thread, such as when using drag&drop to move a resource. This delayed UI updates, particularly dependency updates for edited library elements, until after the refactoring had completed.

This fixes the problem by explicitly running the event loop before performing changes to ensure any pending dependency updates have finished before proceeding.