### PR TITLE
Add array-to-array and array-to-values function blocks for BYTE and INT types

### DIFF
--- a/data/typelibrary/convert-3.0.0/typelib/ARRAY2ARRAY_2_BYTE.fbt
+++ b/data/typelibrary/convert-3.0.0/typelib/ARRAY2ARRAY_2_BYTE.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ARRAY2ARRAY_2_BYTE" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2014 Profactor GmbH, HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-03-30" Remarks="copy ARRAY2ARRAY_2_LREAL and made this block">
+	</VersionInfo>
+	<CompilerInfo packageName="eclipse4diac::convert">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="IN"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="BYTE" Comment="array input" ArraySize="2"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="BYTE" Comment="array output" ArraySize="2"/>
+		</OutputVars>
+	</InterfaceList>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION">
+	</Service>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ARRAY2ARRAY'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/convert-3.0.0/typelib/ARRAY2ARRAY_2_INT.fbt
+++ b/data/typelibrary/convert-3.0.0/typelib/ARRAY2ARRAY_2_INT.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ARRAY2ARRAY_2_INT" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2014 Profactor GmbH, HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-03-30" Remarks="copy ARRAY2ARRAY_2_LREAL and made this block">
+	</VersionInfo>
+	<CompilerInfo packageName="eclipse4diac::convert">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="IN"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="INT" Comment="array input" ArraySize="2"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="INT" Comment="array output" ArraySize="2"/>
+		</OutputVars>
+	</InterfaceList>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION">
+	</Service>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ARRAY2ARRAY'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/convert-3.0.0/typelib/ARRAY2ARRAY_8_BYTE.fbt
+++ b/data/typelibrary/convert-3.0.0/typelib/ARRAY2ARRAY_8_BYTE.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ARRAY2ARRAY_8_BYTE" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2014 Profactor GmbH, HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-03-30" Remarks="copy ARRAY2ARRAY_2_LREAL and made this block">
+	</VersionInfo>
+	<CompilerInfo packageName="eclipse4diac::convert">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="IN"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="BYTE" Comment="array input" ArraySize="8"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="BYTE" Comment="array output" ArraySize="8"/>
+		</OutputVars>
+	</InterfaceList>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION">
+	</Service>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ARRAY2ARRAY'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/convert-3.0.0/typelib/ARRAY2ARRAY_8_INT.fbt
+++ b/data/typelibrary/convert-3.0.0/typelib/ARRAY2ARRAY_8_INT.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ARRAY2ARRAY_8_INT" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2014 Profactor GmbH, HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-03-30" Remarks="copy ARRAY2ARRAY_2_LREAL and made this block">
+	</VersionInfo>
+	<CompilerInfo packageName="eclipse4diac::convert">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="IN"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="INT" Comment="array input" ArraySize="8"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="INT" Comment="array output" ArraySize="8"/>
+		</OutputVars>
+	</InterfaceList>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION">
+	</Service>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ARRAY2ARRAY'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/convert-3.0.0/typelib/ARRAY2VALUES_16_BYTE.fbt
+++ b/data/typelibrary/convert-3.0.0/typelib/ARRAY2VALUES_16_BYTE.fbt
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ARRAY2VALUES_16_BYTE" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2014 Profactor GmbH, HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-03-30" Remarks="copy ARRAY2VALUES_2_LREAL and made this block">
+	</VersionInfo>
+	<CompilerInfo packageName="eclipse4diac::convert">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="IN"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="OUT_1"/>
+				<With Var="OUT_2"/>
+				<With Var="OUT_3"/>
+				<With Var="OUT_4"/>
+				<With Var="OUT_5"/>
+				<With Var="OUT_6"/>
+				<With Var="OUT_7"/>
+				<With Var="OUT_8"/>
+				<With Var="OUT_9"/>
+				<With Var="OUT_10"/>
+				<With Var="OUT_11"/>
+				<With Var="OUT_12"/>
+				<With Var="OUT_13"/>
+				<With Var="OUT_14"/>
+				<With Var="OUT_15"/>
+				<With Var="OUT_16"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="BYTE" Comment="Array input" ArraySize="16"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT_1" Type="BYTE" Comment="output number 1"/>
+			<VarDeclaration Name="OUT_2" Type="BYTE" Comment="output number 2"/>
+			<VarDeclaration Name="OUT_3" Type="BYTE" Comment="output number 3"/>
+			<VarDeclaration Name="OUT_4" Type="BYTE" Comment="output number 4"/>
+			<VarDeclaration Name="OUT_5" Type="BYTE" Comment="output number 5"/>
+			<VarDeclaration Name="OUT_6" Type="BYTE" Comment="output number 6"/>
+			<VarDeclaration Name="OUT_7" Type="BYTE" Comment="output number 7"/>
+			<VarDeclaration Name="OUT_8" Type="BYTE" Comment="output number 8"/>
+			<VarDeclaration Name="OUT_9" Type="BYTE" Comment="output number 9"/>
+			<VarDeclaration Name="OUT_10" Type="BYTE" Comment="output number 10"/>
+			<VarDeclaration Name="OUT_11" Type="BYTE" Comment="output number 11"/>
+			<VarDeclaration Name="OUT_12" Type="BYTE" Comment="output number 12"/>
+			<VarDeclaration Name="OUT_13" Type="BYTE" Comment="output number 13"/>
+			<VarDeclaration Name="OUT_14" Type="BYTE" Comment="output number 14"/>
+			<VarDeclaration Name="OUT_15" Type="BYTE" Comment="output number 15"/>
+			<VarDeclaration Name="OUT_16" Type="BYTE" Comment="output number 16"/>
+		</OutputVars>
+	</InterfaceList>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION">
+	</Service>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ARRAY2VALUES'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/convert-3.0.0/typelib/ARRAY2VALUES_2_BYTE.fbt
+++ b/data/typelibrary/convert-3.0.0/typelib/ARRAY2VALUES_2_BYTE.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ARRAY2VALUES_2_BYTE" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2014 Profactor GmbH, HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-03-30" Remarks="copy ARRAY2VALUES_2_LREAL and made this block">
+	</VersionInfo>
+	<CompilerInfo packageName="eclipse4diac::convert">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="IN"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="OUT_1"/>
+				<With Var="OUT_2"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="BYTE" Comment="Array input" ArraySize="2"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT_1" Type="BYTE" Comment="output number 1"/>
+			<VarDeclaration Name="OUT_2" Type="BYTE" Comment="output number 2"/>
+		</OutputVars>
+	</InterfaceList>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION">
+	</Service>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ARRAY2VALUES'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/convert-3.0.0/typelib/ARRAY2VALUES_32_BYTE.fbt
+++ b/data/typelibrary/convert-3.0.0/typelib/ARRAY2VALUES_32_BYTE.fbt
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ARRAY2VALUES_32_BYTE" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2014 Profactor GmbH, HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-03-30" Remarks="copy ARRAY2VALUES_2_LREAL and made this block">
+	</VersionInfo>
+	<CompilerInfo packageName="eclipse4diac::convert">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="IN"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="OUT_1"/>
+				<With Var="OUT_2"/>
+				<With Var="OUT_3"/>
+				<With Var="OUT_4"/>
+				<With Var="OUT_5"/>
+				<With Var="OUT_6"/>
+				<With Var="OUT_7"/>
+				<With Var="OUT_8"/>
+				<With Var="OUT_9"/>
+				<With Var="OUT_10"/>
+				<With Var="OUT_11"/>
+				<With Var="OUT_12"/>
+				<With Var="OUT_13"/>
+				<With Var="OUT_14"/>
+				<With Var="OUT_15"/>
+				<With Var="OUT_16"/>
+				<With Var="OUT_17"/>
+				<With Var="OUT_18"/>
+				<With Var="OUT_19"/>
+				<With Var="OUT_20"/>
+				<With Var="OUT_21"/>
+				<With Var="OUT_22"/>
+				<With Var="OUT_23"/>
+				<With Var="OUT_24"/>
+				<With Var="OUT_25"/>
+				<With Var="OUT_26"/>
+				<With Var="OUT_27"/>
+				<With Var="OUT_28"/>
+				<With Var="OUT_29"/>
+				<With Var="OUT_30"/>
+				<With Var="OUT_31"/>
+				<With Var="OUT_32"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="BYTE" Comment="Array input" ArraySize="32"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT_1" Type="BYTE" Comment="output number 1"/>
+			<VarDeclaration Name="OUT_2" Type="BYTE" Comment="output number 2"/>
+			<VarDeclaration Name="OUT_3" Type="BYTE" Comment="output number 3"/>
+			<VarDeclaration Name="OUT_4" Type="BYTE" Comment="output number 4"/>
+			<VarDeclaration Name="OUT_5" Type="BYTE" Comment="output number 5"/>
+			<VarDeclaration Name="OUT_6" Type="BYTE" Comment="output number 6"/>
+			<VarDeclaration Name="OUT_7" Type="BYTE" Comment="output number 7"/>
+			<VarDeclaration Name="OUT_8" Type="BYTE" Comment="output number 8"/>
+			<VarDeclaration Name="OUT_9" Type="BYTE" Comment="output number 9"/>
+			<VarDeclaration Name="OUT_10" Type="BYTE" Comment="output number 10"/>
+			<VarDeclaration Name="OUT_11" Type="BYTE" Comment="output number 11"/>
+			<VarDeclaration Name="OUT_12" Type="BYTE" Comment="output number 12"/>
+			<VarDeclaration Name="OUT_13" Type="BYTE" Comment="output number 13"/>
+			<VarDeclaration Name="OUT_14" Type="BYTE" Comment="output number 14"/>
+			<VarDeclaration Name="OUT_15" Type="BYTE" Comment="output number 15"/>
+			<VarDeclaration Name="OUT_16" Type="BYTE" Comment="output number 16"/>
+			<VarDeclaration Name="OUT_17" Type="BYTE" Comment="output number 17"/>
+			<VarDeclaration Name="OUT_18" Type="BYTE" Comment="output number 18"/>
+			<VarDeclaration Name="OUT_19" Type="BYTE" Comment="output number 19"/>
+			<VarDeclaration Name="OUT_20" Type="BYTE" Comment="output number 20"/>
+			<VarDeclaration Name="OUT_21" Type="BYTE" Comment="output number 21"/>
+			<VarDeclaration Name="OUT_22" Type="BYTE" Comment="output number 22"/>
+			<VarDeclaration Name="OUT_23" Type="BYTE" Comment="output number 23"/>
+			<VarDeclaration Name="OUT_24" Type="BYTE" Comment="output number 24"/>
+			<VarDeclaration Name="OUT_25" Type="BYTE" Comment="output number 25"/>
+			<VarDeclaration Name="OUT_26" Type="BYTE" Comment="output number 26"/>
+			<VarDeclaration Name="OUT_27" Type="BYTE" Comment="output number 27"/>
+			<VarDeclaration Name="OUT_28" Type="BYTE" Comment="output number 28"/>
+			<VarDeclaration Name="OUT_29" Type="BYTE" Comment="output number 29"/>
+			<VarDeclaration Name="OUT_30" Type="BYTE" Comment="output number 30"/>
+			<VarDeclaration Name="OUT_31" Type="BYTE" Comment="output number 31"/>
+			<VarDeclaration Name="OUT_32" Type="BYTE" Comment="output number 32"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ARRAY2VALUES'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/convert-3.0.0/typelib/ARRAY2VALUES_4_BYTE.fbt
+++ b/data/typelibrary/convert-3.0.0/typelib/ARRAY2VALUES_4_BYTE.fbt
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ARRAY2VALUES_4_BYTE" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2014 Profactor GmbH, HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-03-30" Remarks="copy ARRAY2VALUES_2_LREAL and made this block">
+	</VersionInfo>
+	<CompilerInfo packageName="eclipse4diac::convert">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="IN"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="OUT_1"/>
+				<With Var="OUT_2"/>
+				<With Var="OUT_3"/>
+				<With Var="OUT_4"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="BYTE" Comment="Array input" ArraySize="4"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT_1" Type="BYTE" Comment="output number 1"/>
+			<VarDeclaration Name="OUT_2" Type="BYTE" Comment="output number 2"/>
+			<VarDeclaration Name="OUT_3" Type="BYTE" Comment="output number 3"/>
+			<VarDeclaration Name="OUT_4" Type="BYTE" Comment="output number 4"/>
+		</OutputVars>
+	</InterfaceList>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION">
+	</Service>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ARRAY2VALUES'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/convert-3.0.0/typelib/ARRAY2VALUES_8_BYTE.fbt
+++ b/data/typelibrary/convert-3.0.0/typelib/ARRAY2VALUES_8_BYTE.fbt
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ARRAY2VALUES_8_BYTE" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2014 Profactor GmbH, HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-03-30" Remarks="copy ARRAY2VALUES_2_LREAL and made this block">
+	</VersionInfo>
+	<CompilerInfo packageName="eclipse4diac::convert">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="IN"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="OUT_1"/>
+				<With Var="OUT_2"/>
+				<With Var="OUT_3"/>
+				<With Var="OUT_4"/>
+				<With Var="OUT_5"/>
+				<With Var="OUT_6"/>
+				<With Var="OUT_7"/>
+				<With Var="OUT_8"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="BYTE" Comment="Array input" ArraySize="8"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT_1" Type="BYTE" Comment="output number 1"/>
+			<VarDeclaration Name="OUT_2" Type="BYTE" Comment="output number 2"/>
+			<VarDeclaration Name="OUT_3" Type="BYTE" Comment="output number 3"/>
+			<VarDeclaration Name="OUT_4" Type="BYTE" Comment="output number 4"/>
+			<VarDeclaration Name="OUT_5" Type="BYTE" Comment="output number 5"/>
+			<VarDeclaration Name="OUT_6" Type="BYTE" Comment="output number 6"/>
+			<VarDeclaration Name="OUT_7" Type="BYTE" Comment="output number 7"/>
+			<VarDeclaration Name="OUT_8" Type="BYTE" Comment="output number 8"/>
+		</OutputVars>
+	</InterfaceList>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION">
+	</Service>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ARRAY2VALUES'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/convert-3.0.0/typelib/ARRAY2VALUES_8_INT.fbt
+++ b/data/typelibrary/convert-3.0.0/typelib/ARRAY2VALUES_8_INT.fbt
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ARRAY2VALUES_8_INT" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2014 Profactor GmbH, HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-03-30" Remarks="copy ARRAY2VALUES_2_LREAL and made this block">
+	</VersionInfo>
+	<CompilerInfo packageName="eclipse4diac::convert">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="IN"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="OUT_1"/>
+				<With Var="OUT_2"/>
+				<With Var="OUT_3"/>
+				<With Var="OUT_4"/>
+				<With Var="OUT_5"/>
+				<With Var="OUT_6"/>
+				<With Var="OUT_7"/>
+				<With Var="OUT_8"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="INT" Comment="Array input" ArraySize="8"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT_1" Type="INT" Comment="output number 1"/>
+			<VarDeclaration Name="OUT_2" Type="INT" Comment="output number 2"/>
+			<VarDeclaration Name="OUT_3" Type="INT" Comment="output number 3"/>
+			<VarDeclaration Name="OUT_4" Type="INT" Comment="output number 4"/>
+			<VarDeclaration Name="OUT_5" Type="INT" Comment="output number 5"/>
+			<VarDeclaration Name="OUT_6" Type="INT" Comment="output number 6"/>
+			<VarDeclaration Name="OUT_7" Type="INT" Comment="output number 7"/>
+			<VarDeclaration Name="OUT_8" Type="INT" Comment="output number 8"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ARRAY2VALUES'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/convert-3.0.0/typelib/VALUES2ARRAY_16_BYTE.fbt
+++ b/data/typelibrary/convert-3.0.0/typelib/VALUES2ARRAY_16_BYTE.fbt
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="VALUES2ARRAY_16_BYTE" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2014 Profactor GmbH, HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-03-30" Remarks="copy VALUES2ARRAY_2_LREAL and made this block">
+	</VersionInfo>
+	<CompilerInfo packageName="eclipse4diac::convert">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="IN_1"/>
+				<With Var="IN_2"/>
+				<With Var="IN_3"/>
+				<With Var="IN_4"/>
+				<With Var="IN_5"/>
+				<With Var="IN_6"/>
+				<With Var="IN_7"/>
+				<With Var="IN_8"/>
+				<With Var="IN_9"/>
+				<With Var="IN_10"/>
+				<With Var="IN_11"/>
+				<With Var="IN_12"/>
+				<With Var="IN_13"/>
+				<With Var="IN_14"/>
+				<With Var="IN_15"/>
+				<With Var="IN_16"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN_1" Type="BYTE" Comment="input number 1"/>
+			<VarDeclaration Name="IN_2" Type="BYTE" Comment="input number 2"/>
+			<VarDeclaration Name="IN_3" Type="BYTE" Comment="input number 3"/>
+			<VarDeclaration Name="IN_4" Type="BYTE" Comment="input number 4"/>
+			<VarDeclaration Name="IN_5" Type="BYTE" Comment="input number 5"/>
+			<VarDeclaration Name="IN_6" Type="BYTE" Comment="input number 6"/>
+			<VarDeclaration Name="IN_7" Type="BYTE" Comment="input number 7"/>
+			<VarDeclaration Name="IN_8" Type="BYTE" Comment="input number 8"/>
+			<VarDeclaration Name="IN_9" Type="BYTE" Comment="input number 9"/>
+			<VarDeclaration Name="IN_10" Type="BYTE" Comment="input number 10"/>
+			<VarDeclaration Name="IN_11" Type="BYTE" Comment="input number 11"/>
+			<VarDeclaration Name="IN_12" Type="BYTE" Comment="input number 12"/>
+			<VarDeclaration Name="IN_13" Type="BYTE" Comment="input number 13"/>
+			<VarDeclaration Name="IN_14" Type="BYTE" Comment="input number 14"/>
+			<VarDeclaration Name="IN_15" Type="BYTE" Comment="input number 15"/>
+			<VarDeclaration Name="IN_16" Type="BYTE" Comment="input number 16"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="BYTE" Comment="Array output" ArraySize="16"/>
+		</OutputVars>
+	</InterfaceList>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION">
+	</Service>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_VALUES2ARRAY'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/convert-3.0.0/typelib/VALUES2ARRAY_2_BYTE.fbt
+++ b/data/typelibrary/convert-3.0.0/typelib/VALUES2ARRAY_2_BYTE.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="VALUES2ARRAY_2_BYTE" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2014 Profactor GmbH, HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-03-30" Remarks="copy VALUES2ARRAY_2_LREAL and made this block">
+	</VersionInfo>
+	<CompilerInfo packageName="eclipse4diac::convert">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="IN_1"/>
+				<With Var="IN_2"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN_1" Type="BYTE" Comment="input number 1"/>
+			<VarDeclaration Name="IN_2" Type="BYTE" Comment="input number 2"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="BYTE" Comment="Array output" ArraySize="2"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_VALUES2ARRAY'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/convert-3.0.0/typelib/VALUES2ARRAY_32_BYTE.fbt
+++ b/data/typelibrary/convert-3.0.0/typelib/VALUES2ARRAY_32_BYTE.fbt
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="VALUES2ARRAY_32_BYTE" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2014 Profactor GmbH, HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-03-30" Remarks="copy VALUES2ARRAY_2_LREAL and made this block">
+	</VersionInfo>
+	<CompilerInfo packageName="eclipse4diac::convert">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="IN_1"/>
+				<With Var="IN_2"/>
+				<With Var="IN_3"/>
+				<With Var="IN_4"/>
+				<With Var="IN_5"/>
+				<With Var="IN_6"/>
+				<With Var="IN_7"/>
+				<With Var="IN_8"/>
+				<With Var="IN_9"/>
+				<With Var="IN_10"/>
+				<With Var="IN_11"/>
+				<With Var="IN_12"/>
+				<With Var="IN_13"/>
+				<With Var="IN_14"/>
+				<With Var="IN_15"/>
+				<With Var="IN_16"/>
+				<With Var="IN_17"/>
+				<With Var="IN_18"/>
+				<With Var="IN_19"/>
+				<With Var="IN_20"/>
+				<With Var="IN_21"/>
+				<With Var="IN_22"/>
+				<With Var="IN_23"/>
+				<With Var="IN_24"/>
+				<With Var="IN_25"/>
+				<With Var="IN_26"/>
+				<With Var="IN_27"/>
+				<With Var="IN_28"/>
+				<With Var="IN_29"/>
+				<With Var="IN_30"/>
+				<With Var="IN_31"/>
+				<With Var="IN_32"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN_1" Type="BYTE" Comment="input number 1"/>
+			<VarDeclaration Name="IN_2" Type="BYTE" Comment="input number 2"/>
+			<VarDeclaration Name="IN_3" Type="BYTE" Comment="input number 3"/>
+			<VarDeclaration Name="IN_4" Type="BYTE" Comment="input number 4"/>
+			<VarDeclaration Name="IN_5" Type="BYTE" Comment="input number 5"/>
+			<VarDeclaration Name="IN_6" Type="BYTE" Comment="input number 6"/>
+			<VarDeclaration Name="IN_7" Type="BYTE" Comment="input number 7"/>
+			<VarDeclaration Name="IN_8" Type="BYTE" Comment="input number 8"/>
+			<VarDeclaration Name="IN_9" Type="BYTE" Comment="input number 9"/>
+			<VarDeclaration Name="IN_10" Type="BYTE" Comment="input number 10"/>
+			<VarDeclaration Name="IN_11" Type="BYTE" Comment="input number 11"/>
+			<VarDeclaration Name="IN_12" Type="BYTE" Comment="input number 12"/>
+			<VarDeclaration Name="IN_13" Type="BYTE" Comment="input number 13"/>
+			<VarDeclaration Name="IN_14" Type="BYTE" Comment="input number 14"/>
+			<VarDeclaration Name="IN_15" Type="BYTE" Comment="input number 15"/>
+			<VarDeclaration Name="IN_16" Type="BYTE" Comment="input number 16"/>
+			<VarDeclaration Name="IN_17" Type="BYTE" Comment="input number 17"/>
+			<VarDeclaration Name="IN_18" Type="BYTE" Comment="input number 18"/>
+			<VarDeclaration Name="IN_19" Type="BYTE" Comment="input number 19"/>
+			<VarDeclaration Name="IN_20" Type="BYTE" Comment="input number 20"/>
+			<VarDeclaration Name="IN_21" Type="BYTE" Comment="input number 21"/>
+			<VarDeclaration Name="IN_22" Type="BYTE" Comment="input number 22"/>
+			<VarDeclaration Name="IN_23" Type="BYTE" Comment="input number 23"/>
+			<VarDeclaration Name="IN_24" Type="BYTE" Comment="input number 24"/>
+			<VarDeclaration Name="IN_25" Type="BYTE" Comment="input number 25"/>
+			<VarDeclaration Name="IN_26" Type="BYTE" Comment="input number 26"/>
+			<VarDeclaration Name="IN_27" Type="BYTE" Comment="input number 27"/>
+			<VarDeclaration Name="IN_28" Type="BYTE" Comment="input number 28"/>
+			<VarDeclaration Name="IN_29" Type="BYTE" Comment="input number 29"/>
+			<VarDeclaration Name="IN_30" Type="BYTE" Comment="input number 30"/>
+			<VarDeclaration Name="IN_31" Type="BYTE" Comment="input number 31"/>
+			<VarDeclaration Name="IN_32" Type="BYTE" Comment="input number 32"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="BYTE" Comment="array output" ArraySize="32"/>
+		</OutputVars>
+	</InterfaceList>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION">
+	</Service>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_VALUES2ARRAY'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/convert-3.0.0/typelib/VALUES2ARRAY_4_BYTE.fbt
+++ b/data/typelibrary/convert-3.0.0/typelib/VALUES2ARRAY_4_BYTE.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="VALUES2ARRAY_4_BYTE" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2014 Profactor GmbH, HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-03-30" Remarks="copy VALUES2ARRAY_2_LREAL and made this block">
+	</VersionInfo>
+	<CompilerInfo packageName="eclipse4diac::convert">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="IN_1"/>
+				<With Var="IN_2"/>
+				<With Var="IN_3"/>
+				<With Var="IN_4"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN_1" Type="BYTE" Comment="input number 1"/>
+			<VarDeclaration Name="IN_2" Type="BYTE" Comment="input number 2"/>
+			<VarDeclaration Name="IN_3" Type="BYTE" Comment="input number 3"/>
+			<VarDeclaration Name="IN_4" Type="BYTE" Comment="input number 4"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="BYTE" Comment="Array output" ArraySize="4"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_VALUES2ARRAY'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/convert-3.0.0/typelib/VALUES2ARRAY_8_BYTE.fbt
+++ b/data/typelibrary/convert-3.0.0/typelib/VALUES2ARRAY_8_BYTE.fbt
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="VALUES2ARRAY_8_BYTE" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2014 Profactor GmbH, HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-03-30" Remarks="copy VALUES2ARRAY_2_LREAL and made this block">
+	</VersionInfo>
+	<CompilerInfo packageName="eclipse4diac::convert">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="IN_1"/>
+				<With Var="IN_2"/>
+				<With Var="IN_3"/>
+				<With Var="IN_4"/>
+				<With Var="IN_5"/>
+				<With Var="IN_6"/>
+				<With Var="IN_7"/>
+				<With Var="IN_8"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN_1" Type="BYTE" Comment="input number 1"/>
+			<VarDeclaration Name="IN_2" Type="BYTE" Comment="input number 2"/>
+			<VarDeclaration Name="IN_3" Type="BYTE" Comment="input number 3"/>
+			<VarDeclaration Name="IN_4" Type="BYTE" Comment="input number 4"/>
+			<VarDeclaration Name="IN_5" Type="BYTE" Comment="input number 5"/>
+			<VarDeclaration Name="IN_6" Type="BYTE" Comment="input number 6"/>
+			<VarDeclaration Name="IN_7" Type="BYTE" Comment="input number 7"/>
+			<VarDeclaration Name="IN_8" Type="BYTE" Comment="input number 8"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="BYTE" Comment="Array output" ArraySize="8"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_VALUES2ARRAY'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/convert-3.0.0/typelib/VALUES2ARRAY_8_INT.fbt
+++ b/data/typelibrary/convert-3.0.0/typelib/VALUES2ARRAY_8_INT.fbt
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="VALUES2ARRAY_8_INT" Comment="Service Interface Function Block Type">
+	<Identification Description="Copyright (c) 2014 Profactor GmbH, HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-03-30" Remarks="copy VALUES2ARRAY_2_LREAL and made this block">
+	</VersionInfo>
+	<CompilerInfo packageName="eclipse4diac::convert">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="IN_1"/>
+				<With Var="IN_2"/>
+				<With Var="IN_3"/>
+				<With Var="IN_4"/>
+				<With Var="IN_5"/>
+				<With Var="IN_6"/>
+				<With Var="IN_7"/>
+				<With Var="IN_8"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN_1" Type="INT" Comment="input number 1"/>
+			<VarDeclaration Name="IN_2" Type="INT" Comment="input number 2"/>
+			<VarDeclaration Name="IN_3" Type="INT" Comment="input number 3"/>
+			<VarDeclaration Name="IN_4" Type="INT" Comment="input number 4"/>
+			<VarDeclaration Name="IN_5" Type="INT" Comment="input number 5"/>
+			<VarDeclaration Name="IN_6" Type="INT" Comment="input number 6"/>
+			<VarDeclaration Name="IN_7" Type="INT" Comment="input number 7"/>
+			<VarDeclaration Name="IN_8" Type="INT" Comment="input number 8"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="INT" Comment="Array output" ArraySize="8"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_VALUES2ARRAY'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>


### PR DESCRIPTION
Introduces more variants of the existing SI Generic Block to show users that this one is not limited to LREAL which one might think looking to the Library.
