### PR TITLE
Fix stale type references after project dereference

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/LibraryElementDependencyUpdater.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/LibraryElementDependencyUpdater.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.model.ui.editors;
 
+import java.util.Collection;
 import java.util.Objects;
 
 import org.eclipse.emf.common.notify.Notification;
@@ -49,6 +50,7 @@ import org.eclipse.swt.widgets.Display;
 public class LibraryElementDependencyUpdater extends LibraryElementDependencyTracker {
 
 	private LibraryElement libraryElement;
+	private TypeLibrary typeLibrary;
 	private boolean updating;
 
 	@Override
@@ -67,8 +69,37 @@ public class LibraryElementDependencyUpdater extends LibraryElementDependencyTra
 							.asyncExec(() -> updateDependency(dependency, notification.getOldStringValue()));
 				}
 			}
+		} else if (notification.getNotifier() == typeLibrary
+				&& TypeLibrary.TYPE_ENTRY_NAME_REFERENCES_FEATURE.equals(notification.getFeature())) {
+			// react when a dependency is no longer visible through this library
+			updateTypeLibraryDependency(notification);
 		} else {
 			super.notifyChanged(notification);
+		}
+	}
+
+	private void updateTypeLibraryDependency(final Notification notification) {
+		switch (notification.getEventType()) {
+		case Notification.REMOVE, Notification.REMOVE_MANY ->
+			updateRemovedTypeEntryNameReference(notification.getOldValue());
+		default -> {
+			// ignore
+		}
+		}
+	}
+
+	private void updateRemovedTypeEntryNameReference(final Object object) {
+		switch (object) {
+		case final Collection<?> collection -> {
+			for (final Object value : collection) {
+				updateRemovedTypeEntryNameReference(value);
+			}
+		}
+		case final TypeEntry dependency when getDependencies().contains(dependency) ->
+			Display.getDefault().asyncExec(() -> updateDependency(dependency, dependency.getFullTypeName()));
+		case null, default -> {
+			// ignore
+		}
 		}
 	}
 
@@ -230,11 +261,21 @@ public class LibraryElementDependencyUpdater extends LibraryElementDependencyTra
 		if (libraryElement != null && !libraryElement.eAdapters().contains(this)) {
 			libraryElement.eAdapters().add(this);
 		}
+		if (libraryElement != null) {
+			typeLibrary = libraryElement.getTypeLibrary();
+			if (typeLibrary != null && !typeLibrary.eAdapters().contains(this)) {
+				typeLibrary.eAdapters().add(this);
+			}
+		}
 	}
 
 	private void uninstall() {
 		if (libraryElement != null) {
 			libraryElement.eAdapters().remove(this);
+		}
+		if (typeLibrary != null) {
+			typeLibrary.eAdapters().remove(this);
+			typeLibrary = null;
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/LibraryElementDependencyUpdater.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/LibraryElementDependencyUpdater.java
@@ -50,7 +50,6 @@ import org.eclipse.swt.widgets.Display;
 public class LibraryElementDependencyUpdater extends LibraryElementDependencyTracker {
 
 	private LibraryElement libraryElement;
-	private TypeLibrary typeLibrary;
 	private boolean updating;
 
 	@Override
@@ -69,7 +68,7 @@ public class LibraryElementDependencyUpdater extends LibraryElementDependencyTra
 							.asyncExec(() -> updateDependency(dependency, notification.getOldStringValue()));
 				}
 			}
-		} else if (notification.getNotifier() == typeLibrary
+		} else if (notification.getNotifier() instanceof TypeLibrary
 				&& TypeLibrary.TYPE_ENTRY_NAME_REFERENCES_FEATURE.equals(notification.getFeature())) {
 			// react when a dependency is no longer visible through this library
 			updateTypeLibraryDependency(notification);
@@ -80,8 +79,10 @@ public class LibraryElementDependencyUpdater extends LibraryElementDependencyTra
 
 	private void updateTypeLibraryDependency(final Notification notification) {
 		switch (notification.getEventType()) {
-		case Notification.REMOVE, Notification.REMOVE_MANY ->
+		case Notification.REMOVE ->
 			updateRemovedTypeEntryNameReference(notification.getOldValue());
+		case Notification.REMOVE_MANY ->
+			((Collection<?>) notification.getOldValue()).forEach(this::updateRemovedTypeEntryNameReference);
 		default -> {
 			// ignore
 		}
@@ -89,17 +90,8 @@ public class LibraryElementDependencyUpdater extends LibraryElementDependencyTra
 	}
 
 	private void updateRemovedTypeEntryNameReference(final Object object) {
-		switch (object) {
-		case final Collection<?> collection -> {
-			for (final Object value : collection) {
-				updateRemovedTypeEntryNameReference(value);
-			}
-		}
-		case final TypeEntry dependency when getDependencies().contains(dependency) ->
+		if (object instanceof final TypeEntry dependency && getDependencies().contains(dependency)) {
 			Display.getDefault().asyncExec(() -> updateDependency(dependency, dependency.getFullTypeName()));
-		case null, default -> {
-			// ignore
-		}
 		}
 	}
 
@@ -261,22 +253,14 @@ public class LibraryElementDependencyUpdater extends LibraryElementDependencyTra
 		if (libraryElement != null && !libraryElement.eAdapters().contains(this)) {
 			libraryElement.eAdapters().add(this);
 		}
-		if (libraryElement != null) {
-			typeLibrary = libraryElement.getTypeLibrary();
-			if (typeLibrary != null && !typeLibrary.eAdapters().contains(this)) {
-				typeLibrary.eAdapters().add(this);
-			}
-		}
 	}
 
 	private void uninstall() {
 		if (libraryElement != null) {
 			libraryElement.eAdapters().remove(this);
 		}
-		if (typeLibrary != null) {
-			typeLibrary.eAdapters().remove(this);
-			typeLibrary = null;
-		}
+		getDependencies().stream().map(TypeEntry::getTypeLibrary).filter(Objects::nonNull).distinct()
+				.forEach(typeLibrary -> typeLibrary.eAdapters().remove(this));
 	}
 
 	@Override
@@ -285,6 +269,7 @@ public class LibraryElementDependencyUpdater extends LibraryElementDependencyTra
 			if (!typeEntry.eAdapters().contains(this)) {
 				typeEntry.eAdapters().add(this);
 			}
+			addTypeLibraryAdapter(typeEntry);
 			return true;
 		}
 		return false;
@@ -293,9 +278,24 @@ public class LibraryElementDependencyUpdater extends LibraryElementDependencyTra
 	@Override
 	protected boolean removeDependency(final TypeEntry typeEntry) {
 		if (super.removeDependency(typeEntry)) {
+			removeTypeLibraryAdapter(typeEntry);
 			typeEntry.eAdapters().remove(this);
 			return true;
 		}
 		return false;
+	}
+
+	private void addTypeLibraryAdapter(final TypeEntry typeEntry) {
+		final TypeLibrary typeLibrary = typeEntry.getTypeLibrary();
+		if (typeLibrary != null && !typeLibrary.eAdapters().contains(this)) {
+			typeLibrary.eAdapters().add(this);
+		}
+	}
+
+	private void removeTypeLibraryAdapter(final TypeEntry typeEntry) {
+		final TypeLibrary typeLibrary = typeEntry.getTypeLibrary();
+		if (typeLibrary != null && getDependencies().stream().noneMatch(entry -> entry.getTypeLibrary() == typeLibrary)) {
+			typeLibrary.eAdapters().remove(this);
+		}
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/TypeLibrary.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/TypeLibrary.java
@@ -78,7 +78,7 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 
 	public static final int TYPE_ENTRY_NAME_REFERENCES_FEATURE_ID = 1;
 
-	private IProject owningProject;
+	private IProject project;
 	private Buildpath buildpath;
 	private final DataTypeLibrary dataTypeLib = new DataTypeLibrary(this);
 	private final Map<String, AdapterTypeEntry> adapterTypes = new ConcurrentHashMap<>();
@@ -206,7 +206,7 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 	}
 
 	public IProject getProject() {
-		return owningProject;
+		return project;
 	}
 
 	public Buildpath getBuildpath() {
@@ -218,10 +218,10 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 	}
 
 	/** Instantiates a new fB type library. */
-	TypeLibrary(final IProject project) {
-		this.owningProject = project;
-		buildpath = BuildpathUtil.loadBuildpath(project);
-		if (project != null && project.isAccessible()) {
+	TypeLibrary(final IProject typeLibraryProject) {
+		project = typeLibraryProject;
+		buildpath = BuildpathUtil.loadBuildpath(typeLibraryProject);
+		if (typeLibraryProject != null && typeLibraryProject.isAccessible()) {
 			checkAdditions();
 		}
 	}
@@ -313,9 +313,8 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 			deleteTypeLibraryMarkers(entry.getFile());
 		}
 		addPackageNameReference(PackageNameHelper.extractPackageName(entry.getFullTypeName()));
-		if (eNotificationRequired() && isPublicNameReference(entry)) {
-			eNotify(new TypeLibraryNotificationImpl(this, Notification.ADD, TYPE_ENTRY_NAME_REFERENCES_FEATURE,
-					TYPE_ENTRY_NAME_REFERENCES_FEATURE_ID, null, entry));
+		if (isPublicNameReference(entry)) {
+			notifyTypeEntryNameReferenceAdded(entry);
 		}
 	}
 
@@ -365,19 +364,52 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 	}
 
 	private boolean retryDuplicate(final TypeEntry entry) {
-		if (!exists(entry)) {
+		if (!isDuplicateRetryCandidate(entry)) {
 			return true;
 		}
 		if (entry instanceof final DataTypeEntry dtEntry) {
 			if (dataTypeLib.addTypeEntry(dtEntry)) {
 				deleteTypeLibraryMarkers(entry.getFile());
+				if (isPublicTypeEntryNameReference(entry)) {
+					notifyTypeEntryNameReferenceAdded(entry);
+				}
 				return true;
 			}
 		} else if (addBlockTypeEntry(entry)) {
 			deleteTypeLibraryMarkers(entry.getFile());
+			if (isPublicTypeEntryNameReference(entry)) {
+				notifyTypeEntryNameReferenceAdded(entry);
+			}
 			return true;
 		}
 		return false;
+	}
+
+	private boolean isDuplicateRetryCandidate(final TypeEntry entry) {
+		final TypeLibrary entryTypeLibrary = entry.getTypeLibrary();
+		if (entryTypeLibrary == this) {
+			return exists(entry);
+		}
+		return isReferencedPublicTypeEntryNameReference(entry, entryTypeLibrary);
+	}
+
+	private boolean isPublicTypeEntryNameReference(final TypeEntry entry) {
+		final TypeLibrary entryTypeLibrary = entry.getTypeLibrary();
+		return entryTypeLibrary == this ? isPublicNameReference(entry)
+				: isReferencedPublicTypeEntryNameReference(entry, entryTypeLibrary);
+	}
+
+	private boolean isReferencedPublicTypeEntryNameReference(final TypeEntry entry,
+			final TypeLibrary referencedTypeLibrary) {
+		return referencedTypeLibrary != null && referencedTypeLibrary != this
+				&& referencedTypeLibrary.getProject() != null
+				&& referencedProjects.contains(referencedTypeLibrary.getProject())
+				&& referencedTypeLibrary.exists(entry) && referencedTypeLibrary.containsTypeEntry(entry)
+				&& referencedTypeLibrary.isPublicNameReference(entry);
+	}
+
+	private boolean containsTypeEntry(final TypeEntry entry) {
+		return entry.getFile() != null && getTypeEntry(entry.getFile()) == entry;
 	}
 
 	protected void addPackageNameReference(final String packageName) {
@@ -404,7 +436,7 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 	}
 
 	public void refresh() {
-		buildpath = BuildpathUtil.loadBuildpath(owningProject);
+		buildpath = BuildpathUtil.loadBuildpath(project);
 		checkDeletions();
 		checkAdditions();
 	}
@@ -440,7 +472,7 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 	private void checkAdditions() {
 		try {
 			checkReferencedProjectsAdditions();
-			checkAdditions(owningProject);
+			checkAdditions(project);
 		} catch (final CoreException e) {
 			FordiacLogHelper.logError(e.getMessage(), e);
 		}
@@ -461,7 +493,7 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 	}
 
 	private void checkReferencedProjectsAdditions() throws CoreException {
-		for (final IProject referencedProject : owningProject.getReferencedProjects()) {
+		for (final IProject referencedProject : project.getReferencedProjects()) {
 			addReferencedProject(referencedProject);
 		}
 	}
@@ -469,7 +501,7 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 	private void checkReferencedProjectDeletions() {
 		final Set<IProject> currentReferencedProjects = new HashSet<>();
 		try {
-			currentReferencedProjects.addAll(Arrays.asList(owningProject.getReferencedProjects()));
+			currentReferencedProjects.addAll(Arrays.asList(project.getReferencedProjects()));
 		} catch (final CoreException e) {
 			FordiacLogHelper.logWarning(e.getMessage(), e);
 		}
@@ -555,11 +587,11 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 		};
 	}
 
-	private boolean addReferencedProject(final IProject project) {
-		if (!referencedProjects.add(project)) {
+	private boolean addReferencedProject(final IProject referencedProject) {
+		if (!referencedProjects.add(referencedProject)) {
 			return false;
 		}
-		final TypeLibrary referencedTypeLibrary = TypeLibraryManager.INSTANCE.getTypeLibrary(project);
+		final TypeLibrary referencedTypeLibrary = TypeLibraryManager.INSTANCE.getTypeLibrary(referencedProject);
 		referencedTypeLibrary.eAdapters().add(typeLibraryAdapter);
 		referencedTypeLibrary.getAllPublicTypes().forEachOrdered(this::addTypeEntryNameReference);
 		return true;
@@ -607,17 +639,18 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 	}
 
 	private boolean hasDataTypeEntryNameReference(final DataTypeEntry entry) {
-		final var dataTypes = dataTypeLib.getDerivedDataTypes().iterator();
-		while (dataTypes.hasNext()) {
-			if (dataTypes.next() == entry) {
-				return true;
-			}
-		}
-		return false;
+		return dataTypeLib.getDerivedTypeEntry(entry.getFullTypeName()) == entry;
 	}
 
 	private boolean hasProgramTypeEntryNameReference(final TypeEntry entry) {
 		return isProgramTypeEntry(entry) && programTypes.get(entry.getFullTypeName().toLowerCase()) == entry;
+	}
+
+	private void notifyTypeEntryNameReferenceAdded(final TypeEntry entry) {
+		if (eNotificationRequired()) {
+			eNotify(new TypeLibraryNotificationImpl(this, Notification.ADD, TYPE_ENTRY_NAME_REFERENCES_FEATURE,
+					TYPE_ENTRY_NAME_REFERENCES_FEATURE_ID, null, entry));
+		}
 	}
 
 	private void notifyTypeEntryNameReferenceRemoved(final TypeEntry entry) {
@@ -636,21 +669,21 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 	}
 
 	private void createTypeLibraryMarker(final IResource resource, final String message) {
-		if (resource != null && owningProject.equals(resource.getProject())) {
+		if (resource != null && project.equals(resource.getProject())) {
 			FordiacMarkerHelper.createMarkers(resource, List.of(ErrorMarkerBuilder.createErrorMarkerBuilder(message)
 					.setType(FordiacErrorMarker.TYPE_LIBRARY_MARKER)));
 		}
 	}
 
 	private void deleteTypeLibraryMarkers(final IResource resource) {
-		if (resource != null && owningProject.equals(resource.getProject())) {
+		if (resource != null && project.equals(resource.getProject())) {
 			FordiacMarkerHelper.updateMarkers(resource, FordiacErrorMarker.TYPE_LIBRARY_MARKER, Collections.emptyList(),
 					true);
 		}
 	}
 
 	void setProject(final IProject newProject) {
-		owningProject = newProject;
+		project = newProject;
 	}
 
 	private static class TypeLibraryNotificationImpl extends NotificationImpl {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/TypeLibrary.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/TypeLibrary.java
@@ -78,7 +78,7 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 
 	public static final int TYPE_ENTRY_NAME_REFERENCES_FEATURE_ID = 1;
 
-	private IProject project;
+	private IProject owningProject;
 	private Buildpath buildpath;
 	private final DataTypeLibrary dataTypeLib = new DataTypeLibrary(this);
 	private final Map<String, AdapterTypeEntry> adapterTypes = new ConcurrentHashMap<>();
@@ -206,7 +206,7 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 	}
 
 	public IProject getProject() {
-		return project;
+		return owningProject;
 	}
 
 	public Buildpath getBuildpath() {
@@ -219,7 +219,7 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 
 	/** Instantiates a new fB type library. */
 	TypeLibrary(final IProject project) {
-		this.project = project;
+		this.owningProject = project;
 		buildpath = BuildpathUtil.loadBuildpath(project);
 		if (project != null && project.isAccessible()) {
 			checkAdditions();
@@ -348,9 +348,8 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 		}
 		removePackageNameReference(PackageNameHelper.extractPackageName(entry.getFullTypeName()));
 		deleteTypeLibraryMarkers(entry.getFile());
-		if (eNotificationRequired() && isPublicNameReference(entry)) {
-			eNotify(new TypeLibraryNotificationImpl(this, Notification.REMOVE, TYPE_ENTRY_NAME_REFERENCES_FEATURE,
-					TYPE_ENTRY_NAME_REFERENCES_FEATURE_ID, entry, null));
+		if (isPublicNameReference(entry)) {
+			notifyTypeEntryNameReferenceRemoved(entry);
 		}
 		retryDuplicates();
 	}
@@ -405,7 +404,7 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 	}
 
 	public void refresh() {
-		buildpath = BuildpathUtil.loadBuildpath(project);
+		buildpath = BuildpathUtil.loadBuildpath(owningProject);
 		checkDeletions();
 		checkAdditions();
 	}
@@ -441,7 +440,7 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 	private void checkAdditions() {
 		try {
 			checkReferencedProjectsAdditions();
-			checkAdditions(project);
+			checkAdditions(owningProject);
 		} catch (final CoreException e) {
 			FordiacLogHelper.logError(e.getMessage(), e);
 		}
@@ -462,7 +461,7 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 	}
 
 	private void checkReferencedProjectsAdditions() throws CoreException {
-		for (final IProject referencedProject : project.getReferencedProjects()) {
+		for (final IProject referencedProject : owningProject.getReferencedProjects()) {
 			addReferencedProject(referencedProject);
 		}
 	}
@@ -470,7 +469,7 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 	private void checkReferencedProjectDeletions() {
 		final Set<IProject> currentReferencedProjects = new HashSet<>();
 		try {
-			currentReferencedProjects.addAll(Arrays.asList(project.getReferencedProjects()));
+			currentReferencedProjects.addAll(Arrays.asList(owningProject.getReferencedProjects()));
 		} catch (final CoreException e) {
 			FordiacLogHelper.logWarning(e.getMessage(), e);
 		}
@@ -566,13 +565,14 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 		return true;
 	}
 
-	private boolean removeReferencedProject(final IProject project) {
-		if (!referencedProjects.remove(project)) {
+	private boolean removeReferencedProject(final IProject referencedProject) {
+		if (!referencedProjects.remove(referencedProject)) {
 			return false;
 		}
-		final TypeLibrary referencedTypeLibrary = TypeLibraryManager.INSTANCE.getTypeLibrary(project);
+		final TypeLibrary referencedTypeLibrary = TypeLibraryManager.INSTANCE.getTypeLibrary(referencedProject);
 		referencedTypeLibrary.eAdapters().remove(typeLibraryAdapter);
-		referencedTypeLibrary.getAllPublicTypes().forEachOrdered(this::removeTypeEntryNameReference);
+		removeDuplicateTypeEntriesFromProject(referencedProject);
+		removeReferencedTypeEntryNameReferences(referencedTypeLibrary);
 		return true;
 	}
 
@@ -580,26 +580,77 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 		return fileMap.values().stream().filter(this::isPublicNameReference);
 	}
 
+	private void removeReferencedTypeEntryNameReferences(final TypeLibrary referencedTypeLibrary) {
+		final var referencedTypes = referencedTypeLibrary.getAllTypes().iterator();
+		while (referencedTypes.hasNext()) {
+			removeReferencedProjectTypeEntryNameReference(referencedTypes.next());
+		}
+	}
+
+	private void removeDuplicateTypeEntriesFromProject(final IProject referencedProject) {
+		duplicates.removeIf(entry -> isTypeEntryFromProject(entry, referencedProject));
+	}
+
+	private void removeReferencedProjectTypeEntryNameReference(final TypeEntry entry) {
+		if (hasTypeEntryNameReference(entry)) {
+			removeTypeEntryNameReference(entry);
+			notifyTypeEntryNameReferenceRemoved(entry);
+		}
+	}
+
+	private boolean hasTypeEntryNameReference(final TypeEntry entry) {
+		return switch (entry) {
+		case final DataTypeEntry dtEntry ->
+			hasDataTypeEntryNameReference(dtEntry) || hasProgramTypeEntryNameReference(entry);
+		default -> getBlockTypeEntry(entry) == entry || hasProgramTypeEntryNameReference(entry);
+		};
+	}
+
+	private boolean hasDataTypeEntryNameReference(final DataTypeEntry entry) {
+		final var dataTypes = dataTypeLib.getDerivedDataTypes().iterator();
+		while (dataTypes.hasNext()) {
+			if (dataTypes.next() == entry) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private boolean hasProgramTypeEntryNameReference(final TypeEntry entry) {
+		return isProgramTypeEntry(entry) && programTypes.get(entry.getFullTypeName().toLowerCase()) == entry;
+	}
+
+	private void notifyTypeEntryNameReferenceRemoved(final TypeEntry entry) {
+		if (eNotificationRequired()) {
+			eNotify(new TypeLibraryNotificationImpl(this, Notification.REMOVE, TYPE_ENTRY_NAME_REFERENCES_FEATURE,
+					TYPE_ENTRY_NAME_REFERENCES_FEATURE_ID, entry, null));
+		}
+	}
+
+	private static boolean isTypeEntryFromProject(final TypeEntry entry, final IProject project) {
+		return entry.getFile() != null && project.equals(entry.getFile().getProject());
+	}
+
 	private static boolean isProgramTypeEntry(final TypeEntry entry) {
 		return entry instanceof FBTypeEntry || entry instanceof SubAppTypeEntry || entry instanceof DataTypeEntry;
 	}
 
 	private void createTypeLibraryMarker(final IResource resource, final String message) {
-		if (resource != null && project.equals(resource.getProject())) {
+		if (resource != null && owningProject.equals(resource.getProject())) {
 			FordiacMarkerHelper.createMarkers(resource, List.of(ErrorMarkerBuilder.createErrorMarkerBuilder(message)
 					.setType(FordiacErrorMarker.TYPE_LIBRARY_MARKER)));
 		}
 	}
 
 	private void deleteTypeLibraryMarkers(final IResource resource) {
-		if (resource != null && project.equals(resource.getProject())) {
+		if (resource != null && owningProject.equals(resource.getProject())) {
 			FordiacMarkerHelper.updateMarkers(resource, FordiacErrorMarker.TYPE_LIBRARY_MARKER, Collections.emptyList(),
 					true);
 		}
 	}
 
 	void setProject(final IProject newProject) {
-		project = newProject;
+		owningProject = newProject;
 	}
 
 	private static class TypeLibraryNotificationImpl extends NotificationImpl {


### PR DESCRIPTION
This fixes two related issues when dereferencing a project:

1. The target project's TypeLibrary kept stale TypeEntry references from the
   dereferenced project, which could create duplicate type markers.
2. Open system editors could still show/use the old TypeEntry because their
   dependency updater was only listening to the TypeEntry itself, not to the
   target TypeLibrary visibility change.