### PR TITLE
Fix UI test execution on macOS (Apple Silicon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ in the root directory of 4diac IDE source code. After the build completes you ca
     
    `plugins/org.eclipse.fordiac.ide.product/target` 
 
+Note for MacOS users: Running UI tests on MacOS requires the `-XstartOnFirstThread` JVM argument. This is handled automatically when using Maven but you must add it to your VM arguments if you run tests directly from your IDE.
+
 More information on how to build, run and extend 4diac IDE can be found in our [Building 4diac IDE Documentation](https://github.com/eclipse-4diac/4diac-documentation/blob/main/src/development/building4diac.adoc)
 
 ## Links

--- a/pom.xml
+++ b/pom.xml
@@ -306,6 +306,17 @@
 			</properties>
 		</profile>
 		<profile>
+		    <id>macosx-ui-test-fix</id>
+		    <activation>
+		        <os>
+		            <family>mac</family>
+		        </os>
+		    </activation>
+		    <properties>
+		        <tycho.testArgLine>-XstartOnFirstThread</tycho.testArgLine>
+		    </properties>
+		</profile>
+		<profile>
 			<id>eclipse-sign</id>
 			<build>
 				<plugins>


### PR DESCRIPTION
**Description**: Running UI tests on macOS, specifically on Apple Silicon, currently fails with an SWTException: Invalid thread access. This happens because the JVM on macOS needs the -XstartOnFirstThread argument to interact correctly with the UI thread. However, adding this flag globally breaks the build for Linux and Windows users.

**Fix**: This PR adds a Maven profile to the root pom.xml that automatically activates only when the OS is macOS. It injects the required -XstartOnFirstThread flag so that Mac users can run the test suite locally without affecting the project's CI or other environments.

**Question for Reviewers**: Since this is an env setup detail for Mac users, should I also document this in the README.md or CONTRIBUTING.md? Let me know where it fits best, and I can update this PR with the documentation change!