### PR TITLE
Add empty FB network in error subapp type

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/SubAppTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/SubAppTypeEntryImpl.java
@@ -42,6 +42,7 @@ public class SubAppTypeEntryImpl extends AbstractInterfaceTypeEntryImpl<SubAppTy
 	protected ErrorSubAppType createErrorLibraryElement() {
 		final ErrorSubAppType type = LibraryElementFactory.eINSTANCE.createErrorSubAppType();
 		type.setInterfaceList(LibraryElementFactory.eINSTANCE.createInterfaceList());
+		type.setFBNetwork(LibraryElementFactory.eINSTANCE.createFBNetwork());
 		return type;
 	}
 


### PR DESCRIPTION
The error subapp type did not have an FB network, which could lead to errors in editors. This adds an empty network to error subapp types.

Fixes https://github.com/eclipse-4diac/4diac-ide/issues/2364