### PR TITLE
Fix "Replace multiple Data Connections with Struct" refactoring in two related areas:

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/connection/ConnectionsToStructRefactoring.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/connection/ConnectionsToStructRefactoring.java
@@ -200,8 +200,8 @@ public class ConnectionsToStructRefactoring extends Refactoring {
 			status.merge(
 					RefactoringStatus.createFatalErrorStatus(Messages.ConnectionsToStructRefactoring_SameFBSameName));
 		}
-		if (conflictResolution
-				&& (lib.getFBTypeEntry("STRUCT_DEMUX") == null || lib.getFBTypeEntry("STRUCT_MUX") == null)) { //$NON-NLS-1$ //$NON-NLS-2$
+		if (conflictResolution && (lib.getFbTypes().noneMatch(type -> "STRUCT_DEMUX".equals(type.getTypeName())) //$NON-NLS-1$
+				|| lib.getFbTypes().noneMatch(type -> "STRUCT_MUX".equals(type.getTypeName())))) { //$NON-NLS-1$
 			status.merge(RefactoringStatus
 					.createFatalErrorStatus(Messages.ConnectionsToStructRefactoring_MissingStructManipulator));
 		}

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/connection/ConnectionsToStructRefactoring.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/connection/ConnectionsToStructRefactoring.java
@@ -264,28 +264,41 @@ public class ConnectionsToStructRefactoring extends Refactoring {
 	public Change createChange(final IProgressMonitor pm) throws CoreException, OperationCanceledException {
 		final CompositeChange compChange = new CommandCompositeChange(
 				Messages.ConnectionsToStructRefactoring_ChangeName);
-		modelEdits = new ArrayList<>();
 		pm.beginTask(Messages.ConnectionsToStructRefactoring_ProgressText, 1);
 
 		if (TypeLibraryManager.INSTANCE.getTypeEntryForURI(structURI) == null) {
 			compChange.add(new CreateStructChange(structURI, vars));
 		}
 
-		modelEdits.add(new ReplaceVarsWithStructModelEdit(sourceURI, replaceableConMap.keySet(), structURI,
+		final List<ModelEdit<?>> typeEdits = new ArrayList<>();
+		typeEdits.add(new ReplaceVarsWithStructModelEdit(sourceURI, replaceableConMap.keySet(), structURI,
 				sourceVarName, false, 0));
-		modelEdits.add(new ReplaceVarsWithStructModelEdit(destinationURI, replaceableConMap.values(), structURI,
+		typeEdits.add(new ReplaceVarsWithStructModelEdit(destinationURI, replaceableConMap.values(), structURI,
 				destinationVarName, true, 0));
+		addModelEditChange(compChange, typeEdits);
 
 		if (TypeLibraryManager.INSTANCE.getTypeEntryForURI(sourceURI).getType() instanceof final FBType sourceType
 				&& TypeLibraryManager.INSTANCE.getTypeEntryForURI(destinationURI)
 						.getType() instanceof final FBType destinationType) {
 
+			modelEdits = new ArrayList<>();
 			update(sourceType, destinationType);
+			addModelEditChange(compChange, modelEdits);
+
+			modelEdits = new ArrayList<>();
 			connect(sourceType, destinationType);
+			addModelEditChange(compChange, modelEdits);
 		}
 		pm.done();
-		compChange.add(ModelEditChange.fromModelEdits(Messages.ConnectionsToStructRefactoring_ChangeName, modelEdits));
 		return compChange;
+	}
+
+	private static void addModelEditChange(final CompositeChange compChange, final List<ModelEdit<?>> edits) {
+		final CompositeChange modelEditChange = ModelEditChange.fromModelEdits(
+				Messages.ConnectionsToStructRefactoring_ChangeName, edits);
+		if (modelEditChange != null) {
+			compChange.add(modelEditChange);
+		}
 	}
 
 	private void update(final FBType sourceType, final FBType destinationType) {
@@ -305,6 +318,7 @@ public class ConnectionsToStructRefactoring extends Refactoring {
 
 	private void connect(final FBType sourceType, final FBType destinationType) {
 		final Map<AutomationSystem, List<URI>> connectMap = new HashMap<>();
+		final Map<AutomationSystem, Map<URI, URI>> sourceMap = new HashMap<>();
 		final Map<FBNetworkElement, FBNetworkElement> correctConnectionMap = new HashMap<>();
 		final List<? extends EObject> sourceSearch = new BlockTypeInstanceSearch(sourceType.getTypeEntry())
 				.performSearch();
@@ -326,12 +340,14 @@ public class ConnectionsToStructRefactoring extends Refactoring {
 					&& cons.size() == replaceableConMap.size()) {
 				correctConnectionMap.put(instance, cons.get(0).getSourceElement());
 				addToMap(connectMap, instance);
+				addToSourceMap(sourceMap, instance, cons.get(0).getSourceElement());
 			}
 		});
 
 		connectMap.entrySet()
 				.forEach(entry -> modelEdits.add(new SystemConnectStructModelEdit(EcoreUtil.getURI(entry.getKey()),
-						entry.getValue(), replaceableConMap, sourceVarName, destinationVarName)));
+						entry.getValue(), sourceMap.get(entry.getKey()), replaceableConMap, sourceVarName,
+						destinationVarName)));
 
 		if (conflictResolution) {
 			conflictResolution(sourceSearch, destinationSearch, correctConnectionMap);
@@ -373,6 +389,15 @@ public class ConnectionsToStructRefactoring extends Refactoring {
 			map.put(element.getFbNetwork().getAutomationSystem(), list);
 			return list;
 		}).add(EcoreUtil.getURI(element));
+	}
+
+	private static void addToSourceMap(final Map<AutomationSystem, Map<URI, URI>> map,
+			final FBNetworkElement destination, final FBNetworkElement source) {
+		Optional.ofNullable(map.get(destination.getFbNetwork().getAutomationSystem())).orElseGet(() -> {
+			final Map<URI, URI> sourceMap = new HashMap<>();
+			map.put(destination.getFbNetwork().getAutomationSystem(), sourceMap);
+			return sourceMap;
+		}).put(EcoreUtil.getURI(destination), EcoreUtil.getURI(source));
 	}
 
 	public TypeLibrary getTypeLibrary() {

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/connection/SystemConnectStructModelEdit.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/connection/SystemConnectStructModelEdit.java
@@ -24,6 +24,8 @@ import org.eclipse.fordiac.ide.model.commands.create.StructDataConnectionCreateC
 import org.eclipse.fordiac.ide.model.commands.delete.DeleteConnectionCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
 import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.Connection;
+import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.typemanagement.Messages;
 import org.eclipse.fordiac.ide.typemanagement.refactoring.ModelEdit;
 import org.eclipse.gef.commands.Command;
@@ -39,6 +41,7 @@ import org.eclipse.ltk.core.refactoring.RefactoringStatus;
  */
 public class SystemConnectStructModelEdit extends ModelEdit<AutomationSystem> {
 	private final Map<String, String> replaceableConMap;
+	private final Map<URI, URI> sourceMap;
 	private final String sourceVarName;
 	private final String destinationVarName;
 	private final List<URI> conlist;
@@ -49,17 +52,19 @@ public class SystemConnectStructModelEdit extends ModelEdit<AutomationSystem> {
 	 * @param elementURI         URI of the target System
 	 * @param list               URIs of the destination FBs which can be connected
 	 *                           by a new Struct Connection
+	 * @param sourceMap          Mapping of destination FB URIs to source FB URIs
 	 * @param replaceableConMap  Mapping of the Output Variables to the Input
 	 *                           Variables
 	 * @param sourceVarName      Name of the Struct Variable Output at the Source
 	 * @param destinationVarName Name of the Struct Variable Input at the
 	 *                           Destination
 	 */
-	public SystemConnectStructModelEdit(final URI elementURI, final List<URI> list,
+	public SystemConnectStructModelEdit(final URI elementURI, final List<URI> list, final Map<URI, URI> sourceMap,
 			final Map<String, String> replaceableConMap, final String sourceVarName, final String destinationVarName) {
 		super(Objects.requireNonNull(elementURI).trimFileExtension().lastSegment()
 				+ Messages.SystemConnectStructChange_Name, elementURI, AutomationSystem.class);
 		this.conlist = Objects.requireNonNull(list);
+		this.sourceMap = Objects.requireNonNull(sourceMap);
 		this.replaceableConMap = Objects.requireNonNull(replaceableConMap);
 		this.sourceVarName = Objects.requireNonNull(sourceVarName);
 		this.destinationVarName = Objects.requireNonNull(destinationVarName);
@@ -85,25 +90,110 @@ public class SystemConnectStructModelEdit extends ModelEdit<AutomationSystem> {
 
 	@Override
 	protected Command createCommand(final AutomationSystem element) {
+		return new Command() {
+			private CompoundCommand commands;
+
+			@Override
+			public boolean canExecute() {
+				return true;
+			}
+
+			@Override
+			public void execute() {
+				commands = createStructConnectionCommands(element);
+			}
+
+			@Override
+			public boolean canUndo() {
+				return commands != null && commands.canUndo();
+			}
+
+			@Override
+			public void undo() {
+				if (commands != null) {
+					commands.undo();
+				}
+			}
+
+			@Override
+			public boolean canRedo() {
+				return commands != null && commands.canRedo();
+			}
+
+			@Override
+			public void redo() {
+				if (commands != null) {
+					commands.redo();
+				}
+			}
+		};
+	}
+
+	private CompoundCommand createStructConnectionCommands(final AutomationSystem element) {
 		final CompoundCommand cmds = new CompoundCommand();
 		conlist.forEach(uri -> {
 			if (element.eResource().getEObject(uri.fragment()) instanceof final BlockFBNetworkElement fbnelem) {
-				final BlockFBNetworkElement source = fbnelem.getInterface().getErrorMarker().stream()
-						.flatMap(err -> err.getInputConnections().stream())
-						.filter(con -> replaceableConMap.containsValue(con.getDestination().getName())).findFirst()
-						.get().getSourceElement();
-				final StructDataConnectionCreateCommand structCon = new StructDataConnectionCreateCommand(
-						fbnelem.getFbNetwork());
+				BlockFBNetworkElement source = getSourceElement(element, uri);
+				List<Connection> connections = getReplaceableConnections(fbnelem, source);
+				if (connections.isEmpty()) {
+					connections = getReplaceableConnections(fbnelem, null);
+					source = getSourceElement(connections);
+				}
+				if (source != null) {
+					final IInterfaceElement structSource = source.getInterface().getOutput(List.of(sourceVarName));
+					final IInterfaceElement structDestination = fbnelem.getInterface()
+							.getInput(List.of(destinationVarName));
+					if (structSource != null && structDestination != null) {
+						final StructDataConnectionCreateCommand structCon = new StructDataConnectionCreateCommand(
+								fbnelem.getFbNetwork());
 
-				structCon.setDestination(fbnelem.getInterface().getInput(List.of(destinationVarName)));
-				structCon.setSource(source.getInterface().getOutput(List.of(sourceVarName)));
-				cmds.add(structCon);
-				fbnelem.getInterface().getErrorMarker().stream().flatMap(err -> err.getInputConnections().stream())
-						.filter(con -> replaceableConMap.containsValue(con.getDestination().getName()))
-						.forEach(con -> cmds.add(new DeleteConnectionCommand(con)));
+						structCon.setDestination(structDestination);
+						structCon.setSource(structSource);
+						if (!hasStructConnection(structSource, structDestination)) {
+							executeAndRemember(cmds, structCon);
+						}
+						if (hasStructConnection(structSource, structDestination)) {
+							connections.forEach(con -> executeAndRemember(cmds, new DeleteConnectionCommand(con)));
+						}
+					}
+				}
 			}
 		});
 		return cmds;
+	}
+
+	private static BlockFBNetworkElement getSourceElement(final List<Connection> connections) {
+		return connections.stream().map(Connection::getSourceElement).filter(Objects::nonNull).findFirst().orElse(null);
+	}
+
+	private BlockFBNetworkElement getSourceElement(final AutomationSystem element, final URI destinationURI) {
+		final URI sourceURI = sourceMap.get(destinationURI);
+		if (sourceURI != null
+				&& element.eResource().getEObject(sourceURI.fragment()) instanceof final BlockFBNetworkElement source) {
+			return source;
+		}
+		return null;
+	}
+
+	private List<Connection> getReplaceableConnections(final BlockFBNetworkElement destination,
+			final BlockFBNetworkElement source) {
+		return destination.getFbNetwork().getDataConnections().stream().map(Connection.class::cast)
+				.filter(con -> source == null || source.equals(con.getSourceElement()))
+				.filter(con -> destination.equals(con.getDestinationElement()))
+				.filter(con -> con.getSource() != null && con.getDestination() != null)
+				.filter(con -> replaceableConMap.containsKey(con.getSource().getName()))
+				.filter(con -> replaceableConMap.get(con.getSource().getName()).equals(con.getDestination().getName()))
+				.toList();
+	}
+
+	private static void executeAndRemember(final CompoundCommand commands, final Command command) {
+		command.execute();
+		commands.add(command);
+	}
+
+	private static boolean hasStructConnection(final IInterfaceElement source, final IInterfaceElement destination) {
+		return source != null && destination != null
+				&& source.getOutputConnections().stream().anyMatch(con -> destination.equals(con.getDestination()));
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/connection/SystemRepairBrokenConnectionModelEdit.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/connection/SystemRepairBrokenConnectionModelEdit.java
@@ -91,6 +91,46 @@ public class SystemRepairBrokenConnectionModelEdit extends ModelEdit<AutomationS
 
 	@Override
 	protected Command createCommand(final AutomationSystem element) {
+		return new Command() {
+			private CompoundCommand commands;
+
+			@Override
+			public boolean canExecute() {
+				return true;
+			}
+
+			@Override
+			public void execute() {
+				commands = createRepairCommands(element);
+			}
+
+			@Override
+			public boolean canUndo() {
+				return commands != null && commands.canUndo();
+			}
+
+			@Override
+			public void undo() {
+				if (commands != null) {
+					commands.undo();
+				}
+			}
+
+			@Override
+			public boolean canRedo() {
+				return commands != null && commands.canRedo();
+			}
+
+			@Override
+			public void redo() {
+				if (commands != null) {
+					commands.redo();
+				}
+			}
+		};
+	}
+
+	private CompoundCommand createRepairCommands(final AutomationSystem element) {
 		final CompoundCommand cmd = new CompoundCommand();
 		if (TypeLibraryManager.INSTANCE.getTypeEntryForURI(structURI)
 				.getType() instanceof final StructuredType structType) {
@@ -112,13 +152,18 @@ public class SystemRepairBrokenConnectionModelEdit extends ModelEdit<AutomationS
 								.getKey();
 
 					}
-					connections.forEach(con -> cmd.add(
+					connections.toList().forEach(con -> execute(cmd,
 							new RepairBrokenConnectionCommand(con, isSource, structType, connectToVar.apply(con))));
 				}
 			});
 		}
 
 		return cmd;
+	}
+
+	private static void execute(final CompoundCommand commands, final Command command) {
+		command.execute();
+		commands.add(command);
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/connection/commands/InsertStructManipulatorCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/connection/commands/InsertStructManipulatorCommand.java
@@ -24,6 +24,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.Position;
 import org.eclipse.fordiac.ide.model.libraryElement.StructManipulator;
+import org.eclipse.fordiac.ide.model.typelibrary.FBTypeEntry;
 import org.eclipse.gef.commands.Command;
 
 /**
@@ -54,8 +55,7 @@ public class InsertStructManipulatorCommand extends Command {
 
 	@Override
 	public boolean canExecute() {
-		return port.getType() instanceof StructuredType && port.getBlockFBNetworkElement().getTypeLibrary()
-				.getFBTypeEntry(isMUX ? STRUCT_MUX_TYPE_NAME : STRUCT_DEMUX_TYPE_NAME) != null;
+		return port.getType() instanceof StructuredType && getStructManipulatorTypeEntry() != null;
 	}
 
 	@Override
@@ -65,9 +65,7 @@ public class InsertStructManipulatorCommand extends Command {
 		final Position pos = LibraryElementFactory.eINSTANCE.createPosition();
 		pos.setX((int) element.getPosition().getX() + (isMUX ? (-1000.0) : 1000.0));
 		pos.setY((int) element.getPosition().getY());
-		muxcreate = new FBCreateCommand(
-				element.getTypeLibrary().getFBTypeEntry(isMUX ? STRUCT_MUX_TYPE_NAME : STRUCT_DEMUX_TYPE_NAME),
-				element.getFbNetwork(), pos);
+		muxcreate = new FBCreateCommand(getStructManipulatorTypeEntry(), element.getFbNetwork(), pos);
 		muxcreate.execute();
 
 		changeStruct = new ChangeStructCommand((StructManipulator) muxcreate.getElement(), structType);
@@ -84,6 +82,12 @@ public class InsertStructManipulatorCommand extends Command {
 
 	public BlockFBNetworkElement getNewElement() {
 		return changeStruct.getNewElement();
+	}
+
+	private FBTypeEntry getStructManipulatorTypeEntry() {
+		final String typeName = isMUX ? STRUCT_MUX_TYPE_NAME : STRUCT_DEMUX_TYPE_NAME;
+		return port.getBlockFBNetworkElement().getTypeLibrary().getFbTypes()
+				.filter(entry -> typeName.equals(entry.getTypeName())).findFirst().orElse(null);
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/connection/commands/RepairBrokenConnectionCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/connection/commands/RepairBrokenConnectionCommand.java
@@ -31,6 +31,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.With;
+import org.eclipse.fordiac.ide.model.typelibrary.FBTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.commands.CompoundCommand;
@@ -91,12 +92,14 @@ public class RepairBrokenConnectionCommand extends Command {
 		if (isSourceReconnect) {
 			optmux = port.getOutputConnections().stream().map(Connection::getDestinationElement)
 					.filter(elem -> elem.getType().getTypeEntry().equals(
-							port.getBlockFBNetworkElement().getTypeLibrary().getFBTypeEntry(STRUCT_DEMUX_TYPE_NAME)))
+							getStructManipulatorTypeEntry(port.getBlockFBNetworkElement().getTypeLibrary(),
+									STRUCT_DEMUX_TYPE_NAME)))
 					.findAny();
 		} else {
 			optmux = port.getInputConnections().stream().map(Connection::getSourceElement)
 					.filter(elem -> elem.getType().getTypeEntry().equals(
-							port.getBlockFBNetworkElement().getTypeLibrary().getFBTypeEntry(STRUCT_MUX_TYPE_NAME)))
+							getStructManipulatorTypeEntry(port.getBlockFBNetworkElement().getTypeLibrary(),
+									STRUCT_MUX_TYPE_NAME)))
 					.findAny();
 		}
 
@@ -112,10 +115,14 @@ public class RepairBrokenConnectionCommand extends Command {
 		final IInterfaceElement port = getPort();
 		if (port != null) {
 			final TypeLibrary lib = port.getBlockFBNetworkElement().getTypeLibrary();
-			return lib.getFBTypeEntry(STRUCT_DEMUX_TYPE_NAME) != null
-					&& lib.getFBTypeEntry(STRUCT_MUX_TYPE_NAME) != null;
+			return getStructManipulatorTypeEntry(lib, STRUCT_DEMUX_TYPE_NAME) != null
+					&& getStructManipulatorTypeEntry(lib, STRUCT_MUX_TYPE_NAME) != null;
 		}
 		return false;
+	}
+
+	private static FBTypeEntry getStructManipulatorTypeEntry(final TypeLibrary lib, final String typeName) {
+		return lib.getFbTypes().filter(entry -> typeName.equals(entry.getTypeName())).findFirst().orElse(null);
 	}
 
 	@Override


### PR DESCRIPTION
The refactoring was broken, due to some changes in the library element infrastructure. 
This RP establishes the functionality again, a broader refactoring of this feature is still required to achieve completeness (e.g. also repair inner networks of types).
