### PR TITLE
Add Additional Features to P2 update site

### DIFF
--- a/features/org.eclipse.fordiac.ide.experimental.feature/feature.xml
+++ b/features/org.eclipse.fordiac.ide.experimental.feature/feature.xml
@@ -35,7 +35,10 @@
 
    <requires>
       <import feature="org.eclipse.fordiac.ide.workbench.feature"/>
-      <import feature="org.eclipse.mylyn.wikitext.feature"/>
+      <import plugin="org.eclipse.mylyn.wikitext.asciidoc"/>
+      <import plugin="org.eclipse.mylyn.wikitext.asciidoc.ui"/>
+      <import plugin="org.eclipse.mylyn.wikitext.ui"/>
+      <import plugin="org.eclipse.mylyn.wikitext.ui.source"/>
    </requires>
 
    <plugin

--- a/plugins/org.eclipse.fordiac.ide.product/category.xml
+++ b/plugins/org.eclipse.fordiac.ide.product/category.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+    <feature id="org.eclipse.fordiac.ide.experimental.feature" >
+        <category name="org.eclipse.fordiac.ide.additional"/>
+    </feature>
+    <feature id="org.eclipse.fordiac.ide.deployment.opcua.feature" >
+        <category name="org.eclipse.fordiac.ide.additional"/>
+    </feature>
+    
+    <category-def name="org.eclipse.fordiac.ide.additional" label="Additional 4diac IDE Features">
+        <description>Additional 4diac IDE features not included into a default 4diac IDE product to be inclueded in the update site</description>
+    </category-def>
+</site>

--- a/plugins/org.eclipse.fordiac.ide.product/pom.xml
+++ b/plugins/org.eclipse.fordiac.ide.product/pom.xml
@@ -52,6 +52,7 @@
 				<version>${tycho.version}</version>
 				<configuration>
 					<includeAllDependencies>true</includeAllDependencies>
+					<categoryFile>${project.basedir}/category.xml</categoryFile>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
OPC UA deployment and the experimental features where not added to our updates side and where therefore not installable. Furthermore pulled only the explicitly required wikitext dependencies to avoid and JDT dependencies.