### PR TITLE
Fix resource creation in library element hasher

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/util/LibraryElementHasher.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/util/LibraryElementHasher.java
@@ -24,7 +24,6 @@ import java.security.NoSuchAlgorithmException;
 import java.text.MessageFormat;
 import java.util.Base64;
 
-import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
@@ -33,6 +32,7 @@ import org.eclipse.emf.ecore.util.EcoreUtil.Copier;
 import org.eclipse.fordiac.ide.model.datatype.helper.InternalAttributeDeclarations;
 import org.eclipse.fordiac.ide.model.emf.HashMetaData;
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.resource.FordiacTypeResourceFactory;
 import org.eclipse.fordiac.ide.model.resource.LibraryElementResource;
 
@@ -50,29 +50,27 @@ public final class LibraryElementHasher {
 	 */
 	public static final String DEFAULT_HASH_ALGORITHM = "SHA3-512"; //$NON-NLS-1$
 
-	private static final String TOHASH_URI = "tohash.xml"; //$NON-NLS-1$
-
 	/**
 	 * Calculate hash with default parameters for the given object
 	 *
-	 * @param eObject The object to hash
+	 * @param element The object to hash
 	 * @return The hash string
 	 * @throws LibraryElementHashException if an error occurs
 	 */
-	public static String hash(final EObject eObject) throws LibraryElementHashException {
-		return hash(eObject, CURRENT_HASH_VERSION, DEFAULT_HASH_ALGORITHM);
+	public static String hash(final LibraryElement element) throws LibraryElementHashException {
+		return hash(element, CURRENT_HASH_VERSION, DEFAULT_HASH_ALGORITHM);
 	}
 
 	/**
 	 * Calculate hash with given parameters for the given object
 	 *
-	 * @param eObject   The object to hash
+	 * @param element   The object to hash
 	 * @param version   The hash version
 	 * @param algorithm The hash algorithm
 	 * @return The hash string
 	 * @throws LibraryElementHashException if an error occurs
 	 */
-	public static String hash(final EObject eObject, final String version, final String algorithm)
+	public static String hash(final LibraryElement element, final String version, final String algorithm)
 			throws LibraryElementHashException {
 		if (!CURRENT_HASH_VERSION.equals(version)) {
 			throw new LibraryElementHashException(MessageFormat.format("Wrong library hash version: {0}", version)); //$NON-NLS-1$
@@ -90,8 +88,8 @@ public final class LibraryElementHasher {
 		sb.append(':');
 
 		final LibraryElementResource typeRes = FordiacTypeResourceFactory.INSTANCE
-				.createResource(URI.createFileURI(TOHASH_URI));
-		typeRes.getContents().add(copyForHashing(eObject));
+				.createResource(element.getTypeEntry().getURI());
+		typeRes.getContents().add(copyForHashing(element));
 
 		try (OutputStream nullOut = OutputStream.nullOutputStream();
 				DigestOutputStream dos = new DigestOutputStream(nullOut, digest)) {


### PR DESCRIPTION
The `FordiacTypeResourceFactory` expects a URI with a file extension matching the kind of resource to create, instead of `xml`. This uses the URI from the type entry to create the resource.