### PR TITLE
Add configurable DataType support for E_MOVE block

### DIFF
--- a/data/typelibrary/events-1.0.0/typelib/E_MOVE.fbt
+++ b/data/typelibrary/events-1.0.0/typelib/E_MOVE.fbt
@@ -6,6 +6,8 @@
 	</VersionInfo>
 	<VersionInfo Organization=" HR Agrartechnik GmbH" Version="1.1" Author="Franz Höpfinger" Date="2024-10-31" Remarks="Copy F_MOVE to E_MOVE and adjust Comments">
 	</VersionInfo>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.2" Author="Franz Höpfinger" Date="2026-03-29" Remarks="Added configurable DataType for E_MOVE similar to F_MOVE">
+	</VersionInfo>
 	<InterfaceList>
 		<EventInputs>
 			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
@@ -24,5 +26,6 @@
 			<VarDeclaration Name="OUT" Type="ANY" Comment="input = output"/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="GenericClassName" Value="'GEN_FORTE_E_MOVE'"/>
 	<Attribute Name="TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/events-3.0.0/typelib/E_MOVE.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_MOVE.fbt
@@ -2,6 +2,8 @@
 <FBType Name="E_MOVE" Comment="Data latch (d) flip flop for ANY Datatype">
 	<Identification Standard="61499" Classification="Sample and Hold" Description="Copyright (c) 2013,2024 TU Wien ACIN,  HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0&#10;&#10;This Block is functional identic to E_D_FF but for ANY Datatype. &#10;it reduces the Number of Events on the Output CNF.&#10;&#10;This Block take the input IN compare it with the output OUT and only if it is not equal forward the event REQ to CNF.&#10;&#10;for REAL and LREAL the Function of this Block is not guaranteed, because of the special cases of rounding Errors in REAL and LREAL.">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-03-29" Remarks="Added configurable DataType for E_MOVE similar to F_MOVE">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization=" HR Agrartechnik GmbH" Version="1.1" Author="Franz Höpfinger" Date="2024-10-31" Remarks="Copy F_MOVE to E_MOVE and adjust Comments">
@@ -28,5 +30,6 @@
 			<VarDeclaration Name="OUT" Type="ANY" Comment="input = output"/>
 		</OutputVars>
 	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_E_MOVE'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/LibraryElementTags.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/LibraryElementTags.java
@@ -1,6 +1,7 @@
 /********************************************************************************
  * Copyright (c) 2008, 2023 Profactor GmbH, fortiss GmbH
  *                          Martin Erich Jobst
+ *                          HR Agrartechnik GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,6 +15,8 @@
  *  Martin Jobst
  *    - add function FB type
  *    - add global constants
+ *  Franz Höpfinger
+ *    - add E_MOVE constants for configurable support
  ********************************************************************************/
 package org.eclipse.fordiac.ide.model;
 
@@ -184,6 +187,8 @@ public final class LibraryElementTags {
 	public static final String TYPENAME_FMOVE = "F_MOVE"; //$NON-NLS-1$
 	public static final String PACKAGE_NAME_FMOVE = "iec61131::selection"; //$NON-NLS-1$
 	public static final String F_MOVE_CONFIG = "DataType"; //$NON-NLS-1$
+	public static final String TYPENAME_EMOVE = "E_MOVE"; //$NON-NLS-1$
+	public static final String PACKAGE_NAME_EMOVE = "iec61499::events"; //$NON-NLS-1$
 	public static final String TYPENAME_MUX = "STRUCT_MUX"; //$NON-NLS-1$
 	public static final String TYPENAME_DEMUX = "STRUCT_DEMUX"; //$NON-NLS-1$
 	public static final String PACKAGE_NAME_MUXERS = "eclipse4diac::convert"; //$NON-NLS-1$

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/BlockInstanceFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/BlockInstanceFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Primetals Technologies Austria GmbH
+ * Copyright (c) 2024, 2025 Primetals Technologies Austria GmbH, HR Agrartechnik GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *   Bianca Wiesmayr - initial implementation
+ *   Franz Höpfinger - added E_MOVE configurable support
  *******************************************************************************/
 package org.eclipse.fordiac.ide.model.helpers;
 
@@ -57,6 +58,10 @@ public final class BlockInstanceFactory {
 		}
 		if (LibraryElementTags.TYPENAME_FMOVE.equals(entry.getTypeName())
 				&& matchesPackageName(entry, LibraryElementTags.PACKAGE_NAME_FMOVE)) {
+			return LibraryElementFactory.eINSTANCE.createConfigurableMoveFB();
+		}
+		if (LibraryElementTags.TYPENAME_EMOVE.equals(entry.getTypeName())
+				&& matchesPackageName(entry, LibraryElementTags.PACKAGE_NAME_EMOVE)) {
 			return LibraryElementFactory.eINSTANCE.createConfigurableMoveFB();
 		}
 		if (LibraryElementPackage.Literals.COMPOSITE_FB_TYPE.equals(entry.getTypeEClass())) {


### PR DESCRIPTION
E_MOVE now uses ConfigurableMoveFB like F_MOVE, enabling the
DataType dropdown in the Properties View. This allows users to
configure the data type for E_MOVE pins at runtime, matching
the behavior of F_MOVE.

F_MOVE is a "forward always" Block, 
E_MOVE is a "sample and hold" Block introduced with this PR: https://github.com/eclipse-4diac/4diac-ide/pull/686

- Add TYPENAME_EMOVE and PACKAGE_NAME_EMOVE constants to LibraryElementTags
- Extend BlockInstanceFactory to create ConfigurableMoveFB for E_MOVE
- Update E_MOVE.fbt type definitions with new VersionInfo entries

Contributed on behalf of HR Agrartechnik GmbH.
Signed-off-by: Franz Höpfinger <f.hoepfinger@hr-agrartechnik.de>
