### PR TITLE
Add library wizard with planning page

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gitlab/src/org/eclipse/fordiac/ide/gitlab/management/GitLabDownloader.java
+++ b/plugins/org.eclipse.fordiac.ide.gitlab/src/org/eclipse/fordiac/ide/gitlab/management/GitLabDownloader.java
@@ -154,7 +154,6 @@ public class GitLabDownloader implements IArchiveDownloader {
 				getPackages(project);
 			}
 		} catch (final IOException e) {
-			FordiacLogHelper.logError("Problem with GitLab import", e); //$NON-NLS-1$
 			return new DownloadResult<>(DownloadResult.Status.ERROR,
 					MessageFormat.format(Messages.Download_Error, e.getMessage()));
 		}

--- a/plugins/org.eclipse.fordiac.ide.library.ui/plugin.properties
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/plugin.properties
@@ -71,3 +71,9 @@ UnifiedLibraryImportWizardPage_select_to_see_details=Select a library to see det
 UnifiedLibraryImportWizardPage_show_latest=Show latest versions only
 UnifiedLibraryImportWizardPage_source=source
 UnifiedLibraryImportWizardPage_work_with=Work with:
+LibraryPlanningPage_SymbolicName=SymbolicName
+LibraryPlanningPage_ActiveVersion=ActiveVersion
+LibraryPlanningPage_Action=Action
+
+ManageLibraryWizard_Label=Manage Libraries
+ManageLibraryWizard_Description=Manage and update version of currently used libraries

--- a/plugins/org.eclipse.fordiac.ide.library.ui/plugin.properties
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/plugin.properties
@@ -71,9 +71,9 @@ UnifiedLibraryImportWizardPage_select_to_see_details=Select a library to see det
 UnifiedLibraryImportWizardPage_show_latest=Show latest versions only
 UnifiedLibraryImportWizardPage_source=source
 UnifiedLibraryImportWizardPage_work_with=Work with:
-LibraryPlanningPage_SymbolicName=SymbolicName
-LibraryPlanningPage_ActiveVersion=ActiveVersion
-LibraryPlanningPage_Action=Action
+LibraryPlanningPage_SymbolicName=Symbolic Name
+LibraryPlanningPage_ActiveVersion=Active Version
+LibraryPlanningPage_Action=Planned Action
 
 ManageLibraryWizard_Label=Manage Libraries
 ManageLibraryWizard_Description=Manage and update version of currently used libraries

--- a/plugins/org.eclipse.fordiac.ide.library.ui/plugin.properties
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/plugin.properties
@@ -74,6 +74,7 @@ UnifiedLibraryImportWizardPage_work_with=Work with:
 
 LibraryChangeAction_Downgrade={0} (downgrade)
 LibraryChangeAction_Empty=select action
+LibraryPlanningPage_LoadRemoteVersions=Load remote versions of linked Libraries
 LibraryChangeAction_Remove=Remove
 LibraryChangeAction_Update={0} (update)
 

--- a/plugins/org.eclipse.fordiac.ide.library.ui/plugin.properties
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/plugin.properties
@@ -71,9 +71,16 @@ UnifiedLibraryImportWizardPage_select_to_see_details=Select a library to see det
 UnifiedLibraryImportWizardPage_show_latest=Show latest versions only
 UnifiedLibraryImportWizardPage_source=source
 UnifiedLibraryImportWizardPage_work_with=Work with:
-LibraryPlanningPage_SymbolicName=Symbolic Name
+
+LibraryChangeAction_Downgrade={0} (downgrade)
+LibraryChangeAction_Empty=select action
+LibraryChangeAction_Remove=Remove
+LibraryChangeAction_Update={0} (update)
+
 LibraryPlanningPage_ActiveVersion=Active Version
 LibraryPlanningPage_Action=Planned Action
+LibraryPlanningPage_SymbolicName=Symbolic Name
+LibraryPlanningPage_Titel=Manage Linked Libraries
 
 ManageLibraryWizard_Label=Manage Libraries
 ManageLibraryWizard_Description=Manage and update version of currently used libraries

--- a/plugins/org.eclipse.fordiac.ide.library.ui/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/plugin.xml
@@ -115,4 +115,48 @@
          </enablement>
       </changePreviewViewer>
    </extension>
+   
+	<extension point="org.eclipse.ui.commands">
+  		<command
+      		id="org.eclipse.fordiac.ide.library.ui.openManageLibraryWizard"
+      		name="Open My Wizard"/>
+	</extension>
+
+<extension point="org.eclipse.ui.handlers">
+  <handler
+      commandId="org.eclipse.fordiac.ide.library.ui.openManageLibraryWizard"
+      class="org.eclipse.fordiac.ide.library.ui.handlers.OpenManageLibraryWizardHandler"/>
+</extension>
+
+   <extension point="org.eclipse.ui.menus">
+      <menuContribution
+            locationURI="popup:org.eclipse.ui.popup.any?after=additions">
+
+         <command
+               commandId="org.eclipse.fordiac.ide.library.ui.openManageLibraryWizard"
+               label="%ManageLibraryWizard_Label"
+               tooltip="%ManageLibraryWizard_Description"
+               style="push">
+
+            <visibleWhen checkEnabled="false">
+               <with variable="selection">
+                  <count value="1"/>
+                  <iterate>
+                  	<or>
+	             		<and>
+		                     <instanceof value="org.eclipse.core.resources.IFolder"/>
+		                     <or>
+		                     	<test property="org.eclipse.core.resources.name" value="External Libraries"></test>
+		                     	<test property="org.eclipse.core.resources.name" value="Standard Libraries"></test>
+		                     </or>
+	                    </and>
+                    	<instanceof value="org.eclipse.core.resources.IProject"/>
+                    </or>
+                  </iterate>
+               </with>
+            </visibleWhen>
+         </command>
+      </menuContribution>
+   </extension>
+
 </plugin>

--- a/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/Messages.java
@@ -114,9 +114,16 @@ public class Messages extends NLS {
 	public static String UnifiedLibraryImportWizardPage_source;
 
 	public static String UnifiedLibraryImportWizardPage_work_with;
-	public static String LibraryPlanningPage_SymbolicName;
+
+	public static String LibraryChangeAction_Downgrade;
+	public static String LibraryChangeAction_Empty;
+	public static String LibraryChangeAction_Remove;
+	public static String LibraryChangeAction_Update;
+
 	public static String LibraryPlanningPage_ActiveVersion;
 	public static String LibraryPlanningPage_Action;
+	public static String LibraryPlanningPage_SymbolicName;
+	public static String LibraryPlanningPage_Titel;
 
 	public static String ManageLibraryWizard_Label;
 	public static String ManageLibraryWizard_Description;

--- a/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/Messages.java
@@ -114,6 +114,12 @@ public class Messages extends NLS {
 	public static String UnifiedLibraryImportWizardPage_source;
 
 	public static String UnifiedLibraryImportWizardPage_work_with;
+	public static String LibraryPlanningPage_SymbolicName;
+	public static String LibraryPlanningPage_ActiveVersion;
+	public static String LibraryPlanningPage_Action;
+
+	public static String ManageLibraryWizard_Label;
+	public static String ManageLibraryWizard_Description;
 
 	static {
 		// initialize resource bundle

--- a/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/Messages.java
@@ -122,6 +122,7 @@ public class Messages extends NLS {
 
 	public static String LibraryPlanningPage_ActiveVersion;
 	public static String LibraryPlanningPage_Action;
+	public static String LibraryPlanningPage_LoadRemoteVersions;
 	public static String LibraryPlanningPage_SymbolicName;
 	public static String LibraryPlanningPage_Titel;
 

--- a/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/handlers/OpenManageLibraryWizardHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/handlers/OpenManageLibraryWizardHandler.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * 	Mario Kastner - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.library.ui.handlers;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.fordiac.ide.library.ui.wizards.ManageLibraryWizard;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.wizard.WizardDialog;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.handlers.HandlerUtil;
+
+public class OpenManageLibraryWizardHandler extends AbstractHandler {
+
+	@Override
+	public Object execute(final ExecutionEvent event) throws ExecutionException {
+		final IEditorPart editor = HandlerUtil.getActiveEditor(event);
+
+		final var shell = (editor != null) ? editor.getSite().getShell() : HandlerUtil.getActiveShell(event);
+
+		final IStructuredSelection selection = HandlerUtil.getCurrentStructuredSelection(event);
+		final IProject project = getProject(selection);
+
+		if (project != null) {
+			final ManageLibraryWizard wizard = new ManageLibraryWizard(project);
+			wizard.setWindowTitle("Manage Linked Libraries");
+			final WizardDialog dialog = new WizardDialog(shell, wizard);
+			dialog.setBlockOnOpen(false);
+			dialog.setModal(false);
+			dialog.create();
+			dialog.open();
+		}
+
+		return Status.OK_STATUS;
+	}
+
+	private static IProject getProject(final IStructuredSelection selection) {
+		if (selection != null && !selection.isEmpty()
+				&& selection.getFirstElement() instanceof final IResource resource) {
+			return resource.getProject();
+		}
+		return null;
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/LibraryChangeAction.java
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/LibraryChangeAction.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Mario Kastner - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.library.ui.wizards;
+
+import java.text.MessageFormat;
+
+import org.eclipse.fordiac.ide.library.model.util.VersionComparator;
+import org.osgi.framework.Version;
+
+public class LibraryChangeAction {
+
+	public enum ActionType {
+		EMPTY, REMOVE, UPDATE, DOWNGRADE
+	}
+
+	private final String targetVersion;
+	private final ActionType actionType;
+	private static final LibraryChangeAction emptyAction = new LibraryChangeAction(Version.emptyVersion.toString(),
+			ActionType.EMPTY);
+	private static final LibraryChangeAction removeAction = new LibraryChangeAction(Version.emptyVersion.toString(),
+			ActionType.REMOVE);
+
+	public static LibraryChangeAction createAction(final LibraryDescriptorNode node, final String targetVersion) {
+		final int result = new VersionComparator().compare(node.getActiveVersion(), targetVersion);
+
+		if (result == 0) {
+			return emptyAction;
+		}
+
+		return result < 0 ? new LibraryChangeAction(targetVersion, ActionType.UPDATE)
+				: new LibraryChangeAction(targetVersion, ActionType.DOWNGRADE);
+	}
+
+	public static LibraryChangeAction emptyAction() {
+		return emptyAction;
+	}
+
+	public static LibraryChangeAction removeAction() {
+		return removeAction;
+	}
+
+	public ActionType getType() {
+		return this.actionType;
+	}
+
+	public String getTargetVersion() {
+		return targetVersion;
+	}
+
+	private LibraryChangeAction(final String targetVersion, final ActionType actionType) {
+		this.targetVersion = targetVersion;
+		this.actionType = actionType;
+	}
+
+	public static String getActionText(final LibraryChangeAction action) {
+		return switch (action.getType()) {
+		case REMOVE: {
+			yield "Remove Library"; //$NON-NLS-1$
+		}
+		case UPDATE: {
+			yield MessageFormat.format("{0} (update)", action.getTargetVersion()); //$NON-NLS-1$
+		}
+		case DOWNGRADE: {
+			yield MessageFormat.format("{0} (downgrade)", action.getTargetVersion()); //$NON-NLS-1$
+		}
+		case EMPTY: {
+			yield "select action ..";//$NON-NLS-1$
+		}
+		default:
+			yield ""; //$NON-NLS-1$
+		};
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/LibraryChangeAction.java
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/LibraryChangeAction.java
@@ -15,6 +15,7 @@ package org.eclipse.fordiac.ide.library.ui.wizards;
 import java.text.MessageFormat;
 
 import org.eclipse.fordiac.ide.library.model.util.VersionComparator;
+import org.eclipse.fordiac.ide.library.ui.Messages;
 import org.osgi.framework.Version;
 
 public class LibraryChangeAction {
@@ -32,11 +33,9 @@ public class LibraryChangeAction {
 
 	public static LibraryChangeAction createAction(final LibraryDescriptorNode node, final String targetVersion) {
 		final int result = new VersionComparator().compare(node.getActiveVersion(), targetVersion);
-
 		if (result == 0) {
 			return emptyAction;
 		}
-
 		return result < 0 ? new LibraryChangeAction(targetVersion, ActionType.UPDATE)
 				: new LibraryChangeAction(targetVersion, ActionType.DOWNGRADE);
 	}
@@ -63,18 +62,22 @@ public class LibraryChangeAction {
 	}
 
 	public static String getActionText(final LibraryChangeAction action) {
+		if (action == null) {
+			return ""; //$NON-NLS-1$
+		}
+
 		return switch (action.getType()) {
 		case REMOVE: {
-			yield "Remove Library"; //$NON-NLS-1$
+			yield Messages.LibraryChangeAction_Remove;
 		}
 		case UPDATE: {
-			yield MessageFormat.format("{0} (update)", action.getTargetVersion()); //$NON-NLS-1$
+			yield MessageFormat.format(Messages.LibraryChangeAction_Update, action.getTargetVersion());
 		}
 		case DOWNGRADE: {
-			yield MessageFormat.format("{0} (downgrade)", action.getTargetVersion()); //$NON-NLS-1$
+			yield MessageFormat.format(Messages.LibraryChangeAction_Downgrade, action.getTargetVersion());
 		}
 		case EMPTY: {
-			yield "select action ..";//$NON-NLS-1$
+			yield Messages.LibraryChangeAction_Empty + " ..";//$NON-NLS-1$
 		}
 		default:
 			yield ""; //$NON-NLS-1$

--- a/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/LibraryDescriptorNode.java
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/LibraryDescriptorNode.java
@@ -19,12 +19,12 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import org.eclipse.fordiac.ide.library.ui.wizards.LibraryChangeAction.ActionType;
-import org.eclipse.jface.viewers.ColumnLabelProvider;
 import org.eclipse.jface.viewers.StyledCellLabelProvider;
 import org.eclipse.jface.viewers.StyledString;
+import org.eclipse.jface.viewers.StyledString.Styler;
 import org.eclipse.jface.viewers.ViewerCell;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.TextStyle;
 import org.eclipse.swt.widgets.Display;
 
 public class LibraryDescriptorNode {
@@ -69,7 +69,7 @@ public class LibraryDescriptorNode {
 		return Collections.emptyList();
 	}
 
-	public LibraryChangeAction getActionType() {
+	public LibraryChangeAction getAction() {
 		return action;
 	}
 
@@ -77,71 +77,60 @@ public class LibraryDescriptorNode {
 		this.action = action;
 	}
 
-	public static class ActionLabelProvider extends StyledCellLabelProvider {
+	public static class LibraryDescriptorLabelProvider extends StyledCellLabelProvider {
+
+		private static final StyledString.Styler UPGRADE_DOWNGRADE_STYLER = new StyledString.Styler() {
+			@Override
+			public void applyStyles(final TextStyle textStyle) {
+				textStyle.foreground = Display.getCurrent().getSystemColor(SWT.COLOR_DARK_RED);
+				textStyle.background = Display.getCurrent().getSystemColor(SWT.COLOR_YELLOW);
+			}
+		};
+
+		private static final StyledString.Styler REMOVE_STYLER = new StyledString.Styler() {
+			@Override
+			public void applyStyles(final TextStyle textStyle) {
+				textStyle.foreground = Display.getCurrent().getSystemColor(SWT.COLOR_WHITE);
+				textStyle.background = Display.getCurrent().getSystemColor(SWT.COLOR_RED);
+			}
+		};
+
+		private final Function<LibraryDescriptorNode, String> textProvider;
+		private final boolean isModifiable;
+
+		public LibraryDescriptorLabelProvider(final Function<LibraryDescriptorNode, String> textProvider,
+				final boolean isModifiable) {
+			Objects.requireNonNull(textProvider);
+			this.textProvider = textProvider;
+			this.isModifiable = isModifiable;
+		}
+
 		@Override
 		public void update(final ViewerCell cell) {
 			if (cell.getElement() instanceof final LibraryDescriptorNode node) {
 				final StyledString styled = new StyledString();
-
 				if (node.getChildren().isEmpty()) {
-					if (node.getActionType().getType() == ActionType.EMPTY) {
-						styled.append(LibraryChangeAction.getActionText(node.getActionType()),
-								StyledString.QUALIFIER_STYLER);
-					} else {
-						styled.append(LibraryChangeAction.getActionText(node.getActionType()));
-					}
+					styled.append(textProvider.apply(node), getStyler(node));
 				}
 				cell.setText(styled.getString());
 				cell.setStyleRanges(styled.getStyleRanges());
-
 				super.update(cell);
 			}
 		}
-	}
 
-	public static class LibraryDescriptorLabelProvider extends ColumnLabelProvider {
-
-		private final Function<LibraryDescriptorNode, String> textProvider;
-
-		public LibraryDescriptorLabelProvider(final Function<LibraryDescriptorNode, String> textProvider) {
-			Objects.requireNonNull(textProvider);
-			this.textProvider = textProvider;
-		}
-
-		@Override
-		public String getText(final Object element) {
-			if (element instanceof final LibraryDescriptorNode desc) {
-				return textProvider.apply(desc);
+		protected Styler getStyler(final LibraryDescriptorNode node) {
+			final ActionType type = node.getAction().getType();
+			if (type == ActionType.EMPTY && isModifiable) {
+				return StyledString.QUALIFIER_STYLER;
 			}
-			return ""; //$NON-NLS-1$
-		}
 
-		@Override
-		public Color getBackground(final Object element) {
-			if (element instanceof final LibraryDescriptorNode desc) {
-				if (desc.getActionType().getType() == ActionType.REMOVE) {
-					return Display.getCurrent().getSystemColor(SWT.COLOR_RED);
-				}
-				if (desc.getActionType().getType() == ActionType.EMPTY) {
-					return super.getBackground(element);
-				}
-			}
-			return Display.getCurrent().getSystemColor(SWT.COLOR_YELLOW);
+			return switch (type) {
+			case ActionType.REMOVE -> REMOVE_STYLER;
+			case ActionType.UPDATE -> UPGRADE_DOWNGRADE_STYLER;
+			case ActionType.DOWNGRADE -> UPGRADE_DOWNGRADE_STYLER;
+			default -> null;
+			};
 		}
-
-		@Override
-		public Color getForeground(final Object element) {
-			if (element instanceof final LibraryDescriptorNode desc) {
-				if (desc.getActionType().getType() == ActionType.REMOVE) {
-					return Display.getCurrent().getSystemColor(SWT.COLOR_WHITE);
-				}
-				if (desc.getActionType().getType() == ActionType.EMPTY) {
-					return super.getForeground(element);
-				}
-			}
-			return Display.getCurrent().getSystemColor(SWT.COLOR_DARK_RED);
-		}
-
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/LibraryDescriptorNode.java
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/LibraryDescriptorNode.java
@@ -51,7 +51,7 @@ public class LibraryDescriptorNode {
 		return activeVersion;
 	}
 
-	public void setActiveVerion(final String activeVersion) {
+	public void setActiveVersion(final String activeVersion) {
 		this.activeVersion = activeVersion;
 	}
 
@@ -100,8 +100,7 @@ public class LibraryDescriptorNode {
 
 		public LibraryDescriptorLabelProvider(final Function<LibraryDescriptorNode, String> textProvider,
 				final boolean isModifiable) {
-			Objects.requireNonNull(textProvider);
-			this.textProvider = textProvider;
+			this.textProvider = Objects.requireNonNull(textProvider);
 			this.isModifiable = isModifiable;
 		}
 
@@ -111,6 +110,8 @@ public class LibraryDescriptorNode {
 				final StyledString styled = new StyledString();
 				if (node.getChildren().isEmpty()) {
 					styled.append(textProvider.apply(node), getStyler(node));
+				} else {
+					styled.append(textProvider.apply(node));
 				}
 				cell.setText(styled.getString());
 				cell.setStyleRanges(styled.getStyleRanges());

--- a/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/LibraryDescriptorNode.java
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/LibraryDescriptorNode.java
@@ -1,0 +1,147 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Mario Kastner - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.library.ui.wizards;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.eclipse.fordiac.ide.library.ui.wizards.LibraryChangeAction.ActionType;
+import org.eclipse.jface.viewers.ColumnLabelProvider;
+import org.eclipse.jface.viewers.StyledCellLabelProvider;
+import org.eclipse.jface.viewers.StyledString;
+import org.eclipse.jface.viewers.ViewerCell;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.widgets.Display;
+
+public class LibraryDescriptorNode {
+	private String name;
+	private String activeVersion;
+	private List<LibraryDescriptorNode> children;
+	private LibraryChangeAction action;
+
+	public LibraryDescriptorNode(final String name, final String activeVersion) {
+		this.name = name;
+		this.activeVersion = activeVersion;
+		this.action = LibraryChangeAction.emptyAction();
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(final String name) {
+		this.name = name;
+	}
+
+	public String getActiveVersion() {
+		return activeVersion;
+	}
+
+	public void setActiveVerion(final String activeVersion) {
+		this.activeVersion = activeVersion;
+	}
+
+	public void addChild(final LibraryDescriptorNode node) {
+		if (this.children == null) {
+			children = new ArrayList<>();
+		}
+		children.add(node);
+	}
+
+	public List<LibraryDescriptorNode> getChildren() {
+		if (children != null) {
+			return children;
+		}
+		return Collections.emptyList();
+	}
+
+	public LibraryChangeAction getActionType() {
+		return action;
+	}
+
+	public void setAction(final LibraryChangeAction action) {
+		this.action = action;
+	}
+
+	public static class ActionLabelProvider extends StyledCellLabelProvider {
+		@Override
+		public void update(final ViewerCell cell) {
+			if (cell.getElement() instanceof final LibraryDescriptorNode node) {
+				final StyledString styled = new StyledString();
+
+				if (node.getChildren().isEmpty()) {
+					if (node.getActionType().getType() == ActionType.EMPTY) {
+						styled.append(LibraryChangeAction.getActionText(node.getActionType()),
+								StyledString.QUALIFIER_STYLER);
+					} else {
+						styled.append(LibraryChangeAction.getActionText(node.getActionType()));
+					}
+				}
+				cell.setText(styled.getString());
+				cell.setStyleRanges(styled.getStyleRanges());
+
+				super.update(cell);
+			}
+		}
+	}
+
+	public static class LibraryDescriptorLabelProvider extends ColumnLabelProvider {
+
+		private final Function<LibraryDescriptorNode, String> textProvider;
+
+		public LibraryDescriptorLabelProvider(final Function<LibraryDescriptorNode, String> textProvider) {
+			Objects.requireNonNull(textProvider);
+			this.textProvider = textProvider;
+		}
+
+		@Override
+		public String getText(final Object element) {
+			if (element instanceof final LibraryDescriptorNode desc) {
+				return textProvider.apply(desc);
+			}
+			return ""; //$NON-NLS-1$
+		}
+
+		@Override
+		public Color getBackground(final Object element) {
+			if (element instanceof final LibraryDescriptorNode desc) {
+				if (desc.getActionType().getType() == ActionType.REMOVE) {
+					return Display.getCurrent().getSystemColor(SWT.COLOR_RED);
+				}
+				if (desc.getActionType().getType() == ActionType.EMPTY) {
+					return super.getBackground(element);
+				}
+			}
+			return Display.getCurrent().getSystemColor(SWT.COLOR_YELLOW);
+		}
+
+		@Override
+		public Color getForeground(final Object element) {
+			if (element instanceof final LibraryDescriptorNode desc) {
+				if (desc.getActionType().getType() == ActionType.REMOVE) {
+					return Display.getCurrent().getSystemColor(SWT.COLOR_WHITE);
+				}
+				if (desc.getActionType().getType() == ActionType.EMPTY) {
+					return super.getForeground(element);
+				}
+			}
+			return Display.getCurrent().getSystemColor(SWT.COLOR_DARK_RED);
+		}
+
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/LibraryPlanningPage.java
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/LibraryPlanningPage.java
@@ -28,6 +28,7 @@ import org.eclipse.fordiac.ide.library.download.DownloadResult;
 import org.eclipse.fordiac.ide.library.ui.Messages;
 import org.eclipse.fordiac.ide.library.ui.wizards.LibraryDescriptorNode.LibraryDescriptorLabelProvider;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
+import org.eclipse.jface.dialogs.IMessageProvider;
 import org.eclipse.jface.layout.TreeColumnLayout;
 import org.eclipse.jface.viewers.CellEditor;
 import org.eclipse.jface.viewers.CellLabelProvider;
@@ -231,11 +232,11 @@ public class LibraryPlanningPage extends WizardPage {
 
 		// Get available remote Versions
 		initRemoteVersionLookup();
-
 	}
 
 	private void initRemoteVersionLookup() {
 		final GitLabDownloader downloader = new GitLabDownloader();
+		final StringBuilder message = new StringBuilder();
 		downloader.convertEndpointsToDownloader().stream().forEach(d -> {
 			if (d.isActive()) {
 				final DownloadResult<Void> fetch = downloader.fetchProjectsAndPackages();
@@ -247,10 +248,14 @@ public class LibraryPlanningPage extends WizardPage {
 								.map(LeafNode::getVersion).forEach(v -> remoteVersionLookup
 										.computeIfAbsent(symbolicName, s -> new ArrayList<>()).add(v));
 					}
-
+				} else {
+					message.append(fetch.message());
 				}
 			}
 		});
+		if (!message.isEmpty()) {
+			setMessage(message.toString(), IMessageProvider.WARNING);
+		}
 	}
 
 	private TreeViewerColumn createColumn(final String name, final CellLabelProvider labelProvider) {

--- a/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/LibraryPlanningPage.java
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/LibraryPlanningPage.java
@@ -144,15 +144,15 @@ public class LibraryPlanningPage extends WizardPage {
 
 	private void configureColumns(final TreeColumnLayout layout) {
 		final TreeViewerColumn symbolicNameColumn = createColumn(Messages.LibraryPlanningPage_SymbolicName,
-				new LibraryDescriptorLabelProvider(LibraryDescriptorNode::getName));
+				new LibraryDescriptorLabelProvider(LibraryDescriptorNode::getName, false));
 		layout.setColumnData(symbolicNameColumn.getColumn(), new ColumnWeightData(40));
 
 		final TreeViewerColumn activeVersionColumn = createColumn(Messages.LibraryPlanningPage_ActiveVersion,
-				new LibraryDescriptorLabelProvider(LibraryDescriptorNode::getActiveVersion));
+				new LibraryDescriptorLabelProvider(LibraryDescriptorNode::getActiveVersion, false));
 		layout.setColumnData(activeVersionColumn.getColumn(), new ColumnWeightData(20));
 
 		final TreeViewerColumn actionColumn = createColumn(Messages.LibraryPlanningPage_Action,
-				new LibraryDescriptorNode.ActionLabelProvider());
+				new LibraryDescriptorLabelProvider(node -> LibraryChangeAction.getActionText(node.getAction()), true));
 		layout.setColumnData(actionColumn.getColumn(), new ColumnWeightData(20));
 
 		actionColumn.setEditingSupport(new EditingSupport(treeViewer) {
@@ -172,7 +172,7 @@ public class LibraryPlanningPage extends WizardPage {
 			@Override
 			protected Object getValue(final Object element) {
 				if (element instanceof final LibraryDescriptorNode rec) {
-					return Integer.valueOf(getAvailableActions(rec).indexOf(rec.getActionType()));
+					return Integer.valueOf(getAvailableActions(rec).indexOf(rec.getAction()));
 				}
 				return Integer.valueOf(0);
 			}

--- a/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/LibraryPlanningPage.java
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/LibraryPlanningPage.java
@@ -61,6 +61,10 @@ public class LibraryPlanningPage extends WizardPage {
 		this.remoteVersionLookup = new HashMap<>();
 	}
 
+	public List<LibraryDescriptorNode> getModifiedNodes() {
+		return getLibraryNodes().filter(node -> node.getAction().getType() != ActionType.EMPTY).toList();
+	}
+
 	@Override
 	public void createControl(final Composite parent) {
 		final Composite root = new Composite(parent, SWT.NONE);
@@ -260,9 +264,11 @@ public class LibraryPlanningPage extends WizardPage {
 	}
 
 	private void checkPageComplete() {
-		final boolean actionPresent = input.stream().flatMap(node -> node.getChildren().stream())
-				.anyMatch(node -> node.getAction().getType() != ActionType.EMPTY);
-		setPageComplete(actionPresent);
+		setPageComplete(getLibraryNodes().anyMatch(node -> node.getAction().getType() != ActionType.EMPTY));
+	}
+
+	private Stream<LibraryDescriptorNode> getLibraryNodes() {
+		return input.stream().flatMap(node -> node.getChildren().stream());
 	}
 
 	private TreeViewerColumn createColumn(final String name, final CellLabelProvider labelProvider) {

--- a/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/LibraryPlanningPage.java
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/LibraryPlanningPage.java
@@ -26,6 +26,7 @@ import org.eclipse.fordiac.ide.gitlab.treeviewer.LeafNode;
 import org.eclipse.fordiac.ide.library.LibraryManager;
 import org.eclipse.fordiac.ide.library.download.DownloadResult;
 import org.eclipse.fordiac.ide.library.ui.Messages;
+import org.eclipse.fordiac.ide.library.ui.wizards.LibraryChangeAction.ActionType;
 import org.eclipse.fordiac.ide.library.ui.wizards.LibraryDescriptorNode.LibraryDescriptorLabelProvider;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 import org.eclipse.jface.dialogs.IMessageProvider;
@@ -51,6 +52,7 @@ public class LibraryPlanningPage extends WizardPage {
 	private final IProject project;
 	private final Map<String, List<String>> localVersionLookup;
 	private final Map<String, List<String>> remoteVersionLookup;
+	private List<LibraryDescriptorNode> input;
 
 	protected LibraryPlanningPage(final String pageName, final IProject project) {
 		super(pageName);
@@ -117,18 +119,16 @@ public class LibraryPlanningPage extends WizardPage {
 			}
 		});
 
-		treeViewer.setInput(getViewerInput());
+		input = getViewerInput();
+		treeViewer.setInput(input);
 		treeViewer.getTree().setLinesVisible(true);
 		setControl(root);
 
 		setPageComplete(false);
 
 		treeViewer.expandAll();
-
-		treeViewer.getTree().getDisplay().asyncExec(() -> {
-			treeViewer.getTree().pack();
-			treeViewer.getTree().layout();
-		});
+		treeViewer.getTree().pack();
+		root.layout();
 
 	}
 
@@ -166,6 +166,7 @@ public class LibraryPlanningPage extends WizardPage {
 					if (i.intValue() >= 0 && i.intValue() < actions.size()) {
 						rec.setAction(actions.get(i.intValue()));
 						treeViewer.update(element, null);
+						checkPageComplete();
 					}
 				}
 			}
@@ -256,6 +257,12 @@ public class LibraryPlanningPage extends WizardPage {
 		if (!message.isEmpty()) {
 			setMessage(message.toString(), IMessageProvider.WARNING);
 		}
+	}
+
+	private void checkPageComplete() {
+		final boolean actionPresent = input.stream().flatMap(node -> node.getChildren().stream())
+				.anyMatch(node -> node.getAction().getType() != ActionType.EMPTY);
+		setPageComplete(actionPresent);
 	}
 
 	private TreeViewerColumn createColumn(final String name, final CellLabelProvider labelProvider) {

--- a/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/LibraryPlanningPage.java
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/LibraryPlanningPage.java
@@ -21,7 +21,10 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.fordiac.ide.gitlab.management.GitLabDownloader;
+import org.eclipse.fordiac.ide.gitlab.treeviewer.LeafNode;
 import org.eclipse.fordiac.ide.library.LibraryManager;
+import org.eclipse.fordiac.ide.library.download.DownloadResult;
 import org.eclipse.fordiac.ide.library.ui.Messages;
 import org.eclipse.fordiac.ide.library.ui.wizards.LibraryDescriptorNode.LibraryDescriptorLabelProvider;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
@@ -45,12 +48,14 @@ public class LibraryPlanningPage extends WizardPage {
 
 	private TreeViewer treeViewer;
 	private final IProject project;
-	private final Map<String, List<String>> versionLookup;
+	private final Map<String, List<String>> localVersionLookup;
+	private final Map<String, List<String>> remoteVersionLookup;
 
 	protected LibraryPlanningPage(final String pageName, final IProject project) {
 		super(pageName);
 		this.project = project;
-		this.versionLookup = new HashMap<>();
+		this.localVersionLookup = new HashMap<>();
+		this.remoteVersionLookup = new HashMap<>();
 	}
 
 	@Override
@@ -148,7 +153,6 @@ public class LibraryPlanningPage extends WizardPage {
 
 		final TreeViewerColumn actionColumn = createColumn(Messages.LibraryPlanningPage_Action,
 				new LibraryDescriptorNode.ActionLabelProvider());
-
 		layout.setColumnData(actionColumn.getColumn(), new ColumnWeightData(20));
 
 		actionColumn.setEditingSupport(new EditingSupport(treeViewer) {
@@ -191,7 +195,10 @@ public class LibraryPlanningPage extends WizardPage {
 			}
 
 			private List<String> getAvailableVersions(final LibraryDescriptorNode node) {
-				return versionLookup.getOrDefault(node.getName(), Collections.emptyList());
+				return Stream
+						.concat(localVersionLookup.getOrDefault(node.getName(), Collections.emptyList()).stream(),
+								remoteVersionLookup.getOrDefault(node.getName(), Collections.emptyList()).stream())
+						.distinct().toList();
 			}
 
 			private List<String> getAvailableActionStrings(final LibraryDescriptorNode node) {
@@ -212,17 +219,38 @@ public class LibraryPlanningPage extends WizardPage {
 	private void initVersionLookup() {
 		// Get available standard libs
 		LibraryManager.getLinkedLibraries(project.getFolder(TypeLibraryTags.STANDARD_LIB_FOLDER_NAME))
-				.forEach(i -> versionLookup.computeIfAbsent(i.symbolicName(), s -> new ArrayList<>())
+				.forEach(i -> localVersionLookup.computeIfAbsent(i.symbolicName(), s -> new ArrayList<>())
 						.addAll(LibraryManager.INSTANCE.getAllAvailableVersions(i.symbolicName()).map(Version::toString)
 								.toList()));
 
 		// Get available external libs
 		LibraryManager.getLinkedLibraries(project.getFolder(TypeLibraryTags.EXTERNAL_LIB_FOLDER_NAME))
-				.forEach(i -> versionLookup.computeIfAbsent(i.symbolicName(), s -> new ArrayList<>())
+				.forEach(i -> localVersionLookup.computeIfAbsent(i.symbolicName(), s -> new ArrayList<>())
 						.addAll(LibraryManager.INSTANCE.getAllAvailableVersions(i.symbolicName()).map(Version::toString)
 								.toList()));
 
-		// TODO download available versions
+		// Get available remote Versions
+		initRemoteVersionLookup();
+
+	}
+
+	private void initRemoteVersionLookup() {
+		final GitLabDownloader downloader = new GitLabDownloader();
+		downloader.convertEndpointsToDownloader().stream().forEach(d -> {
+			if (d.isActive()) {
+				final DownloadResult<Void> fetch = downloader.fetchProjectsAndPackages();
+				if (fetch.status() == DownloadResult.Status.OK) {
+					final Map<String, List<LeafNode>> packagesAndLeaves = downloader.getPackagesAndLeaves();
+
+					for (final String symbolicName : localVersionLookup.keySet()) {
+						packagesAndLeaves.getOrDefault(symbolicName, Collections.emptyList()).stream()
+								.map(LeafNode::getVersion).forEach(v -> remoteVersionLookup
+										.computeIfAbsent(symbolicName, s -> new ArrayList<>()).add(v));
+					}
+
+				}
+			}
+		});
 	}
 
 	private TreeViewerColumn createColumn(final String name, final CellLabelProvider labelProvider) {

--- a/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/LibraryPlanningPage.java
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/LibraryPlanningPage.java
@@ -126,24 +126,25 @@ public class LibraryPlanningPage extends WizardPage {
 		input = getViewerInput();
 		treeViewer.setInput(input);
 		treeViewer.getTree().setLinesVisible(true);
-		setControl(root);
+		treeViewer.expandAll();
 
+		setControl(root);
 		setPageComplete(false);
 
-		treeViewer.expandAll();
-		treeViewer.getTree().pack();
 		root.layout();
 
 	}
 
 	private List<LibraryDescriptorNode> getViewerInput() {
-		final LibraryDescriptorNode stdLib = new LibraryDescriptorNode(TypeLibraryTags.STANDARD_LIB_FOLDER_NAME, "");
+		final LibraryDescriptorNode stdLib = new LibraryDescriptorNode(TypeLibraryTags.STANDARD_LIB_FOLDER_NAME, ""); //$NON-NLS-1$
 		LibraryManager.getLinkedLibraries(project.getFolder(TypeLibraryTags.STANDARD_LIB_FOLDER_NAME)).stream().forEach(
 				lib -> stdLib.addChild(new LibraryDescriptorNode(lib.symbolicName(), lib.version().toString())));
+		stdLib.setAction(null);
 
-		final LibraryDescriptorNode extLib = new LibraryDescriptorNode(TypeLibraryTags.EXTERNAL_LIB_FOLDER_NAME, "");
+		final LibraryDescriptorNode extLib = new LibraryDescriptorNode(TypeLibraryTags.EXTERNAL_LIB_FOLDER_NAME, ""); //$NON-NLS-1$
 		LibraryManager.getLinkedLibraries(project.getFolder(TypeLibraryTags.EXTERNAL_LIB_FOLDER_NAME)).stream().forEach(
 				lib -> extLib.addChild(new LibraryDescriptorNode(lib.symbolicName(), lib.version().toString())));
+		extLib.setAction(null);
 		return List.of(extLib, stdLib);
 	}
 
@@ -212,10 +213,10 @@ public class LibraryPlanningPage extends WizardPage {
 			}
 
 			private List<LibraryChangeAction> getAvailableActions(final LibraryDescriptorNode node) {
-				return Stream
-						.concat(Stream.of(LibraryChangeAction.emptyAction(), LibraryChangeAction.removeAction()),
-								getAvailableVersions(node).stream().map(v -> LibraryChangeAction.createAction(node, v)))
-						.distinct().toList();
+				return Stream.concat(Stream.of(LibraryChangeAction.emptyAction(), LibraryChangeAction.removeAction()),
+						getAvailableVersions(node).stream().filter(v -> !v.equals(node.getActiveVersion()))
+								.map(v -> LibraryChangeAction.createAction(node, v)))
+						.toList();
 			}
 
 		});

--- a/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/LibraryPlanningPage.java
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/LibraryPlanningPage.java
@@ -21,6 +21,10 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.fordiac.ide.gitlab.management.GitLabDownloader;
 import org.eclipse.fordiac.ide.gitlab.treeviewer.LeafNode;
 import org.eclipse.fordiac.ide.library.LibraryManager;
@@ -44,6 +48,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.osgi.framework.Version;
 
 public class LibraryPlanningPage extends WizardPage {
@@ -51,14 +56,14 @@ public class LibraryPlanningPage extends WizardPage {
 	private TreeViewer treeViewer;
 	private final IProject project;
 	private final Map<String, List<String>> localVersionLookup;
-	private final Map<String, List<String>> remoteVersionLookup;
+	private Map<String, List<String>> remoteVersionLookup;
 	private List<LibraryDescriptorNode> input;
 
 	protected LibraryPlanningPage(final String pageName, final IProject project) {
 		super(pageName);
 		this.project = project;
 		this.localVersionLookup = new HashMap<>();
-		this.remoteVersionLookup = new HashMap<>();
+		this.remoteVersionLookup = Map.of();
 	}
 
 	public List<LibraryDescriptorNode> getModifiedNodes() {
@@ -80,7 +85,7 @@ public class LibraryPlanningPage extends WizardPage {
 				SWT.BORDER | SWT.SINGLE | SWT.H_SCROLL | SWT.V_SCROLL | SWT.FULL_SELECTION);
 		treeViewer.getTree().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
-		initVersionLookup();
+		initLocalVersionLookup();
 
 		configureColumns(columnLayout);
 
@@ -132,6 +137,8 @@ public class LibraryPlanningPage extends WizardPage {
 		setPageComplete(false);
 
 		root.layout();
+
+		startRemoteVersionLookupJob();
 
 	}
 
@@ -223,7 +230,7 @@ public class LibraryPlanningPage extends WizardPage {
 
 	}
 
-	private void initVersionLookup() {
+	private void initLocalVersionLookup() {
 		// Get available standard libs
 		LibraryManager.getLinkedLibraries(project.getFolder(TypeLibraryTags.STANDARD_LIB_FOLDER_NAME))
 				.forEach(i -> localVersionLookup.computeIfAbsent(i.symbolicName(), s -> new ArrayList<>())
@@ -235,33 +242,6 @@ public class LibraryPlanningPage extends WizardPage {
 				.forEach(i -> localVersionLookup.computeIfAbsent(i.symbolicName(), s -> new ArrayList<>())
 						.addAll(LibraryManager.INSTANCE.getAllAvailableVersions(i.symbolicName()).map(Version::toString)
 								.toList()));
-
-		// Get available remote Versions
-		initRemoteVersionLookup();
-	}
-
-	private void initRemoteVersionLookup() {
-		final GitLabDownloader downloader = new GitLabDownloader();
-		final StringBuilder message = new StringBuilder();
-		downloader.convertEndpointsToDownloader().stream().forEach(d -> {
-			if (d.isActive()) {
-				final DownloadResult<Void> fetch = downloader.fetchProjectsAndPackages();
-				if (fetch.status() == DownloadResult.Status.OK) {
-					final Map<String, List<LeafNode>> packagesAndLeaves = downloader.getPackagesAndLeaves();
-
-					for (final String symbolicName : localVersionLookup.keySet()) {
-						packagesAndLeaves.getOrDefault(symbolicName, Collections.emptyList()).stream()
-								.map(LeafNode::getVersion).forEach(v -> remoteVersionLookup
-										.computeIfAbsent(symbolicName, s -> new ArrayList<>()).add(v));
-					}
-				} else {
-					message.append(fetch.message());
-				}
-			}
-		});
-		if (!message.isEmpty()) {
-			setMessage(message.toString(), IMessageProvider.WARNING);
-		}
 	}
 
 	private void checkPageComplete() {
@@ -277,6 +257,65 @@ public class LibraryPlanningPage extends WizardPage {
 		column.getColumn().setText(name);
 		column.setLabelProvider(labelProvider);
 		return column;
+	}
+
+	private void startRemoteVersionLookupJob() {
+		setMessage(Messages.LibraryPlanningPage_LoadRemoteVersions + " ...", IMessageProvider.INFORMATION); //$NON-NLS-1$
+		final Job job = new Job(Messages.LibraryPlanningPage_LoadRemoteVersions) {
+			@Override
+			protected IStatus run(final IProgressMonitor monitor) {
+				final Map<String, List<String>> fetchedVersions = new HashMap<>();
+				final StringBuilder warningMessage = new StringBuilder();
+
+				loadRemoteVersionLookup(fetchedVersions, warningMessage);
+
+				Display.getDefault().asyncExec(() -> {
+					if (treeViewer == null || treeViewer.getTree().isDisposed()) {
+						return;
+					}
+
+					remoteVersionLookup = fetchedVersions;
+
+					if (!warningMessage.isEmpty()) {
+						setMessage(warningMessage.toString(), IMessageProvider.WARNING);
+					} else {
+						setMessage(null);
+					}
+
+					treeViewer.refresh();
+				});
+
+				return Status.OK_STATUS;
+			}
+		};
+
+		job.setUser(false);
+		job.schedule();
+	}
+
+	private void loadRemoteVersionLookup(final Map<String, List<String>> target, final StringBuilder message) {
+		final GitLabDownloader downloader = new GitLabDownloader();
+
+		downloader.convertEndpointsToDownloader().forEach(d -> {
+			if (d.isActive()) {
+				final DownloadResult<Void> fetch = downloader.fetchProjectsAndPackages();
+
+				if (fetch.status() == DownloadResult.Status.OK) {
+					final Map<String, List<LeafNode>> packagesAndLeaves = downloader.getPackagesAndLeaves();
+
+					for (final String symbolicName : localVersionLookup.keySet()) {
+						packagesAndLeaves.getOrDefault(symbolicName, Collections.emptyList()).stream()
+								.map(LeafNode::getVersion).distinct()
+								.forEach(v -> target.computeIfAbsent(symbolicName, s -> new ArrayList<>()).add(v));
+					}
+				} else {
+					if (!message.isEmpty()) {
+						message.append(System.lineSeparator());
+					}
+					message.append(fetch.message());
+				}
+			}
+		});
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/LibraryPlanningPage.java
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/LibraryPlanningPage.java
@@ -1,0 +1,235 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Mario Kastner - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.library.ui.wizards;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.fordiac.ide.library.LibraryManager;
+import org.eclipse.fordiac.ide.library.ui.Messages;
+import org.eclipse.fordiac.ide.library.ui.wizards.LibraryDescriptorNode.LibraryDescriptorLabelProvider;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
+import org.eclipse.jface.layout.TreeColumnLayout;
+import org.eclipse.jface.viewers.CellEditor;
+import org.eclipse.jface.viewers.CellLabelProvider;
+import org.eclipse.jface.viewers.ColumnWeightData;
+import org.eclipse.jface.viewers.ComboBoxCellEditor;
+import org.eclipse.jface.viewers.EditingSupport;
+import org.eclipse.jface.viewers.ITreeContentProvider;
+import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.jface.viewers.TreeViewerColumn;
+import org.eclipse.jface.wizard.WizardPage;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.osgi.framework.Version;
+
+public class LibraryPlanningPage extends WizardPage {
+
+	private TreeViewer treeViewer;
+	private final IProject project;
+	private final Map<String, List<String>> versionLookup;
+
+	protected LibraryPlanningPage(final String pageName, final IProject project) {
+		super(pageName);
+		this.project = project;
+		this.versionLookup = new HashMap<>();
+	}
+
+	@Override
+	public void createControl(final Composite parent) {
+		final Composite root = new Composite(parent, SWT.NONE);
+		root.setLayout(new GridLayout(1, false));
+
+		final Composite treeContainer = new Composite(root, SWT.NONE);
+		treeContainer.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+
+		final TreeColumnLayout columnLayout = new TreeColumnLayout();
+		treeContainer.setLayout(columnLayout);
+
+		treeViewer = new TreeViewer(treeContainer,
+				SWT.BORDER | SWT.SINGLE | SWT.H_SCROLL | SWT.V_SCROLL | SWT.FULL_SELECTION);
+		treeViewer.getTree().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+
+		initVersionLookup();
+
+		configureColumns(columnLayout);
+
+		treeViewer.getTree().setHeaderVisible(true);
+		treeViewer.setContentProvider(new ITreeContentProvider() {
+
+			@Override
+			public boolean hasChildren(final Object element) {
+				if (element instanceof final Collection<?> list) {
+					return !list.isEmpty();
+				}
+				if (element instanceof final LibraryDescriptorNode desc) {
+					return !desc.getChildren().isEmpty();
+				}
+				return false;
+			}
+
+			@Override
+			public Object getParent(final Object element) {
+				return null;
+			}
+
+			@Override
+			public Object[] getElements(final Object inputElement) {
+				if (inputElement instanceof final Collection<?> list) {
+					return list.toArray();
+				}
+				return new Object[0];
+			}
+
+			@Override
+			public Object[] getChildren(final Object parentElement) {
+				if (parentElement instanceof final Collection<?> list) {
+					return list.toArray();
+				}
+				if (parentElement instanceof final LibraryDescriptorNode desc) {
+					return desc.getChildren().toArray();
+				}
+				return new Object[0];
+			}
+		});
+
+		treeViewer.setInput(getViewerInput());
+		treeViewer.getTree().setLinesVisible(true);
+		setControl(root);
+
+		setPageComplete(false);
+
+		treeViewer.expandAll();
+
+		treeViewer.getTree().getDisplay().asyncExec(() -> {
+			treeViewer.getTree().pack();
+			treeViewer.getTree().layout();
+		});
+
+	}
+
+	private List<LibraryDescriptorNode> getViewerInput() {
+		final LibraryDescriptorNode stdLib = new LibraryDescriptorNode(TypeLibraryTags.STANDARD_LIB_FOLDER_NAME, "");
+		LibraryManager.getLinkedLibraries(project.getFolder(TypeLibraryTags.STANDARD_LIB_FOLDER_NAME)).stream().forEach(
+				lib -> stdLib.addChild(new LibraryDescriptorNode(lib.symbolicName(), lib.version().toString())));
+
+		final LibraryDescriptorNode extLib = new LibraryDescriptorNode(TypeLibraryTags.EXTERNAL_LIB_FOLDER_NAME, "");
+		LibraryManager.getLinkedLibraries(project.getFolder(TypeLibraryTags.EXTERNAL_LIB_FOLDER_NAME)).stream().forEach(
+				lib -> extLib.addChild(new LibraryDescriptorNode(lib.symbolicName(), lib.version().toString())));
+		return List.of(extLib, stdLib);
+	}
+
+	private void configureColumns(final TreeColumnLayout layout) {
+		final TreeViewerColumn symbolicNameColumn = createColumn(Messages.LibraryPlanningPage_SymbolicName,
+				new LibraryDescriptorLabelProvider(LibraryDescriptorNode::getName));
+		layout.setColumnData(symbolicNameColumn.getColumn(), new ColumnWeightData(40));
+
+		final TreeViewerColumn activeVersionColumn = createColumn(Messages.LibraryPlanningPage_ActiveVersion,
+				new LibraryDescriptorLabelProvider(LibraryDescriptorNode::getActiveVersion));
+		layout.setColumnData(activeVersionColumn.getColumn(), new ColumnWeightData(20));
+
+		final TreeViewerColumn actionColumn = createColumn(Messages.LibraryPlanningPage_Action,
+				new LibraryDescriptorNode.ActionLabelProvider());
+
+		layout.setColumnData(actionColumn.getColumn(), new ColumnWeightData(20));
+
+		actionColumn.setEditingSupport(new EditingSupport(treeViewer) {
+
+			@Override
+			protected void setValue(final Object element, final Object value) {
+				if (element instanceof final LibraryDescriptorNode rec && value instanceof final Integer i) {
+					final List<LibraryChangeAction> actions = getAvailableActions(rec);
+
+					if (i.intValue() >= 0 && i.intValue() < actions.size()) {
+						rec.setAction(actions.get(i.intValue()));
+						treeViewer.update(element, null);
+					}
+				}
+			}
+
+			@Override
+			protected Object getValue(final Object element) {
+				if (element instanceof final LibraryDescriptorNode rec) {
+					return Integer.valueOf(getAvailableActions(rec).indexOf(rec.getActionType()));
+				}
+				return Integer.valueOf(0);
+			}
+
+			@Override
+			protected CellEditor getCellEditor(final Object element) {
+				if (element instanceof final LibraryDescriptorNode rec) {
+					return new ComboBoxCellEditor(treeViewer.getTree(),
+							getAvailableActionStrings(rec).toArray(new String[0]), SWT.READ_ONLY);
+				}
+				return new ComboBoxCellEditor(treeViewer.getTree(), new String[0], SWT.READ_ONLY);
+			}
+
+			@Override
+			protected boolean canEdit(final Object element) {
+				if (element instanceof final LibraryDescriptorNode rec) {
+					return rec.getChildren().isEmpty();
+				}
+				return false;
+			}
+
+			private List<String> getAvailableVersions(final LibraryDescriptorNode node) {
+				return versionLookup.getOrDefault(node.getName(), Collections.emptyList());
+			}
+
+			private List<String> getAvailableActionStrings(final LibraryDescriptorNode node) {
+				return getAvailableActions(node).stream().map(LibraryChangeAction::getActionText).toList();
+			}
+
+			private List<LibraryChangeAction> getAvailableActions(final LibraryDescriptorNode node) {
+				return Stream
+						.concat(Stream.of(LibraryChangeAction.emptyAction(), LibraryChangeAction.removeAction()),
+								getAvailableVersions(node).stream().map(v -> LibraryChangeAction.createAction(node, v)))
+						.distinct().toList();
+			}
+
+		});
+
+	}
+
+	private void initVersionLookup() {
+		// Get available standard libs
+		LibraryManager.getLinkedLibraries(project.getFolder(TypeLibraryTags.STANDARD_LIB_FOLDER_NAME))
+				.forEach(i -> versionLookup.computeIfAbsent(i.symbolicName(), s -> new ArrayList<>())
+						.addAll(LibraryManager.INSTANCE.getAllAvailableVersions(i.symbolicName()).map(Version::toString)
+								.toList()));
+
+		// Get available external libs
+		LibraryManager.getLinkedLibraries(project.getFolder(TypeLibraryTags.EXTERNAL_LIB_FOLDER_NAME))
+				.forEach(i -> versionLookup.computeIfAbsent(i.symbolicName(), s -> new ArrayList<>())
+						.addAll(LibraryManager.INSTANCE.getAllAvailableVersions(i.symbolicName()).map(Version::toString)
+								.toList()));
+
+		// TODO download available versions
+	}
+
+	private TreeViewerColumn createColumn(final String name, final CellLabelProvider labelProvider) {
+		final TreeViewerColumn column = new TreeViewerColumn(treeViewer, SWT.NONE);
+		column.getColumn().setText(name);
+		column.setLabelProvider(labelProvider);
+		return column;
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/ManageLibraryWizard.java
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/ManageLibraryWizard.java
@@ -13,16 +13,14 @@
 package org.eclipse.fordiac.ide.library.ui.wizards;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.fordiac.ide.library.ui.Messages;
 import org.eclipse.jface.wizard.Wizard;
 
 public class ManageLibraryWizard extends Wizard {
-
-	private final IProject project;
 	private final LibraryPlanningPage planningPage;
 
 	public ManageLibraryWizard(final IProject project) {
-		this.project = project;
-		this.planningPage = new LibraryPlanningPage("Plan Libraries", project);
+		this.planningPage = new LibraryPlanningPage(Messages.LibraryPlanningPage_Titel, project);
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/ManageLibraryWizard.java
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/ManageLibraryWizard.java
@@ -18,19 +18,22 @@ import org.eclipse.jface.wizard.Wizard;
 public class ManageLibraryWizard extends Wizard {
 
 	private final IProject project;
+	private final LibraryPlanningPage planningPage;
 
 	public ManageLibraryWizard(final IProject project) {
 		this.project = project;
+		this.planningPage = new LibraryPlanningPage("Plan Libraries", project);
 	}
 
 	@Override
 	public boolean performFinish() {
+		// TODO apply changes after validation
 		return false;
 	}
 
 	@Override
 	public void addPages() {
-		addPage(new LibraryPlanningPage("Plan Libraries", project));
+		addPage(planningPage);
 		super.addPages();
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/ManageLibraryWizard.java
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/ManageLibraryWizard.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * 	Mario Kastner - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.library.ui.wizards;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.jface.wizard.Wizard;
+
+public class ManageLibraryWizard extends Wizard {
+
+	private final IProject project;
+
+	public ManageLibraryWizard(final IProject project) {
+		this.project = project;
+	}
+
+	@Override
+	public boolean performFinish() {
+		return false;
+	}
+
+	@Override
+	public void addPages() {
+		addPage(new LibraryPlanningPage("Plan Libraries", project));
+		super.addPages();
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/LibraryManager.java
+++ b/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/LibraryManager.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -1017,4 +1018,40 @@ public enum LibraryManager {
 		final Path fordiacInstallPath = installLocationFile.toPath();
 		return fordiacInstallPath.resolve(TypeLibraryTags.TYPE_LIBRARY);
 	}
+
+	private static Stream<Version> getAvailableVersions(final Map<String, List<LibraryRecord>> lib,
+			final String symbolicName) {
+		return lib.getOrDefault(symbolicName, Collections.emptyList()).stream().map(LibraryRecord::version);
+	}
+
+	public Stream<Version> getAllAvailableVersions(final String symbolicName) {
+		return Stream.concat(getAvailableVersions(getExtractedLibraries(), symbolicName),
+				getAvailableVersions(getStandardLibraries(), symbolicName));
+	}
+
+	public static List<LibraryRecord> getLinkedLibraries(final IFolder root) {
+		final List<LibraryRecord> libs = new ArrayList<>();
+		try {
+			root.accept(resource -> {
+				if (resource.equals(root)) {
+					return true;
+				}
+				if (resource instanceof final IFolder libFolder) {
+					if (!libFolder.exists() || !libFolder.isLinked()) {
+						return false;
+					}
+					final Manifest man = ManifestHelper.getContainerManifest(libFolder);
+					if (man != null) {
+						libs.add(new LibraryRecord(libFolder.getName(), null,
+								man.getProduct().getVersionInfo().getVersion(), null, null, null));
+					}
+				}
+				return false;
+			});
+		} catch (final CoreException e) {
+			e.printStackTrace();
+		}
+		return libs;
+	}
+
 }

--- a/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/LibraryManager.java
+++ b/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/LibraryManager.java
@@ -542,7 +542,8 @@ public enum LibraryManager {
 					errors.append(" | "); //$NON-NLS-1$
 					errors.append(downloader.getName());
 					errors.append(": "); //$NON-NLS-1$
-					errors.append(symbolicName + " ");
+					errors.append(symbolicName);
+					errors.append(" "); //$NON-NLS-1$
 					errors.append(dlResult.message());
 				}
 			} catch (final IOException e) {
@@ -682,6 +683,39 @@ public enum LibraryManager {
 		if (maxSeverity >= IMarker.SEVERITY_ERROR) {
 			throw new OperationCanceledException("Unresolvable dependencies"); //$NON-NLS-1$
 		}
+	}
+
+	public Stream<Version> getAllAvailableVersions(final String symbolicName) {
+		return Stream.concat(getAvailableVersions(getExtractedLibraries(), symbolicName),
+				getAvailableVersions(getStandardLibraries(), symbolicName));
+	}
+
+	public static List<LibraryRecord> getLinkedLibraries(final IFolder root) {
+		final List<LibraryRecord> libs = new ArrayList<>();
+		try {
+			root.accept(resource -> {
+				if (resource.equals(root)) {
+					return true;
+				}
+				if (resource instanceof final IFolder libFolder) {
+					if (!libFolder.exists() || !libFolder.isLinked()) {
+						return false;
+					}
+					final Manifest manifest = ManifestHelper.getContainerManifest(libFolder);
+					if (manifest != null && manifest.getProduct() != null) {
+						libs.add(new LibraryRecord(ManifestHelper.getSymbolicName(manifest, ""), //$NON-NLS-1$
+								manifest.getProduct().getName(),
+								ManifestHelper.getVersion(manifest, Version.emptyVersion),
+								manifest.getProduct().getComment(), libFolder.getLocation().toPath(),
+								libFolder.getLocationURI()));
+					}
+				}
+				return false;
+			});
+		} catch (final CoreException e) {
+			e.printStackTrace();
+		}
+		return libs;
 	}
 
 	/**
@@ -1022,36 +1056,6 @@ public enum LibraryManager {
 	private static Stream<Version> getAvailableVersions(final Map<String, List<LibraryRecord>> lib,
 			final String symbolicName) {
 		return lib.getOrDefault(symbolicName, Collections.emptyList()).stream().map(LibraryRecord::version);
-	}
-
-	public Stream<Version> getAllAvailableVersions(final String symbolicName) {
-		return Stream.concat(getAvailableVersions(getExtractedLibraries(), symbolicName),
-				getAvailableVersions(getStandardLibraries(), symbolicName));
-	}
-
-	public static List<LibraryRecord> getLinkedLibraries(final IFolder root) {
-		final List<LibraryRecord> libs = new ArrayList<>();
-		try {
-			root.accept(resource -> {
-				if (resource.equals(root)) {
-					return true;
-				}
-				if (resource instanceof final IFolder libFolder) {
-					if (!libFolder.exists() || !libFolder.isLinked()) {
-						return false;
-					}
-					final Manifest man = ManifestHelper.getContainerManifest(libFolder);
-					if (man != null) {
-						libs.add(new LibraryRecord(libFolder.getName(), null,
-								man.getProduct().getVersionInfo().getVersion(), null, null, null));
-					}
-				}
-				return false;
-			});
-		} catch (final CoreException e) {
-			e.printStackTrace();
-		}
-		return libs;
 	}
 
 }


### PR DESCRIPTION
The planning page of the Library wizard shows all libraries linked into the project. The user is able to select multiple actions for each library which includes: 

- Removing the library
- Updating
- Downgrading 

The versions for upgrade/downgrade actions are looked up in the locally available libraries or in the package registry of a specified gitlab endpoint.