### PR TITLE
Check if InterfaceElement has a project

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editors/InitialValueEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editors/InitialValueEditor.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.gef.editors;
 
+import org.eclipse.core.resources.IProject;
 import org.eclipse.fordiac.ide.gef.preferences.GefPreferenceConstants;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeValueCommand;
 import org.eclipse.fordiac.ide.model.edit.helper.InitialValueHelper;
@@ -79,21 +80,21 @@ public class InitialValueEditor extends XtextEmbeddedFieldEditor {
 	}
 
 	protected void updateInitialValue(final String value) {
-		if (!getControl().isDisposed()
-				&& FordiacMessages.ComputingPlaceholderValue.equals(getModelAccess().getEditablePart())) {
-			final var commandExecutorCache = getCommandExecutor();
-			setCommandExecutor(null);
-			if (value.length() <= PreferenceStoreProvider
-					.getStore(GefPreferenceConstants.GEF_PREFERENCES_ID,
-							ModelHelper.getProjectFromContextChecked(getInterfaceElement()))
-					.getInt(GefPreferenceConstants.MAX_DEFAULT_VALUE_LENGTH)) {
-				getModelAccess().updateModel(value);
-			} else {
-				getModelAccess().updateModel(FordiacMessages.ValueTooLarge);
-			}
-			getControl().setSelection(0);
-			setCommandExecutor(commandExecutorCache);
+		final IProject project = ModelHelper.getProjectFromContext(getInterfaceElement());
+		if (project == null || getControl().isDisposed()
+				|| !FordiacMessages.ComputingPlaceholderValue.equals(getModelAccess().getEditablePart())) {
+			return;
 		}
+		final var commandExecutorCache = getCommandExecutor();
+		setCommandExecutor(null);
+		if (value.length() <= PreferenceStoreProvider.getStore(GefPreferenceConstants.GEF_PREFERENCES_ID, project)
+				.getInt(GefPreferenceConstants.MAX_DEFAULT_VALUE_LENGTH)) {
+			getModelAccess().updateModel(value);
+		} else {
+			getModelAccess().updateModel(FordiacMessages.ValueTooLarge);
+		}
+		getControl().setSelection(0);
+		setCommandExecutor(commandExecutorCache);
 	}
 
 	public IInterfaceElement getInterfaceElement() {


### PR DESCRIPTION
The InitialValueEditor performs updates in the background. It can happen the the interface element is removed while the update is running. With this check an exception can be circumvented.

@mx990 I regularly see an exception for getting the project in log files. I somehow have the gut feeling my fix cures partly the symptom. I'm not even shure how to reproduce it. 