### PR TITLE
Fix new project target selection combobox

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/UnifiedLibraryImportWizardPage.java
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/UnifiedLibraryImportWizardPage.java
@@ -164,6 +164,11 @@ public class UnifiedLibraryImportWizardPage extends WizardPage {
 	}
 
 	@Override
+	public boolean isPageComplete() {
+		return (allowUnavailableTargetProject && getControl() == null) || super.isPageComplete();
+	}
+
+	@Override
 	public void createControl(final Composite parent) {
 		showLatestOnly = true;
 		final Composite root = new Composite(parent, SWT.NONE);
@@ -263,6 +268,7 @@ public class UnifiedLibraryImportWizardPage extends WizardPage {
 		final var accessibleProjects = getSelectableFordiacProjects();
 
 		projectCombo.setInput(accessibleProjects);
+		projectCombo.getCombo().setEnabled(!allowUnavailableTargetProject);
 
 		if (targetProject == null) {
 			if (accessibleProjects.isEmpty()) {

--- a/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/UnifiedLibraryImportWizardPage.java
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/wizards/UnifiedLibraryImportWizardPage.java
@@ -74,9 +74,11 @@ import org.eclipse.ui.model.WorkbenchLabelProvider;
 public class UnifiedLibraryImportWizardPage extends WizardPage {
 
 	private IProject targetProject;
+	private final boolean allowUnavailableTargetProject;
 	private final List<ILibrarySource> sources;
 
 	private ComboViewer sourceCombo;
+	private ComboViewer projectCombo;
 
 	private Composite configHost;
 	private StackLayout configLayout;
@@ -106,10 +108,16 @@ public class UnifiedLibraryImportWizardPage extends WizardPage {
 	}
 
 	public UnifiedLibraryImportWizardPage(final IProject targetProject, final String[] defaultSelectedLibraries) {
+		this(targetProject, defaultSelectedLibraries, false);
+	}
+
+	public UnifiedLibraryImportWizardPage(final IProject targetProject, final String[] defaultSelectedLibraries,
+			final boolean allowUnavailableTargetProject) {
 		super(Messages.UnifiedLibraryImportWizardPage_Available_Libraries);
 		setTitle(Messages.UnifiedLibraryImportWizardPage_LibraryImport);
 		setDescription(Messages.UnifiedLibraryImportWizardPage_brows);
 		this.targetProject = targetProject;
+		this.allowUnavailableTargetProject = allowUnavailableTargetProject;
 		this.showLatestOnly = true;
 		this.hideEmptyProjects = true;
 		this.sources = new ArrayList<>(LibrarySourceBuilder.getAllSources());
@@ -242,7 +250,7 @@ public class UnifiedLibraryImportWizardPage extends WizardPage {
 		final Label label = new Label(container, SWT.NONE);
 		label.setText(Messages.UnifiedLibraryImportWizardPage_ImportIntoProject);
 
-		final ComboViewer projectCombo = new ComboViewer(container, SWT.READ_ONLY);
+		projectCombo = new ComboViewer(container, SWT.READ_ONLY);
 		projectCombo.getCombo().setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 		projectCombo.setContentProvider(ArrayContentProvider.getInstance());
 		projectCombo.setLabelProvider(new LabelProvider() {
@@ -252,7 +260,7 @@ public class UnifiedLibraryImportWizardPage extends WizardPage {
 			}
 		});
 
-		final var accessibleProjects = getAccessibleFordiacProjects();
+		final var accessibleProjects = getSelectableFordiacProjects();
 
 		projectCombo.setInput(accessibleProjects);
 
@@ -275,6 +283,14 @@ public class UnifiedLibraryImportWizardPage extends WizardPage {
 	private static List<IProject> getAccessibleFordiacProjects() {
 		return Arrays.stream(ResourcesPlugin.getWorkspace().getRoot().getProjects())
 				.filter(SystemManager::hasFordiacProjectNature).toList();
+	}
+
+	private List<IProject> getSelectableFordiacProjects() {
+		final List<IProject> projects = new ArrayList<>(getAccessibleFordiacProjects());
+		if (allowUnavailableTargetProject && targetProject != null && !projects.contains(targetProject)) {
+			projects.add(targetProject);
+		}
+		return projects;
 	}
 
 	private void createConfigArea(final Composite parent) {
@@ -637,7 +653,33 @@ public class UnifiedLibraryImportWizardPage extends WizardPage {
 	}
 
 	public void setTargetProject(final IProject project) {
+		final IProject previousProject = targetProject;
 		this.targetProject = project;
+		updateProjectSelection();
+		if (allowUnavailableTargetProject && previousProject == null && targetProject != null) {
+			scheduleRefresh();
+		}
+	}
+
+	private void updateProjectSelection() {
+		if (projectCombo == null || projectCombo.getCombo().isDisposed()) {
+			return;
+		}
+
+		final var accessibleProjects = getSelectableFordiacProjects();
+		projectCombo.setInput(accessibleProjects);
+		projectCombo.getCombo().setEnabled(!allowUnavailableTargetProject);
+
+		if (targetProject == null) {
+			if (accessibleProjects.isEmpty()) {
+				setErrorMessage(Messages.UnifiedLibraryImportWizardPage_no_project);
+				setPageComplete(false);
+				return;
+			}
+			targetProject = accessibleProjects.getFirst();
+		}
+
+		projectCombo.setSelection(new StructuredSelection(targetProject));
 	}
 
 	public Map<Required, URI> getChosenLibraries() {

--- a/plugins/org.eclipse.fordiac.ide.product/org.eclipse.fordiac.ide.product.target
+++ b/plugins/org.eclipse.fordiac.ide.product/org.eclipse.fordiac.ide.product.target
@@ -90,7 +90,7 @@
 				<dependency>
 					<groupId>org.eclipse.milo</groupId>
 					<artifactId>milo-sdk-client</artifactId>
-					<version>1.1.2</version>
+					<version>1.1.3</version>
 					<type>jar</type>
 				</dependency>
 			</dependencies>

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/wizard/New4diacProjectWizard.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/wizard/New4diacProjectWizard.java
@@ -19,6 +19,7 @@ package org.eclipse.fordiac.ide.systemmanagement.ui.wizard;
 import java.lang.reflect.InvocationTargetException;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -29,6 +30,7 @@ import org.eclipse.fordiac.ide.systemmanagement.ui.Messages;
 import org.eclipse.fordiac.ide.typemanagement.util.SystemCreator;
 import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.ui.INewWizard;
 import org.eclipse.ui.IWorkbench;
@@ -64,12 +66,20 @@ public class New4diacProjectWizard extends Wizard implements INewWizard {
 		page.setTitle(Messages.New4diacProjectWizard_WizardTitle);
 		page.setDescription(Messages.New4diacProjectWizard_WizardDesc);
 
-		libPage = new UnifiedLibraryImportWizardPage(null, LIBRARY_STANDARD_SELECTION);
+		libPage = new UnifiedLibraryImportWizardPage(null, LIBRARY_STANDARD_SELECTION, true);
 		libPage.setTitle(Messages.New4diacProjectWizard_LibPageName);
 		libPage.setDescription(Messages.New4diacProjectWizard_LibPageDesc);
 
 		addPage(page);
 		addPage(libPage);
+	}
+
+	@Override
+	public IWizardPage getNextPage(final IWizardPage currentPage) {
+		if (currentPage == page) {
+			libPage.setTargetProject(ResourcesPlugin.getWorkspace().getRoot().getProject(page.getProjectName()));
+		}
+		return super.getNextPage(currentPage);
 	}
 
 	/*

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/wizard/New4diacProjectWizard.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/wizard/New4diacProjectWizard.java
@@ -106,7 +106,9 @@ public class New4diacProjectWizard extends Wizard implements INewWizard {
 			return false;
 		}
 
-		libPage.performImport(getContainer());
+		if (libPage.getControl() != null) {
+			libPage.performImport(getContainer());
+		}
 
 		// everything worked fine
 		return true;


### PR DESCRIPTION
When the new 4diac project wizard is opened in an empty workspace, the
library import page could not preselect the project because it did not
exist yet.

Allow the new project wizard to pass the future project handle to the
library import page while keeping the regular import wizard behavior
unchanged.