### PR TITLE
Validate unused FB and SubApp instances

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.ui/plugin.properties
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/plugin.properties
@@ -82,4 +82,5 @@ ValidationJob_ValidationJobName=Validate {0}
 ValidationPreferencePage_EventMultipleOutputConnections=Multiple output connections on event may lead to undefined execution order
 ValidationPreferencePage_NoValueForGenericTypeVariable=Should not specify a value for variable of generic type in defining type
 ValidationPreferencePage_PotentialProgrammingProblems=Potential programming problems
+ValidationPreferencePage_UnusedInstance=An FB or SubApp instance is never executed, since it has no incoming event connections
 ValidationPreferencePage_ValueForGenericInstanceVariable=Should specify a value for unconnected variable of generic type in instance

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/Messages.java
@@ -88,6 +88,7 @@ public final class Messages extends NLS {
 	public static String ValidationPreferencePage_EventMultipleOutputConnections;
 	public static String ValidationPreferencePage_NoValueForGenericTypeVariable;
 	public static String ValidationPreferencePage_PotentialProgrammingProblems;
+	public static String ValidationPreferencePage_UnusedInstance;
 	public static String ValidationPreferencePage_ValueForGenericInstanceVariable;
 
 	static {

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/preferences/ValidationPreferencePage.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/preferences/ValidationPreferencePage.java
@@ -74,6 +74,8 @@ public class ValidationPreferencePage extends FordiacPropertyPreferencePage {
 		addField(new ComboFieldEditor(ValidationPreferences.EVENT_MULTIPLE_OUTPUT_CONNECTIONS,
 				Messages.ValidationPreferencePage_EventMultipleOutputConnections, SEVERITIES,
 				potentialProblemsSection));
+		addField(new ComboFieldEditor(ValidationPreferences.UNUSED_INSTANCE,
+				Messages.ValidationPreferencePage_UnusedInstance, SEVERITIES, potentialProblemsSection));
 	}
 
 	private static Composite createSection(final String label, final Composite composite, final boolean expanded) {

--- a/plugins/org.eclipse.fordiac.ide.model/model/fordiac.genmodel
+++ b/plugins/org.eclipse.fordiac.ide.model/model/fordiac.genmodel
@@ -150,6 +150,11 @@
           body="if(!(newTypeEntry instanceof org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry)){&#xA;&#x9;throw new IllegalArgumentException(&quot;Non InterfaceTypeEntry given in setTypeEntry of BlockFBNetworkElement&quot;);  //$NON-NLS-1$&#xA;}&#xA;super.setTypeEntry(newTypeEntry);&#xA;">
         <genParameters ecoreParameter="lib.ecore#//BlockFBNetworkElement/setTypeEntry/newTypeEntry"/>
       </genOperations>
+      <genOperations ecoreOperation="lib.ecore#//BlockFBNetworkElement/validateUnused"
+          body="return org.eclipse.fordiac.ide.model.libraryElement.impl.BlockFBNetworkElementAnnotations.validateUnused(this, diagnostics, context);">
+        <genParameters ecoreParameter="lib.ecore#//BlockFBNetworkElement/validateUnused/diagnostics"/>
+        <genParameters ecoreParameter="lib.ecore#//BlockFBNetworkElement/validateUnused/context"/>
+      </genOperations>
     </genClasses>
     <genClasses ecoreClass="lib.ecore#//CFBInstance">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference lib.ecore#//CFBInstance/cfbNetwork"/>

--- a/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
+++ b/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
@@ -324,6 +324,21 @@
       </eAnnotations>
       <eParameters name="newTypeEntry" eType="#//TypeEntry"/>
     </eOperations>
+    <eOperations name="validateUnused" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore">
+        <details key="invariant" value="true"/>
+      </eAnnotations>
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="body" value="return org.eclipse.fordiac.ide.model.libraryElement.impl.BlockFBNetworkElementAnnotations.validateUnused(this, diagnostics, context);"/>
+      </eAnnotations>
+      <eParameters name="diagnostics" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDiagnosticChain"/>
+      <eParameters name="context">
+        <eGenericType eClassifier="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EMap">
+          <eTypeArguments eClassifier="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EJavaObject"/>
+          <eTypeArguments eClassifier="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EJavaObject"/>
+        </eGenericType>
+      </eParameters>
+    </eOperations>
     <eStructuralFeatures xsi:type="ecore:EReference" name="interface" eType="#//InterfaceList"
         containment="true" eOpposite="#//InterfaceList/BlockFBNetworkElement"/>
   </eClassifiers>

--- a/plugins/org.eclipse.fordiac.ide.model/plugin.properties
+++ b/plugins/org.eclipse.fordiac.ide.model/plugin.properties
@@ -59,6 +59,7 @@ ConnectionValidator_VarInOutStringSizeMismatch=String length {0} does not match 
 ConnectionValidator_NegatedConnectionIsNotValid=Only connections between normal BOOL variables may be negated
 ContainerVarDeclarationAnnotations_MemberInitialValue=A member already has an initial value
 ContainerVarDeclarationAnnotations_MemberInputConnection=A member is already connected for this input
+BlockFBNetworkElementAnnotations_Unused=The instance ''{0}'' is never executed, since it has no incoming event connections
 DataTypeExporter_UNSUPPORTED_DATA_TYPE=This data type is not (yet) supported: {0}
 DataTypeImporter_UNSUPPORTED_DATATYPE_IN_FILE=Unsupported data type in {0}
 DataTypeLibrary_InvalidMaxLengthInStringType=Invalid max length in string type ''{0}''

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/BlockFBNetworkElement.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/BlockFBNetworkElement.java
@@ -16,6 +16,8 @@
  */
 package org.eclipse.fordiac.ide.model.libraryElement;
 
+import java.util.Map;
+import org.eclipse.emf.common.util.DiagnosticChain;
 import org.eclipse.fordiac.ide.model.typelibrary.InterfaceTypeEntry;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 
@@ -109,4 +111,12 @@ public interface BlockFBNetworkElement extends FBNetworkElement {
 	 * @generated
 	 */
 	void setTypeEntry(TypeEntry newTypeEntry);
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @model annotation="http://www.eclipse.org/emf/2002/Ecore invariant='true'"
+	 * @generated
+	 */
+	boolean validateUnused(DiagnosticChain diagnostics, Map<Object, Object> context);
 } // BlockFBNetworkElement

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/BlockFBNetworkElementImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/BlockFBNetworkElementImpl.java
@@ -16,8 +16,10 @@
  */
 package org.eclipse.fordiac.ide.model.libraryElement.impl;
 
+import java.util.Map;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;
+import org.eclipse.emf.common.util.DiagnosticChain;
 import org.eclipse.emf.ecore.EClass;
 
 import org.eclipse.emf.ecore.InternalEObject;
@@ -209,6 +211,16 @@ public abstract class BlockFBNetworkElementImpl extends FBNetworkElementImpl imp
 		}
 		super.setTypeEntry(newTypeEntry);
 		
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public boolean validateUnused(final DiagnosticChain diagnostics, final Map<Object, Object> context) {
+		return org.eclipse.fordiac.ide.model.libraryElement.impl.BlockFBNetworkElementAnnotations.validateUnused(this, diagnostics, context);
 	}
 
 	/**

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
@@ -5283,6 +5283,15 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 		op = addEOperation(blockFBNetworkElementEClass, null, "setTypeEntry", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 		addEParameter(op, this.getTypeEntry(), "newTypeEntry", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
+		op = addEOperation(blockFBNetworkElementEClass, ecorePackage.getEBoolean(), "validateUnused", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEParameter(op, ecorePackage.getEDiagnosticChain(), "diagnostics", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		g1 = createEGenericType(ecorePackage.getEMap());
+		g2 = createEGenericType(ecorePackage.getEJavaObject());
+		g1.getETypeArguments().add(g2);
+		g2 = createEGenericType(ecorePackage.getEJavaObject());
+		g1.getETypeArguments().add(g2);
+		addEParameter(op, g1, "context", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+
 		initEClass(cfbInstanceEClass, CFBInstance.class, "CFBInstance", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getCFBInstance_CfbNetwork(), this.getFBNetwork(), null, "cfbNetwork", null, 0, 1, CFBInstance.class, IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
@@ -7154,6 +7163,12 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 		   });
 		addAnnotation
 		  (baseFBTypeEClass.getEOperations().get(1),
+		   source,
+		   new String[] {
+			   "invariant", "true" //$NON-NLS-1$ //$NON-NLS-2$
+		   });
+		addAnnotation
+		  (blockFBNetworkElementEClass.getEOperations().get(6),
 		   source,
 		   new String[] {
 			   "invariant", "true" //$NON-NLS-1$ //$NON-NLS-2$

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/util/LibraryElementValidator.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/util/LibraryElementValidator.java
@@ -209,12 +209,20 @@ public class LibraryElementValidator extends EObjectValidator {
 	public static final int BASE_FB_TYPE__VALIDATE_INTERNAL_FBS = 3;
 
 	/**
+	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Unused' of 'Block FB Network Element'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public static final int BLOCK_FB_NETWORK_ELEMENT__VALIDATE_UNUSED = 4;
+
+	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Package Name' of 'Compiler Info'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int COMPILER_INFO__VALIDATE_PACKAGE_NAME = 4;
+	public static final int COMPILER_INFO__VALIDATE_PACKAGE_NAME = 5;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Data Type' of 'Configurable FB'.
@@ -222,7 +230,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONFIGURABLE_FB__VALIDATE_DATA_TYPE = 5;
+	public static final int CONFIGURABLE_FB__VALIDATE_DATA_TYPE = 6;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Missing Source' of 'Connection'.
@@ -230,7 +238,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONNECTION__VALIDATE_MISSING_SOURCE = 6;
+	public static final int CONNECTION__VALIDATE_MISSING_SOURCE = 7;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Missing Source Endpoint' of 'Connection'.
@@ -238,7 +246,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONNECTION__VALIDATE_MISSING_SOURCE_ENDPOINT = 7;
+	public static final int CONNECTION__VALIDATE_MISSING_SOURCE_ENDPOINT = 8;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Missing Destination' of 'Connection'.
@@ -246,7 +254,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONNECTION__VALIDATE_MISSING_DESTINATION = 8;
+	public static final int CONNECTION__VALIDATE_MISSING_DESTINATION = 9;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Missing Destination Endpoint' of 'Connection'.
@@ -254,7 +262,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONNECTION__VALIDATE_MISSING_DESTINATION_ENDPOINT = 9;
+	public static final int CONNECTION__VALIDATE_MISSING_DESTINATION_ENDPOINT = 10;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Duplicate' of 'Connection'.
@@ -262,7 +270,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONNECTION__VALIDATE_DUPLICATE = 10;
+	public static final int CONNECTION__VALIDATE_DUPLICATE = 11;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Type Mismatch' of 'Connection'.
@@ -270,7 +278,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONNECTION__VALIDATE_TYPE_MISMATCH = 11;
+	public static final int CONNECTION__VALIDATE_TYPE_MISMATCH = 12;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Mapped Var In Outs Do Not Cross Resource Boundaries' of 'Connection'.
@@ -278,7 +286,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONNECTION__VALIDATE_MAPPED_VAR_IN_OUTS_DO_NOT_CROSS_RESOURCE_BOUNDARIES = 12;
+	public static final int CONNECTION__VALIDATE_MAPPED_VAR_IN_OUTS_DO_NOT_CROSS_RESOURCE_BOUNDARIES = 13;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Var In Out Array Sizes Are Compatible' of 'Connection'.
@@ -286,7 +294,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONNECTION__VALIDATE_VAR_IN_OUT_ARRAY_SIZES_ARE_COMPATIBLE = 13;
+	public static final int CONNECTION__VALIDATE_VAR_IN_OUT_ARRAY_SIZES_ARE_COMPATIBLE = 14;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Var In Out String Lengths Match' of 'Connection'.
@@ -294,7 +302,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONNECTION__VALIDATE_VAR_IN_OUT_STRING_LENGTHS_MATCH = 14;
+	public static final int CONNECTION__VALIDATE_VAR_IN_OUT_STRING_LENGTHS_MATCH = 15;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Var In Outs Are Not Connected To Outs' of 'Connection'.
@@ -302,7 +310,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONNECTION__VALIDATE_VAR_IN_OUTS_ARE_NOT_CONNECTED_TO_OUTS = 15;
+	public static final int CONNECTION__VALIDATE_VAR_IN_OUTS_ARE_NOT_CONNECTED_TO_OUTS = 16;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Var In Out Connections Forms No Loop' of 'Connection'.
@@ -310,7 +318,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONNECTION__VALIDATE_VAR_IN_OUT_CONNECTIONS_FORMS_NO_LOOP = 16;
+	public static final int CONNECTION__VALIDATE_VAR_IN_OUT_CONNECTIONS_FORMS_NO_LOOP = 17;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Negated Connection' of 'Connection'.
@@ -318,7 +326,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONNECTION__VALIDATE_NEGATED_CONNECTION = 17;
+	public static final int CONNECTION__VALIDATE_NEGATED_CONNECTION = 18;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Member Input Connections' of 'Container Var Declaration'.
@@ -326,7 +334,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONTAINER_VAR_DECLARATION__VALIDATE_MEMBER_INPUT_CONNECTIONS = 18;
+	public static final int CONTAINER_VAR_DECLARATION__VALIDATE_MEMBER_INPUT_CONNECTIONS = 19;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Member Initial Values' of 'Container Var Declaration'.
@@ -334,7 +342,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int CONTAINER_VAR_DECLARATION__VALIDATE_MEMBER_INITIAL_VALUES = 19;
+	public static final int CONTAINER_VAR_DECLARATION__VALIDATE_MEMBER_INITIAL_VALUES = 20;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Value' of 'Error Marker Interface'.
@@ -342,7 +350,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int ERROR_MARKER_INTERFACE__VALIDATE_VALUE = 20;
+	public static final int ERROR_MARKER_INTERFACE__VALIDATE_VALUE = 21;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Attributes' of 'Error Marker Interface'.
@@ -350,7 +358,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int ERROR_MARKER_INTERFACE__VALIDATE_ATTRIBUTES = 21;
+	public static final int ERROR_MARKER_INTERFACE__VALIDATE_ATTRIBUTES = 22;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Multiple Output Connections' of 'Event'.
@@ -358,7 +366,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int EVENT__VALIDATE_MULTIPLE_OUTPUT_CONNECTIONS = 22;
+	public static final int EVENT__VALIDATE_MULTIPLE_OUTPUT_CONNECTIONS = 23;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Collisions' of 'FB Network'.
@@ -366,7 +374,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int FB_NETWORK__VALIDATE_COLLISIONS = 23;
+	public static final int FB_NETWORK__VALIDATE_COLLISIONS = 24;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Name' of 'FB Network Element'.
@@ -374,7 +382,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int FB_NETWORK_ELEMENT__VALIDATE_NAME = 24;
+	public static final int FB_NETWORK_ELEMENT__VALIDATE_NAME = 25;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Type' of 'FB Network Element'.
@@ -382,7 +390,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int FB_NETWORK_ELEMENT__VALIDATE_TYPE = 25;
+	public static final int FB_NETWORK_ELEMENT__VALIDATE_TYPE = 26;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Collisions' of 'Group'.
@@ -390,7 +398,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int GROUP__VALIDATE_COLLISIONS = 26;
+	public static final int GROUP__VALIDATE_COLLISIONS = 27;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Name' of 'IInterface Element'.
@@ -398,7 +406,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int IINTERFACE_ELEMENT__VALIDATE_NAME = 27;
+	public static final int IINTERFACE_ELEMENT__VALIDATE_NAME = 28;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Name' of 'INamed Element'.
@@ -406,7 +414,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int INAMED_ELEMENT__VALIDATE_NAME = 28;
+	public static final int INAMED_ELEMENT__VALIDATE_NAME = 29;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Type' of 'ITyped Element'.
@@ -414,7 +422,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int ITYPED_ELEMENT__VALIDATE_TYPE = 29;
+	public static final int ITYPED_ELEMENT__VALIDATE_TYPE = 30;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Name' of 'Library Element'.
@@ -422,7 +430,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int LIBRARY_ELEMENT__VALIDATE_NAME = 30;
+	public static final int LIBRARY_ELEMENT__VALIDATE_NAME = 31;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Package' of 'Library Element'.
@@ -430,7 +438,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int LIBRARY_ELEMENT__VALIDATE_PACKAGE = 31;
+	public static final int LIBRARY_ELEMENT__VALIDATE_PACKAGE = 32;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Event Usage' of 'Simple FB Type'.
@@ -438,7 +446,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int SIMPLE_FB_TYPE__VALIDATE_EVENT_USAGE = 32;
+	public static final int SIMPLE_FB_TYPE__VALIDATE_EVENT_USAGE = 33;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Type' of 'Typed Configureable Object'.
@@ -446,7 +454,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int TYPED_CONFIGUREABLE_OBJECT__VALIDATE_TYPE = 33;
+	public static final int TYPED_CONFIGUREABLE_OBJECT__VALIDATE_TYPE = 34;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Name' of 'Var Config Instance'.
@@ -454,7 +462,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_CONFIG_INSTANCE__VALIDATE_NAME = 34;
+	public static final int VAR_CONFIG_INSTANCE__VALIDATE_NAME = 35;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Multiple Input Connections' of 'Var Declaration'.
@@ -462,7 +470,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_MULTIPLE_INPUT_CONNECTIONS = 35;
+	public static final int VAR_DECLARATION__VALIDATE_MULTIPLE_INPUT_CONNECTIONS = 36;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate No Value For Generic Type Variable' of 'Var Declaration'.
@@ -470,7 +478,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_NO_VALUE_FOR_GENERIC_TYPE_VARIABLE = 36;
+	public static final int VAR_DECLARATION__VALIDATE_NO_VALUE_FOR_GENERIC_TYPE_VARIABLE = 37;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Illegal Variable Length Array Variable' of 'Var Declaration'.
@@ -478,7 +486,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_ILLEGAL_VARIABLE_LENGTH_ARRAY_VARIABLE = 37;
+	public static final int VAR_DECLARATION__VALIDATE_ILLEGAL_VARIABLE_LENGTH_ARRAY_VARIABLE = 38;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate No Value For Variable Length Array Variable' of 'Var Declaration'.
@@ -486,7 +494,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_NO_VALUE_FOR_VARIABLE_LENGTH_ARRAY_VARIABLE = 38;
+	public static final int VAR_DECLARATION__VALIDATE_NO_VALUE_FOR_VARIABLE_LENGTH_ARRAY_VARIABLE = 39;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Value For Generic Instance Variable' of 'Var Declaration'.
@@ -494,7 +502,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_VALUE_FOR_GENERIC_INSTANCE_VARIABLE = 39;
+	public static final int VAR_DECLARATION__VALIDATE_VALUE_FOR_GENERIC_INSTANCE_VARIABLE = 40;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Value Overridden By Sub App Input' of 'Var Declaration'.
@@ -502,7 +510,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_VALUE_OVERRIDDEN_BY_SUB_APP_INPUT = 40;
+	public static final int VAR_DECLARATION__VALIDATE_VALUE_OVERRIDDEN_BY_SUB_APP_INPUT = 41;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Var In Out Source Type Is Well Defined' of 'Var Declaration'.
@@ -510,7 +518,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_VAR_IN_OUT_SOURCE_TYPE_IS_WELL_DEFINED = 41;
+	public static final int VAR_DECLARATION__VALIDATE_VAR_IN_OUT_SOURCE_TYPE_IS_WELL_DEFINED = 42;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Var In Out Is Withed' of 'Var Declaration'.
@@ -518,7 +526,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_VAR_IN_OUT_IS_WITHED = 42;
+	public static final int VAR_DECLARATION__VALIDATE_VAR_IN_OUT_IS_WITHED = 43;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Var In Out Subapp Interface' of 'Var Declaration'.
@@ -526,7 +534,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_VAR_IN_OUT_SUBAPP_INTERFACE = 43;
+	public static final int VAR_DECLARATION__VALIDATE_VAR_IN_OUT_SUBAPP_INTERFACE = 44;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Var In Out Subapp Network' of 'Var Declaration'.
@@ -534,7 +542,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_VAR_IN_OUT_SUBAPP_NETWORK = 44;
+	public static final int VAR_DECLARATION__VALIDATE_VAR_IN_OUT_SUBAPP_NETWORK = 45;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Destination Type Mismatch' of 'Var Declaration'.
@@ -542,7 +550,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_DESTINATION_TYPE_MISMATCH = 45;
+	public static final int VAR_DECLARATION__VALIDATE_DESTINATION_TYPE_MISMATCH = 46;
 
 	/**
 	 * The {@link org.eclipse.emf.common.util.Diagnostic#getCode() code} for constraint 'Validate Hidden Pin Connected' of 'Var Declaration'.
@@ -550,7 +558,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public static final int VAR_DECLARATION__VALIDATE_HIDDEN_PIN_CONNECTED = 46;
+	public static final int VAR_DECLARATION__VALIDATE_HIDDEN_PIN_CONNECTED = 47;
 
 	/**
 	 * A constant with a fixed name that can be used as the base value for additional hand written constants.
@@ -558,7 +566,7 @@ public class LibraryElementValidator extends EObjectValidator {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	private static final int GENERATED_DIAGNOSTIC_CODE_COUNT = 46;
+	private static final int GENERATED_DIAGNOSTIC_CODE_COUNT = 47;
 
 	/**
 	 * A constant with a fixed name that can be used as the base value for additional hand written constants in a derived class.
@@ -937,6 +945,7 @@ public class LibraryElementValidator extends EObjectValidator {
 		if (result || diagnostics != null) result &= validate_EveryMapEntryUnique(adapterFB, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateName(adapterFB, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateType(adapterFB, diagnostics, context);
+		if (result || diagnostics != null) result &= validateBlockFBNetworkElement_validateUnused(adapterFB, diagnostics, context);
 		return result;
 	}
 
@@ -1158,7 +1167,18 @@ public class LibraryElementValidator extends EObjectValidator {
 		if (result || diagnostics != null) result &= validate_EveryMapEntryUnique(blockFBNetworkElement, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateName(blockFBNetworkElement, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateType(blockFBNetworkElement, diagnostics, context);
+		if (result || diagnostics != null) result &= validateBlockFBNetworkElement_validateUnused(blockFBNetworkElement, diagnostics, context);
 		return result;
+	}
+
+	/**
+	 * Validates the validateUnused constraint of '<em>Block FB Network Element</em>'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public boolean validateBlockFBNetworkElement_validateUnused(BlockFBNetworkElement blockFBNetworkElement, DiagnosticChain diagnostics, Map<Object, Object> context) {
+		return blockFBNetworkElement.validateUnused(diagnostics, context);
 	}
 
 	/**
@@ -1178,6 +1198,7 @@ public class LibraryElementValidator extends EObjectValidator {
 		if (result || diagnostics != null) result &= validate_EveryMapEntryUnique(cfbInstance, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateName(cfbInstance, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateType(cfbInstance, diagnostics, context);
+		if (result || diagnostics != null) result &= validateBlockFBNetworkElement_validateUnused(cfbInstance, diagnostics, context);
 		return result;
 	}
 
@@ -1236,6 +1257,7 @@ public class LibraryElementValidator extends EObjectValidator {
 		if (result || diagnostics != null) result &= validate_EveryMapEntryUnique(communicationChannel, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateName(communicationChannel, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateType(communicationChannel, diagnostics, context);
+		if (result || diagnostics != null) result &= validateBlockFBNetworkElement_validateUnused(communicationChannel, diagnostics, context);
 		return result;
 	}
 
@@ -1351,6 +1373,7 @@ public class LibraryElementValidator extends EObjectValidator {
 		if (result || diagnostics != null) result &= validate_EveryMapEntryUnique(configurableFB, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateName(configurableFB, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateType(configurableFB, diagnostics, context);
+		if (result || diagnostics != null) result &= validateBlockFBNetworkElement_validateUnused(configurableFB, diagnostics, context);
 		if (result || diagnostics != null) result &= validateConfigurableFB_validateDataType(configurableFB, diagnostics, context);
 		return result;
 	}
@@ -1382,6 +1405,7 @@ public class LibraryElementValidator extends EObjectValidator {
 		if (result || diagnostics != null) result &= validate_EveryMapEntryUnique(configurableMoveFB, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateName(configurableMoveFB, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateType(configurableMoveFB, diagnostics, context);
+		if (result || diagnostics != null) result &= validateBlockFBNetworkElement_validateUnused(configurableMoveFB, diagnostics, context);
 		if (result || diagnostics != null) result &= validateConfigurableFB_validateDataType(configurableMoveFB, diagnostics, context);
 		return result;
 	}
@@ -1646,6 +1670,7 @@ public class LibraryElementValidator extends EObjectValidator {
 		if (result || diagnostics != null) result &= validate_EveryMapEntryUnique(demultiplexer, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateName(demultiplexer, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateType(demultiplexer, diagnostics, context);
+		if (result || diagnostics != null) result &= validateBlockFBNetworkElement_validateUnused(demultiplexer, diagnostics, context);
 		if (result || diagnostics != null) result &= validateConfigurableFB_validateDataType(demultiplexer, diagnostics, context);
 		return result;
 	}
@@ -1914,6 +1939,7 @@ public class LibraryElementValidator extends EObjectValidator {
 		if (result || diagnostics != null) result &= validate_EveryMapEntryUnique(errorMarkerFBNElement, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateName(errorMarkerFBNElement, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateType(errorMarkerFBNElement, diagnostics, context);
+		if (result || diagnostics != null) result &= validateBlockFBNetworkElement_validateUnused(errorMarkerFBNElement, diagnostics, context);
 		return result;
 	}
 
@@ -2097,6 +2123,7 @@ public class LibraryElementValidator extends EObjectValidator {
 		if (result || diagnostics != null) result &= validate_EveryMapEntryUnique(fb, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateName(fb, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateType(fb, diagnostics, context);
+		if (result || diagnostics != null) result &= validateBlockFBNetworkElement_validateUnused(fb, diagnostics, context);
 		return result;
 	}
 
@@ -2637,6 +2664,7 @@ public class LibraryElementValidator extends EObjectValidator {
 		if (result || diagnostics != null) result &= validate_EveryMapEntryUnique(multiplexer, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateName(multiplexer, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateType(multiplexer, diagnostics, context);
+		if (result || diagnostics != null) result &= validateBlockFBNetworkElement_validateUnused(multiplexer, diagnostics, context);
 		if (result || diagnostics != null) result &= validateConfigurableFB_validateDataType(multiplexer, diagnostics, context);
 		return result;
 	}
@@ -2790,6 +2818,7 @@ public class LibraryElementValidator extends EObjectValidator {
 		if (result || diagnostics != null) result &= validate_EveryMapEntryUnique(resourceTypeFB, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateName(resourceTypeFB, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateType(resourceTypeFB, diagnostics, context);
+		if (result || diagnostics != null) result &= validateBlockFBNetworkElement_validateUnused(resourceTypeFB, diagnostics, context);
 		return result;
 	}
 
@@ -3052,6 +3081,7 @@ public class LibraryElementValidator extends EObjectValidator {
 		if (result || diagnostics != null) result &= validate_EveryMapEntryUnique(structManipulator, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateName(structManipulator, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateType(structManipulator, diagnostics, context);
+		if (result || diagnostics != null) result &= validateBlockFBNetworkElement_validateUnused(structManipulator, diagnostics, context);
 		if (result || diagnostics != null) result &= validateConfigurableFB_validateDataType(structManipulator, diagnostics, context);
 		return result;
 	}
@@ -3073,6 +3103,7 @@ public class LibraryElementValidator extends EObjectValidator {
 		if (result || diagnostics != null) result &= validate_EveryMapEntryUnique(subApp, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateName(subApp, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateType(subApp, diagnostics, context);
+		if (result || diagnostics != null) result &= validateBlockFBNetworkElement_validateUnused(subApp, diagnostics, context);
 		return result;
 	}
 
@@ -3218,6 +3249,7 @@ public class LibraryElementValidator extends EObjectValidator {
 		if (result || diagnostics != null) result &= validate_EveryMapEntryUnique(typedSubApp, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateName(typedSubApp, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateType(typedSubApp, diagnostics, context);
+		if (result || diagnostics != null) result &= validateBlockFBNetworkElement_validateUnused(typedSubApp, diagnostics, context);
 		return result;
 	}
 
@@ -3238,6 +3270,7 @@ public class LibraryElementValidator extends EObjectValidator {
 		if (result || diagnostics != null) result &= validate_EveryMapEntryUnique(untypedSubApp, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateName(untypedSubApp, diagnostics, context);
 		if (result || diagnostics != null) result &= validateFBNetworkElement_validateType(untypedSubApp, diagnostics, context);
+		if (result || diagnostics != null) result &= validateBlockFBNetworkElement_validateUnused(untypedSubApp, diagnostics, context);
 		return result;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/Messages.java
@@ -251,6 +251,8 @@ public final class Messages extends NLS {
 
 	public static String BaseFBTypeAnnotations_UnsupportedInternalFBType;
 
+	public static String BlockFBNetworkElementAnnotations_Unused;
+
 	public static String SystemImporter_Mapping_WrongString;
 	public static String SystemImporter_Mapping_MissingDevice;
 	public static String SystemImporter_Mapping_MissingResource;

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/BlockFBNetworkElementAnnotations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/BlockFBNetworkElementAnnotations.java
@@ -1,7 +1,8 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
- *                          Johannes Kepler University,
- *                          Primetals Technologies Austria GmbH
+ * Copyright (c) 2008 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
+ *                    Johannes Kepler University,
+ *                    Primetals Technologies Austria GmbH
+ *                    Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,11 +20,26 @@
  *                   sub-app support
  *   			   - extracted from annotations class and extended with group
  *   			     functions
+ *   Martin Erich Jobst - add unused validation
  *******************************************************************************/
 package org.eclipse.fordiac.ide.model.libraryElement.impl;
 
+import java.text.MessageFormat;
+import java.util.Collection;
+import java.util.Map;
+
+import org.eclipse.emf.common.util.BasicDiagnostic;
+import org.eclipse.emf.common.util.Diagnostic;
+import org.eclipse.emf.common.util.DiagnosticChain;
+import org.eclipse.fordiac.ide.model.Messages;
+import org.eclipse.fordiac.ide.model.errormarker.FordiacMarkerHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.Connection;
+import org.eclipse.fordiac.ide.model.libraryElement.Event;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
+import org.eclipse.fordiac.ide.model.libraryElement.util.LibraryElementValidator;
+import org.eclipse.fordiac.ide.model.typelibrary.EventTypeLibrary;
+import org.eclipse.fordiac.ide.model.validation.ValidationPreferences;
 
 public final class BlockFBNetworkElementAnnotations {
 
@@ -34,8 +50,40 @@ public final class BlockFBNetworkElementAnnotations {
 		});
 	}
 
+	public static boolean validateUnused(final BlockFBNetworkElement fbne, final DiagnosticChain diagnostics,
+			final Map<Object, Object> context) {
+		if (fbne.isMapped() && fbne.getMapping().getTo() == fbne) {
+			return true; // avoid duplicate error on mapped instance
+		}
+		if (isUnused(fbne) && (!fbne.isMapped() || isUnused(fbne.getOpposite()))) {
+			if (diagnostics != null) {
+				diagnostics.add(new BasicDiagnostic(
+						ValidationPreferences.getDiagnosticSeverity(ValidationPreferences.UNUSED_INSTANCE,
+								Diagnostic.WARNING, fbne),
+						LibraryElementValidator.DIAGNOSTIC_SOURCE,
+						LibraryElementValidator.BLOCK_FB_NETWORK_ELEMENT__VALIDATE_UNUSED,
+						MessageFormat.format(Messages.BlockFBNetworkElementAnnotations_Unused, fbne.getQualifiedName()),
+						FordiacMarkerHelper.getDiagnosticData(fbne,
+								LibraryElementPackage.Literals.INAMED_ELEMENT__NAME)));
+			}
+			return false;
+		}
+		return true;
+	}
+
+	private static boolean isUnused(final BlockFBNetworkElement fbne) {
+		return isUnused(fbne.getInterface().getEventInputs());
+	}
+
+	private static boolean isUnused(final Collection<? extends Event> events) {
+		return !events.isEmpty() && events.stream().allMatch(BlockFBNetworkElementAnnotations::isUnused);
+	}
+
+	private static boolean isUnused(final Event event) {
+		return event.getInputConnections().isEmpty() && !EventTypeLibrary.EINIT.equalsIgnoreCase(event.getTypeName());
+	}
+
 	private BlockFBNetworkElementAnnotations() {
 		throw new UnsupportedOperationException();
 	}
-
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/validation/PreferenceInitializer.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/validation/PreferenceInitializer.java
@@ -31,6 +31,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 		preferences.put(ValidationPreferences.VALUE_FOR_GENERIC_INSTANCE_VARIABLE,
 				ValidationPreferences.SEVERITY_WARNING);
 		preferences.put(ValidationPreferences.EVENT_MULTIPLE_OUTPUT_CONNECTIONS, ValidationPreferences.SEVERITY_IGNORE);
+		preferences.put(ValidationPreferences.UNUSED_INSTANCE, ValidationPreferences.SEVERITY_WARNING);
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/validation/ValidationPreferences.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/validation/ValidationPreferences.java
@@ -36,6 +36,7 @@ public final class ValidationPreferences {
 	public static final String NO_VALUE_FOR_GENERIC_TYPE_VARIABLE = "noValueForGenericTypeVariable"; //$NON-NLS-1$
 	public static final String VALUE_FOR_GENERIC_INSTANCE_VARIABLE = "valueForGenericInstanceVariable"; //$NON-NLS-1$
 	public static final String EVENT_MULTIPLE_OUTPUT_CONNECTIONS = "eventMultipleOutputConnections"; //$NON-NLS-1$
+	public static final String UNUSED_INSTANCE = "unusedInstance"; //$NON-NLS-1$
 
 	public static int getDiagnosticSeverity(final String key, final int defaultValue, final EObject context) {
 		final Resource resource = context != null ? context.eResource() : null;


### PR DESCRIPTION
Add validation for unused FB and SubApp instances that have no incoming event connections or EInit input events. This validation is a warning by default.