### PR TITLE
Potential fix for code scanning alert no. 11: Implicit narrowing conversion in compound assignment

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/FBShapeHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/FBShapeHelper.java
@@ -140,7 +140,7 @@ public final class FBShapeHelper {
 	 * @return The height in Y coordinates
 	 */
 	public static double getSubappHeightAdjust(final FBNetworkElement element) {
-		int commentLines = 1;
+		long commentLines = 1;
 		if (element.getComment() != null && !element.getComment().isBlank()) {
 			commentLines += element.getComment().chars().filter(c -> c == '\n').count();
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/eclipse-4diac/4diac-ide/security/code-scanning/11](https://github.com/eclipse-4diac/4diac-ide/security/code-scanning/11)

Use a `long` for `commentLines` in `getSubappHeightAdjust(...)` so the `+=` operation no longer narrows a `long` into an `int`. This preserves behavior while removing the implicit narrowing conversion.

In `plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/FBShapeHelper.java`:
- Change `int commentLines = 1;` to `long commentLines = 1;`
- Keep the existing `+= count()` logic unchanged.
- No imports or new methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
