### PR TITLE
Potential fix for code scanning alert no. 13: Implicit narrowing conversion in compound assignment

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.util/src/org/eclipse/fordiac/ide/util/ColorHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.util/src/org/eclipse/fordiac/ide/util/ColorHelper.java
@@ -48,8 +48,8 @@ public final class ColorHelper {
 		h += GOLDEN_RATIO_CONJUGATE;
 		h %= 1;
 
-		s += ((rand.nextDouble() * 0.5) - 0.25);
-		v += ((rand.nextDouble() * 0.2) - 0.1);
+		s = s + (float) ((rand.nextDouble() * 0.5) - 0.25);
+		v = v + (float) ((rand.nextDouble() * 0.2) - 0.1);
 
 		return new RGB((float) (h * 360.0), s, v);
 	}

--- a/plugins/org.eclipse.fordiac.ide.util/src/org/eclipse/fordiac/ide/util/ColorHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.util/src/org/eclipse/fordiac/ide/util/ColorHelper.java
@@ -48,8 +48,8 @@ public final class ColorHelper {
 		h += GOLDEN_RATIO_CONJUGATE;
 		h %= 1;
 
-		s = s + (float) ((rand.nextDouble() * 0.5) - 0.25);
-		v = v + (float) ((rand.nextDouble() * 0.2) - 0.1);
+		s += (float) ((rand.nextDouble() * 0.5) - 0.25);
+		v += (float) ((rand.nextDouble() * 0.2) - 0.1);
 
 		return new RGB((float) (h * 360.0), s, v);
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/eclipse-4diac/4diac-ide/security/code-scanning/13](https://github.com/eclipse-4diac/4diac-ide/security/code-scanning/13)

To fix this without changing behavior, keep `s` and `v` as `float` (matching method signature and `RGB` usage), and ensure the added deltas are computed as `float` before assignment.  
Best targeted fix in `plugins/org.eclipse.fordiac.ide.util/src/org/eclipse/fordiac/ide/util/ColorHelper.java`:

- Replace compound assignments on lines 51–52 with explicit non-compound assignments and explicit cast of the random delta to `float`.
- This avoids the implicit narrowing cast hidden inside `+=` while preserving the same numeric intent.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
