### PR TITLE
Introduces generic D-Flip-Flop

### DIFF
--- a/data/typelibrary/events-3.0.0/typelib/E_D_FF.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_D_FF.fbt
@@ -1,46 +1,48 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-
-<FBType Comment="Data latch (d) flip flop" Name="E_D_FF">
-  <Identification Description="Copyright (c) 2017 fortiss GmbH&#13;&#10;&#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61499-1 Annex A"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="E_D_FF" Comment="Data latch (d) flip flop">
+	<Identification Standard="61499-1 Annex A" Description="Copyright (c) 2017 fortiss GmbH&#10;&#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-  <VersionInfo Author="Alois Zoitl" Date="2017-09-22" Organization="fortiss GmbH" Remarks="initial API and implementation and/or initial documentation" Version="1.0"/>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-09-22" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
 	<CompilerInfo packageName="iec61499::events">
 	</CompilerInfo>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Clock" Name="CLK" Type="Event">
-        <With Var="D"/>
-      </Event>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Triggered if clock results in a change of Q" Name="EO" Type="Event">
-        <With Var="Q"/>
-      </Event>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="Value to latch" Name="D" Type="BOOL"/>
-    </InputVars>
-    <OutputVars>
-      <VarDeclaration Comment="Latched value" Name="Q" Type="BOOL"/>
-    </OutputVars>
-  </InterfaceList>
-  <BasicFB>
-    <ECC>
-      <ECState Comment="Initial State" Name="START" x="400.0" y="700.0"/>
-      <ECState Comment="Initialization" Name="SET" x="1235.0" y="665.0">
-        <ECAction Algorithm="LATCH" Output="EO"/>
-      </ECState>
-      <ECState Comment="" Name="RESET" x="800.0" y="1400.0">
-        <ECAction Algorithm="LATCH" Output="EO"/>
-      </ECState>
-      <ECTransition Comment="" Condition="CLK[D]" Destination="SET" Source="START" x="855.0" y="775.0"/>
-      <ECTransition Comment="" Condition="CLK[NOT D]" Destination="RESET" Source="SET" x="1510.0" y="1215.0"/>
-      <ECTransition Comment="" Condition="CLK[D]" Destination="SET" Source="RESET" x="890.0" y="1055.0"/>
-    </ECC>
-    <Algorithm Comment="new algorithm" Name="LATCH">
-      <ST Text="Q := D;"/>
-    </Algorithm>
-  </BasicFB>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="CLK" Type="Event" Comment="Clock">
+				<With Var="D"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="EO" Type="Event" Comment="Triggered if clock results in a change of Q">
+				<With Var="Q"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="D" Type="BOOL" Comment="Value to latch"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="Q" Type="BOOL" Comment="Latched value"/>
+		</OutputVars>
+	</InterfaceList>
+	<BasicFB>
+		<ECC>
+			<ECState Name="START" Comment="Initial State" x="400" y="700">
+			</ECState>
+			<ECState Name="SET" Comment="Initialization" x="1235" y="665">
+				<ECAction Algorithm="LATCH" Output="EO"/>
+			</ECState>
+			<ECState Name="RESET" x="800" y="1400">
+				<ECAction Algorithm="LATCH" Output="EO"/>
+			</ECState>
+			<ECTransition Source="START" Destination="SET" Condition="CLK[D]" Comment="" x="855" y="775"/>
+			<ECTransition Source="SET" Destination="RESET" Condition="CLK[NOT D]" Comment="" x="1510" y="1215"/>
+			<ECTransition Source="RESET" Destination="SET" Condition="CLK[D]" Comment="" x="890" y="1055"/>
+		</ECC>
+		<Algorithm Name="LATCH" Comment="new algorithm">
+			<ST><![CDATA[Q := D;]]></ST>
+		</Algorithm>
+	</BasicFB>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/events-3.0.0/typelib/E_D_FF_ANY.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_D_FF_ANY.fbt
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="E_D_FF_ANY" Comment="Data latch (d) flip flop">
+	<Identification Standard="61499-1 Annex A" Description="Copyright (c) 2017 fortiss GmbH, HR Agrartechnik GmbH&#10;&#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-04-17" Remarks="E_D_FF copied and replace BOOL by ANY">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::events">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="CLK" Type="Event" Comment="Clock">
+				<With Var="D"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="EO" Type="Event" Comment="Triggered if clock results in a change of Q">
+				<With Var="Q"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="D" Type="ANY" Comment="Value to latch"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="Q" Type="ANY" Comment="Latched value"/>
+		</OutputVars>
+	</InterfaceList>
+	<BasicFB>
+		<ECC>
+			<ECState Name="START" Comment="Initial State" x="400" y="700">
+			</ECState>
+			<ECState Name="SET" Comment="Initialization" x="1235" y="665">
+				<ECAction Algorithm="LATCH" Output="EO"/>
+			</ECState>
+			<ECTransition Source="SET" Destination="START" Condition="1" Comment="" x="946.67" y="1186.67"/>
+			<ECTransition Source="START" Destination="SET" Condition="CLK[NE(Q, D)]" Comment="" x="980" y="320"/>
+		</ECC>
+		<Algorithm Name="LATCH" Comment="new algorithm">
+			<ST><![CDATA[Q := D;]]></ST>
+		</Algorithm>
+	</BasicFB>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>


### PR DESCRIPTION
Adds `E_D_FF_ANY`, a new function block that provides a data latch for any data type, extending the functionality of the existing `E_D_FF` to be generic. This block reduces output events by only signaling a change (`EO`) when the input (`D`) differs from the latched output (`Q`).

Removes the older `E_MOVE` function block definitions from `events-3.0.0`, as their functionality is superseded or made redundant by the new generic D-Flip-Flop. --> https://github.com/eclipse-4diac/4diac-ide/pull/2444

Updates the `E_D_FF` function block in `events-3.0.0` to align with the latest storage format, including XML attribute reordering and wrapping ST code in CDATA.