### PR TITLE
Fix: correct input reference for WORD_01 in SPLIT_DWORD_INTO_WORDS

### DIFF
--- a/data/typelibrary/utils-3.0.0/typelib/splitting/SPLIT_DWORD_INTO_WORDS.fct
+++ b/data/typelibrary/utils-3.0.0/typelib/splitting/SPLIT_DWORD_INTO_WORDS.fct
@@ -2,6 +2,8 @@
 <Function Name="SPLIT_DWORD_INTO_WORDS" Comment="this Function extracts the 2 WORD from a dword">
 	<Identification Standard="61499-1" Description="Copyright (c) 2024 HR Agrartechnik GmbH    &#10;    &#10;This program and the accompanying materials are made     &#10;available under the terms of the Eclipse Public License 2.0     &#10;which is available at https://www.eclipse.org/legal/epl-2.0/     &#10;     &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik" Version="3.1" Author="Franz Höpfinger" Date="2026-05-16" Remarks="Fix Bug in word 1">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="HR Agrartechnik" Version="1.1" Author="Moritz Ortmeier" Date="2024-07-24" Remarks="rename Function and change Output Variables">
@@ -44,7 +46,7 @@ VAR_OUTPUT
 END_VAR
 
 WORD_00 := IN.%W0;
-WORD_01 := IN.%X1;
+WORD_01 := IN.%W1;
 
 END_FUNCTION
 ]]></ST>


### PR DESCRIPTION
The input reference for WORD_01 was mistakenly using IN.%X1 instead of IN.%W1. This update corrects that reference, aligning it with the intended usage.
