### PR TITLE
AutomationSystem Always has to have an SystemConfiguratin

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/SystemEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/SystemEntryImpl.java
@@ -40,7 +40,9 @@ public class SystemEntryImpl extends AbstractCheckedTypeEntryImpl<AutomationSyst
 
 	@Override
 	protected ErrorAutomationSystem createErrorLibraryElement() {
-		return LibraryElementFactory.eINSTANCE.createErrorAutomationSystem();
+		final ErrorAutomationSystem errorSystem = LibraryElementFactory.eINSTANCE.createErrorAutomationSystem();
+		errorSystem.setSystemConfiguration(LibraryElementFactory.eINSTANCE.createSystemConfiguration());
+		return errorSystem;
 	}
 
 	@Override


### PR DESCRIPTION
The ErrorAutomationSystemCreation didn't add a system configuration element which lead to errors in editors.