### PR TITLE
Fix: Add PV to REQ event for CTU function blocks

### DIFF
--- a/data/typelibrary/iec61131-3-3.0.0/typelib/counters/FB_CTU.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/counters/FB_CTU.fbt
@@ -13,6 +13,7 @@
 			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
 				<With Var="CU"/>
 				<With Var="R"/>
+				<With Var="PV"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/counters/FB_CTU_DINT.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/counters/FB_CTU_DINT.fbt
@@ -13,6 +13,7 @@
 			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
 				<With Var="CU"/>
 				<With Var="R"/>
+				<With Var="PV"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/counters/FB_CTU_LINT.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/counters/FB_CTU_LINT.fbt
@@ -13,6 +13,7 @@
 			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
 				<With Var="CU"/>
 				<With Var="R"/>
+				<With Var="PV"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/counters/FB_CTU_UDINT.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/counters/FB_CTU_UDINT.fbt
@@ -13,6 +13,7 @@
 			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
 				<With Var="CU"/>
 				<With Var="R"/>
+				<With Var="PV"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/counters/FB_CTU_ULINT.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/counters/FB_CTU_ULINT.fbt
@@ -13,6 +13,7 @@
 			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
 				<With Var="CU"/>
 				<With Var="R"/>
+				<With Var="PV"/>
 			</Event>
 		</EventInputs>
 		<EventOutputs>


### PR DESCRIPTION
The preset value (PV) input was missing from the event-associated variables for the normal execution request (REQ) event. Including PV ensures it is correctly processed during the execution of all CTU counter variants.
