### PR TITLE
Ensure that Interfacebar Layout is Only Invoked on Valid Viewers

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/SubAppForFBNetworkEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/SubAppForFBNetworkEditPart.java
@@ -59,6 +59,7 @@ import org.eclipse.fordiac.ide.model.ui.actions.OpenListenerManager;
 import org.eclipse.fordiac.ide.model.ui.editors.AdvancedScrollingGraphicalViewer;
 import org.eclipse.fordiac.ide.ui.editors.EditorUtils;
 import org.eclipse.gef.EditPart;
+import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.Request;
@@ -335,6 +336,7 @@ public class SubAppForFBNetworkEditPart extends AbstractBlockFBNElementEditPart 
 		final SubAppForFbNetworkFigure figure = getFigure();
 		figure.updateTypeLabel(getModel());
 		figure.updateExpandedFigure();
+		layoutExpandedInterface();
 	}
 
 	private void updateEditPolicies() {
@@ -445,7 +447,13 @@ public class SubAppForFBNetworkEditPart extends AbstractBlockFBNElementEditPart 
 
 	public void layoutExpandedInterface() {
 		if (getModel().isUnfolded()) {
-			Display.getDefault().asyncExec(() -> getFigure().layoutExpandedInterface());
+			Display.getDefault().execute(() -> {
+				final EditPartViewer viewer = getViewer();
+				// if we have no viewer or the viewer's control is disposed we can not layout
+				if (viewer != null && viewer.getControl() != null && !viewer.getControl().isDisposed()) {
+					getFigure().layoutExpandedInterface();
+				}
+			});
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/SubAppForFbNetworkFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/figures/SubAppForFbNetworkFigure.java
@@ -54,7 +54,6 @@ import org.eclipse.fordiac.ide.ui.imageprovider.FordiacImage;
 import org.eclipse.fordiac.ide.ui.preferences.UIPreferenceConstants;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.PlatformUI;
 
 /** The Class SubAppForFbNetworkFigure. */
@@ -148,7 +147,6 @@ public class SubAppForFbNetworkFigure extends FBNetworkElementFigure {
 			if (expandedMainFigure == null) {
 				transformToExpandedSubapp();
 			}
-			Display.getDefault().asyncExec(this::layoutExpandedInterface); // initial interface layout
 		} else if (expandedMainFigure != null) {
 			transformToCollapsedSubapp();
 		}


### PR DESCRIPTION
The interfacebar layout for expanded subapps needs to be run in the display thread. In order to ensure better performance and correctness this is now done with execute and a dispose check is added for not preforming a layout calculation on closing editors.