### PR TITLE
Adds workflow which marks inactive issues and PRs as stale

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,28 @@
+---
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+permissions: {}
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+        with:
+          days-before-issue-stale: 90
+          days-before-issue-close: 180
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue has been marked as stale because it has been open for 90 days with no activity."
+          close-issue-message: "This issue has been closed because it has been inactive for 180 days since being marked as stale."
+          days-before-pr-stale: 45
+          days-before-pr-close: 90
+          stale-pr-message: "This PR has been marked as stale because it has been open for 45 days with no activity."
+          close-pr-message: "This PR has been closed because it has been inactive for 90 days since being marked as stale."
+          exempt-issue-labels: "backlog"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a workflow to mark inactive issues and PRs as stale and on continued inactivity close them.