### PR TITLE
Add E_RF_TRIG for edge detection in events library

### DIFF
--- a/data/typelibrary/events-3.0.0/typelib/E_F_TRIG.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_F_TRIG.fbt
@@ -15,7 +15,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="EO" Type="Event" Comment="confirmation that an falling edge was detected">
+			<Event Name="EO" Type="Event" Comment="confirmation that a falling edge was detected">
 			</Event>
 		</EventOutputs>
 		<InputVars>

--- a/data/typelibrary/events-3.0.0/typelib/E_RF_TRIG.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_RF_TRIG.fbt
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="E_RF_TRIG" Comment="Boolean falling and rising edge detection">
+	<Identification Standard="61499-1 Annex A" Description="Copyright (c) 2017 fortiss GmbH, HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-08" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::events">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="EI" Type="Event" Comment="check for rising or falling edge">
+				<With Var="QI"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="ER" Type="Event" Comment="confirmation that a rising edge was detected">
+			</Event>
+			<Event Name="EF" Type="Event" Comment="confirmation that a falling edge was detected">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="QI" Type="BOOL" Comment="value to check for a rising or falling edge"/>
+		</InputVars>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="E_D_FF" Type="iec61499::events::E_D_FF" x="400" y="-600">
+		</FB>
+		<FB Name="E_SWITCH" Type="iec61499::events::E_SWITCH" x="1400" y="-600">
+		</FB>
+		<EventConnections>
+			<Connection Source="EI" Destination="E_D_FF.CLK" dx1="560"/>
+			<Connection Source="E_D_FF.EO" Destination="E_SWITCH.EI"/>
+			<Connection Source="E_SWITCH.EO1" Destination="ER" dx1="1540"/>
+			<Connection Source="E_SWITCH.EO0" Destination="EF" dx1="2000"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="QI" Destination="E_D_FF.D" dx1="253.33"/>
+			<Connection Source="E_D_FF.Q" Destination="E_SWITCH.G" dx1="213.33"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/events-3.0.0/typelib/E_R_TRIG.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_R_TRIG.fbt
@@ -15,7 +15,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="EO" Type="Event" Comment="confirmation that an rising edge was detected">
+			<Event Name="EO" Type="Event" Comment="confirmation that a rising edge was detected">
 			</Event>
 		</EventOutputs>
 		<InputVars>


### PR DESCRIPTION
Introduces the E_RF_TRIG function block to detect rising and falling edges. This enhancement allows for more precise event-driven programming by distinguishing between edge transitions in boolean inputs.

this is also needed for: 
https://github.com/eclipse-4diac/4diac-ide/pull/2438