### PR TITLE
Replace E_PERMIT with E_R_TRIG in E_TP function block

### DIFF
--- a/data/typelibrary/events-3.0.0/typelib/timers/E_TP.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/timers/E_TP.fbt
@@ -2,11 +2,13 @@
 <FBType Name="E_TP" Comment="standard timer function block (pulse)">
 	<Identification Standard="61499-2" Classification="standard timer function block" Description="Copyright (c) 2024 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-05-13" Remarks="E_R_TRIG instead of E_PERMIT">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.1" Author="Franz Hoepfinger" Date="2024-04-23" Remarks="Add a Reset to Timer FBs">
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.1" Author="Franz Höpfinger" Date="2024-04-23" Remarks="Add a Reset to Timer FBs">
 	</VersionInfo>
-	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Hoepfinger" Date="2024-03-04">
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2024-03-04">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::events::timers">
 	</CompilerInfo>
@@ -34,25 +36,25 @@
 		</OutputVars>
 	</InterfaceList>
 	<FBNetwork>
-		<FB Name="E_DELAY" Type="iec61499::events::E_DELAY" Comment="" x="353.33333333333337" y="-260.0">
+		<FB Name="E_DELAY" Type="iec61499::events::E_DELAY" x="353.33" y="-260">
 		</FB>
-		<FB Name="E_RS" Type="iec61499::events::E_RS" Comment="" x="1506.6666666666667" y="-553.3333333333334">
+		<FB Name="E_RS" Type="iec61499::events::E_RS" x="1506.67" y="-553.33">
 		</FB>
-		<FB Name="E_PERMIT" Type="iec61499::events::E_PERMIT" Comment="" x="-1866.6666666666667" y="-933.3333333333334">
+		<FB Name="E_R_TRIG" Type="iec61499::events::E_R_TRIG" x="-1866.67" y="-933.33">
 		</FB>
 		<EventConnections>
-			<Connection Source="E_RS.EO" Destination="CNF" Comment="" dx1="966.6666666666667"/>
-			<Connection Source="R" Destination="E_DELAY.STOP" Comment="" dx1="226.66666666666669"/>
-			<Connection Source="R" Destination="E_RS.R" Comment="" dx1="226.66666666666669" dx2="1426.6666666666667" dy="880.0"/>
-			<Connection Source="E_DELAY.EO" Destination="E_RS.R" Comment="" dx1="266.6666666666667"/>
-			<Connection Source="REQ" Destination="E_PERMIT.EI" Comment="" dx1="1066.6666666666667"/>
-			<Connection Source="E_PERMIT.EO" Destination="E_RS.S" Comment="" dx1="1360.0"/>
-			<Connection Source="E_PERMIT.EO" Destination="E_DELAY.START" Comment="" dx1="780.0"/>
+			<Connection Source="E_RS.EO" Destination="CNF" dx1="966.67"/>
+			<Connection Source="R" Destination="E_DELAY.STOP" dx1="226.67"/>
+			<Connection Source="R" Destination="E_RS.R" dx1="226.67" dx2="1426.67" dy="880"/>
+			<Connection Source="E_DELAY.EO" Destination="E_RS.R" dx1="266.67"/>
+			<Connection Source="REQ" Destination="E_R_TRIG.EI" dx1="1066.67"/>
+			<Connection Source="E_R_TRIG.EO" Destination="E_RS.S" dx1="1360"/>
+			<Connection Source="E_R_TRIG.EO" Destination="E_DELAY.START" dx1="780"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="PT" Destination="E_DELAY.DT" Comment="" dx1="193.33333333333334"/>
-			<Connection Source="E_RS.Q" Destination="Q" Comment="" dx1="1000.0"/>
-			<Connection Source="IN" Destination="E_PERMIT.PERMIT" Comment="" dx1="1066.6666666666667"/>
+			<Connection Source="PT" Destination="E_DELAY.DT" dx1="193.33"/>
+			<Connection Source="E_RS.Q" Destination="Q" dx1="1000"/>
+			<Connection Source="IN" Destination="E_R_TRIG.QI" dx1="1066.67"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>


### PR DESCRIPTION
Updates the E_TP function block to use E_R_TRIG instead of E_PERMIT, reflecting changes in the event-driven programming approach for enhanced edge detection accuracy. Adjustments also include minor formatting improvements and consistency in author name spelling.
