### PR TITLE
Fix copying folders defaulting to overwrite

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/copy/FordiacCopyProcessor.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/copy/FordiacCopyProcessor.java
@@ -20,8 +20,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.core.resources.IContainer;
-import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -181,10 +179,6 @@ public final class FordiacCopyProcessor extends CopyProcessor {
 
 		if (areEqualInWorkspaceOrOnDisk(file, current)) {
 			return queries.queryOverwriteSelf(file, destination);
-		}
-
-		if (current instanceof IFolder || !(current instanceof IFile)) {
-			return ExistsResolve.OVERWRITE;
 		}
 		return queries.queryOverwrite(file, destination);
 	}


### PR DESCRIPTION
Copying a folder would default to overwriting existing ones. Fixed to now ask the user before overwriting (same as for files).