### PR TITLE
[Replay Debugging] Refactor model to have EventMarkers as edit part

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/action/MoveDown.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/action/MoveDown.java
@@ -11,7 +11,6 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.action;
 
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.editpart.ResourceEditPart;

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/action/MoveOneEventBackwards.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/action/MoveOneEventBackwards.java
@@ -11,7 +11,6 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.action;
 
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.editpart.ResourceEditPart;

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/action/MoveOneEventForward.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/action/MoveOneEventForward.java
@@ -11,7 +11,6 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.action;
 
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.editpart.ResourceEditPart;

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/action/MoveUp.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/action/MoveUp.java
@@ -11,7 +11,6 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.action;
 
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.editpart.ResourceEditPart;

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/DeviceEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/DeviceEditPart.java
@@ -11,7 +11,6 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.editpart;
 
 import java.beans.PropertyChangeEvent;

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/EventMarkerEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/EventMarkerEditPart.java
@@ -1,0 +1,179 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Jose Cabral
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Jose Cabral
+ *     - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+package org.eclipse.fordiac.ide.debug.replaydebugging.ui.editpart;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.Viewport;
+import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.fordiac.ide.debug.replaydebugging.ui.figure.EventMarkerFigure;
+import org.eclipse.fordiac.ide.debug.replaydebugging.ui.model.EventMarker;
+import org.eclipse.gef.EditPart;
+import org.eclipse.gef.EditPolicy;
+import org.eclipse.gef.GraphicalEditPart;
+import org.eclipse.gef.editparts.AbstractGraphicalEditPart;
+import org.eclipse.gef.editparts.ScalableRootEditPart;
+import org.eclipse.gef.editpolicies.NonResizableEditPolicy;
+import org.eclipse.swt.widgets.Display;
+
+/**
+ * @brief EditPart for a timeline in the replay debugging view.
+ *
+ *        It can be selected, allowing keyboard navigation to work. It uses a
+ *        TimlineWithChildrenFigure as its figure, returning the children figure
+ *        as content pane for the child timelines. It listens to the timeline
+ *        for new events and new spawned timelines, refreshing itself
+ *        accordingly. It also listens to the replay navigator for state
+ *        changes, refreshing the event states when they happen.
+ *
+ *        The edit part also centers the current event in the view when it
+ *        changes, but only if the current event is outside of the current view
+ *        area.
+ */
+public class EventMarkerEditPart extends AbstractGraphicalEditPart
+		implements EventMarkerFigure.SelectedEventListener, PropertyChangeListener {
+
+	@Override
+	protected IFigure createFigure() {
+		final var eventMarker = (EventMarker) getModel();
+		return new EventMarkerFigure(eventMarker.getIndex());
+	}
+
+	@Override
+	protected void createEditPolicies() {
+		installEditPolicy(EditPolicy.SELECTION_FEEDBACK_ROLE, new NonResizableEditPolicy() {
+			@Override
+			public void showSelection() {
+				// Redirect selection to the parent
+				final EditPart parent = getHost().getParent();
+				if (parent != null && parent.getViewer() != null) {
+					parent.getViewer().select(parent);
+				}
+			}
+		});
+	}
+
+	@Override
+	protected void refreshVisuals() {
+		super.refreshVisuals();
+		final var figure = getEventMarkerFigure();
+		figure.setIsValid(getEventMarkerModel().getValid());
+		figure.setIsCurrentEvent(getEventMarkerModel().getIsCurrentEvent());
+		figure.repaint();
+	}
+
+	private void safeRefresh() {
+		final Display display = getViewer().getControl().getDisplay();
+		display.asyncExec(() -> {
+			if (isActive()) {
+				refreshVisuals();
+			}
+		});
+	}
+
+	@Override
+	protected void refreshChildren() {
+		super.refreshChildren();
+		((GraphicalEditPart) getViewer().getContents()).getFigure().invalidateTree();
+	}
+
+	private EventMarker getEventMarkerModel() {
+		return (EventMarker) getModel();
+	}
+
+	private EventMarkerFigure getEventMarkerFigure() {
+		return ((EventMarkerFigure) getFigure());
+	}
+
+	private void centerOnFigure() {
+		if (!figure.isShowing()) {
+			return;
+		}
+
+		final ScalableRootEditPart root = (ScalableRootEditPart) getViewer().getRootEditPart();
+
+		final Viewport viewport = (Viewport) root.getFigure();
+		final IFigure contents = viewport.getContents();
+
+		// Convert figure bounds → viewport content coordinates
+		final Rectangle bounds = figure.getBounds().getCopy();
+		figure.translateToAbsolute(bounds);
+		contents.translateToRelative(bounds);
+
+		final Rectangle viewArea = viewport.getClientArea();
+
+		final int centerX = bounds.x + bounds.width / 2;
+		final int centerY = bounds.y + bounds.height / 2;
+
+		final int viewLeft = viewArea.x;
+		final int viewTop = viewArea.y;
+		final int viewRight = viewLeft + viewArea.width;
+		final int viewBottom = viewTop + viewArea.height;
+
+		// Only center if center point is outside
+		final int margin = 20;
+
+		if (centerX >= viewLeft + margin && centerX <= viewRight - margin && centerY >= viewTop + margin
+				&& centerY <= viewBottom - margin) {
+			return;
+		}
+
+		int targetX = centerX - viewArea.width / 2;
+		int targetY = centerY - viewArea.height / 2;
+
+		final int maxX = contents.getBounds().width - viewArea.width;
+		final int maxY = contents.getBounds().height - viewArea.height;
+
+		targetX = Math.clamp(targetX, 0, Math.max(0, maxX));
+		targetY = Math.clamp(targetY, 0, Math.max(0, maxY));
+
+		viewport.setHorizontalLocation(targetX);
+		viewport.setVerticalLocation(targetY);
+	}
+
+	@Override
+	public void activate() {
+		super.activate();
+		((EventMarker) getModel()).addPropertyChangeListener(this);
+		getEventMarkerFigure().addEventSelectionListener(this);
+	}
+
+	@Override
+	public void deactivate() {
+		getEventMarkerFigure().removeEventSelectionListener(this);
+		((EventMarker) getModel()).removePropertyChangeListener(this);
+		super.deactivate();
+	}
+
+	// calls from the figure
+
+	@Override
+	public void eventSelected(final int eventIndex) {
+		centerOnFigure();
+		getEventMarkerModel().eventSelected();
+	}
+
+	// call from model
+
+	@Override
+	public void propertyChange(final PropertyChangeEvent evt) {
+		if (evt.getPropertyName().equals(EventMarker.PROPERTY_EVENT_CHANGED)) {
+			safeRefresh();
+		}
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/EventMarkerEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/EventMarkerEditPart.java
@@ -11,22 +11,18 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.editpart;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
 import org.eclipse.draw2d.IFigure;
-import org.eclipse.draw2d.Viewport;
-import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.figure.EventMarkerFigure;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.model.EventMarker;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.editparts.AbstractGraphicalEditPart;
-import org.eclipse.gef.editparts.ScalableRootEditPart;
 import org.eclipse.gef.editpolicies.NonResizableEditPolicy;
 import org.eclipse.swt.widgets.Display;
 
@@ -49,7 +45,7 @@ public class EventMarkerEditPart extends AbstractGraphicalEditPart
 
 	@Override
 	protected IFigure createFigure() {
-		final var eventMarker = (EventMarker) getModel();
+		final var eventMarker = getModel();
 		return new EventMarkerFigure(eventMarker.getIndex());
 	}
 
@@ -60,8 +56,8 @@ public class EventMarkerEditPart extends AbstractGraphicalEditPart
 			public void showSelection() {
 				// Redirect selection to the parent
 				final EditPart parent = getHost().getParent();
-				if (parent != null && parent.getViewer() != null) {
-					parent.getViewer().select(parent);
+				if (parent != null) {
+					getHost().getViewer().select(parent);
 				}
 			}
 		});
@@ -70,9 +66,9 @@ public class EventMarkerEditPart extends AbstractGraphicalEditPart
 	@Override
 	protected void refreshVisuals() {
 		super.refreshVisuals();
-		final var figure = getEventMarkerFigure();
-		figure.setIsValid(getEventMarkerModel().getValid());
-		figure.setIsCurrentEvent(getEventMarkerModel().getIsCurrentEvent());
+		final var figure = getFigure();
+		figure.setIsCurrentEvent(getModel().getIsCurrentEvent());
+		figure.setIsValid(getModel().getValid());
 		figure.repaint();
 	}
 
@@ -91,80 +87,35 @@ public class EventMarkerEditPart extends AbstractGraphicalEditPart
 		((GraphicalEditPart) getViewer().getContents()).getFigure().invalidateTree();
 	}
 
-	private EventMarker getEventMarkerModel() {
-		return (EventMarker) getModel();
+	@Override
+	public EventMarker getModel() {
+		return (EventMarker) super.getModel();
 	}
 
-	private EventMarkerFigure getEventMarkerFigure() {
-		return ((EventMarkerFigure) getFigure());
-	}
-
-	private void centerOnFigure() {
-		if (!figure.isShowing()) {
-			return;
-		}
-
-		final ScalableRootEditPart root = (ScalableRootEditPart) getViewer().getRootEditPart();
-
-		final Viewport viewport = (Viewport) root.getFigure();
-		final IFigure contents = viewport.getContents();
-
-		// Convert figure bounds → viewport content coordinates
-		final Rectangle bounds = figure.getBounds().getCopy();
-		figure.translateToAbsolute(bounds);
-		contents.translateToRelative(bounds);
-
-		final Rectangle viewArea = viewport.getClientArea();
-
-		final int centerX = bounds.x + bounds.width / 2;
-		final int centerY = bounds.y + bounds.height / 2;
-
-		final int viewLeft = viewArea.x;
-		final int viewTop = viewArea.y;
-		final int viewRight = viewLeft + viewArea.width;
-		final int viewBottom = viewTop + viewArea.height;
-
-		// Only center if center point is outside
-		final int margin = 20;
-
-		if (centerX >= viewLeft + margin && centerX <= viewRight - margin && centerY >= viewTop + margin
-				&& centerY <= viewBottom - margin) {
-			return;
-		}
-
-		int targetX = centerX - viewArea.width / 2;
-		int targetY = centerY - viewArea.height / 2;
-
-		final int maxX = contents.getBounds().width - viewArea.width;
-		final int maxY = contents.getBounds().height - viewArea.height;
-
-		targetX = Math.clamp(targetX, 0, Math.max(0, maxX));
-		targetY = Math.clamp(targetY, 0, Math.max(0, maxY));
-
-		viewport.setHorizontalLocation(targetX);
-		viewport.setVerticalLocation(targetY);
+	@Override
+	public EventMarkerFigure getFigure() {
+		return ((EventMarkerFigure) super.getFigure());
 	}
 
 	@Override
 	public void activate() {
 		super.activate();
-		((EventMarker) getModel()).addPropertyChangeListener(this);
-		getEventMarkerFigure().addEventSelectionListener(this);
+		getModel().addPropertyChangeListener(this);
+		getFigure().addEventSelectionListener(this);
 	}
 
 	@Override
 	public void deactivate() {
-		getEventMarkerFigure().removeEventSelectionListener(this);
-		((EventMarker) getModel()).removePropertyChangeListener(this);
+		getFigure().removeEventSelectionListener(this);
+		getModel().removePropertyChangeListener(this);
 		super.deactivate();
 	}
 
 	// calls from the figure
 
 	@Override
-	public void eventSelected(final int eventIndex) {
-		centerOnFigure();
-		getEventMarkerModel().eventSelected();
+	public void eventSelected() {
+		getModel().eventSelected();
 	}
 
 	// call from model

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/ResourceEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/ResourceEditPart.java
@@ -14,17 +14,12 @@
 
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.editpart;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.draw2d.IFigure;
-import org.eclipse.fordiac.ide.debug.replaydebugging.core.ReplayNavigator;
-import org.eclipse.fordiac.ide.debug.replaydebugging.core.Timeline;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.figure.NameStackedFigure;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.model.Resource;
 import org.eclipse.gef.EditPolicy;
-import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.editparts.AbstractGraphicalEditPart;
 import org.eclipse.gef.editpolicies.NonResizableEditPolicy;
 
@@ -56,7 +51,7 @@ public class ResourceEditPart extends AbstractGraphicalEditPart {
 	@Override
 	protected List<?> getModelChildren() {
 		final var model = (Resource) getModel();
-		return List.of(model.getReplayNavigator().getRootTimeline());
+		return List.of(model.getRootTimelineModel());
 	}
 
 	@Override
@@ -65,105 +60,18 @@ public class ResourceEditPart extends AbstractGraphicalEditPart {
 	}
 
 	public void moveForward() {
-		final var replayNavigator = ((Resource) getModel()).getReplayNavigator();
-		replayNavigator.moveOneEventForward();
+		((Resource) getModel()).moveForward();
 	}
 
 	public void moveBackwards() {
-		final var replayNavigator = ((Resource) getModel()).getReplayNavigator();
-		replayNavigator.moveOneEventBackwards();
+		((Resource) getModel()).moveBackwards();
 	}
 
 	public void moveUp() {
-		final var replayNavigator = ((Resource) getModel()).getReplayNavigator();
-		final var currentEventPosition = replayNavigator.getCurrentEventPosition();
-		final var currentTimeline = currentEventPosition.timeline();
-		final var currentEvent = currentEventPosition.eventNumber();
-
-		final var finalPosition = findNextTimelineWithValidEventNumber(currentTimeline, currentEvent, true);
-		if (finalPosition == null) {
-			return;
-		}
-		replayNavigator.moveToEvent(finalPosition);
-	}
-
-	private void collectTimelinesDFS(final GraphicalEditPart part, final List<TimelineEditPart> result) {
-
-		if (part instanceof final TimelineEditPart tep) {
-			result.add(tep);
-		}
-
-		for (final Object child : part.getChildren()) {
-			if (child instanceof final GraphicalEditPart gep) {
-				collectTimelinesDFS(gep, result);
-			}
-		}
-	}
-
-	private ReplayNavigator.EventPosition findNextTimelineWithValidEventNumber(final Timeline currentTimeline,
-			final int eventNumber, final boolean reversed) {
-
-		final List<TimelineEditPart> timelines = new ArrayList<>();
-
-		// Collect all TimelineEditParts inside this ResourceEditPart
-		collectTimelinesDFS(this, timelines);
-
-		if (reversed) {
-			Collections.reverse(timelines);
-		}
-
-		// Find index of current timeline
-		int currentIndex = -1;
-		for (int i = 0; i < timelines.size(); i++) {
-			if (timelines.get(i).getModel() == currentTimeline) {
-				currentIndex = i;
-				break;
-			}
-		}
-
-		if (currentIndex == -1) {
-			return null; // current timeline not found
-		}
-
-		final int currentGlobalEventNumber = currentTimeline.getGlobalIndexStart() + eventNumber;
-
-		// Continue searching AFTER the current one
-		for (int i = currentIndex + 1; i < timelines.size(); i++) {
-
-			final Timeline timeline = (Timeline) timelines.get(i).getModel();
-
-			final int start = timeline.getGlobalIndexStart();
-			final int end = timeline.getGlobalIndexEnd();
-
-			if (currentGlobalEventNumber >= start && currentGlobalEventNumber <= end) {
-				return new ReplayNavigator.EventPosition(timeline, currentGlobalEventNumber - start);
-			}
-		}
-
-		return null;
+		((Resource) getModel()).moveUp();
 	}
 
 	public void moveDown() {
-		final var replayNavigator = ((Resource) getModel()).getReplayNavigator();
-		final var currentEventPosition = replayNavigator.getCurrentEventPosition();
-		final var currentTimeline = currentEventPosition.timeline();
-		final var currentEvent = currentEventPosition.eventNumber();
-
-		var hasSpawnedAtCurrentPosition = false;
-		for (final var spawnedTimeline : currentTimeline.getSpawnedTimelines()) {
-			if (currentTimeline.getSpawnedTimelineEventNumber(spawnedTimeline) == currentEvent) {
-				hasSpawnedAtCurrentPosition = true;
-				break;
-			}
-		}
-		// if there's at least one spawned timeline, move down but one event later to
-		// follow the first timeline that appears
-		final var finalPosition = findNextTimelineWithValidEventNumber(currentTimeline,
-				hasSpawnedAtCurrentPosition ? currentEvent + 1 : currentEvent, false);
-		if (finalPosition == null) {
-			return;
-		}
-		replayNavigator.moveToEvent(finalPosition);
+		((Resource) getModel()).moveDown();
 	}
-
 }

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/ResourceEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/ResourceEditPart.java
@@ -11,7 +11,6 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.editpart;
 
 import java.util.List;
@@ -39,7 +38,7 @@ public class ResourceEditPart extends AbstractGraphicalEditPart {
 	}
 
 	private String getReplayNavigatorName() {
-		final var model = (Resource) getModel();
+		final var model = getModel();
 		return model.getName();
 	}
 
@@ -50,7 +49,7 @@ public class ResourceEditPart extends AbstractGraphicalEditPart {
 
 	@Override
 	protected List<?> getModelChildren() {
-		final var model = (Resource) getModel();
+		final var model = getModel();
 		return List.of(model.getRootTimelineModel());
 	}
 
@@ -59,19 +58,24 @@ public class ResourceEditPart extends AbstractGraphicalEditPart {
 		installEditPolicy(EditPolicy.SELECTION_FEEDBACK_ROLE, new NonResizableEditPolicy());
 	}
 
+	@Override
+	public Resource getModel() {
+		return (Resource) super.getModel();
+	}
+
 	public void moveForward() {
-		((Resource) getModel()).moveForward();
+		getModel().moveForward();
 	}
 
 	public void moveBackwards() {
-		((Resource) getModel()).moveBackwards();
+		getModel().moveBackwards();
 	}
 
 	public void moveUp() {
-		((Resource) getModel()).moveUp();
+		getModel().moveUp();
 	}
 
 	public void moveDown() {
-		((Resource) getModel()).moveDown();
+		getModel().moveDown();
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/ResourceEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/ResourceEditPart.java
@@ -38,8 +38,7 @@ public class ResourceEditPart extends AbstractGraphicalEditPart {
 	}
 
 	private String getReplayNavigatorName() {
-		final var model = getModel();
-		return model.getName();
+		return getModel().getName();
 	}
 
 	@Override
@@ -49,8 +48,7 @@ public class ResourceEditPart extends AbstractGraphicalEditPart {
 
 	@Override
 	protected List<?> getModelChildren() {
-		final var model = getModel();
-		return List.of(model.getRootTimelineModel());
+		return List.of(getModel().getRootTimelineModel());
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/SessionEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/SessionEditPart.java
@@ -11,7 +11,6 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.editpart;
 
 import java.beans.PropertyChangeEvent;

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/SessionEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/SessionEditPart.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.ToolbarLayout;
+import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.model.Session;
 import org.eclipse.gef.editparts.AbstractGraphicalEditPart;
 import org.eclipse.swt.widgets.Display;
@@ -38,7 +39,14 @@ public class SessionEditPart extends AbstractGraphicalEditPart implements Proper
 
 	@Override
 	protected IFigure createFigure() {
-		final Figure figure = new Figure();
+
+		final Figure figure = new Figure() {
+			@Override
+			public Dimension getPreferredSize(final int wHint, final int hHint) {
+				// Let the layout manager compute the true preferred size
+				return getLayoutManager().getPreferredSize(this, wHint, hHint);
+			}
+		};
 		figure.setLayoutManager(new ToolbarLayout(false)); // vertical
 		figure.setOpaque(true);
 		return figure;

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/TimelineConnectionEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/TimelineConnectionEditPart.java
@@ -104,12 +104,15 @@ public class TimelineConnectionEditPart extends AbstractConnectionEditPart imple
 		final Display display = getViewer().getControl().getDisplay();
 		if (display.getThread() == Thread.currentThread()) {
 			refreshChildren();
+			refreshVisuals();
 			return;
 		}
 
 		display.asyncExec(() -> {
 			if (isActive()) {
 				refreshChildren();
+				refreshVisuals();
+
 			}
 		});
 	}

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/TimelineConnectionEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/TimelineConnectionEditPart.java
@@ -11,7 +11,6 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.editpart;
 
 import java.beans.PropertyChangeEvent;
@@ -71,17 +70,22 @@ public class TimelineConnectionEditPart extends AbstractConnectionEditPart imple
 	}
 
 	@Override
+	public TimelineConnection getModel() {
+		return (TimelineConnection) super.getModel();
+	}
+
+	@Override
 	public void activate() {
 		if (!isActive()) {
 			super.activate();
-			((TimelineConnection) getModel()).addPropertyChangeListener(this);
+			getModel().addPropertyChangeListener(this);
 		}
 	}
 
 	@Override
 	public void deactivate() {
 		if (isActive()) {
-			((TimelineConnection) getModel()).removePropertyChangeListener(this);
+			getModel().removePropertyChangeListener(this);
 			super.deactivate();
 		}
 	}
@@ -90,8 +94,7 @@ public class TimelineConnectionEditPart extends AbstractConnectionEditPart imple
 	protected void refreshVisuals() {
 		final Connection connection = getConnectionFigure();
 		// Assuming your model has a getColor() method
-		final Color newColor = ((TimelineConnection) getModel()).isInCurrentPosition() ? ColorConstants.black
-				: ColorConstants.gray;
+		final Color newColor = getModel().isInCurrentPosition() ? ColorConstants.black : ColorConstants.gray;
 		connection.setForegroundColor(newColor);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/TimelineEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/TimelineEditPart.java
@@ -14,24 +14,23 @@
 
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.editpart;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.draw2d.ConnectionAnchor;
 import org.eclipse.draw2d.IFigure;
-import org.eclipse.draw2d.Viewport;
 import org.eclipse.draw2d.geometry.Rectangle;
-import org.eclipse.fordiac.ide.debug.replaydebugging.core.DatapointsState;
-import org.eclipse.fordiac.ide.debug.replaydebugging.core.ReplayNavigator;
-import org.eclipse.fordiac.ide.debug.replaydebugging.core.ReplayNavigator.StateListener;
-import org.eclipse.fordiac.ide.debug.replaydebugging.core.Timeline;
+import org.eclipse.fordiac.ide.debug.replaydebugging.ui.figure.CommonConstants;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.figure.TimelineAnchor;
-import org.eclipse.fordiac.ide.debug.replaydebugging.ui.figure.TimelineFigure;
-import org.eclipse.fordiac.ide.debug.replaydebugging.ui.figure.TimelineFigure.SelectedEventListener;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.figure.TimelineWithChildrenFigure;
-import org.eclipse.fordiac.ide.debug.replaydebugging.ui.model.Session;
+import org.eclipse.fordiac.ide.debug.replaydebugging.ui.model.EventMarker;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.model.TimelineConnection;
+import org.eclipse.fordiac.ide.debug.replaydebugging.ui.model.TimelineModel;
 import org.eclipse.gef.ConnectionEditPart;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPolicy;
@@ -39,7 +38,6 @@ import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.NodeEditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.editparts.AbstractGraphicalEditPart;
-import org.eclipse.gef.editparts.ScalableRootEditPart;
 import org.eclipse.gef.editpolicies.NonResizableEditPolicy;
 import org.eclipse.swt.widgets.Display;
 
@@ -57,16 +55,12 @@ import org.eclipse.swt.widgets.Display;
  *        changes, but only if the current event is outside of the current view
  *        area.
  */
-public class TimelineEditPart extends AbstractGraphicalEditPart implements NodeEditPart, Timeline.NewEventListener,
-		Timeline.NewSpawnedTimelineListener, SelectedEventListener, StateListener {
-
-	private ReplayNavigator replayNavigator;
+public class TimelineEditPart extends AbstractGraphicalEditPart implements NodeEditPart, PropertyChangeListener {
 
 	@Override
 	protected IFigure createFigure() {
-		final var timeline = (Timeline) getModel();
-		replayNavigator = ((Session) getViewer().getContents().getModel()).getResource(timeline).getReplayNavigator();
-		return new TimelineWithChildrenFigure(timeline);
+		final var model = (TimelineModel) getModel();
+		return new TimelineWithChildrenFigure(model.getGlobalStartPosition(), model.getEventMarkers().size());
 	}
 
 	@Override
@@ -85,196 +79,136 @@ public class TimelineEditPart extends AbstractGraphicalEditPart implements NodeE
 
 	@Override
 	protected List<?> getModelChildren() {
-		final Timeline model = (Timeline) getModel();
-		final ArrayList<Timeline> timelines = new ArrayList<>(model.getSpawnedTimelines());
+		final var model = (TimelineModel) getModel();
 
-		Collections.sort(timelines,
-				(timeline1, timeline2) -> Integer.compare(model.getSpawnedTimelineEventNumber(timeline2),
-						model.getSpawnedTimelineEventNumber(timeline1)));
-		return timelines;
+		return Stream.concat(model.getSpawnedTimelineModels().stream(), model.getEventMarkers().stream())
+				.collect(Collectors.toList());
 	}
 
 	@Override
 	public IFigure getContentPane() {
-		return ((TimelineWithChildrenFigure) getFigure()).getChildrenFigure();
+		return ((TimelineWithChildrenFigure) getFigure()).getSpawnedTimelinesPane();
 	}
 
 	@Override
-	protected void refreshVisuals() {
-		super.refreshVisuals();
-		updateCurrentEvent();
+	protected void addChildVisual(final EditPart childEditPart, final int index) {
+		final var fig = (TimelineWithChildrenFigure) getFigure();
+
+		if (childEditPart instanceof final EventMarkerEditPart marker) {
+			final IFigure markerFigure = ((GraphicalEditPart) childEditPart).getFigure();
+
+			fig.getTimelineFigure().add(markerFigure);
+
+			final int x = (((EventMarker) marker.getModel()).getIndex()
+					+ ((TimelineModel) getModel()).getGlobalStartPosition()) * CommonConstants.TOTAL_MARKER_SPACE;
+
+			fig.getTimelineFigure().setConstraint(markerFigure,
+					new Rectangle(x, 0, CommonConstants.MARKER_SIZE, CommonConstants.MARKER_SIZE));
+
+		} else {
+			fig.getSpawnedTimelinesPane().add(((GraphicalEditPart) childEditPart).getFigure());
+		}
+	}
+
+	@Override
+	protected void removeChildVisual(final EditPart childEditPart) {
+		final var fig = (TimelineWithChildrenFigure) getFigure();
+
+		if (childEditPart instanceof EventMarkerEditPart) {
+			final IFigure markerFigure = ((GraphicalEditPart) childEditPart).getFigure();
+			fig.getSpawnedTimelinesPane().remove(markerFigure);
+		} else {
+			fig.getSpawnedTimelinesPane().remove(((GraphicalEditPart) childEditPart).getFigure());
+		}
 	}
 
 	@Override
 	protected void refreshChildren() {
 		super.refreshChildren();
-		((GraphicalEditPart) getViewer().getContents()).getFigure().invalidateTree();
+
+		// remove and add all timelines to sort them when a new one is added
+		final var fig = (TimelineWithChildrenFigure) getFigure();
+		final IFigure pane = fig.getSpawnedTimelinesPane();
+
+		final List<IFigure> children = new ArrayList<>(pane.getChildren());
+		children.forEach(pane::remove);
+
+		getModelChildren().stream().filter(TimelineModel.class::isInstance)
+				.map(m -> (GraphicalEditPart) getViewer().getEditPartRegistry().get(m)).filter(Objects::nonNull)
+				.forEach(ep -> pane.add(ep.getFigure()));
+
+		pane.revalidate();
+		pane.repaint();
 	}
 
-	private TimelineFigure getTimelineFigure() {
-		return ((TimelineWithChildrenFigure) getFigure()).getTimelineFigure();
-	}
-
-	private void updateCurrentEvent() {
-		final var fig = getTimelineFigure();
-
-		final var currentPosition = replayNavigator.getCurrentEventPosition();
-
-		final Timeline model = (Timeline) getModel();
-
-		var currentTimeline = currentPosition.timeline();
-		var firstInvalid = currentPosition.eventNumber() + 1;
-
-		while (currentTimeline != model) {
-			final var parentTimeline = currentTimeline.getParentTimeline();
-			if (parentTimeline == null) {
-				firstInvalid = 0;
-				break;
-			}
-			firstInvalid = parentTimeline.getSpawnedTimelineEventNumber(currentTimeline) + 1;
-			currentTimeline = currentTimeline.getParentTimeline();
-		}
-
-		fig.updateEventStates(firstInvalid,
-				currentPosition.timeline() == getModel() ? currentPosition.eventNumber() : -1);
-
-		centerOnFigure(fig.getCurrentSelectedEventFigure());
-	}
-
-	private void centerOnFigure(final IFigure figure) {
-		if (figure == null || !figure.isShowing()) {
-			return;
-		}
-
-		final ScalableRootEditPart root = (ScalableRootEditPart) getViewer().getRootEditPart();
-
-		final Viewport viewport = (Viewport) root.getFigure();
-		final IFigure contents = viewport.getContents();
-
-		// Convert figure bounds → viewport content coordinates
-		final Rectangle bounds = figure.getBounds().getCopy();
-		figure.translateToAbsolute(bounds);
-		contents.translateToRelative(bounds);
-
-		final Rectangle viewArea = viewport.getClientArea();
-
-		final int centerX = bounds.x + bounds.width / 2;
-		final int centerY = bounds.y + bounds.height / 2;
-
-		final int viewLeft = viewArea.x;
-		final int viewTop = viewArea.y;
-		final int viewRight = viewLeft + viewArea.width;
-		final int viewBottom = viewTop + viewArea.height;
-
-		// Only center if center point is outside
-		final int margin = 20;
-
-		if (centerX >= viewLeft + margin && centerX <= viewRight - margin && centerY >= viewTop + margin
-				&& centerY <= viewBottom - margin) {
-			return;
-		}
-
-		int targetX = centerX - viewArea.width / 2;
-		int targetY = centerY - viewArea.height / 2;
-
-		final int maxX = contents.getBounds().width - viewArea.width;
-		final int maxY = contents.getBounds().height - viewArea.height;
-
-		targetX = Math.clamp(targetX, 0, Math.max(0, maxX));
-		targetY = Math.clamp(targetY, 0, Math.max(0, maxY));
-
-		viewport.setHorizontalLocation(targetX);
-		viewport.setVerticalLocation(targetY);
+	@Override
+	protected void refreshVisuals() {
+		super.refreshVisuals();
+		final var fig = (TimelineWithChildrenFigure) getFigure();
+		fig.getLineFigure().setFirstInvalid(((TimelineModel) getModel()).getFirstInvalid());
 	}
 
 	@Override
 	public void activate() {
 		super.activate();
-		final Timeline timeline = (Timeline) getModel();
-		timeline.addNewEventListener(this);
-		timeline.addNewSpawnedTimelineListener(this);
-
-		replayNavigator.addStateChangeListener(this);
-		getTimelineFigure().addEventSelectionListener(this);
+		((TimelineModel) getModel()).addPropertyChangeListener(this);
 	}
 
 	@Override
 	public void deactivate() {
-		final Timeline model = (Timeline) getModel();
-		model.removeNewEventListener(this);
-		model.removeNewSpawnedTimelineListener(this);
-
-		replayNavigator.removeStateChangeListener(this);
-		getTimelineFigure().removeEventSelectionListener(this);
+		((TimelineModel) getModel()).removePropertyChangeListener(this);
+		((TimelineModel) getModel()).dispose();
 		super.deactivate();
+	}
+
+	private static void revalidateUpToRoot(IFigure figure) {
+		while (figure != null) {
+			figure.revalidate();
+			figure = figure.getParent();
+		}
 	}
 
 	private void safeRefresh(final boolean newTimelines, final boolean newEvents) {
 		final Display display = getViewer().getControl().getDisplay();
 		display.asyncExec(() -> {
 			if (isActive()) {
-
-				if (newEvents) {
-					getTimelineFigure().rebuildMarkers();
-				}
-				if (newTimelines) {
+				if (newTimelines || newEvents) {
+					final var fig = ((TimelineWithChildrenFigure) getFigure());
+					fig.updateMaxNumberOfEvents(((TimelineModel) getModel()).getEventMarkers().size());
 					refreshChildren();
 					refreshSourceConnections();
+
+					revalidateUpToRoot(fig); // invalidate the whole chain
+					fig.revalidate(); // then queue the layout pass
 				}
 				refreshVisuals();
 			}
 		});
 	}
 
-	// calls from the model
-
-	@Override
-	public void timelineSpawned(final Timeline spawnedTimeline) {
-		final Timeline timeline = (Timeline) getModel();
-		((Session) getViewer().getContents().getModel()).getResource(timeline).addTimeline(spawnedTimeline);
-		safeRefresh(true, false);
-	}
-
-	@Override
-	public void eventAdded(final Timeline timeline) {
-		safeRefresh(false, true);
-	}
-
-	@Override
-	public void stateUpdated(final ReplayNavigator replayNavigator, final DatapointsState changedValues) {
-		safeRefresh(false, false);
-	}
-
-	// calls from the figure
-
-	@Override
-	public void eventSelected(final Timeline timeline, final int eventIndex) {
-		replayNavigator.moveToEvent(new ReplayNavigator.EventPosition(timeline, eventIndex));
-	}
-
 	// connections and anchors
 
 	@Override
 	public List<?> getModelSourceConnections() {
-		final Timeline timeline = (Timeline) getModel();
-		return ((Session) getViewer().getContents().getModel()).getResource(timeline).getSources(timeline);
+		return ((TimelineModel) getModel()).getSources();
 	}
 
 	@Override
 	public List<?> getModelTargetConnections() {
-		final Timeline timeline = (Timeline) getModel();
-		return ((Session) getViewer().getContents().getModel()).getResource(timeline).getTargets(timeline);
+		return ((TimelineModel) getModel()).getTargets();
 	}
 
 	@Override
 	public ConnectionAnchor getSourceConnectionAnchor(final ConnectionEditPart connection) {
 		final TimelineConnection conn = (TimelineConnection) connection.getModel();
-		return new TimelineAnchor(getTimelineFigure(), conn.spawnedIndex(), (Timeline) getModel(), true);
+		return new TimelineAnchor(((TimelineWithChildrenFigure) getFigure()).getLineFigure(), conn.spawnedIndex(),
+				((TimelineModel) getModel()).getEventMarkers().size(), true);
 	}
 
 	@Override
 	public ConnectionAnchor getTargetConnectionAnchor(final ConnectionEditPart connection) {
-		return new TimelineAnchor(getTimelineFigure(), 0, (Timeline) getModel(), false);
+		return new TimelineAnchor(((TimelineWithChildrenFigure) getFigure()).getLineFigure(), 0,
+				((TimelineModel) getModel()).getEventMarkers().size(), false);
 	}
 
 	@Override
@@ -285,6 +219,17 @@ public class TimelineEditPart extends AbstractGraphicalEditPart implements NodeE
 	@Override
 	public ConnectionAnchor getTargetConnectionAnchor(final Request request) {
 		return null;
+	}
+
+	@Override
+	public void propertyChange(final PropertyChangeEvent evt) {
+		if (evt.getPropertyName().equals(TimelineModel.PROPERTY_EVENT_ADDED)) {
+			safeRefresh(false, true);
+		} else if (evt.getPropertyName().equals(TimelineModel.PROPERTY_TIMELINE_ADDED)) {
+			safeRefresh(true, false);
+		} else if (evt.getPropertyName().equals(TimelineModel.PROPERTY_STATE_CHANGED)) {
+			safeRefresh(false, false);
+		}
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/TimelineEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/TimelineEditPart.java
@@ -11,7 +11,6 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.editpart;
 
 import java.beans.PropertyChangeEvent;
@@ -28,7 +27,6 @@ import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.figure.CommonConstants;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.figure.TimelineAnchor;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.figure.TimelineWithChildrenFigure;
-import org.eclipse.fordiac.ide.debug.replaydebugging.ui.model.EventMarker;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.model.TimelineConnection;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.model.TimelineModel;
 import org.eclipse.gef.ConnectionEditPart;
@@ -59,7 +57,7 @@ public class TimelineEditPart extends AbstractGraphicalEditPart implements NodeE
 
 	@Override
 	protected IFigure createFigure() {
-		final var model = (TimelineModel) getModel();
+		final var model = getModel();
 		return new TimelineWithChildrenFigure(model.getGlobalStartPosition(), model.getEventMarkers().size());
 	}
 
@@ -79,7 +77,7 @@ public class TimelineEditPart extends AbstractGraphicalEditPart implements NodeE
 
 	@Override
 	protected List<?> getModelChildren() {
-		final var model = (TimelineModel) getModel();
+		final var model = getModel();
 
 		return Stream.concat(model.getSpawnedTimelineModels().stream(), model.getEventMarkers().stream())
 				.collect(Collectors.toList());
@@ -87,20 +85,30 @@ public class TimelineEditPart extends AbstractGraphicalEditPart implements NodeE
 
 	@Override
 	public IFigure getContentPane() {
-		return ((TimelineWithChildrenFigure) getFigure()).getSpawnedTimelinesPane();
+		return getFigure().getSpawnedTimelinesPane();
+	}
+
+	@Override
+	public TimelineWithChildrenFigure getFigure() {
+		return (TimelineWithChildrenFigure) super.getFigure();
+	}
+
+	@Override
+	public TimelineModel getModel() {
+		return (TimelineModel) super.getModel();
 	}
 
 	@Override
 	protected void addChildVisual(final EditPart childEditPart, final int index) {
-		final var fig = (TimelineWithChildrenFigure) getFigure();
+		final var fig = getFigure();
 
 		if (childEditPart instanceof final EventMarkerEditPart marker) {
 			final IFigure markerFigure = ((GraphicalEditPart) childEditPart).getFigure();
 
 			fig.getTimelineFigure().add(markerFigure);
 
-			final int x = (((EventMarker) marker.getModel()).getIndex()
-					+ ((TimelineModel) getModel()).getGlobalStartPosition()) * CommonConstants.TOTAL_MARKER_SPACE;
+			final int x = (marker.getModel().getIndex() + getModel().getGlobalStartPosition())
+					* CommonConstants.TOTAL_MARKER_SPACE;
 
 			fig.getTimelineFigure().setConstraint(markerFigure,
 					new Rectangle(x, 0, CommonConstants.MARKER_SIZE, CommonConstants.MARKER_SIZE));
@@ -112,7 +120,7 @@ public class TimelineEditPart extends AbstractGraphicalEditPart implements NodeE
 
 	@Override
 	protected void removeChildVisual(final EditPart childEditPart) {
-		final var fig = (TimelineWithChildrenFigure) getFigure();
+		final var fig = getFigure();
 
 		if (childEditPart instanceof EventMarkerEditPart) {
 			final IFigure markerFigure = ((GraphicalEditPart) childEditPart).getFigure();
@@ -127,7 +135,7 @@ public class TimelineEditPart extends AbstractGraphicalEditPart implements NodeE
 		super.refreshChildren();
 
 		// remove and add all timelines to sort them when a new one is added
-		final var fig = (TimelineWithChildrenFigure) getFigure();
+		final var fig = getFigure();
 		final IFigure pane = fig.getSpawnedTimelinesPane();
 
 		final List<IFigure> children = new ArrayList<>(pane.getChildren());
@@ -144,20 +152,20 @@ public class TimelineEditPart extends AbstractGraphicalEditPart implements NodeE
 	@Override
 	protected void refreshVisuals() {
 		super.refreshVisuals();
-		final var fig = (TimelineWithChildrenFigure) getFigure();
-		fig.getLineFigure().setFirstInvalid(((TimelineModel) getModel()).getFirstInvalid());
+		final var fig = getFigure();
+		fig.getLineFigure().setFirstInvalid(getModel().getFirstInvalid());
 	}
 
 	@Override
 	public void activate() {
 		super.activate();
-		((TimelineModel) getModel()).addPropertyChangeListener(this);
+		getModel().addPropertyChangeListener(this);
 	}
 
 	@Override
 	public void deactivate() {
-		((TimelineModel) getModel()).removePropertyChangeListener(this);
-		((TimelineModel) getModel()).dispose();
+		getModel().removePropertyChangeListener(this);
+		getModel().dispose();
 		super.deactivate();
 	}
 
@@ -173,8 +181,8 @@ public class TimelineEditPart extends AbstractGraphicalEditPart implements NodeE
 		display.asyncExec(() -> {
 			if (isActive()) {
 				if (newTimelines || newEvents) {
-					final var fig = ((TimelineWithChildrenFigure) getFigure());
-					fig.updateMaxNumberOfEvents(((TimelineModel) getModel()).getEventMarkers().size());
+					final var fig = (getFigure());
+					fig.updateMaxNumberOfEvents(getModel().getEventMarkers().size());
 					refreshChildren();
 					refreshSourceConnections();
 
@@ -190,25 +198,24 @@ public class TimelineEditPart extends AbstractGraphicalEditPart implements NodeE
 
 	@Override
 	public List<?> getModelSourceConnections() {
-		return ((TimelineModel) getModel()).getSources();
+		return getModel().getSources();
 	}
 
 	@Override
 	public List<?> getModelTargetConnections() {
-		return ((TimelineModel) getModel()).getTargets();
+		return getModel().getTargets();
 	}
 
 	@Override
 	public ConnectionAnchor getSourceConnectionAnchor(final ConnectionEditPart connection) {
 		final TimelineConnection conn = (TimelineConnection) connection.getModel();
-		return new TimelineAnchor(((TimelineWithChildrenFigure) getFigure()).getLineFigure(), conn.spawnedIndex(),
-				((TimelineModel) getModel()).getEventMarkers().size(), true);
+		return new TimelineAnchor(getFigure().getLineFigure(), conn.spawnedIndex(), getModel().getEventMarkers().size(),
+				true);
 	}
 
 	@Override
 	public ConnectionAnchor getTargetConnectionAnchor(final ConnectionEditPart connection) {
-		return new TimelineAnchor(((TimelineWithChildrenFigure) getFigure()).getLineFigure(), 0,
-				((TimelineModel) getModel()).getEventMarkers().size(), false);
+		return new TimelineAnchor(getFigure().getLineFigure(), 0, getModel().getEventMarkers().size(), false);
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/TimelineEditPartFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/TimelineEditPartFactory.java
@@ -11,7 +11,6 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.editpart;
 
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.model.Device;

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/TimelineEditPartFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/TimelineEditPartFactory.java
@@ -14,11 +14,12 @@
 
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.editpart;
 
-import org.eclipse.fordiac.ide.debug.replaydebugging.core.Timeline;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.model.Device;
+import org.eclipse.fordiac.ide.debug.replaydebugging.ui.model.EventMarker;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.model.Resource;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.model.Session;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.model.TimelineConnection;
+import org.eclipse.fordiac.ide.debug.replaydebugging.ui.model.TimelineModel;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartFactory;
 
@@ -51,8 +52,14 @@ public class TimelineEditPartFactory implements EditPartFactory {
 			return part;
 		}
 
-		if (model instanceof Timeline) {
+		if (model instanceof TimelineModel) {
 			final var part = new TimelineEditPart();
+			part.setModel(model);
+			return part;
+		}
+
+		if (model instanceof EventMarker) {
+			final var part = new EventMarkerEditPart();
 			part.setModel(model);
 			return part;
 		}

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/CommonConstants.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/CommonConstants.java
@@ -11,7 +11,6 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.figure;
 
 /**

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/EventMarkerFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/EventMarkerFigure.java
@@ -17,10 +17,13 @@ package org.eclipse.fordiac.ide.debug.replaydebugging.ui.figure;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.MouseEvent;
 import org.eclipse.draw2d.MouseListener;
+import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.swt.graphics.Color;
 
 /**
  * @brief A figure representing an event marker in the timeline.
@@ -30,7 +33,13 @@ import org.eclipse.draw2d.MouseListener;
  */
 public class EventMarkerFigure extends Figure {
 
+	private static final Color CURRENT_EVENT_COLOR = ColorConstants.yellow;
+	private static final Color NOT_CURRENT_EVENT_COLOR = ColorConstants.blue;
+	private static final Color INVALID_COLOR = ColorConstants.gray;
+
 	private final int eventIndex;
+	private boolean isValid = false;
+	private boolean isCurrentEvent = false;
 
 	public EventMarkerFigure(final int eventIndex) {
 		this.eventIndex = eventIndex;
@@ -60,8 +69,21 @@ public class EventMarkerFigure extends Figure {
 		return eventIndex;
 	}
 
+	public void setIsValid(final boolean isValid) {
+		this.isValid = isValid;
+	}
+
+	public void setIsCurrentEvent(final boolean isCurrentEvent) {
+		this.isCurrentEvent = isCurrentEvent;
+	}
+
 	@Override
 	protected void paintFigure(final Graphics g) {
+		if (!isValid) {
+			setBackgroundColor(INVALID_COLOR);
+		} else {
+			setBackgroundColor(isCurrentEvent ? CURRENT_EVENT_COLOR : NOT_CURRENT_EVENT_COLOR);
+		}
 		g.fillOval(getBounds());
 	}
 
@@ -79,6 +101,11 @@ public class EventMarkerFigure extends Figure {
 
 	public void removeEventSelectionListener(final SelectedEventListener listener) {
 		listeners.remove(listener);
+	}
+
+	@Override
+	public Dimension getPreferredSize(final int wHint, final int hHint) {
+		return new Dimension(CommonConstants.MARKER_SIZE, CommonConstants.MARKER_SIZE);
 	}
 
 	private void notifyListeners() {

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/EventMarkerFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/EventMarkerFigure.java
@@ -11,7 +11,6 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.figure;
 
 import java.util.HashSet;
@@ -38,7 +37,6 @@ public class EventMarkerFigure extends Figure {
 	private static final Color INVALID_COLOR = ColorConstants.gray;
 
 	private final int eventIndex;
-	private boolean isValid = false;
 	private boolean isCurrentEvent = false;
 
 	public EventMarkerFigure(final int eventIndex) {
@@ -70,7 +68,11 @@ public class EventMarkerFigure extends Figure {
 	}
 
 	public void setIsValid(final boolean isValid) {
-		this.isValid = isValid;
+		if (!isValid) {
+			setBackgroundColor(INVALID_COLOR);
+		} else {
+			setBackgroundColor(isCurrentEvent ? CURRENT_EVENT_COLOR : NOT_CURRENT_EVENT_COLOR);
+		}
 	}
 
 	public void setIsCurrentEvent(final boolean isCurrentEvent) {
@@ -79,18 +81,13 @@ public class EventMarkerFigure extends Figure {
 
 	@Override
 	protected void paintFigure(final Graphics g) {
-		if (!isValid) {
-			setBackgroundColor(INVALID_COLOR);
-		} else {
-			setBackgroundColor(isCurrentEvent ? CURRENT_EVENT_COLOR : NOT_CURRENT_EVENT_COLOR);
-		}
 		g.fillOval(getBounds());
 	}
 
 	// Listener
 
 	public interface SelectedEventListener {
-		void eventSelected(int eventIndex);
+		void eventSelected();
 	}
 
 	private final Set<SelectedEventListener> listeners = new HashSet<>();
@@ -110,7 +107,7 @@ public class EventMarkerFigure extends Figure {
 
 	private void notifyListeners() {
 		for (final var listener : listeners) {
-			listener.eventSelected(eventIndex);
+			listener.eventSelected();
 		}
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/LineFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/LineFigure.java
@@ -11,7 +11,6 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.figure;
 
 import org.eclipse.draw2d.ColorConstants;
@@ -21,25 +20,20 @@ import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
 
 /**
- * @brief Figure representing a single timeline of events in the replay
- *        debugging.
+ * @brief Figure representing a single line of a timeline of events in the
+ *        replay debugging.
  *
- *        It is responsible for drawing the line and the event markers, as well
- *        as handling the selection of events and notifying the listeners about
- *        it.
- *
- *        The line is drawn in black for the valid events, and gray for the
- *        invalid ones. The current event is highlighted in yellow, while the
- *        past events are highlighted in blue.
+ *        It is responsible for drawing the line. The line is drawn in black for
+ *        the valid events, and gray for the invalid ones.
  */
-public class TimelineFigure extends Figure {
+public class LineFigure extends Figure {
 
 	private static final int LINE_WITDH = 4;
 
 	int maxNumberOfEvents;
 	private int firstInvalid = 0;
 
-	public TimelineFigure(final int maxNumberOfEvents) {
+	public LineFigure(final int maxNumberOfEvents) {
 		this.maxNumberOfEvents = maxNumberOfEvents;
 		setOpaque(true);
 	}

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/NameStackedFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/NameStackedFigure.java
@@ -11,7 +11,6 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.figure;
 
 import org.eclipse.draw2d.ColorConstants;

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/NameStackedFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/NameStackedFigure.java
@@ -68,7 +68,7 @@ public class NameStackedFigure extends RoundedRectangle {
 		final Dimension labelSize = nameLabel.getPreferredSize();
 		final Dimension contentSize = contentPane.getPreferredSize();
 
-		final int width = Math.max(labelSize.width, contentSize.width);
+		final int width = Math.max(labelSize.width, contentSize.width) + SPACING;
 		final int height = labelSize.height + contentSize.height + SPACING * 2;
 
 		return new Dimension(width, height);

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/TimelineAnchor.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/TimelineAnchor.java
@@ -18,7 +18,6 @@ import org.eclipse.draw2d.AbstractConnectionAnchor;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
-import org.eclipse.fordiac.ide.debug.replaydebugging.core.Timeline;
 
 /**
  * @brief Anchor for the connections of the timeline events
@@ -32,13 +31,13 @@ import org.eclipse.fordiac.ide.debug.replaydebugging.core.Timeline;
 public class TimelineAnchor extends AbstractConnectionAnchor {
 
 	private final int eventIndex;
-	private final Timeline timeline;
+	private final int numberOfEvents;
 	private final boolean isSource;
 
-	public TimelineAnchor(final IFigure owner, final int eventIndex, final Timeline timeline, final boolean isSource) {
+	public TimelineAnchor(final IFigure owner, final int eventIndex, final int numberOfEvents, final boolean isSource) {
 		super(owner);
 		this.eventIndex = eventIndex;
-		this.timeline = timeline;
+		this.numberOfEvents = numberOfEvents;
 		this.isSource = isSource;
 	}
 
@@ -49,11 +48,10 @@ public class TimelineAnchor extends AbstractConnectionAnchor {
 		getOwner().translateToAbsolute(bounds);
 
 		final int availableWidth = bounds.width;
-		final int markerSpacing = availableWidth / (timeline.getMaxEventNumber() + 1);
+		final int markerSpacing = availableWidth / numberOfEvents;
 
 		final int x = bounds.x + (eventIndex * markerSpacing) + (isSource ? markerSpacing / 2 : 0);
 		final int y = bounds.y + (isSource ? bounds.height : bounds.height / 2);
-
 		return new Point(x, y);
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/TimelineAnchor.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/TimelineAnchor.java
@@ -11,7 +11,6 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.figure;
 
 import org.eclipse.draw2d.AbstractConnectionAnchor;

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/TimelineFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/TimelineFigure.java
@@ -14,18 +14,11 @@
 
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.figure;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
-import org.eclipse.fordiac.ide.debug.replaydebugging.core.Timeline;
-import org.eclipse.swt.graphics.Color;
 
 /**
  * @brief Figure representing a single timeline of events in the replay
@@ -39,90 +32,30 @@ import org.eclipse.swt.graphics.Color;
  *        invalid ones. The current event is highlighted in yellow, while the
  *        past events are highlighted in blue.
  */
-public class TimelineFigure extends Figure implements EventMarkerFigure.SelectedEventListener {
+public class TimelineFigure extends Figure {
 
 	private static final int LINE_WITDH = 4;
-	private static final Color CURRENT_EVENT_COLOR = ColorConstants.yellow;
-	private static final Color NOT_CURRENT_EVENT_COLOR = ColorConstants.blue;
-	private static final Color INVALID_COLOR = ColorConstants.gray;
 
-	final Timeline timeline;
-	private int currentEvent = -1;
+	int maxNumberOfEvents;
 	private int firstInvalid = 0;
-	private final List<EventMarkerFigure> markers = new ArrayList<>();
 
-	public TimelineFigure(final Timeline timeline) {
-		this.timeline = timeline;
+	public TimelineFigure(final int maxNumberOfEvents) {
+		this.maxNumberOfEvents = maxNumberOfEvents;
 		setOpaque(true);
-		setLayoutManager(null);
-		rebuildMarkers();
-		for (final var marker : markers) {
-			marker.setBackgroundColor(INVALID_COLOR);
-		}
-		repaint();
 	}
 
-	public void rebuildMarkers() {
-		removeAll();
-		markers.clear();
-		final int count = timeline.getMaxEventNumber();
-
-		for (int i = 0; i <= count; i++) {
-			final EventMarkerFigure marker = new EventMarkerFigure(i);
-			marker.addEventSelectionListener(this);
-			markers.add(marker);
-			add(marker);
-		}
-		updateEventStates(firstInvalid, currentEvent);
-		revalidate();
-		repaint();
-	}
-
-	public void updateEventStates(final int firstInvalid, final int currentEvent) {
-		if (currentEvent >= markers.size() || firstInvalid > markers.size()) {
-			return;
-		}
-		for (int runner = 0; runner < firstInvalid; runner++) {
-			markers.get(runner).setBackgroundColor(NOT_CURRENT_EVENT_COLOR);
-		}
-		for (int runner = firstInvalid; runner < markers.size(); runner++) {
-			markers.get(runner).setBackgroundColor(INVALID_COLOR);
-		}
+	public void setFirstInvalid(final int firstInvalid) {
 		this.firstInvalid = firstInvalid;
-
-		if (this.currentEvent >= 0 && this.currentEvent < markers.size()) {
-			final var color = this.currentEvent >= firstInvalid ? INVALID_COLOR : NOT_CURRENT_EVENT_COLOR;
-			markers.get(this.currentEvent).setBackgroundColor(color);
-		}
-		if (currentEvent >= 0 && currentEvent < markers.size()) {
-			markers.get(currentEvent).setBackgroundColor(CURRENT_EVENT_COLOR);
-		}
-		this.currentEvent = currentEvent;
+		repaint();
 	}
 
-	public Figure getCurrentSelectedEventFigure() {
-		if (currentEvent != -1) {
-			return markers.get(currentEvent);
-		}
-		return null;
-	}
-
-	@Override
-	protected void layout() {
-		final Rectangle area = getBounds();
-
-		final int centerY = area.y + area.height / 2;
-
-		for (final EventMarkerFigure marker : markers) {
-			final int x = area.x + (marker.getEventIndex()) * (CommonConstants.TOTAL_MARKER_SPACE);
-			marker.setBounds(new Rectangle(x, centerY - CommonConstants.MARKER_SIZE / 2, CommonConstants.MARKER_SIZE,
-					CommonConstants.MARKER_SIZE));
-		}
+	public void setMaxNumberOfEvents(final int maxNumberOfEvents) {
+		this.maxNumberOfEvents = maxNumberOfEvents;
 	}
 
 	@Override
 	public Dimension getPreferredSize(final int wHint, final int hHint) {
-		final var width = markers.size() * CommonConstants.TOTAL_MARKER_SPACE;
+		final var width = maxNumberOfEvents * CommonConstants.TOTAL_MARKER_SPACE;
 		return new Dimension(width, CommonConstants.MARKER_SIZE);
 	}
 
@@ -140,35 +73,6 @@ public class TimelineFigure extends Figure implements EventMarkerFigure.Selected
 
 		g.setForegroundColor(ColorConstants.gray);
 		g.drawLine(endBlack, centerY, area.x + area.width - CommonConstants.EVENT_SPACING, centerY);
-
 	}
 
-	// Callback from selected event marker
-
-	@Override
-	public void eventSelected(final int eventIndex) {
-		notifyListeners(eventIndex);
-	}
-
-	// Listener
-
-	public interface SelectedEventListener {
-		void eventSelected(Timeline timeline, int eventIndex);
-	}
-
-	private final Set<SelectedEventListener> listeners = new HashSet<>();
-
-	public void addEventSelectionListener(final SelectedEventListener listener) {
-		listeners.add(listener);
-	}
-
-	public void removeEventSelectionListener(final SelectedEventListener listener) {
-		listeners.remove(listener);
-	}
-
-	private void notifyListeners(final int eventIndex) {
-		for (final var listener : listeners) {
-			listener.eventSelected(timeline, eventIndex);
-		}
-	}
 }

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/TimelineWithChildrenFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/TimelineWithChildrenFigure.java
@@ -11,7 +11,6 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.figure;
 
 import org.eclipse.draw2d.Figure;
@@ -28,7 +27,7 @@ import org.eclipse.draw2d.geometry.Rectangle;
 public class TimelineWithChildrenFigure extends Figure {
 
 	private final Figure timelineFigure;
-	private final TimelineFigure lineFigure;
+	private final LineFigure lineFigure;
 	private final Figure childrenFigure;
 	private final int startPosition;
 	private static final int SPACING_BETWEEN_TIMELINES = CommonConstants.MARKER_SIZE / 2;
@@ -47,7 +46,7 @@ public class TimelineWithChildrenFigure extends Figure {
 
 		timelineFigure.setLayoutManager(new XYLayout());
 
-		lineFigure = new TimelineFigure(maxNumberOfEvents);
+		lineFigure = new LineFigure(maxNumberOfEvents);
 
 		final int figureWidth = maxNumberOfEvents * CommonConstants.TOTAL_MARKER_SPACE;
 		final int figureHeight = CommonConstants.MARKER_SIZE;
@@ -68,7 +67,7 @@ public class TimelineWithChildrenFigure extends Figure {
 		return timelineFigure;
 	}
 
-	public TimelineFigure getLineFigure() {
+	public LineFigure getLineFigure() {
 		return lineFigure;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/TimelineWithChildrenFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/TimelineWithChildrenFigure.java
@@ -16,68 +16,83 @@ package org.eclipse.fordiac.ide.debug.replaydebugging.ui.figure;
 
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.ToolbarLayout;
 import org.eclipse.draw2d.XYLayout;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
-import org.eclipse.fordiac.ide.debug.replaydebugging.core.Timeline;
 
 /**
  * @brief Figure that represents a timeline and its spawned timelines (children)
  */
 public class TimelineWithChildrenFigure extends Figure {
 
-	private final Figure timelineFigureWrapper;
-	private final TimelineFigure timelineFigure;
-	private int startPosition;
+	private final Figure timelineFigure;
+	private final TimelineFigure lineFigure;
 	private final Figure childrenFigure;
+	private final int startPosition;
 	private static final int SPACING_BETWEEN_TIMELINES = CommonConstants.MARKER_SIZE / 2;
 
-	public TimelineWithChildrenFigure(final Timeline timeline) {
-		final var parentTimeline = timeline.getParentTimeline();
-		if (parentTimeline == null) {
-			startPosition = 0;
-		} else {
-			startPosition = Timeline.getSpawnedTimelineGlobalEventNumber(timeline);
-		}
+	public TimelineWithChildrenFigure(final int startPosition, final int maxNumberOfEvents) {
+		this.startPosition = startPosition;
 		final var layout = new ToolbarLayout(false);
 		layout.setSpacing(SPACING_BETWEEN_TIMELINES);
 		layout.setStretchMinorAxis(true);
 		setLayoutManager(layout);
 		setOpaque(true);
 
-		// we add a wrapper around the timeline figure to use an XYLayout and be able to
-		// position it according to the start position of the timeline
-		timelineFigureWrapper = new Figure();
-		timelineFigureWrapper.setLayoutManager(new XYLayout());
+		// the timeline figure contains a line, and the events are later added by the
+		// caller
+		timelineFigure = new Figure();
 
-		timelineFigure = new TimelineFigure(timeline);
-		timelineFigureWrapper.add(timelineFigure,
-				new Rectangle(startPosition * CommonConstants.TOTAL_MARKER_SPACE, 0, -1, -1));
+		timelineFigure.setLayoutManager(new XYLayout());
+
+		lineFigure = new TimelineFigure(maxNumberOfEvents);
+
+		final int figureWidth = maxNumberOfEvents * CommonConstants.TOTAL_MARKER_SPACE;
+		final int figureHeight = CommonConstants.MARKER_SIZE;
+
+		timelineFigure.add(lineFigure,
+				new Rectangle(startPosition * CommonConstants.TOTAL_MARKER_SPACE, 0, figureWidth, figureHeight));
 
 		childrenFigure = new Figure();
 
 		childrenFigure.setLayoutManager(new ToolbarLayout(false));
 		childrenFigure.setOpaque(true);
 
-		add(timelineFigureWrapper); // first row
+		add(timelineFigure); // first row
 		add(childrenFigure); // spawned timelines stacked below
 	}
 
-	public TimelineFigure getTimelineFigure() {
+	public IFigure getTimelineFigure() {
 		return timelineFigure;
 	}
 
-	public Figure getChildrenFigure() {
+	public TimelineFigure getLineFigure() {
+		return lineFigure;
+	}
+
+	public Figure getSpawnedTimelinesPane() {
 		return childrenFigure;
+	}
+
+	public void updateMaxNumberOfEvents(final int maxNumberOfEvents) {
+		lineFigure.setMaxNumberOfEvents(maxNumberOfEvents);
+
+		final int newWidth = maxNumberOfEvents * CommonConstants.TOTAL_MARKER_SPACE;
+		timelineFigure.setConstraint(lineFigure, new Rectangle(startPosition * CommonConstants.TOTAL_MARKER_SPACE, 0,
+				newWidth, CommonConstants.MARKER_SIZE));
+
+		revalidate();
+		repaint();
 	}
 
 	@Override
 	public Dimension getPreferredSize(final int wHint, final int hHint) {
-		final Dimension timelineSize = timelineFigureWrapper.getPreferredSize();
+		final Dimension timelineSize = lineFigure.getPreferredSize();
 		final Dimension contentSize = childrenFigure.getPreferredSize();
 
-		final int width = Math.max(timelineSize.width, contentSize.width);
+		final int width = Math.max(startPosition * CommonConstants.MARKER_SIZE + timelineSize.width, contentSize.width);
 		final int height = timelineSize.height + contentSize.height + SPACING_BETWEEN_TIMELINES;
 
 		return new Dimension(width, height);

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/model/Device.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/model/Device.java
@@ -11,7 +11,6 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.model;
 
 import java.beans.PropertyChangeListener;

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/model/EventMarker.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/model/EventMarker.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Jose Cabral
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Jose Cabral
+ *     - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+package org.eclipse.fordiac.ide.debug.replaydebugging.ui.model;
+
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+import java.util.function.Consumer;
+
+public class EventMarker {
+	private final int index;
+	private final Consumer<Integer> eventSelected;
+	private boolean isCurrentEvent = false;
+	private boolean isValid = false;
+
+	public static final String PROPERTY_EVENT_CHANGED = "eventChanged"; //$NON-NLS-1$
+
+	private final PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(this);
+
+	public EventMarker(final int index, final Consumer<Integer> eventSelected) {
+		this.index = index;
+		this.eventSelected = eventSelected;
+	}
+
+	public int getIndex() {
+		return index;
+	}
+
+	public boolean getIsCurrentEvent() {
+		return isCurrentEvent;
+	}
+
+	public void setIsCurrentEvent(final boolean isCurrentEvent) {
+		this.isCurrentEvent = isCurrentEvent;
+		propertyChangeSupport.firePropertyChange(PROPERTY_EVENT_CHANGED, null, null);
+	}
+
+	public boolean getValid() {
+		return isValid;
+	}
+
+	public void setIsValid(final boolean isValid) {
+		this.isValid = isValid;
+		propertyChangeSupport.firePropertyChange(PROPERTY_EVENT_CHANGED, null, null);
+	}
+
+	public void eventSelected() {
+		eventSelected.accept(Integer.valueOf(index));
+	}
+
+	// Listener to this
+
+	public void addPropertyChangeListener(final PropertyChangeListener listener) {
+		propertyChangeSupport.addPropertyChangeListener(listener);
+	}
+
+	public void removePropertyChangeListener(final PropertyChangeListener listener) {
+		propertyChangeSupport.removePropertyChangeListener(listener);
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/model/EventMarker.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/model/EventMarker.java
@@ -11,7 +11,6 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.model;
 
 import java.beans.PropertyChangeListener;

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/model/Resource.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/model/Resource.java
@@ -14,11 +14,14 @@
 
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.model;
 
-import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.Set;
+import java.util.function.Function;
 
+import org.eclipse.fordiac.ide.debug.replaydebugging.core.DatapointsState;
 import org.eclipse.fordiac.ide.debug.replaydebugging.core.ReplayNavigator;
+import org.eclipse.fordiac.ide.debug.replaydebugging.core.ReplayNavigator.EventPosition;
 import org.eclipse.fordiac.ide.debug.replaydebugging.core.Timeline;
 
 /**
@@ -27,50 +30,154 @@ import org.eclipse.fordiac.ide.debug.replaydebugging.core.Timeline;
  *        It offers a name and the replay navigator, and manages the models for
  *        connections between timelines.
  */
-public class Resource {
-	private final ReplayNavigator navigator;
-	private final Set<TimelineConnection> connections = new HashSet<>();
+public class Resource implements ReplayNavigator.StateListener {
+	private final ReplayNavigator replayNavigator;
+	private final TimelineModel rootTimelineModel;
 
-	public Resource(final ReplayNavigator navigator) {
-		this.navigator = navigator;
-		addChildConnections(navigator.getRootTimeline());
+	public Resource(final ReplayNavigator replayNavigator) {
+		this.replayNavigator = replayNavigator;
+		this.rootTimelineModel = new TimelineModel(replayNavigator.getRootTimeline(), this::eventSelected);
+		replayNavigator.addStateChangeListener(this);
+		updateCurrentPosition();
 	}
 
-	public String getName() {
-		return navigator.getIdentifier().resourceName();
+	public void dispose() {
+		replayNavigator.removeStateChangeListener(this);
 	}
 
 	public ReplayNavigator getReplayNavigator() {
-		return navigator;
+		return replayNavigator;
 	}
 
-	private void addParentConnection(final Timeline timeline) {
-		final var parentTimeline = timeline.getParentTimeline();
-		if (parentTimeline == null) {
+	public String getName() {
+		return replayNavigator.getIdentifier().resourceName();
+	}
+
+	public TimelineModel getRootTimelineModel() {
+		return rootTimelineModel;
+	}
+
+	private void updateCurrentPosition() {
+		final var currentEventPosition = replayNavigator.getCurrentEventPosition();
+
+		var runnerTimeline = currentEventPosition.timeline();
+		final List<Timeline> presentTimelines = new ArrayList<>();
+		while (runnerTimeline != null) {
+			presentTimelines.add(runnerTimeline);
+			runnerTimeline = runnerTimeline.getParentTimeline();
+		}
+
+		rootTimelineModel.updateCurrentPosition(currentEventPosition, presentTimelines.reversed());
+	}
+
+	private void eventSelected(final Timeline timeline, final Integer index) {
+		replayNavigator.moveToEvent(new EventPosition(timeline, index.intValue()));
+	}
+
+	public void moveForward() {
+		replayNavigator.moveOneEventForward();
+	}
+
+	public void moveBackwards() {
+		replayNavigator.moveOneEventBackwards();
+	}
+
+	public void moveUp() {
+		final var currentEventPosition = replayNavigator.getCurrentEventPosition();
+		final var currentTimeline = currentEventPosition.timeline();
+		final var currentEvent = currentEventPosition.eventNumber();
+
+		final var finalPosition = findNextTimelineWithValidEventNumber(currentTimeline, currentEvent, true);
+		if (finalPosition == null) {
 			return;
 		}
-		final int spawnedIndex = parentTimeline.getSpawnedTimelineEventNumber(timeline);
-		connections.add(new TimelineConnection(parentTimeline, timeline, spawnedIndex, navigator));
+		replayNavigator.moveToEvent(finalPosition);
 	}
 
-	private void addChildConnections(final Timeline timeline) {
-		for (final var spawnedTimeline : timeline.getSpawnedTimelines()) {
-			final int spawnedIndex = timeline.getSpawnedTimelineEventNumber(spawnedTimeline);
-			connections.add(new TimelineConnection(timeline, spawnedTimeline, spawnedIndex, navigator));
-			addTimeline(spawnedTimeline);
+	public void moveDown() {
+		final var currentEventPosition = replayNavigator.getCurrentEventPosition();
+		final var currentTimeline = currentEventPosition.timeline();
+		final var currentEvent = currentEventPosition.eventNumber();
+
+		var hasSpawnedAtCurrentPosition = false;
+		for (final var spawnedTimeline : currentTimeline.getSpawnedTimelines()) {
+			if (currentTimeline.getSpawnedTimelineEventNumber(spawnedTimeline) == currentEvent) {
+				hasSpawnedAtCurrentPosition = true;
+				break;
+			}
 		}
+		// if there's at least one spawned timeline, move down but one event later to
+		// follow the first timeline that appears
+		final var finalPosition = findNextTimelineWithValidEventNumber(currentTimeline,
+				hasSpawnedAtCurrentPosition ? currentEvent + 1 : currentEvent, false);
+		if (finalPosition == null) {
+			return;
+		}
+		replayNavigator.moveToEvent(finalPosition);
 	}
 
-	public void addTimeline(final Timeline timeline) {
-		addParentConnection(timeline);
-		addChildConnections(timeline);
+	private ReplayNavigator.EventPosition findNextTimelineWithValidEventNumber(final Timeline currentTimeline,
+			final int eventNumber, final boolean reversed) {
+
+		final List<Timeline> timelines = new ArrayList<>();
+
+		// Collect all Timelines inside this Resource
+		collectTimelinesBFS(replayNavigator.getRootTimeline(), timelines);
+
+		if (reversed) {
+			Collections.reverse(timelines);
+		}
+
+		// Find index of current timeline
+		int currentIndex = -1;
+		for (int i = 0; i < timelines.size(); i++) {
+			if (timelines.get(i) == currentTimeline) {
+				currentIndex = i;
+				break;
+			}
+		}
+
+		if (currentIndex == -1) {
+			return null; // current timeline not found
+		}
+
+		final int currentGlobalEventNumber = currentTimeline.getGlobalIndexStart() + eventNumber;
+
+		// Continue searching AFTER the current one
+		for (int i = currentIndex + 1; i < timelines.size(); i++) {
+
+			final Timeline timeline = timelines.get(i);
+
+			final int start = timeline.getGlobalIndexStart();
+			final int end = timeline.getGlobalIndexEnd();
+
+			if (currentGlobalEventNumber >= start && currentGlobalEventNumber <= end) {
+				return new ReplayNavigator.EventPosition(timeline, currentGlobalEventNumber - start);
+			}
+		}
+
+		return null;
 	}
 
-	public List<TimelineConnection> getSources(final Timeline timeline) {
-		return connections.stream().filter(connection -> connection.parent().equals(timeline)).toList();
+	private void collectTimelinesBFS(final Timeline timeline, final List<Timeline> result) {
+
+		result.add(timeline);
+
+		final var spawnedTimelines = new ArrayList<>(timeline.getSpawnedTimelines());
+
+		Collections.sort(spawnedTimelines, TimelineModel.getTimelineComparator(timeline, Function.identity()));
+
+		for (final var spawned : spawnedTimelines) {
+			collectTimelinesBFS(spawned, result);
+		}
+
 	}
 
-	public List<TimelineConnection> getTargets(final Timeline timeline) {
-		return connections.stream().filter(connection -> connection.child().equals(timeline)).toList();
+	// callback from the replay navigator
+
+	@Override
+	public void stateUpdated(final ReplayNavigator replayNavigator, final DatapointsState changedValues) {
+		updateCurrentPosition();
 	}
+
 }

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/model/Resource.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/model/Resource.java
@@ -11,7 +11,6 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.model;
 
 import java.util.ArrayList;

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/model/Session.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/model/Session.java
@@ -11,7 +11,6 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.model;
 
 import java.beans.PropertyChangeListener;

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/model/TimelineConnection.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/model/TimelineConnection.java
@@ -17,10 +17,6 @@ package org.eclipse.fordiac.ide.debug.replaydebugging.ui.model;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 
-import org.eclipse.fordiac.ide.debug.replaydebugging.core.DatapointsState;
-import org.eclipse.fordiac.ide.debug.replaydebugging.core.ReplayNavigator;
-import org.eclipse.fordiac.ide.debug.replaydebugging.core.Timeline;
-
 /**
  * @brief Model class for a connection between two timelines
  *
@@ -29,30 +25,27 @@ import org.eclipse.fordiac.ide.debug.replaydebugging.core.Timeline;
  *        its state accordingly. It also provides a property change support for
  *        notifying listeners about changes in the connection state.
  */
-public class TimelineConnection implements ReplayNavigator.StateListener {
+public class TimelineConnection {
 
-	public static final String PROPERTY_TIMELINECONNECTION_CHANGED = "timlineConnectionChanged"; //$NON-NLS-1$
+	public static final String PROPERTY_TIMELINECONNECTION_CHANGED = "timelineConnectionChanged"; //$NON-NLS-1$
 	private final PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(this);
 
-	private final Timeline parent;
-	private final Timeline child;
+	private final TimelineModel parent;
+	private final TimelineModel child;
 	private final int spawnedIndex;
-	private final ReplayNavigator replayNavigator;
+	private boolean isInCurrentPosition = false;
 
-	public TimelineConnection(final Timeline parent, final Timeline child, final int spawnedIndex,
-			final ReplayNavigator replayNavigator) {
+	public TimelineConnection(final TimelineModel parent, final TimelineModel child, final int spawnedIndex) {
 		this.parent = parent;
 		this.child = child;
 		this.spawnedIndex = spawnedIndex;
-		this.replayNavigator = replayNavigator;
-		replayNavigator.addStateChangeListener(this);
 	}
 
-	public Timeline parent() {
+	public TimelineModel parent() {
 		return parent;
 	}
 
-	public Timeline child() {
+	public TimelineModel child() {
 		return child;
 	}
 
@@ -61,22 +54,15 @@ public class TimelineConnection implements ReplayNavigator.StateListener {
 	}
 
 	public boolean isInCurrentPosition() {
-		var currentTimeline = replayNavigator.getCurrentEventPosition().timeline();
-		while (currentTimeline != null) {
-			if (currentTimeline == child) {
-				return true;
-			}
-			currentTimeline = currentTimeline.getParentTimeline();
-		}
-		return false;
+		return isInCurrentPosition;
 	}
 
-	@Override
-	public void stateUpdated(final ReplayNavigator replayNavigator, final DatapointsState changedValues) {
+	public void setIsInCurrentPosition(final boolean isInCurrentPosition) {
+		this.isInCurrentPosition = isInCurrentPosition;
 		propertyChangeSupport.firePropertyChange(PROPERTY_TIMELINECONNECTION_CHANGED, null, null);
 	}
 
-	// Listener
+	// Listener to this
 
 	public void addPropertyChangeListener(final PropertyChangeListener listener) {
 		propertyChangeSupport.addPropertyChangeListener(listener);

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/model/TimelineConnection.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/model/TimelineConnection.java
@@ -11,7 +11,6 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.model;
 
 import java.beans.PropertyChangeListener;

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/model/TimelineModel.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/model/TimelineModel.java
@@ -1,0 +1,176 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Jose Cabral
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Jose Cabral
+ *     - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+package org.eclipse.fordiac.ide.debug.replaydebugging.ui.model;
+
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.eclipse.fordiac.ide.debug.replaydebugging.core.ReplayNavigator.EventPosition;
+import org.eclipse.fordiac.ide.debug.replaydebugging.core.Timeline;
+
+public class TimelineModel implements Timeline.NewEventListener, Timeline.NewSpawnedTimelineListener {
+
+	private final Timeline timeline;
+	private TimelineConnection connectionToParentTimelineModel;
+
+	private final List<TimelineConnection> spawnedConnections = new ArrayList<>();
+	private final List<EventMarker> eventMarkers = new ArrayList<>();
+	private final BiConsumer<Timeline, Integer> eventSelected;
+
+	private int firstInvalid = -1;
+
+	public static final String PROPERTY_EVENT_ADDED = "eventAdded"; //$NON-NLS-1$
+	public static final String PROPERTY_TIMELINE_ADDED = "timelineAdded"; //$NON-NLS-1$
+	public static final String PROPERTY_STATE_CHANGED = "stateChanged"; //$NON-NLS-1$
+
+	private final PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(this);
+
+	public TimelineModel(final Timeline timeline, final BiConsumer<Timeline, Integer> eventSelected) {
+		this.timeline = timeline;
+		this.eventSelected = eventSelected;
+
+		for (var i = 0; i <= timeline.getMaxEventNumber(); i++) {
+			eventMarkers.add(new EventMarker(i, this::eventSelected));
+		}
+
+		for (final var spawnedTimeline : timeline.getSpawnedTimelines()) {
+			addNewSpawnedTimeline(spawnedTimeline);
+		}
+
+		timeline.addNewEventListener(this);
+		timeline.addNewSpawnedTimelineListener(this);
+	}
+
+	public List<EventMarker> getEventMarkers() {
+		return eventMarkers;
+	}
+
+	public int getFirstInvalid() {
+		return firstInvalid;
+	}
+
+	public int getGlobalStartPosition() {
+		return Timeline.getSpawnedTimelineGlobalEventNumber(timeline);
+	}
+
+	private Timeline getTimeline() {
+		return timeline;
+	}
+
+	public List<TimelineModel> getSpawnedTimelineModels() {
+		final List<TimelineModel> timelines = spawnedConnections.stream().map(TimelineConnection::child)
+				.collect(Collectors.toList());
+
+		Collections.sort(timelines, getTimelineComparator(timeline, TimelineModel::getTimeline));
+		return timelines;
+	}
+
+	public static <T> Comparator<T> getTimelineComparator(final Timeline parentTimeline,
+			final Function<T, Timeline> timelineExtractor) {
+		return (timeline1, timeline2) -> Integer.compare(
+				parentTimeline.getSpawnedTimelineEventNumber(timelineExtractor.apply(timeline2)),
+				parentTimeline.getSpawnedTimelineEventNumber(timelineExtractor.apply(timeline1)));
+	}
+
+	private void addNewSpawnedTimeline(final Timeline spawnedTimeline) {
+		final var spawnedModel = new TimelineModel(spawnedTimeline, eventSelected);
+		final var connectionToChild = new TimelineConnection(this, spawnedModel,
+				timeline.getSpawnedTimelineEventNumber(spawnedTimeline));
+		spawnedModel.connectionToParentTimelineModel = connectionToChild;
+		spawnedConnections.add(connectionToChild);
+	}
+
+	public void updateCurrentPosition(final EventPosition currentEventPosition, final List<Timeline> presentTimelines) {
+		cleanAllEventStates();
+
+		firstInvalid = -1;
+		if (currentEventPosition.timeline() == timeline) {
+			firstInvalid = currentEventPosition.eventNumber() + 1;
+			eventMarkers.get(currentEventPosition.eventNumber()).setIsCurrentEvent(true);
+		} else {
+			for (var i = 0; i < presentTimelines.size(); i++) {
+				if (presentTimelines.get(i) == timeline) {
+					firstInvalid = timeline.getSpawnedTimelineEventNumber(presentTimelines.get(i + 1)) + 1;
+				}
+			}
+		}
+
+		for (var i = 0; i < eventMarkers.size(); i++) {
+			eventMarkers.get(i).setIsValid(i < firstInvalid);
+		}
+
+		for (final var spawnedConnection : spawnedConnections) {
+			spawnedConnection.setIsInCurrentPosition(presentTimelines.contains(spawnedConnection.child().timeline));
+			spawnedConnection.child().updateCurrentPosition(currentEventPosition, presentTimelines);
+		}
+		propertyChangeSupport.firePropertyChange(PROPERTY_STATE_CHANGED, null, null);
+	}
+
+	private void cleanAllEventStates() {
+		for (final var eventMarker : eventMarkers) {
+			eventMarker.setIsValid(false);
+			eventMarker.setIsCurrentEvent(false);
+		}
+	}
+
+	public void dispose() {
+		timeline.removeNewEventListener(this);
+		timeline.removeNewSpawnedTimelineListener(this);
+	}
+
+	private void eventSelected(final Integer index) {
+		eventSelected.accept(timeline, index);
+	}
+
+	public List<TimelineConnection> getSources() {
+		return spawnedConnections;
+	}
+
+	public List<TimelineConnection> getTargets() {
+		return connectionToParentTimelineModel == null ? List.of() : List.of(connectionToParentTimelineModel);
+	}
+
+	// Callbacks from the timeline
+
+	@Override
+	public void eventAdded(final Timeline timeline) {
+		eventMarkers.add(new EventMarker(timeline.getMaxEventNumber(), this::eventSelected));
+		propertyChangeSupport.firePropertyChange(PROPERTY_EVENT_ADDED, null, null);
+	}
+
+	@Override
+	public void timelineSpawned(final Timeline spawnedTimeline) {
+		addNewSpawnedTimeline(spawnedTimeline);
+		propertyChangeSupport.firePropertyChange(PROPERTY_TIMELINE_ADDED, null, null);
+	}
+
+	// Listener to this
+
+	public void addPropertyChangeListener(final PropertyChangeListener listener) {
+		propertyChangeSupport.addPropertyChangeListener(listener);
+	}
+
+	public void removePropertyChangeListener(final PropertyChangeListener listener) {
+		propertyChangeSupport.removePropertyChangeListener(listener);
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/model/TimelineModel.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/model/TimelineModel.java
@@ -11,7 +11,6 @@
  *   Jose Cabral
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-
 package org.eclipse.fordiac.ide.debug.replaydebugging.ui.model;
 
 import java.beans.PropertyChangeListener;


### PR DESCRIPTION
After a discussion about the best approach to handle handler/commands in another PR, it was decided to properly implement edit parts for the events. Previously events were just figures and many workarounds were present to make it work. 

This PR solves this by adding models and removing some dependencies that made things harder.

I tried to separate into commits which changes that belonged together, but the dependencies were so large so it was not easy. Each separate commit doesn't compile on its own. 

Note: the functionality remains the same except some edge cases, but I decided to open this and fix those issues later. 

**Design**

The major changes are relate to the design, so it's better to understand that first.
1. The replaydebugging plugin (not UI) has the underlying logic about eveerything related to timelines, model and replay navigator.
2. The replaydebugging plugin was previously  directly accessed in the editParts, either as model or accesing them directly. This is the major change. The classes under `replaydebugging.ui.model` now represent a layer between the `replaydebugging` plugin and the EditParts. Therefore there's a `TimelineModel` and an `EventMaker` which contain the access to the underlying elements, as well as information that concerns the UI part, for example which event is invalid (gray) or which connection belongs to the current overall position.
3. This layer now is the listener to changes in the `replaydebugging` plugin, and redirects the changes to the EditPart by firing property changes.
4. The EditParts now listen to their own model and not direclty to the `replaydebugging` plugin.
5. The lifetime of the models was also cleaned up. A `resource` contains now one `TimelineModel` from the root timeline, and each `TimelineModel` contains the connection to its child timelines and its events. This allows to easily set the desired state for each model when needed.
6. The TimlineFigure now is only a line, and a the wrapper around it makes sure that the Event Figures are place on top of it. 
7. Ugly logic for moving up/down in the resource was moved to the model of the resource.

There might be still some things to solve, such as the selection of events vs resource and so on, but I'd rather omit those issues for now as this is mainly about redesigning the architecutre.

**How to review this PR**

I'd go with the separated view and check only the new stuff. Checking the `diff` makes no much sense as the old stuff is just noise.

Commit by commit? Maybe, but not ideal.