### PR TITLE
Add algorithms for F_LOWER_BOUND and F_UPPER_BOUND as Simple FB

### DIFF
--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arrays/F_LOWER_BOUND.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arrays/F_LOWER_BOUND.fbt
@@ -4,7 +4,7 @@
 	</Identification>
 	<VersionInfo Organization="Demmler Andreas Fahrzeugbau" Version="1.0" Author="Franz Höpfinger" Date="2026-01-23" Remarks="Initial Implementation">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::selection">
+	<CompilerInfo packageName="iec61131::arrays">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -26,5 +26,17 @@
 			<VarDeclaration Name="OUT" Type="ANY_INT" Comment="lowest index of the Dimension"/>
 		</OutputVars>
 	</InterfaceList>
+	<SimpleFB>
+		<ECState Name="REQ">
+			<ECAction Algorithm="REQ" Output="CNF"/>
+		</ECState>
+		<Algorithm Name="REQ">
+			<ST><![CDATA[ALGORITHM REQ
+OUT := LOWER_BOUND(ARR, DIM);
+END_ALGORITHM
+
+]]></ST>
+		</Algorithm>
+	</SimpleFB>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arrays/F_UPPER_BOUND.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arrays/F_UPPER_BOUND.fbt
@@ -4,7 +4,7 @@
 	</Identification>
 	<VersionInfo Organization="Demmler Andreas Fahrzeugbau" Version="1.0" Author="Franz Höpfinger" Date="2026-01-23" Remarks="Initial Implementation">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::selection">
+	<CompilerInfo packageName="iec61131::arrays">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -26,5 +26,17 @@
 			<VarDeclaration Name="OUT" Type="ANY_INT" Comment="highest index of the Dimension"/>
 		</OutputVars>
 	</InterfaceList>
+	<SimpleFB>
+		<ECState Name="REQ">
+			<ECAction Algorithm="REQ" Output="CNF"/>
+		</ECState>
+		<Algorithm Name="REQ">
+			<ST><![CDATA[ALGORITHM REQ
+OUT := UPPER_BOUND(ARR, DIM);
+END_ALGORITHM
+
+]]></ST>
+		</Algorithm>
+	</SimpleFB>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>


### PR DESCRIPTION


We agreed to make IEC 61131-3 FBs as Simple FBs here: https://github.com/eclipse-4diac/4diac-ide/pull/2082#pullrequestreview-3732337580

this PR converts these 2 into a Simple FB. 

https://github.com/eclipse-4diac/4diac-ide/pull/2046#issuecomment-4204097974 the Question is if "select" should stay as Package, or better "array" ? 


references: 
https://github.com/eclipse-4diac/4diac-ide/discussions/2342 
https://github.com/eclipse-4diac/4diac-ide/pull/2046

