### PR TITLE
Remove QO output from RT_E_CYCLE

### DIFF
--- a/data/typelibrary/rtevents-3.0.0/typelib/RT_E_CYCLE.fbt
+++ b/data/typelibrary/rtevents-3.0.0/typelib/RT_E_CYCLE.fbt
@@ -26,9 +26,6 @@
       <VarDeclaration Name="Deadline" Type="TIME" />
       <VarDeclaration Name="WCET" Type="TIME" />
     </InputVars>
-    <OutputVars>
-      <VarDeclaration Name="QO" Type="BOOL" />
-    </OutputVars>
   </InterfaceList>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>


### PR DESCRIPTION
no need to remove the "WITH" construct, as it was never connected, which is also wrong.
following the Discussion in https://github.com/eclipse-4diac/4diac-ide/pull/2408 this PR is made.
