### PR TITLE
Make E_PULSE and E_TP timers non-retriggerable

### DIFF
--- a/data/typelibrary/events-3.0.0/typelib/timers/E_PULSE.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/timers/E_PULSE.fbt
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="E_PULSE" Comment="standard timer function block (pulse)">
-	<Identification Standard="61499-2" Description="Copyright (c) 2023, 2024 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  &#10;   &#10;   &#10;E_TP -- Impulse forming FB  &#10;&#10;Generate a Impulse with a given Time.  &#10;This FB makes a Impulse of Duration TM on the Output QO.">
+<FBType Name="E_PULSE" Comment="standard timer function block (pulse) - non-retriggerable">
+	<Identification Standard="61499-2" Description="Copyright (c) 2023 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  &#10;   &#10;   &#10;E_PULSE -- Impulse forming FB  &#10;&#10;Generate an Impulse with a given Time.  &#10;This FB makes an Impulse of Duration PT on the Output Q.">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-04-19" Remarks="Made non-retriggerable">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.1" Author="Franz Hoepfinger" Date="2024-04-23" Remarks="Add a Reset to Timer FBs">
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.1" Author="Franz Höpfinger" Date="2024-04-23" Remarks="Add a Reset to Timer FBs">
 	</VersionInfo>
-	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0.1" Author="Franz Hoepfinger" Date="2024-03-05" Remarks="renamed to E_PULSE">
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0.1" Author="Franz Höpfinger" Date="2024-03-05" Remarks="renamed to E_PULSE">
 	</VersionInfo>
-	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Hoepfinger" Date="2023-08-21" Remarks="initial implementation as E_IMPULSE">
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2023-08-21" Remarks="initial implementation as E_IMPULSE">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::events::timers">
 	</CompilerInfo>
@@ -33,21 +35,27 @@
 		</OutputVars>
 	</InterfaceList>
 	<FBNetwork>
-		<FB Name="E_DELAY" Type="iec61499::events::E_DELAY" x="-780" y="-573.33">
+		<FB Name="E_DELAY" Type="iec61499::events::E_DELAY" x="-600" y="-600">
 		</FB>
-		<FB Name="E_SR" Type="iec61499::events::E_SR" x="373.33" y="-986.67">
+		<FB Name="E_RS" Type="iec61499::events::E_RS" x="400" y="-1100">
+		</FB>
+		<FB Name="CheckRunning" Type="iec61499::events::E_PERMIT" x="-2000" y="-800">
 		</FB>
 		<EventConnections>
-			<Connection Source="REQ" Destination="E_DELAY.START" dx1="480"/>
-			<Connection Source="REQ" Destination="E_SR.S" dx1="1053.33"/>
-			<Connection Source="E_DELAY.EO" Destination="E_SR.R" dx1="253.33"/>
-			<Connection Source="E_SR.EO" Destination="CNF" dx1="1533.33"/>
+			<Connection Source="REQ" Destination="CheckRunning.EI" dx1="2493.33"/>
+			<Connection Source="CheckRunning.EO" Destination="E_DELAY.START" dx1="273.33"/>
+			<Connection Source="CheckRunning.EO" Destination="E_RS.S" dx1="1053.33"/>
+			<Connection Source="E_DELAY.EO" Destination="E_RS.R" dx1="253.33"/>
+			<Connection Source="E_RS.EO" Destination="CNF" dx1="1480"/>
 			<Connection Source="R" Destination="E_DELAY.STOP" dx1="366.67"/>
-			<Connection Source="R" Destination="E_SR.R" dx1="960"/>
+			<Connection Source="R" Destination="E_RS.R" dx1="4846.67"/>
 		</EventConnections>
 		<DataConnections>
 			<Connection Source="PT" Destination="E_DELAY.DT" dx1="266.67"/>
-			<Connection Source="E_SR.Q" Destination="Q" dx1="2340"/>
+			<Connection Source="E_RS.Q" Destination="Q" dx1="1480"/>
+			<Connection Source="E_RS.Q" Destination="CheckRunning.PERMIT" dx1="80" dx2="200" dy="780">
+				<Attribute Name="Negated" Value="true"/>
+			</Connection>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/data/typelibrary/events-3.0.0/typelib/timers/E_TP.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/timers/E_TP.fbt
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="E_TP" Comment="standard timer function block (pulse)">
-	<Identification Standard="61499-2" Classification="standard timer function block" Description="Copyright (c) 2024 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+<FBType Name="E_TP" Comment="standard timer function block (pulse) - non-retriggerable">
+	<Identification Standard="61499-2" Classification="standard timer function block" Description="Copyright (c) 2024 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  &#10;   &#10;   &#10;E_TP -- Impulse forming FB  &#10;&#10;Generate an Impulse with a given Time.  &#10;This FB makes an Impulse of Duration PT on the Output Q on rising edge of IN.">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-04-19" Remarks="Made non-retriggerable">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.1" Author="Franz Hoepfinger" Date="2024-04-23" Remarks="Add a Reset to Timer FBs">
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.1" Author="Franz Höpfinger" Date="2024-04-23" Remarks="Add a Reset to Timer FBs">
 	</VersionInfo>
-	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Hoepfinger" Date="2024-03-04">
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2024-03-04">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::events::timers">
 	</CompilerInfo>
@@ -17,7 +19,6 @@
 				<With Var="PT"/>
 			</Event>
 			<Event Name="R" Type="Event" Comment="Reset">
-				<With Var="IN"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>
@@ -34,25 +35,31 @@
 		</OutputVars>
 	</InterfaceList>
 	<FBNetwork>
-		<FB Name="E_DELAY" Type="iec61499::events::E_DELAY" Comment="" x="353.33333333333337" y="-260.0">
+		<FB Name="E_DELAY" Type="iec61499::events::E_DELAY" x="353.33" y="-260">
 		</FB>
-		<FB Name="E_RS" Type="iec61499::events::E_RS" Comment="" x="1506.6666666666667" y="-553.3333333333334">
+		<FB Name="E_SR" Type="iec61499::events::E_SR" x="1506.67" y="-553.33">
 		</FB>
-		<FB Name="E_PERMIT" Type="iec61499::events::E_PERMIT" Comment="" x="-1866.6666666666667" y="-933.3333333333334">
+		<FB Name="E_R_TRIG" Type="iec61499::events::E_R_TRIG" x="-2000" y="-800">
+		</FB>
+		<FB Name="CheckRunning" Type="iec61499::events::E_PERMIT" x="-3300" y="-1100">
 		</FB>
 		<EventConnections>
-			<Connection Source="E_RS.EO" Destination="CNF" Comment="" dx1="966.6666666666667"/>
-			<Connection Source="R" Destination="E_DELAY.STOP" Comment="" dx1="226.66666666666669"/>
-			<Connection Source="R" Destination="E_RS.R" Comment="" dx1="226.66666666666669" dx2="1426.6666666666667" dy="880.0"/>
-			<Connection Source="E_DELAY.EO" Destination="E_RS.R" Comment="" dx1="266.6666666666667"/>
-			<Connection Source="REQ" Destination="E_PERMIT.EI" Comment="" dx1="1066.6666666666667"/>
-			<Connection Source="E_PERMIT.EO" Destination="E_RS.S" Comment="" dx1="1360.0"/>
-			<Connection Source="E_PERMIT.EO" Destination="E_DELAY.START" Comment="" dx1="780.0"/>
+			<Connection Source="E_SR.EO" Destination="CNF" dx1="966.67"/>
+			<Connection Source="R" Destination="E_DELAY.STOP" dx1="226.67"/>
+			<Connection Source="R" Destination="E_SR.R" dx1="226.67"/>
+			<Connection Source="E_DELAY.EO" Destination="E_SR.R" dx1="266.67"/>
+			<Connection Source="E_R_TRIG.EO" Destination="E_SR.S" dx1="1360"/>
+			<Connection Source="E_R_TRIG.EO" Destination="E_DELAY.START" dx1="780"/>
+			<Connection Source="REQ" Destination="CheckRunning.EI" dx1="80"/>
+			<Connection Source="CheckRunning.EO" Destination="E_R_TRIG.EI" dx1="100"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="PT" Destination="E_DELAY.DT" Comment="" dx1="193.33333333333334"/>
-			<Connection Source="E_RS.Q" Destination="Q" Comment="" dx1="1000.0"/>
-			<Connection Source="IN" Destination="E_PERMIT.PERMIT" Comment="" dx1="1066.6666666666667"/>
+			<Connection Source="PT" Destination="E_DELAY.DT" dx1="193.33"/>
+			<Connection Source="E_SR.Q" Destination="Q" dx1="1746.67"/>
+			<Connection Source="IN" Destination="E_R_TRIG.QI" dx1="1066.67"/>
+			<Connection Source="E_SR.Q" Destination="CheckRunning.PERMIT" dx1="100" dx2="233.33" dy="500">
+				<Attribute Name="Negated" Value="true"/>
+			</Connection>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>


### PR DESCRIPTION
New REQ events are now ignored while a pulse is active, ensuring the timer completes its full duration without interruption.

According to IEC 61131-3 TP is non-retriggerable, always producing the same Output Pulse independent from the Input.
