### PR TITLE
Show Edit Interface Sections also for FB instances

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.application/plugin.xml
@@ -262,20 +262,20 @@
               tab="org.eclipse.fordiac.ide.application.property.tab.EditVarInOut">
         </propertySection>
         <propertySection
-              class="org.eclipse.fordiac.ide.application.properties.EditTypedSubappInterfaceEventSection"
-              filter="org.eclipse.fordiac.ide.application.properties.TypedSubappInterfaceEditingFilter"
+              class="org.eclipse.fordiac.ide.application.properties.EditTypedInterfaceEventSection"
+              filter="org.eclipse.fordiac.ide.application.properties.TypedInterfaceEditingFilter"
               id="org.eclipse.fordiac.ide.application.properties.section.EditTypedEvents"
               tab="org.eclipse.fordiac.ide.application.property.tab.EditEvents">
         </propertySection>
         <propertySection
-              class="org.eclipse.fordiac.ide.application.properties.EditTypedSubappInterfaceDataSection"
-              filter="org.eclipse.fordiac.ide.application.properties.TypedSubappInterfaceEditingFilter"
+              class="org.eclipse.fordiac.ide.application.properties.EditTypedInterfaceDataSection"
+              filter="org.eclipse.fordiac.ide.application.properties.TypedInterfaceEditingFilter"
               id="org.eclipse.fordiac.ide.application.properties.section.EditTypedData"
               tab="org.eclipse.fordiac.ide.application.property.tab.EditData">
         </propertySection>
         <propertySection
-              class="org.eclipse.fordiac.ide.application.properties.EditTypedSubappVarInOutSection"
-              filter="org.eclipse.fordiac.ide.application.properties.TypedSubappInterfaceEditingFilter"
+              class="org.eclipse.fordiac.ide.application.properties.EditTypedVarInOutSection"
+              filter="org.eclipse.fordiac.ide.application.properties.TypedInterfaceEditingFilter"
               id="org.eclipse.fordiac.ide.application.properties.section.EditTypedVarInOut"
               tab="org.eclipse.fordiac.ide.application.property.tab.EditVarInOut">
         </propertySection>
@@ -305,7 +305,7 @@
         </propertySection>
         <propertySection
               class="org.eclipse.fordiac.ide.application.properties.EditTypedInterfaceAdapterSection"
-              filter="org.eclipse.fordiac.ide.application.properties.TypedSubappInterfaceEditingFilter"
+              filter="org.eclipse.fordiac.ide.application.properties.TypedInterfaceEditingFilter"
               id="org.eclipse.fordiac.ide.application.properties.section.EditTypedAdapters"
               tab="org.eclipse.fordiac.ide.application.property.tab.EditAdapters">
         </propertySection>

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/AbstractEditTypeVarInOutSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/AbstractEditTypeVarInOutSection.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Patrick Aigner - initial API and implementation and/or initial documentation
+ *   Alois Zoitl    - Extracted from EditUntypedSubappVarInOutSection
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.application.properties;
+
+import org.eclipse.fordiac.ide.gef.nat.DefaultImportCopyPasteLayerConfiguration;
+import org.eclipse.fordiac.ide.gef.nat.InitialValueEditorConfiguration;
+import org.eclipse.fordiac.ide.gef.nat.TypeDeclarationEditorConfiguration;
+import org.eclipse.fordiac.ide.gef.nat.VarDeclarationColumnAccessor;
+import org.eclipse.fordiac.ide.gef.nat.VarDeclarationConfigLabelAccumulator;
+import org.eclipse.fordiac.ide.gef.nat.VarDeclarationDataLayer;
+import org.eclipse.fordiac.ide.gef.nat.VarDeclarationTableColumn;
+import org.eclipse.fordiac.ide.gef.nat.VarDeclarationVisibleEditableRule;
+import org.eclipse.fordiac.ide.gef.properties.AbstractEditVarInOutSection;
+import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.ui.widget.nattable.ChangeableListDataProvider;
+import org.eclipse.fordiac.ide.ui.widget.nattable.CheckBoxConfigurationNebula;
+import org.eclipse.fordiac.ide.ui.widget.nattable.NatTableColumnProvider;
+import org.eclipse.fordiac.ide.ui.widget.nattable.NatTableWidgetFactory;
+import org.eclipse.gef.commands.Command;
+import org.eclipse.nebula.widgets.nattable.config.IEditableRule;
+import org.eclipse.nebula.widgets.nattable.layer.DataLayer;
+import org.eclipse.swt.widgets.Composite;
+
+public abstract class AbstractEditTypeVarInOutSection extends AbstractEditVarInOutSection {
+
+	@Override
+	protected void setTableInput() {
+		inputProvider.setInput(getInterface().getInOutVars());
+		if (isShowTableEditButtons()) {
+			inputButtons.setEnabled(isEditable());
+		}
+	}
+
+	@Override
+	public void setupInputTable(final Composite parent) {
+		final var columns = VarDeclarationTableColumn.defaultColumnsWith(VarDeclarationTableColumn.VISIBLEIN,
+				VarDeclarationTableColumn.VISIBLEOUT);
+		inputProvider = new ChangeableListDataProvider<>(new VarDeclarationColumnAccessor(this, columns) {
+			@Override
+			public Command createCommand(final VarDeclaration rowObject, final VarDeclarationTableColumn column,
+					final Object newValue) {
+				return switch (column) {
+				default -> super.createCommand(rowObject, column, newValue);
+				};
+			}
+		});
+		final DataLayer inputDataLayer = new VarDeclarationDataLayer(inputProvider, columns);
+		inputDataLayer.setConfigLabelAccumulator(
+				new VarDeclarationConfigLabelAccumulator(inputProvider, this::getAnnotationModel, columns));
+		final NatTableColumnProvider<VarDeclarationTableColumn> columnProvider = new NatTableColumnProvider<>(columns);
+		inputTable = NatTableWidgetFactory.createRowNatTable(parent, inputDataLayer, columnProvider,
+				new VarDeclarationVisibleEditableRule(getSectionEditableRule(), inputProvider, columns,
+						VarDeclarationTableColumn.ALL_EDITABLE),
+				null, this, true);
+		inputTable.addConfiguration(new InitialValueEditorConfiguration(inputProvider));
+		inputTable.addConfiguration(new TypeDeclarationEditorConfiguration(inputProvider));
+		inputTable.addConfiguration(new CheckBoxConfigurationNebula());
+		inputTable.addConfiguration(new DefaultImportCopyPasteLayerConfiguration(columnProvider, this));
+		inputTable.configure();
+	}
+
+	@Override
+	protected BlockFBNetworkElement getType() {
+		return (BlockFBNetworkElement) type;
+	}
+
+	protected InterfaceList getInterface() {
+		return (getType() != null) ? getType().getInterface() : null;
+	}
+
+	@Override
+	protected IEditableRule getSectionEditableRule() {
+		return IEditableRule.ALWAYS_EDITABLE;
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/AbstractEditTypedInterfaceDataSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/AbstractEditTypedInterfaceDataSection.java
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ * Copyright (c) 2017 fortiss GmbH, Johannes Kepler University Linz,
+ *                    Primetals Technologies Germany GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Alois Zoitl - extracted from EditUntypedSubappInterfaceDataSection
+ *******************************************************************************/
+
+package org.eclipse.fordiac.ide.application.properties;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import org.eclipse.fordiac.ide.gef.nat.DefaultImportCopyPasteLayerConfiguration;
+import org.eclipse.fordiac.ide.gef.nat.InitialValueEditorConfiguration;
+import org.eclipse.fordiac.ide.gef.nat.TypeDeclarationEditorConfiguration;
+import org.eclipse.fordiac.ide.gef.nat.VarDeclarationColumnAccessor;
+import org.eclipse.fordiac.ide.gef.nat.VarDeclarationConfigLabelAccumulator;
+import org.eclipse.fordiac.ide.gef.nat.VarDeclarationDataLayer;
+import org.eclipse.fordiac.ide.gef.nat.VarDeclarationTableColumn;
+import org.eclipse.fordiac.ide.gef.properties.AbstractEditInterfaceDataSection;
+import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.ui.widget.nattable.ChangeableListDataProvider;
+import org.eclipse.fordiac.ide.ui.widget.nattable.CheckBoxConfigurationNebula;
+import org.eclipse.fordiac.ide.ui.widget.nattable.NatTableColumnEditableRule;
+import org.eclipse.fordiac.ide.ui.widget.nattable.NatTableColumnProvider;
+import org.eclipse.fordiac.ide.ui.widget.nattable.NatTableWidgetFactory;
+import org.eclipse.gef.commands.Command;
+import org.eclipse.nebula.widgets.nattable.config.IEditableRule;
+import org.eclipse.nebula.widgets.nattable.data.IRowDataProvider;
+import org.eclipse.nebula.widgets.nattable.layer.DataLayer;
+import org.eclipse.swt.widgets.Group;
+
+public abstract class AbstractEditTypedInterfaceDataSection extends AbstractEditInterfaceDataSection {
+
+	@Override
+	protected BlockFBNetworkElement getType() {
+		return (BlockFBNetworkElement) type;
+	}
+
+	@Override
+	protected InterfaceList getInterface() {
+		return (getType() != null) ? getType().getInterface() : null;
+	}
+
+	@Override
+	public void setupOutputTable(final Group outputsGroup) {
+		final var columns = VarDeclarationTableColumn.defaultColumnsWith(VarDeclarationTableColumn.VISIBLE);
+		outputProvider = new ChangeableListDataProvider<>(new VarDeclarationColumnAccessor(this, columns) {
+			@Override
+			public Command createCommand(final VarDeclaration rowObject, final VarDeclarationTableColumn column,
+					final Object newValue) {
+				return switch (column) {
+				case NAME -> onNameChange(rowObject, Objects.toString(newValue, NULL_DEFAULT));
+				default -> super.createCommand(rowObject, column, newValue);
+				};
+			}
+		});
+		final DataLayer outputDataLayer = new VarDeclarationDataLayer(outputProvider, columns);
+		outputDataLayer.setConfigLabelAccumulator(
+				new VarDeclarationConfigLabelAccumulator(outputProvider, this::getAnnotationModel, columns));
+		final NatTableColumnProvider<VarDeclarationTableColumn> columnProvider = new NatTableColumnProvider<>(columns);
+		outputTable = NatTableWidgetFactory.createRowNatTable(outputsGroup, outputDataLayer, columnProvider,
+				new UntypedSubappInterfaceEditableRule(getSectionEditableRule(), columns, outputProvider), null, this,
+				false);
+		outputTable.addConfiguration(new InitialValueEditorConfiguration(outputProvider));
+		outputTable.addConfiguration(new TypeDeclarationEditorConfiguration(outputProvider));
+		outputTable.addConfiguration(new CheckBoxConfigurationNebula());
+		outputTable.addConfiguration(new DefaultImportCopyPasteLayerConfiguration(columnProvider, this));
+		outputTable.configure();
+	}
+
+	@Override
+	public void setupInputTable(final Group inputsGroup) {
+		inputProvider = new ChangeableListDataProvider<>(
+				new VarDeclarationColumnAccessor(this, VarDeclarationTableColumn.DEFAULT_COLUMNS_VISIBLE_VARCONFIG) {
+					@Override
+					public Command createCommand(final VarDeclaration rowObject, final VarDeclarationTableColumn column,
+							final Object newValue) {
+						return switch (column) {
+						case NAME -> onNameChange(rowObject, Objects.toString(newValue, NULL_DEFAULT));
+						default -> super.createCommand(rowObject, column, newValue);
+						};
+					}
+				});
+		final DataLayer inputDataLayer = new VarDeclarationDataLayer(inputProvider,
+				VarDeclarationTableColumn.DEFAULT_COLUMNS_VISIBLE_VARCONFIG);
+		inputDataLayer.setConfigLabelAccumulator(new VarDeclarationConfigLabelAccumulator(inputProvider,
+				this::getAnnotationModel, VarDeclarationTableColumn.DEFAULT_COLUMNS_VISIBLE_VARCONFIG));
+		final NatTableColumnProvider<VarDeclarationTableColumn> columnProvider = new NatTableColumnProvider<>(
+				VarDeclarationTableColumn.DEFAULT_COLUMNS_VISIBLE_VARCONFIG);
+		inputTable = NatTableWidgetFactory
+				.createRowNatTable(inputsGroup, inputDataLayer, columnProvider,
+						new UntypedSubappInterfaceEditableRule(getSectionEditableRule(),
+								VarDeclarationTableColumn.DEFAULT_COLUMNS_VISIBLE_VARCONFIG, inputProvider),
+						null, this, true);
+		inputTable.addConfiguration(new InitialValueEditorConfiguration(inputProvider));
+		inputTable.addConfiguration(new TypeDeclarationEditorConfiguration(inputProvider));
+		inputTable.addConfiguration(new CheckBoxConfigurationNebula());
+		inputTable.addConfiguration(new DefaultImportCopyPasteLayerConfiguration(columnProvider, this));
+		inputTable.configure();
+	}
+
+	private static class UntypedSubappInterfaceEditableRule
+			extends NatTableColumnEditableRule<VarDeclarationTableColumn> {
+
+		private static final Set<VarDeclarationTableColumn> CONNECTED_UNEDITABLE_COLUMNS = Set
+				.of(VarDeclarationTableColumn.VISIBLE);
+
+		private final IRowDataProvider<VarDeclaration> dataProvider;
+
+		public UntypedSubappInterfaceEditableRule(final IEditableRule parent,
+				final List<VarDeclarationTableColumn> columns, final IRowDataProvider<VarDeclaration> dataProvider) {
+			super(parent, columns, VarDeclarationTableColumn.ALL_EDITABLE);
+			this.dataProvider = dataProvider;
+		}
+
+		@Override
+		public boolean isEditable(final int columnIndex, final int rowIndex) {
+			final VarDeclaration rowItem = dataProvider.getRowObject(rowIndex);
+			if (isConnected(rowItem) && CONNECTED_UNEDITABLE_COLUMNS.contains(getColumns().get(columnIndex))) {
+				return false;
+			}
+			return super.isEditable(columnIndex, rowIndex);
+		}
+
+		private static boolean isConnected(final VarDeclaration varDeclaration) {
+			return !varDeclaration.getInputConnections().isEmpty() || !varDeclaration.getOutputConnections().isEmpty();
+		}
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/EditTypedInterfaceAdapterSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/EditTypedInterfaceAdapterSection.java
@@ -15,16 +15,17 @@ package org.eclipse.fordiac.ide.application.properties;
 import java.util.Set;
 
 import org.eclipse.fordiac.ide.gef.nat.TypedElementTableColumn;
+import org.eclipse.fordiac.ide.gef.properties.AbstractEditInterfaceAdapterSection;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeInterfaceOrderCommand;
 import org.eclipse.fordiac.ide.model.commands.delete.DeleteInterfaceCommand;
+import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
-import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
+import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.ui.providers.CreationCommand;
 import org.eclipse.fordiac.ide.ui.widget.nattable.NatTableColumnEditableRule;
-import org.eclipse.gef.EditPart;
 import org.eclipse.nebula.widgets.nattable.config.IEditableRule;
 
-public class EditTypedInterfaceAdapterSection extends EditInterfaceAdapterSection {
+public class EditTypedInterfaceAdapterSection extends AbstractEditInterfaceAdapterSection {
 	@Override
 	protected CreationCommand newCreateCommand(final IInterfaceElement interfaceElement, final boolean isInput) {
 		return null;
@@ -37,15 +38,8 @@ public class EditTypedInterfaceAdapterSection extends EditInterfaceAdapterSectio
 	}
 
 	@Override
-	protected SubApp getInputType(final Object input) {
-		Object candidate = null;
-		if (input instanceof final EditPart editPart) {
-			candidate = editPart.getModel();
-		}
-		if (candidate instanceof final SubApp subapp && subapp.isTyped()) {
-			return subapp;
-		}
-		return null;
+	protected BlockFBNetworkElement getInputType(final Object input) {
+		return TypedInterfaceEditingFilter.getTypedElementFromSelectedElement(input);
 	}
 
 	@Override
@@ -56,6 +50,16 @@ public class EditTypedInterfaceAdapterSection extends EditInterfaceAdapterSectio
 	@Override
 	protected ChangeInterfaceOrderCommand newOrderCommand(final IInterfaceElement selection, final boolean moveUp) {
 		return null;
+	}
+
+	@Override
+	protected BlockFBNetworkElement getType() {
+		return (BlockFBNetworkElement) type;
+	}
+
+	@Override
+	protected InterfaceList getInterface() {
+		return (getType() != null) ? getType().getInterface() : null;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/EditTypedInterfaceDataSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/EditTypedInterfaceDataSection.java
@@ -9,37 +9,35 @@
  *
  * Contributors:
  *   Patrick Aigner - initial API and implementation and/or initial documentation
+ *   Alois Zoitl    - Reworked to handle all typed blocks
  *******************************************************************************/
 package org.eclipse.fordiac.ide.application.properties;
 
+import org.eclipse.fordiac.ide.gef.nat.VarDeclarationTableColumn;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeInterfaceOrderCommand;
 import org.eclipse.fordiac.ide.model.commands.delete.DeleteInterfaceCommand;
+import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
-import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
 import org.eclipse.fordiac.ide.ui.providers.CreationCommand;
-import org.eclipse.gef.EditPart;
+import org.eclipse.fordiac.ide.ui.widget.nattable.NatTableColumnEditableRule;
+import org.eclipse.nebula.widgets.nattable.config.IEditableRule;
 
-public class EditTypedSubappVarInOutSection extends EditUntypedSubappVarInOutSection {
+public class EditTypedInterfaceDataSection extends AbstractEditTypedInterfaceDataSection {
+
 	@Override
-	protected CreationCommand newCreateCommand(final IInterfaceElement ie) {
+	protected CreationCommand newCreateCommand(final IInterfaceElement interfaceElement, final boolean isInput) {
 		return null;
 	}
 
 	@Override
-	protected CreationCommand newInsertCommand(final IInterfaceElement ie, final int index) {
+	protected CreationCommand newInsertCommand(final IInterfaceElement interfaceElement, final boolean isInput,
+			final int index) {
 		return null;
 	}
 
 	@Override
-	protected SubApp getInputType(final Object input) {
-		Object candidate = null;
-		if (input instanceof final EditPart editPart) {
-			candidate = editPart.getModel();
-		}
-		if (candidate instanceof final SubApp subapp && subapp.isTyped()) {
-			return subapp;
-		}
-		return null;
+	protected BlockFBNetworkElement getInputType(final Object input) {
+		return TypedInterfaceEditingFilter.getTypedElementFromSelectedElement(input);
 	}
 
 	@Override
@@ -55,5 +53,12 @@ public class EditTypedSubappVarInOutSection extends EditUntypedSubappVarInOutSec
 	@Override
 	public boolean isShowTableEditButtons() {
 		return false;
+	}
+
+	@Override
+	protected IEditableRule getSectionEditableRule() {
+		return new NatTableColumnEditableRule<>(IEditableRule.ALWAYS_EDITABLE,
+				VarDeclarationTableColumn.DEFAULT_COLUMNS_VISIBLE_VARCONFIG,
+				VarDeclarationTableColumn.DEFAULT_EDITABLE);
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/EditTypedInterfaceEventSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/EditTypedInterfaceEventSection.java
@@ -15,16 +15,17 @@ package org.eclipse.fordiac.ide.application.properties;
 import java.util.Set;
 
 import org.eclipse.fordiac.ide.gef.nat.TypedElementTableColumn;
+import org.eclipse.fordiac.ide.gef.properties.AbstractEditInterfaceEventSection;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeInterfaceOrderCommand;
 import org.eclipse.fordiac.ide.model.commands.delete.DeleteInterfaceCommand;
+import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
-import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
+import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.ui.providers.CreationCommand;
 import org.eclipse.fordiac.ide.ui.widget.nattable.NatTableColumnEditableRule;
-import org.eclipse.gef.EditPart;
 import org.eclipse.nebula.widgets.nattable.config.IEditableRule;
 
-public class EditTypedSubappInterfaceEventSection extends EditUntypedSubappInterfaceEventSection {
+public class EditTypedInterfaceEventSection extends AbstractEditInterfaceEventSection {
 	@Override
 	protected CreationCommand newCreateCommand(final IInterfaceElement interfaceElement, final boolean isInput) {
 		return null;
@@ -37,15 +38,8 @@ public class EditTypedSubappInterfaceEventSection extends EditUntypedSubappInter
 	}
 
 	@Override
-	protected SubApp getInputType(final Object input) {
-		Object candidate = null;
-		if (input instanceof final EditPart editPart) {
-			candidate = editPart.getModel();
-		}
-		if (candidate instanceof final SubApp subapp && subapp.isTyped()) {
-			return subapp;
-		}
-		return null;
+	protected BlockFBNetworkElement getInputType(final Object input) {
+		return TypedInterfaceEditingFilter.getTypedElementFromSelectedElement(input);
 	}
 
 	@Override
@@ -56,6 +50,16 @@ public class EditTypedSubappInterfaceEventSection extends EditUntypedSubappInter
 	@Override
 	protected ChangeInterfaceOrderCommand newOrderCommand(final IInterfaceElement selection, final boolean moveUp) {
 		return null;
+	}
+
+	@Override
+	protected BlockFBNetworkElement getType() {
+		return (BlockFBNetworkElement) type;
+	}
+
+	@Override
+	protected InterfaceList getInterface() {
+		return (getType() != null) ? getType().getInterface() : null;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/EditTypedVarInOutSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/EditTypedVarInOutSection.java
@@ -12,39 +12,26 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.application.properties;
 
-import org.eclipse.fordiac.ide.gef.nat.VarDeclarationTableColumn;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeInterfaceOrderCommand;
 import org.eclipse.fordiac.ide.model.commands.delete.DeleteInterfaceCommand;
+import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
-import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
 import org.eclipse.fordiac.ide.ui.providers.CreationCommand;
-import org.eclipse.fordiac.ide.ui.widget.nattable.NatTableColumnEditableRule;
-import org.eclipse.gef.EditPart;
-import org.eclipse.nebula.widgets.nattable.config.IEditableRule;
 
-public class EditTypedSubappInterfaceDataSection extends EditUntypedSubappInterfaceDataSection {
-
+public class EditTypedVarInOutSection extends AbstractEditTypeVarInOutSection {
 	@Override
-	protected CreationCommand newCreateCommand(final IInterfaceElement interfaceElement, final boolean isInput) {
+	protected CreationCommand newCreateCommand(final IInterfaceElement ie) {
 		return null;
 	}
 
 	@Override
-	protected CreationCommand newInsertCommand(final IInterfaceElement interfaceElement, final boolean isInput,
-			final int index) {
+	protected CreationCommand newInsertCommand(final IInterfaceElement ie, final int index) {
 		return null;
 	}
 
 	@Override
-	protected SubApp getInputType(final Object input) {
-		Object candidate = null;
-		if (input instanceof final EditPart editPart) {
-			candidate = editPart.getModel();
-		}
-		if (candidate instanceof final SubApp subapp && subapp.isTyped()) {
-			return subapp;
-		}
-		return null;
+	protected BlockFBNetworkElement getInputType(final Object input) {
+		return TypedInterfaceEditingFilter.getTypedElementFromSelectedElement(input);
 	}
 
 	@Override
@@ -60,12 +47,5 @@ public class EditTypedSubappInterfaceDataSection extends EditUntypedSubappInterf
 	@Override
 	public boolean isShowTableEditButtons() {
 		return false;
-	}
-
-	@Override
-	protected IEditableRule getSectionEditableRule() {
-		return new NatTableColumnEditableRule<>(IEditableRule.ALWAYS_EDITABLE,
-				VarDeclarationTableColumn.DEFAULT_COLUMNS_VISIBLE_VARCONFIG,
-				VarDeclarationTableColumn.DEFAULT_EDITABLE);
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/EditUntypedSubappInterfaceDataSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/EditUntypedSubappInterfaceDataSection.java
@@ -1,7 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2017 fortiss GmbH
- * 				 2019, 2020 Johannes Kepler University Linz
- * 				 2020 - 2023 Primetals Technologies Germany GmbH
+ * Copyright (c) 2017 fortiss GmbH, Johannes Kepler University Linz,
+ *                    Primetals Technologies Germany GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,45 +17,22 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.application.properties;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-
 import org.eclipse.fordiac.ide.application.commands.ChangeSubAppInterfaceOrderCommand;
 import org.eclipse.fordiac.ide.application.commands.CreateSubAppInterfaceElementCommand;
 import org.eclipse.fordiac.ide.application.commands.ResizeGroupOrSubappCommand;
 import org.eclipse.fordiac.ide.application.commands.ResizingSubappInterfaceCreationCommand;
 import org.eclipse.fordiac.ide.application.utilities.GetEditPartFromGraficalViewerHelper;
-import org.eclipse.fordiac.ide.gef.nat.DefaultImportCopyPasteLayerConfiguration;
-import org.eclipse.fordiac.ide.gef.nat.InitialValueEditorConfiguration;
-import org.eclipse.fordiac.ide.gef.nat.TypeDeclarationEditorConfiguration;
-import org.eclipse.fordiac.ide.gef.nat.VarDeclarationColumnAccessor;
-import org.eclipse.fordiac.ide.gef.nat.VarDeclarationConfigLabelAccumulator;
-import org.eclipse.fordiac.ide.gef.nat.VarDeclarationDataLayer;
-import org.eclipse.fordiac.ide.gef.nat.VarDeclarationTableColumn;
-import org.eclipse.fordiac.ide.gef.properties.AbstractEditInterfaceDataSection;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeInterfaceOrderCommand;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeNameCommand;
 import org.eclipse.fordiac.ide.model.commands.delete.DeleteInterfaceCommand;
 import org.eclipse.fordiac.ide.model.commands.delete.DeleteSubAppInterfaceElementCommand;
 import org.eclipse.fordiac.ide.model.data.DataType;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
-import org.eclipse.fordiac.ide.model.libraryElement.InterfaceList;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
-import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.ui.providers.CreationCommand;
-import org.eclipse.fordiac.ide.ui.widget.nattable.ChangeableListDataProvider;
-import org.eclipse.fordiac.ide.ui.widget.nattable.CheckBoxConfigurationNebula;
-import org.eclipse.fordiac.ide.ui.widget.nattable.NatTableColumnEditableRule;
-import org.eclipse.fordiac.ide.ui.widget.nattable.NatTableColumnProvider;
-import org.eclipse.fordiac.ide.ui.widget.nattable.NatTableWidgetFactory;
 import org.eclipse.gef.commands.Command;
-import org.eclipse.nebula.widgets.nattable.config.IEditableRule;
-import org.eclipse.nebula.widgets.nattable.data.IRowDataProvider;
-import org.eclipse.nebula.widgets.nattable.layer.DataLayer;
-import org.eclipse.swt.widgets.Group;
 
-public class EditUntypedSubappInterfaceDataSection extends AbstractEditInterfaceDataSection {
+public class EditUntypedSubappInterfaceDataSection extends AbstractEditTypedInterfaceDataSection {
 
 	@Override
 	protected CreationCommand newCreateCommand(final IInterfaceElement interfaceElement, final boolean isInput) {
@@ -73,63 +49,6 @@ public class EditUntypedSubappInterfaceDataSection extends AbstractEditInterface
 		final CreateSubAppInterfaceElementCommand cmd = new CreateSubAppInterfaceElementCommand(interfaceElement,
 				isInput, getType().getInterface(), index);
 		return ResizingSubappInterfaceCreationCommand.wrapCreateCommand(cmd, getType());
-	}
-
-	@Override
-	public void setupOutputTable(final Group outputsGroup) {
-		final var columns = VarDeclarationTableColumn.defaultColumnsWith(VarDeclarationTableColumn.VISIBLE);
-		outputProvider = new ChangeableListDataProvider<>(new VarDeclarationColumnAccessor(this, columns) {
-			@Override
-			public Command createCommand(final VarDeclaration rowObject, final VarDeclarationTableColumn column,
-					final Object newValue) {
-				return switch (column) {
-				case NAME -> onNameChange(rowObject, Objects.toString(newValue, NULL_DEFAULT));
-				default -> super.createCommand(rowObject, column, newValue);
-				};
-			}
-		});
-		final DataLayer outputDataLayer = new VarDeclarationDataLayer(outputProvider, columns);
-		outputDataLayer.setConfigLabelAccumulator(
-				new VarDeclarationConfigLabelAccumulator(outputProvider, this::getAnnotationModel, columns));
-		final NatTableColumnProvider<VarDeclarationTableColumn> columnProvider = new NatTableColumnProvider<>(columns);
-		outputTable = NatTableWidgetFactory.createRowNatTable(outputsGroup, outputDataLayer, columnProvider,
-				new UntypedSubappInterfaceEditableRule(getSectionEditableRule(), columns, outputProvider), null, this,
-				false);
-		outputTable.addConfiguration(new InitialValueEditorConfiguration(outputProvider));
-		outputTable.addConfiguration(new TypeDeclarationEditorConfiguration(outputProvider));
-		outputTable.addConfiguration(new CheckBoxConfigurationNebula());
-		outputTable.addConfiguration(new DefaultImportCopyPasteLayerConfiguration(columnProvider, this));
-		outputTable.configure();
-	}
-
-	@Override
-	public void setupInputTable(final Group inputsGroup) {
-		inputProvider = new ChangeableListDataProvider<>(new VarDeclarationColumnAccessor(this,
-				VarDeclarationTableColumn.DEFAULT_COLUMNS_VISIBLE_VARCONFIG) {
-			@Override
-			public Command createCommand(final VarDeclaration rowObject, final VarDeclarationTableColumn column,
-					final Object newValue) {
-				return switch (column) {
-				case NAME -> onNameChange(rowObject, Objects.toString(newValue, NULL_DEFAULT));
-				default -> super.createCommand(rowObject, column, newValue);
-				};
-			}
-		});
-		final DataLayer inputDataLayer = new VarDeclarationDataLayer(inputProvider,
-				VarDeclarationTableColumn.DEFAULT_COLUMNS_VISIBLE_VARCONFIG);
-		inputDataLayer.setConfigLabelAccumulator(new VarDeclarationConfigLabelAccumulator(inputProvider,
-				this::getAnnotationModel, VarDeclarationTableColumn.DEFAULT_COLUMNS_VISIBLE_VARCONFIG));
-		final NatTableColumnProvider<VarDeclarationTableColumn> columnProvider = new NatTableColumnProvider<>(
-				VarDeclarationTableColumn.DEFAULT_COLUMNS_VISIBLE_VARCONFIG);
-		inputTable = NatTableWidgetFactory.createRowNatTable(inputsGroup, inputDataLayer, columnProvider,
-				new UntypedSubappInterfaceEditableRule(getSectionEditableRule(),
-						VarDeclarationTableColumn.DEFAULT_COLUMNS_VISIBLE_VARCONFIG, inputProvider),
-				null, this, true);
-		inputTable.addConfiguration(new InitialValueEditorConfiguration(inputProvider));
-		inputTable.addConfiguration(new TypeDeclarationEditorConfiguration(inputProvider));
-		inputTable.addConfiguration(new CheckBoxConfigurationNebula());
-		inputTable.addConfiguration(new DefaultImportCopyPasteLayerConfiguration(columnProvider, this));
-		inputTable.configure();
 	}
 
 	@Override
@@ -153,11 +72,6 @@ public class EditUntypedSubappInterfaceDataSection extends AbstractEditInterface
 	}
 
 	@Override
-	protected InterfaceList getInterface() {
-		return (getType() != null) ? getType().getInterface() : null;
-	}
-
-	@Override
 	public Command onNameChange(final IInterfaceElement ie, final String newValue) {
 		final ChangeNameCommand nameChangeCmd = ChangeNameCommand.forName(ie, newValue);
 		if (getType().isUnfolded()) {
@@ -167,30 +81,4 @@ public class EditUntypedSubappInterfaceDataSection extends AbstractEditInterface
 		return nameChangeCmd;
 	}
 
-	private class UntypedSubappInterfaceEditableRule extends NatTableColumnEditableRule<VarDeclarationTableColumn> {
-
-		private static final Set<VarDeclarationTableColumn> CONNECTED_UNEDITABLE_COLUMNS = Set
-				.of(VarDeclarationTableColumn.VISIBLE);
-
-		private final IRowDataProvider<VarDeclaration> dataProvider;
-
-		public UntypedSubappInterfaceEditableRule(final IEditableRule parent,
-				final List<VarDeclarationTableColumn> columns, final IRowDataProvider<VarDeclaration> dataProvider) {
-			super(parent, columns, VarDeclarationTableColumn.ALL_EDITABLE);
-			this.dataProvider = dataProvider;
-		}
-
-		@Override
-		public boolean isEditable(final int columnIndex, final int rowIndex) {
-			final VarDeclaration rowItem = dataProvider.getRowObject(rowIndex);
-			if (isConnected(rowItem) && CONNECTED_UNEDITABLE_COLUMNS.contains(getColumns().get(columnIndex))) {
-				return false;
-			}
-			return super.isEditable(columnIndex, rowIndex);
-		}
-
-		private static boolean isConnected(final VarDeclaration varDeclaration) {
-			return !varDeclaration.getInputConnections().isEmpty() || !varDeclaration.getOutputConnections().isEmpty();
-		}
-	}
 }

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/EditUntypedSubappVarInOutSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/EditUntypedSubappVarInOutSection.java
@@ -12,30 +12,12 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.application.properties;
 
-import org.eclipse.fordiac.ide.gef.nat.DefaultImportCopyPasteLayerConfiguration;
-import org.eclipse.fordiac.ide.gef.nat.InitialValueEditorConfiguration;
-import org.eclipse.fordiac.ide.gef.nat.TypeDeclarationEditorConfiguration;
-import org.eclipse.fordiac.ide.gef.nat.VarDeclarationColumnAccessor;
-import org.eclipse.fordiac.ide.gef.nat.VarDeclarationConfigLabelAccumulator;
-import org.eclipse.fordiac.ide.gef.nat.VarDeclarationDataLayer;
-import org.eclipse.fordiac.ide.gef.nat.VarDeclarationTableColumn;
-import org.eclipse.fordiac.ide.gef.nat.VarDeclarationVisibleEditableRule;
-import org.eclipse.fordiac.ide.gef.properties.AbstractEditVarInOutSection;
 import org.eclipse.fordiac.ide.model.commands.create.CreateVarInOutCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
-import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.ui.providers.CreationCommand;
-import org.eclipse.fordiac.ide.ui.widget.nattable.ChangeableListDataProvider;
-import org.eclipse.fordiac.ide.ui.widget.nattable.CheckBoxConfigurationNebula;
-import org.eclipse.fordiac.ide.ui.widget.nattable.NatTableColumnProvider;
-import org.eclipse.fordiac.ide.ui.widget.nattable.NatTableWidgetFactory;
-import org.eclipse.gef.commands.Command;
-import org.eclipse.nebula.widgets.nattable.config.IEditableRule;
-import org.eclipse.nebula.widgets.nattable.layer.DataLayer;
-import org.eclipse.swt.widgets.Composite;
 
-public class EditUntypedSubappVarInOutSection extends AbstractEditVarInOutSection {
+public class EditUntypedSubappVarInOutSection extends AbstractEditTypeVarInOutSection {
 
 	@Override
 	protected CreationCommand newCreateCommand(final IInterfaceElement ie) {
@@ -49,53 +31,7 @@ public class EditUntypedSubappVarInOutSection extends AbstractEditVarInOutSectio
 	}
 
 	@Override
-	protected void setTableInput() {
-		inputProvider.setInput(getType().getInterface().getInOutVars());
-		if (isShowTableEditButtons()) {
-			inputButtons.setEnabled(isEditable());
-		}
-	}
-
-	@Override
-	public void setupInputTable(final Composite parent) {
-		final var columns = VarDeclarationTableColumn.defaultColumnsWith(VarDeclarationTableColumn.VISIBLEIN,
-				VarDeclarationTableColumn.VISIBLEOUT);
-		inputProvider = new ChangeableListDataProvider<>(new VarDeclarationColumnAccessor(this, columns) {
-			@Override
-			public Command createCommand(final VarDeclaration rowObject, final VarDeclarationTableColumn column,
-					final Object newValue) {
-				return switch (column) {
-				default -> super.createCommand(rowObject, column, newValue);
-				};
-			}
-		});
-		final DataLayer inputDataLayer = new VarDeclarationDataLayer(inputProvider, columns);
-		inputDataLayer.setConfigLabelAccumulator(
-				new VarDeclarationConfigLabelAccumulator(inputProvider, this::getAnnotationModel, columns));
-		final NatTableColumnProvider<VarDeclarationTableColumn> columnProvider = new NatTableColumnProvider<>(columns);
-		inputTable = NatTableWidgetFactory.createRowNatTable(parent, inputDataLayer, columnProvider,
-				new VarDeclarationVisibleEditableRule(getSectionEditableRule(), inputProvider, columns,
-						VarDeclarationTableColumn.ALL_EDITABLE),
-				null, this, true);
-		inputTable.addConfiguration(new InitialValueEditorConfiguration(inputProvider));
-		inputTable.addConfiguration(new TypeDeclarationEditorConfiguration(inputProvider));
-		inputTable.addConfiguration(new CheckBoxConfigurationNebula());
-		inputTable.addConfiguration(new DefaultImportCopyPasteLayerConfiguration(columnProvider, this));
-		inputTable.configure();
-	}
-
-	@Override
-	protected SubApp getType() {
-		return (SubApp) type;
-	}
-
-	@Override
 	protected SubApp getInputType(final Object input) {
 		return SubappPropertySectionFilter.getFBNetworkElementFromSelectedElement(input);
-	}
-
-	@Override
-	protected IEditableRule getSectionEditableRule() {
-		return IEditableRule.ALWAYS_EDITABLE;
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/TypedInterfaceEditingFilter.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/TypedInterfaceEditingFilter.java
@@ -12,19 +12,31 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.application.properties;
 
-import org.eclipse.fordiac.ide.application.editparts.SubAppForFBNetworkEditPart;
+import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
+import org.eclipse.gef.EditPart;
 import org.eclipse.jface.viewers.IFilter;
 
-public class TypedSubappInterfaceEditingFilter implements IFilter {
+public class TypedInterfaceEditingFilter implements IFilter {
 
 	@Override
 	public boolean select(final Object toTest) {
-		if (toTest instanceof final SubAppForFBNetworkEditPart subAppEP) {
-			final SubApp subapp = subAppEP.getModel();
-			return subapp.isTyped() && !subapp.isContainedInTypedInstance();
+		return getTypedElementFromSelectedElement(toTest) != null;
+	}
+
+	static BlockFBNetworkElement getTypedElementFromSelectedElement(final Object element) {
+		if (element instanceof final EditPart ep && ep.getModel() instanceof final BlockFBNetworkElement bfbne) {
+			if (bfbne.isContainedInTypedInstance()) {
+				return null;
+			}
+
+			if (bfbne instanceof final SubApp subapp && !subapp.isTyped()) {
+				return null;
+			}
+
+			return bfbne;
 		}
-		return false;
+		return null;
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.subapptypeeditor/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.subapptypeeditor/plugin.xml
@@ -213,20 +213,20 @@
                tab="org.eclipse.fordiac.ide.application.property.tab.EditVarInOut">
          </propertySection>
          <propertySection
-               class="org.eclipse.fordiac.ide.application.properties.EditTypedSubappInterfaceEventSection"
+               class="org.eclipse.fordiac.ide.application.properties.EditTypedInterfaceEventSection"
                id="org.eclipse.fordiac.ide.application.properties.section.EditTypedEvents"
-               filter="org.eclipse.fordiac.ide.application.properties.TypedSubappInterfaceEditingFilter"
+               filter="org.eclipse.fordiac.ide.application.properties.TypedInterfaceEditingFilter"
                tab="org.eclipse.fordiac.ide.application.property.tab.EditEvents">
          </propertySection>
          <propertySection
-               class="org.eclipse.fordiac.ide.application.properties.EditTypedSubappInterfaceDataSection"
+               class="org.eclipse.fordiac.ide.application.properties.EditTypedInterfaceDataSection"
                id="org.eclipse.fordiac.ide.application.properties.section.EditTypedData"
-               filter="org.eclipse.fordiac.ide.application.properties.TypedSubappInterfaceEditingFilter"
+               filter="org.eclipse.fordiac.ide.application.properties.TypedInterfaceEditingFilter"
                tab="org.eclipse.fordiac.ide.application.property.tab.EditData">
          </propertySection>
-         <propertySection class="org.eclipse.fordiac.ide.application.properties.EditTypedSubappVarInOutSection"
+         <propertySection class="org.eclipse.fordiac.ide.application.properties.EditTypedVarInOutSection"
                id="org.eclipse.fordiac.ide.application.properties.section.EditTypedVarInOut"
-               filter="org.eclipse.fordiac.ide.application.properties.TypedSubappInterfaceEditingFilter"
+               filter="org.eclipse.fordiac.ide.application.properties.TypedInterfaceEditingFilter"
                tab="org.eclipse.fordiac.ide.application.property.tab.EditVarInOut">
          </propertySection>
          <propertySection
@@ -238,7 +238,7 @@
          <propertySection
                class="org.eclipse.fordiac.ide.application.properties.EditTypedInterfaceAdapterSection"
                id="org.eclipse.fordiac.ide.application.properties.section.EditTypedAdapters"
-               filter="org.eclipse.fordiac.ide.application.properties.TypedSubappInterfaceEditingFilter"
+               filter="org.eclipse.fordiac.ide.application.properties.TypedInterfaceEditingFilter"
                tab="org.eclipse.fordiac.ide.application.property.tab.EditAdapters">
          </propertySection>
          <propertySection class="org.eclipse.fordiac.ide.application.properties.PinEventInfoSection"


### PR DESCRIPTION
The interface edit sections for typed subapps are now also shown for FB instances. Harmonizing the look and feel and make space in the interface section for pin member access (e.g., children of structs).