### PR TITLE
Validate multiple output connections on event

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.ui/plugin.properties
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/plugin.properties
@@ -79,6 +79,7 @@ ValidationJob_ReloadJobName=Reload annotations for {0}
 ValidationJob_UpdateJobName=Update annotations for {0}
 ValidationJob_ValidationJobName=Validate {0}
 
+ValidationPreferencePage_EventMultipleOutputConnections=Multiple output connections on event may lead to undefined execution order
 ValidationPreferencePage_NoValueForGenericTypeVariable=Should not specify a value for variable of generic type in defining type
 ValidationPreferencePage_PotentialProgrammingProblems=Potential programming problems
 ValidationPreferencePage_ValueForGenericInstanceVariable=Should specify a value for unconnected variable of generic type in instance

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/Messages.java
@@ -85,6 +85,7 @@ public final class Messages extends NLS {
 	public static String ValidationJob_UpdateJobName;
 	public static String ValidationJob_ValidationJobName;
 
+	public static String ValidationPreferencePage_EventMultipleOutputConnections;
 	public static String ValidationPreferencePage_NoValueForGenericTypeVariable;
 	public static String ValidationPreferencePage_PotentialProgrammingProblems;
 	public static String ValidationPreferencePage_ValueForGenericInstanceVariable;

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/preferences/ValidationPreferencePage.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/preferences/ValidationPreferencePage.java
@@ -71,6 +71,9 @@ public class ValidationPreferencePage extends FordiacPropertyPreferencePage {
 		addField(new ComboFieldEditor(ValidationPreferences.VALUE_FOR_GENERIC_INSTANCE_VARIABLE,
 				Messages.ValidationPreferencePage_ValueForGenericInstanceVariable, SEVERITIES,
 				potentialProblemsSection));
+		addField(new ComboFieldEditor(ValidationPreferences.EVENT_MULTIPLE_OUTPUT_CONNECTIONS,
+				Messages.ValidationPreferencePage_EventMultipleOutputConnections, SEVERITIES,
+				potentialProblemsSection));
 	}
 
 	private static Composite createSection(final String label, final Composite composite, final boolean expanded) {

--- a/plugins/org.eclipse.fordiac.ide.model/model/fordiac.genmodel
+++ b/plugins/org.eclipse.fordiac.ide.model/model/fordiac.genmodel
@@ -459,6 +459,11 @@
       <genOperations ecoreOperation="lib.ecore#//Event/getOutputParameters" body="return org.eclipse.fordiac.ide.model.libraryElement.impl.CallableAnnotations.getOutputParameters(this);"/>
       <genOperations ecoreOperation="lib.ecore#//Event/getInOutParameters" body="return org.eclipse.fordiac.ide.model.libraryElement.impl.CallableAnnotations.getInOutParameters(this);"/>
       <genOperations ecoreOperation="lib.ecore#//Event/getReturnType" body="return org.eclipse.fordiac.ide.model.libraryElement.impl.CallableAnnotations.getReturnType(this);"/>
+      <genOperations ecoreOperation="lib.ecore#//Event/validateMultipleOutputConnections"
+          body="return org.eclipse.fordiac.ide.model.libraryElement.impl.EventAnnotations.validateMultipleOutputConnections(this, diagnostics, context);">
+        <genParameters ecoreParameter="lib.ecore#//Event/validateMultipleOutputConnections/diagnostics"/>
+        <genParameters ecoreParameter="lib.ecore#//Event/validateMultipleOutputConnections/context"/>
+      </genOperations>
     </genClasses>
     <genClasses ecoreClass="lib.ecore#//EventConnection">
       <genFeatures property="None" notify="false" createChild="false" ecoreFeature="ecore:EReference lib.ecore#//EventConnection/fBNetwork"/>

--- a/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
+++ b/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
@@ -1144,6 +1144,21 @@
         <details key="body" value="return org.eclipse.fordiac.ide.model.libraryElement.impl.CallableAnnotations.getReturnType(this);"/>
       </eAnnotations>
     </eOperations>
+    <eOperations name="validateMultipleOutputConnections" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore">
+        <details key="invariant" value="true"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="body" value="return org.eclipse.fordiac.ide.model.libraryElement.impl.EventAnnotations.validateMultipleOutputConnections(this, diagnostics, context);"/>
+      </eAnnotations>
+      <eParameters name="diagnostics" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDiagnosticChain"/>
+      <eParameters name="context">
+        <eGenericType eClassifier="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EMap">
+          <eTypeArguments eClassifier="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EJavaObject"/>
+          <eTypeArguments eClassifier="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EJavaObject"/>
+        </eGenericType>
+      </eParameters>
+    </eOperations>
     <eStructuralFeatures xsi:type="ecore:EReference" name="with" upperBound="-1" eType="#//With"
         containment="true" resolveProxies="false">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">

--- a/plugins/org.eclipse.fordiac.ide.model/plugin.properties
+++ b/plugins/org.eclipse.fordiac.ide.model/plugin.properties
@@ -69,6 +69,7 @@ Error_SelfInsertion={0} cannot be inserted into itself!
 Error_TSAinCFB=Typed SubApp cannot be inserted into Composite Function Block!
 ErrorMarkerInterfaceAnnotations_MissingVariableForAttribute=Missing variable for attribute: {0}
 ErrorMarkerInterfaceAnnotations_MissingVariableForValue=Missing variable for value: {0}
+EventAnnotations_MultipleOutputConnections=Multiple output connections on event may lead to undefined execution order
 AttributeAnnotations_MissingAttributeDeclaration=Attribute Declaration ''{0}'' not found 
 FBNetworkAnnotations_CollisionMessage=Collision between {0} and {1}
 FBNetworkAnnotations_InterfaceBarCollisionMessage=Collision of {0} with Maximum Size of Interface Bar of {1}

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/Event.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/Event.java
@@ -16,6 +16,8 @@
  */
 package org.eclipse.fordiac.ide.model.libraryElement;
 
+import java.util.Map;
+import org.eclipse.emf.common.util.DiagnosticChain;
 import org.eclipse.emf.common.util.EList;
 
 import org.eclipse.fordiac.ide.model.data.DataType;
@@ -81,5 +83,13 @@ public interface Event extends IInterfaceElement, ICallable {
 	 * @generated
 	 */
 	DataType getReturnType();
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @model annotation="http://www.eclipse.org/emf/2002/Ecore invariant='true'"
+	 * @generated
+	 */
+	boolean validateMultipleOutputConnections(DiagnosticChain diagnostics, Map<Object, Object> context);
 
 } // Event

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/EventImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/EventImpl.java
@@ -411,6 +411,16 @@ public class EventImpl extends EObjectImpl implements Event {
 	 * @generated
 	 */
 	@Override
+	public boolean validateMultipleOutputConnections(final DiagnosticChain diagnostics, final Map<Object, Object> context) {
+		return org.eclipse.fordiac.ide.model.libraryElement.impl.EventAnnotations.validateMultipleOutputConnections(this, diagnostics, context);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public String getSignature() {
 		return org.eclipse.fordiac.ide.model.libraryElement.impl.CallableAnnotations.getSignature(this);
 	}

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
@@ -5694,6 +5694,15 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 
 		addEOperation(eventEClass, theDataPackage.getDataType(), "getReturnType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
+		op = addEOperation(eventEClass, ecorePackage.getEBoolean(), "validateMultipleOutputConnections", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEParameter(op, ecorePackage.getEDiagnosticChain(), "diagnostics", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		g1 = createEGenericType(ecorePackage.getEMap());
+		g2 = createEGenericType(ecorePackage.getEJavaObject());
+		g1.getETypeArguments().add(g2);
+		g2 = createEGenericType(ecorePackage.getEJavaObject());
+		g1.getETypeArguments().add(g2);
+		addEParameter(op, g1, "context", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+
 		initEClass(eventConnectionEClass, EventConnection.class, "EventConnection", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getEventConnection_FBNetwork(), this.getFBNetwork(), this.getFBNetwork_EventConnections(), "fBNetwork", null, 0, 1, EventConnection.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
@@ -7253,6 +7262,12 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 		   });
 		addAnnotation
 		  (errorMarkerInterfaceEClass.getEOperations().get(1),
+		   source,
+		   new String[] {
+			   "invariant", "true" //$NON-NLS-1$ //$NON-NLS-2$
+		   });
+		addAnnotation
+		  (eventEClass.getEOperations().get(4),
 		   source,
 		   new String[] {
 			   "invariant", "true" //$NON-NLS-1$ //$NON-NLS-2$

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/util/LibraryElementValidator.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/util/LibraryElementValidator.java
@@ -353,12 +353,20 @@ public class LibraryElementValidator extends EObjectValidator {
 	public static final int ERROR_MARKER_INTERFACE__VALIDATE_ATTRIBUTES = 21;
 
 	/**
+	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Multiple Output Connections' of 'Event'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public static final int EVENT__VALIDATE_MULTIPLE_OUTPUT_CONNECTIONS = 22;
+
+	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Collisions' of 'FB Network'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int FB_NETWORK__VALIDATE_COLLISIONS = 22;
+	public static final int FB_NETWORK__VALIDATE_COLLISIONS = 23;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Name' of 'FB Network Element'.
@@ -366,7 +374,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int FB_NETWORK_ELEMENT__VALIDATE_NAME = 23;
+	public static final int FB_NETWORK_ELEMENT__VALIDATE_NAME = 24;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Type' of 'FB Network Element'.
@@ -374,7 +382,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int FB_NETWORK_ELEMENT__VALIDATE_TYPE = 24;
+	public static final int FB_NETWORK_ELEMENT__VALIDATE_TYPE = 25;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Collisions' of 'Group'.
@@ -382,7 +390,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int GROUP__VALIDATE_COLLISIONS = 25;
+	public static final int GROUP__VALIDATE_COLLISIONS = 26;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Name' of 'IInterface Element'.
@@ -390,7 +398,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int IINTERFACE_ELEMENT__VALIDATE_NAME = 26;
+	public static final int IINTERFACE_ELEMENT__VALIDATE_NAME = 27;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Name' of 'INamed Element'.
@@ -398,7 +406,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int INAMED_ELEMENT__VALIDATE_NAME = 27;
+	public static final int INAMED_ELEMENT__VALIDATE_NAME = 28;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Type' of 'ITyped Element'.
@@ -406,7 +414,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int ITYPED_ELEMENT__VALIDATE_TYPE = 28;
+	public static final int ITYPED_ELEMENT__VALIDATE_TYPE = 29;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Name' of 'Library Element'.
@@ -414,7 +422,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int LIBRARY_ELEMENT__VALIDATE_NAME = 29;
+	public static final int LIBRARY_ELEMENT__VALIDATE_NAME = 30;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Package' of 'Library Element'.
@@ -422,7 +430,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int LIBRARY_ELEMENT__VALIDATE_PACKAGE = 30;
+	public static final int LIBRARY_ELEMENT__VALIDATE_PACKAGE = 31;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Event Usage' of 'Simple FB Type'.
@@ -430,7 +438,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int SIMPLE_FB_TYPE__VALIDATE_EVENT_USAGE = 31;
+	public static final int SIMPLE_FB_TYPE__VALIDATE_EVENT_USAGE = 32;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Type' of 'Typed Configureable Object'.
@@ -438,7 +446,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int TYPED_CONFIGUREABLE_OBJECT__VALIDATE_TYPE = 32;
+	public static final int TYPED_CONFIGUREABLE_OBJECT__VALIDATE_TYPE = 33;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Name' of 'Var Config Instance'.
@@ -446,7 +454,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_CONFIG_INSTANCE__VALIDATE_NAME = 33;
+	public static final int VAR_CONFIG_INSTANCE__VALIDATE_NAME = 34;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Multiple Input Connections' of 'Var Declaration'.
@@ -454,7 +462,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_MULTIPLE_INPUT_CONNECTIONS = 34;
+	public static final int VAR_DECLARATION__VALIDATE_MULTIPLE_INPUT_CONNECTIONS = 35;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate No Value For Generic Type Variable' of 'Var Declaration'.
@@ -462,7 +470,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_NO_VALUE_FOR_GENERIC_TYPE_VARIABLE = 35;
+	public static final int VAR_DECLARATION__VALIDATE_NO_VALUE_FOR_GENERIC_TYPE_VARIABLE = 36;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Illegal Variable Length Array Variable' of 'Var Declaration'.
@@ -470,7 +478,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_ILLEGAL_VARIABLE_LENGTH_ARRAY_VARIABLE = 36;
+	public static final int VAR_DECLARATION__VALIDATE_ILLEGAL_VARIABLE_LENGTH_ARRAY_VARIABLE = 37;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate No Value For Variable Length Array Variable' of 'Var Declaration'.
@@ -478,7 +486,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_NO_VALUE_FOR_VARIABLE_LENGTH_ARRAY_VARIABLE = 37;
+	public static final int VAR_DECLARATION__VALIDATE_NO_VALUE_FOR_VARIABLE_LENGTH_ARRAY_VARIABLE = 38;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Value For Generic Instance Variable' of 'Var Declaration'.
@@ -486,7 +494,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_VALUE_FOR_GENERIC_INSTANCE_VARIABLE = 38;
+	public static final int VAR_DECLARATION__VALIDATE_VALUE_FOR_GENERIC_INSTANCE_VARIABLE = 39;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Value Overridden By Sub App Input' of 'Var Declaration'.
@@ -494,7 +502,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_VALUE_OVERRIDDEN_BY_SUB_APP_INPUT = 39;
+	public static final int VAR_DECLARATION__VALIDATE_VALUE_OVERRIDDEN_BY_SUB_APP_INPUT = 40;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Var In Out Source Type Is Well Defined' of 'Var Declaration'.
@@ -502,7 +510,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_VAR_IN_OUT_SOURCE_TYPE_IS_WELL_DEFINED = 40;
+	public static final int VAR_DECLARATION__VALIDATE_VAR_IN_OUT_SOURCE_TYPE_IS_WELL_DEFINED = 41;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Var In Out Is Withed' of 'Var Declaration'.
@@ -510,7 +518,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_VAR_IN_OUT_IS_WITHED = 41;
+	public static final int VAR_DECLARATION__VALIDATE_VAR_IN_OUT_IS_WITHED = 42;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Var In Out Subapp Interface' of 'Var Declaration'.
@@ -518,7 +526,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_VAR_IN_OUT_SUBAPP_INTERFACE = 42;
+	public static final int VAR_DECLARATION__VALIDATE_VAR_IN_OUT_SUBAPP_INTERFACE = 43;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Var In Out Subapp Network' of 'Var Declaration'.
@@ -526,7 +534,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_VAR_IN_OUT_SUBAPP_NETWORK = 43;
+	public static final int VAR_DECLARATION__VALIDATE_VAR_IN_OUT_SUBAPP_NETWORK = 44;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Destination Type Mismatch' of 'Var Declaration'.
@@ -534,7 +542,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_DESTINATION_TYPE_MISMATCH = 44;
+	public static final int VAR_DECLARATION__VALIDATE_DESTINATION_TYPE_MISMATCH = 45;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Hidden Pin Connected' of 'Var Declaration'.
@@ -542,7 +550,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_HIDDEN_PIN_CONNECTED = 45;
+	public static final int VAR_DECLARATION__VALIDATE_HIDDEN_PIN_CONNECTED = 46;
 
 	/**
 	 * A constant with a fixed name that can be used as the base value for additional hand written constants.
@@ -550,7 +558,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	private static final int GENERATED_DIAGNOSTIC_CODE_COUNT = 45;
+	private static final int GENERATED_DIAGNOSTIC_CODE_COUNT = 46;
 
 	/**
 	 * A constant with a fixed name that can be used as the base value for additional hand written constants in a derived class.
@@ -2028,7 +2036,18 @@ public class LibraryElementValidator extends EObjectValidator {
 		if (result || diagnostics != null) result &= validate_EveryMapEntryUnique(event, diagnostics, context);
 		if (result || diagnostics != null) result &= validateIInterfaceElement_validateName(event, diagnostics, context);
 		if (result || diagnostics != null) result &= validateITypedElement_validateType(event, diagnostics, context);
+		if (result || diagnostics != null) result &= validateEvent_validateMultipleOutputConnections(event, diagnostics, context);
 		return result;
+	}
+
+	/**
+	 * Validates the validateMultipleOutputConnections constraint of '<em>Event</em>'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public boolean validateEvent_validateMultipleOutputConnections(Event event, DiagnosticChain diagnostics, Map<Object, Object> context) {
+		return event.validateMultipleOutputConnections(diagnostics, context);
 	}
 
 	/**

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/Messages.java
@@ -87,6 +87,8 @@ public final class Messages extends NLS {
 	public static String AttributeAnnotations_MissingAttributeDeclaration;
 
 	public static String ErrorMarkerInterfaceAnnotations_MissingVariableForValue;
+
+	public static String EventAnnotations_MultipleOutputConnections;
 	public static String FBNetworkAnnotations_CollisionMessage;
 	public static String FBNetworkAnnotations_InterfaceBarCollisionMessage;
 

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/EventAnnotations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/EventAnnotations.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Martin Erich Jobst
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Martin Jobst - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.model.libraryElement.impl;
+
+import java.util.Map;
+
+import org.eclipse.emf.common.util.BasicDiagnostic;
+import org.eclipse.emf.common.util.Diagnostic;
+import org.eclipse.emf.common.util.DiagnosticChain;
+import org.eclipse.fordiac.ide.model.Messages;
+import org.eclipse.fordiac.ide.model.errormarker.FordiacMarkerHelper;
+import org.eclipse.fordiac.ide.model.libraryElement.Event;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
+import org.eclipse.fordiac.ide.model.libraryElement.util.LibraryElementValidator;
+import org.eclipse.fordiac.ide.model.validation.ValidationPreferences;
+
+public final class EventAnnotations {
+
+	public static boolean validateMultipleOutputConnections(final Event event, final DiagnosticChain diagnostics,
+			final Map<Object, Object> context) {
+		if (event.getOutputConnections().size() > 1) {
+			if (diagnostics != null) {
+				diagnostics.add(new BasicDiagnostic(
+						ValidationPreferences.getDiagnosticSeverity(
+								ValidationPreferences.EVENT_MULTIPLE_OUTPUT_CONNECTIONS, Diagnostic.OK, event),
+						LibraryElementValidator.DIAGNOSTIC_SOURCE,
+						LibraryElementValidator.EVENT__VALIDATE_MULTIPLE_OUTPUT_CONNECTIONS,
+						Messages.EventAnnotations_MultipleOutputConnections, FordiacMarkerHelper.getDiagnosticData(
+								event, LibraryElementPackage.Literals.IINTERFACE_ELEMENT__OUTPUT_CONNECTIONS)));
+			}
+			return false;
+		}
+		return true;
+	}
+
+	private EventAnnotations() {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/validation/PreferenceInitializer.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/validation/PreferenceInitializer.java
@@ -30,6 +30,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 				ValidationPreferences.SEVERITY_IGNORE);
 		preferences.put(ValidationPreferences.VALUE_FOR_GENERIC_INSTANCE_VARIABLE,
 				ValidationPreferences.SEVERITY_WARNING);
+		preferences.put(ValidationPreferences.EVENT_MULTIPLE_OUTPUT_CONNECTIONS, ValidationPreferences.SEVERITY_IGNORE);
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/validation/ValidationPreferences.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/validation/ValidationPreferences.java
@@ -35,6 +35,7 @@ public final class ValidationPreferences {
 	public static final String PACKAGENAME_MISMATCH_FOLDER = "packagenameMismatchFolder"; //$NON-NLS-1$
 	public static final String NO_VALUE_FOR_GENERIC_TYPE_VARIABLE = "noValueForGenericTypeVariable"; //$NON-NLS-1$
 	public static final String VALUE_FOR_GENERIC_INSTANCE_VARIABLE = "valueForGenericInstanceVariable"; //$NON-NLS-1$
+	public static final String EVENT_MULTIPLE_OUTPUT_CONNECTIONS = "eventMultipleOutputConnections"; //$NON-NLS-1$
 
 	public static int getDiagnosticSeverity(final String key, final int defaultValue, final EObject context) {
 		final Resource resource = context != null ? context.eResource() : null;


### PR DESCRIPTION
Add validation for multiple output connections on event, which may lead to undefined execution order. This validation is disabled by default.