### PR TITLE
Extracted OPC UA Deployment into own Feature

### DIFF
--- a/features/org.eclipse.fordiac.ide.deployment.opcua.feature/.project
+++ b/features/org.eclipse.fordiac.ide.deployment.opcua.feature/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.fordiac.ide.deployment.opcua.feature</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/features/org.eclipse.fordiac.ide.deployment.opcua.feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/org.eclipse.fordiac.ide.deployment.opcua.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/org.eclipse.fordiac.ide.deployment.opcua.feature/build.properties
+++ b/features/org.eclipse.fordiac.ide.deployment.opcua.feature/build.properties
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2026 Johannes Kepler University Linz
+# 
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# https://www.eclipse.org/legal/epl-2.0/.
+# 
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Contributors:
+#   Alois Zoitl - initial API and implementation
+###############################################################################
+
+bin.includes = feature.xml,\
+               feature.properties

--- a/features/org.eclipse.fordiac.ide.deployment.opcua.feature/feature.properties
+++ b/features/org.eclipse.fordiac.ide.deployment.opcua.feature/feature.properties
@@ -1,0 +1,27 @@
+###############################################################################
+# Copyright (c) 2026 Johannes Kepler University Linz
+# 
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# https://www.eclipse.org/legal/epl-2.0/.
+# 
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Contributors:
+#   Alois Zoitl - initial API and implementation
+###############################################################################
+
+featureName=Deployment OPC UA
+providerName=Eclipse 4diac
+description=This feature allows the deployment of IEC 61499 Systems to IEC 61499 Runtime Systems utilzing OPC UA as transport protocol
+copyright=Copyright (c) 2026 Johannes Kepler University Linz\n\
+\n\
+This program and the accompanying materials are made\n\
+available under the terms of the Eclipse Public License 2.0\n\
+which is available at https://www.eclipse.org/legal/epl-2.0/\n\
+\n\
+SPDX-License-Identifier: EPL-2.0\n\
+\n\
+Contributors:\n\
+  Alois Zoitl - initial API and implementation and/or initial documentation\n\
+\n

--- a/features/org.eclipse.fordiac.ide.deployment.opcua.feature/feature.xml
+++ b/features/org.eclipse.fordiac.ide.deployment.opcua.feature/feature.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
  *******************************************************************************
- * Copyright (c) 2017, 2026 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Johannes Kepler University Linz
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -10,11 +10,11 @@
  * SPDX-License-Identifier: EPL-2.0
  * 
  * Contributors:
- *   See git history
+ *   Alois Zoitl - initial API and implementation
  *******************************************************************************
 -->
 <feature
-      id="org.eclipse.fordiac.ide.deployment.feature"
+      id="org.eclipse.fordiac.ide.deployment.opcua.feature"
       label="%featureName"
       version="3.2.0.qualifier"
       provider-name="%providerName"
@@ -33,37 +33,28 @@
       %license
    </license>
 
+   <includes
+         id="org.eclipse.fordiac.ide.milo"
+         version="0.0.0"/>
+
    <requires>
-      <import feature="org.eclipse.fordiac.ide.workbench.feature"/>
-      <import feature="org.eclipse.fordiac.ide.typeeditor.feature"/>
+      <import feature="org.eclipse.fordiac.ide.deployment.feature"/>
    </requires>
 
    <plugin
-         id="org.eclipse.fordiac.ide.deployment"
+         id="org.eclipse.fordiac.ide.deployment.opcua"
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.fordiac.ide.deployment.iec61499"
+         id="org.eclipse.fordiac.ide.deployment.opcua.milo.transport"
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.fordiac.ide.deployment.eval"
+         id="org.eclipse.fordiac.ide.deployment.opcua.milo.sdk_client"
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.fordiac.ide.deployment.debug"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.fordiac.ide.deployment.debug.ui"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.fordiac.ide.deployment.bootfile"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.fordiac.ide.deployment.interpreter"
+         id="org.eclipse.fordiac.ide.deployment.opcua.milo.stack_core"
          version="0.0.0"/>
 
 </feature>

--- a/plugins/org.eclipse.fordiac.ide.product/org.eclipse.fordiac.ide.product
+++ b/plugins/org.eclipse.fordiac.ide.product/org.eclipse.fordiac.ide.product
@@ -96,7 +96,6 @@
       <feature id="org.eclipse.emf.compare.rcp.ui"/>
       <feature id="org.eclipse.nebula.widgets.nattable.core.feature"/>
       <feature id="org.eclipse.emf.compare.egit" installMode="root"/>
-      <feature id="org.eclipse.fordiac.ide.milo" installMode="root"/>
    </features>
 
    <configurations>


### PR DESCRIPTION
In order to better isolate the Eclipse Milo dependencies the OPC UA deployment functionality is extracted into an own feature which is not added to the product per default.

FYI @ ruspl-afed.