### PR TITLE
Prevent duplicate creation of xtext resource during copy

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/STCoreResourceRelocationContext.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/refactoring/STCoreResourceRelocationContext.java
@@ -42,7 +42,11 @@ public class STCoreResourceRelocationContext extends ResourceRelocationContext {
 						(final Resource it) -> original.setURI(change.getToURI()));
 				return original;
 			case COPY:
-				final Resource copy = getResourceSet().createResource(change.getToURI());
+				Resource copy = getResourceSet().getResource(change.getToURI(), false);
+				if (copy != null) {
+					return copy;
+				}
+				copy = getResourceSet().createResource(change.getToURI());
 				try {
 					copy.load(getResourceSet().getURIConverter().createInputStream(change.getFromURI()), null);
 				} catch (final IOException e) {


### PR DESCRIPTION
Copy & pasting typed subapps in the type library was broken because of the Xtext copy participant. In particular, the `loadAndWatchResource` method of the `STCoreResourceRelocationContext` was called twice, attempting to create multiple resources. (see also #2394)