### PR TITLE
Check Value and Comment in Attribute Type Export

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/model/data.ecore
+++ b/plugins/org.eclipse.fordiac.ide.model/model/data.ecore
@@ -73,7 +73,8 @@
     </eOperations>
     <eStructuralFeatures xsi:type="ecore:EReference" name="baseType" lowerBound="1"
         eType="#//DataType"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="initialValue" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="initialValue" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"
+        defaultValueLiteral=""/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="EnumeratedType" eSuperTypes="#//AnyDerivedType">
     <eOperations name="isAssignableFrom" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Boolean">

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/data/DirectlyDerivedType.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/data/DirectlyDerivedType.java
@@ -59,12 +59,13 @@ public interface DirectlyDerivedType extends AnyDerivedType {
 
 	/**
 	 * Returns the value of the '<em><b>Initial Value</b></em>' attribute.
+	 * The default value is <code>""</code>.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Initial Value</em>' attribute.
 	 * @see #setInitialValue(String)
 	 * @see org.eclipse.fordiac.ide.model.data.DataPackage#getDirectlyDerivedType_InitialValue()
-	 * @model
+	 * @model default=""
 	 * @generated
 	 */
 	String getInitialValue();

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/data/impl/DataPackageImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/data/impl/DataPackageImpl.java
@@ -1565,7 +1565,7 @@ public class DataPackageImpl extends EPackageImpl implements DataPackage {
 
 		initEClass(directlyDerivedTypeEClass, DirectlyDerivedType.class, "DirectlyDerivedType", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getDirectlyDerivedType_BaseType(), this.getDataType(), null, "baseType", null, 1, 1, DirectlyDerivedType.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
-		initEAttribute(getDirectlyDerivedType_InitialValue(), ecorePackage.getEString(), "initialValue", null, 0, 1, DirectlyDerivedType.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
+		initEAttribute(getDirectlyDerivedType_InitialValue(), ecorePackage.getEString(), "initialValue", "", 0, 1, DirectlyDerivedType.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$ //$NON-NLS-2$
 
 		op = addEOperation(directlyDerivedTypeEClass, theXMLTypePackage.getBoolean(), "isAssignableFrom", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 		addEParameter(op, this.getDataType(), "other", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/data/impl/DirectlyDerivedTypeImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/data/impl/DirectlyDerivedTypeImpl.java
@@ -57,7 +57,7 @@ public class DirectlyDerivedTypeImpl extends AnyDerivedTypeImpl implements Direc
 	 * @generated
 	 * @ordered
 	 */
-	protected static final String INITIAL_VALUE_EDEFAULT = null;
+	protected static final String INITIAL_VALUE_EDEFAULT = "";
 	/**
 	 * The cached value of the '{@link #getInitialValue() <em>Initial Value</em>}' attribute.
 	 * <!-- begin-user-doc -->

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/AttributeTypeExporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/AttributeTypeExporter.java
@@ -57,8 +57,12 @@ public class AttributeTypeExporter extends AbstractTypeExporter {
 		addEmptyStartElement(LibraryElementTags.DIRECTLY_DERIVED_TYPE);
 		getWriter().writeAttribute(LibraryElementTags.BASE_TYPE_ATTRIBUTE,
 				PackageNameHelper.getFullTypeName(type.getBaseType()));
-		getWriter().writeAttribute(LibraryElementTags.INITIALVALUE_ATTRIBUTE, type.getInitialValue());
-		getWriter().writeAttribute(LibraryElementTags.COMMENT_ATTRIBUTE, type.getComment());
+
+		if (type.getInitialValue() != null && !type.getInitialValue().isBlank()) {
+			getWriter().writeAttribute(LibraryElementTags.INITIALVALUE_ATTRIBUTE, type.getInitialValue());
+		}
+
+		addCommentAttribute(type.getComment());
 	}
 
 	private void createStructContent(final StructuredType type) throws XMLStreamException {


### PR DESCRIPTION
Attribute type export of directly derived values didn't correctly handle empty comments and values. Furthermore the model had a null initial value for directly derived types.