### PR TITLE
Add retriggerable timer function blocks E_PULSE_RETRIG and E_TP_RETRIG

### DIFF
--- a/data/typelibrary/events-3.0.0/typelib/timers/E_PULSE_RETRIG.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/timers/E_PULSE_RETRIG.fbt
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="E_PULSE_RETRIG" Comment="standard timer function block (pulse) - retriggerable version">
+	<Identification Standard="61499-2" Description="Copyright (c) 2023 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  &#10;   &#10;   &#10;E_PULSE_RETRIG -- Impulse forming FB (Retriggerable) &#10;&#10;Generate an Impulse with a given Time.  &#10;This FB makes an Impulse of Duration PT on the Output Q. New REQ restarts the timer.">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-04-19" Remarks="retriggerable version">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::events::timers">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request (Restarts the timer)">
+				<With Var="PT"/>
+			</Event>
+			<Event Name="R" Type="Event" Comment="Reset">
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="Q"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="PT" Type="TIME" Comment="Pulse time"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="Q" Type="BOOL" Comment="Output"/>
+		</OutputVars>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="E_DELAY" Type="iec61499::events::E_RDELAY" x="-780" y="-573.33">
+		</FB>
+		<FB Name="E_SR" Type="iec61499::events::E_SR" x="373.33" y="-986.67">
+		</FB>
+		<EventConnections>
+			<Connection Source="REQ" Destination="E_RDELAY.START" dx1="480"/>
+			<Connection Source="REQ" Destination="E_SR.S" dx1="1053.33"/>
+			<Connection Source="E_RDELAY.EO" Destination="E_SR.R" dx1="253.33"/>
+			<Connection Source="E_SR.EO" Destination="CNF" dx1="1533.33"/>
+			<Connection Source="R" Destination="E_RDELAY.STOP" dx1="366.67"/>
+			<Connection Source="R" Destination="E_SR.R" dx1="960"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="PT" Destination="E_RDELAY.DT" dx1="266.67"/>
+			<Connection Source="E_SR.Q" Destination="Q" dx1="2340"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/events-3.0.0/typelib/timers/E_TP_RETRIG.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/timers/E_TP_RETRIG.fbt
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="E_TP_RETRIG" Comment="standard timer function block (pulse) - retriggerable version">
+	<Identification Standard="61499-2" Classification="standard timer function block" Description="Copyright (c) 2024 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  &#10;   &#10;   &#10;E_TP_RETRIG -- Timer Pulse FB (Retriggerable) &#10;&#10;Generate an Impulse with a given Time.  &#10;This FB makes an Impulse of Duration PT on the Output Q on rising edge of IN. New REQ restarts the timer.">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.1" Author="Franz Höpfinger" Date="2026-04-19" Remarks="retriggerable version">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::events::timers">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request (Restarts the timer)">
+				<With Var="IN"/>
+				<With Var="PT"/>
+			</Event>
+			<Event Name="R" Type="Event" Comment="Reset">
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="Q"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="BOOL" Comment="Input"/>
+			<VarDeclaration Name="PT" Type="TIME" Comment="Pulse time"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="Q" Type="BOOL" Comment="Output"/>
+		</OutputVars>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="E_RDELAY" Type="iec61499::events::E_RDELAY" x="353.33" y="-260">
+		</FB>
+		<FB Name="E_SR" Type="iec61499::events::E_SR" x="1506.67" y="-553.33">
+		</FB>
+		<FB Name="E_R_TRIG" Type="iec61499::events::E_R_TRIG" x="-1866.67" y="-933.33">
+		</FB>
+		<EventConnections>
+			<Connection Source="E_SR.EO" Destination="CNF" dx1="966.67"/>
+			<Connection Source="R" Destination="E_RDELAY.STOP" dx1="226.67"/>
+			<Connection Source="R" Destination="E_SR.R" dx1="226.67"/>
+			<Connection Source="E_RDELAY.EO" Destination="E_SR.R" dx1="266.67"/>
+			<Connection Source="REQ" Destination="E_R_TRIG.EI" dx1="1066.67"/>
+			<Connection Source="E_R_TRIG.EO" Destination="E_SR.S" dx1="1360"/>
+			<Connection Source="E_R_TRIG.EO" Destination="E_RDELAY.START" dx1="780"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="PT" Destination="E_RDELAY.DT" dx1="193.33"/>
+			<Connection Source="E_SR.Q" Destination="Q" dx1="1000"/>
+			<Connection Source="IN" Destination="E_R_TRIG.QI" dx1="1066.67"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>


### PR DESCRIPTION
Introduces new function blocks E_PULSE_RETRIG and E_TP_RETRIG in the event timers library to support retriggerable timer functionality, addressing the need for impulses with specified duration that can be restarted with a new request.
