### PR TITLE
Fix incorrect handling of ANY_DERIVED in FORTE export

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/util/ForteNgExportUtil.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/util/ForteNgExportUtil.xtend
@@ -210,6 +210,8 @@ final class ForteNgExportUtil {
 			AdapterType: '''«type.generateTypeNamespace»::FORTE_«type.generateTypeNamePlain»'''
 			ArrayType:
 				generateArrayTypeName(type.subranges, type.baseType)
+			// match ANY_DERIVED exclusively
+			DataType case type === GenericTypes.ANY_DERIVED: '''CIEC_ANY_DERIVED'''
 			// match generic types (must be before other data types)
 			DataType case GenericTypes.isAnyType(type): '''CIEC_«type.generateTypeNamePlain»_VARIANT'''
 			StringType: '''CIEC_«type.generateTypeNamePlain»«IF type.isSetMaxLength»_FIXED<«type.maxLength»>«ENDIF»'''
@@ -327,6 +329,8 @@ final class ForteNgExportUtil {
 					"forte_array_fixed"
 			AdapterType:
 				type.name + "_adp"
+			AnyDerivedType case type === GenericTypes.ANY_DERIVED:
+				"forte_any_derived"
 			AnyDerivedType:
 				type.name + "_dtp"
 			DataType case GenericTypes.isAnyType(type): '''forte_«type.generateTypeNamePlain.toLowerCase»_variant'''


### PR DESCRIPTION
## Description
ANY_DERIVED was incorrectly treated as a derived datatype, resulting in ANY_DERIVED_dtp.h and CIEC_ANY_DERIVED_VARIANT. This happened because it was handled by generic cases instead of as a built-in type.

## Fix
Added a type-safe check using GenericTypes.ANY_DERIVED to map it to forte_any_derived.h and CIEC_ANY_DERIVED. This avoids incorrect _dtp and _VARIANT generation while preserving behavior for other types.

#2047 