### PR TITLE
Fixed exception in SubAppCrossingConnectionCommand

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/CreateSubAppCrossingConnectionsCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/commands/CreateSubAppCrossingConnectionsCommand.java
@@ -386,6 +386,9 @@ public class CreateSubAppCrossingConnectionsCommand extends Command implements S
 		}
 
 		final IInterfaceElement typePin = template.findInTypeInterface();
+		if (typePin == null) {
+			return;
+		}
 		final var searchSupport = ISearchFactory.createSearchSupport(typePin, typePin.eClass().getInstanceClass());
 		if (searchSupport == null) {
 			return;


### PR DESCRIPTION
Exception happend when template was from an UntypedSubApp
Fix for #2331 