### PR TITLE
Fix dependency update for renamed type entries

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractUpdateBlockFBNElementCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/AbstractUpdateBlockFBNElementCommand.java
@@ -353,7 +353,7 @@ public abstract class AbstractUpdateBlockFBNElementCommand extends Command
 
 	private void transferInstanceComments() {
 		oldElement.getInterface().getAllInterfaceElements().filter(ie -> !ie.getComment().isBlank()).forEach(ie -> {
-			final IInterfaceElement newIE = newElement.getInterface().getInterfaceElement(ie);
+			final IInterfaceElement newIE = getNewInterfaceElementForPreservingInstanceData(ie);
 			if (newIE != null) {
 				newIE.setComment(ie.getComment());
 			}
@@ -579,11 +579,19 @@ public abstract class AbstractUpdateBlockFBNElementCommand extends Command
 	private void copyAttributes() {
 		newElement.getAttributes().addAll(EcoreUtil.copyAll(oldElement.getAttributes()));
 		oldElement.getInterface().getAllInterfaceElements().filter(ie -> !ie.getAttributes().isEmpty()).forEach(ie -> {
-			final IInterfaceElement newIE = newElement.getInterface().getInterfaceElement(ie);
+			final IInterfaceElement newIE = getNewInterfaceElementForPreservingInstanceData(ie);
 			if (newIE != null) {
 				newIE.getAttributes().addAll(EcoreUtil.copyAll(ie.getAttributes()));
 			}
 		});
+	}
+
+	private IInterfaceElement getNewInterfaceElementForPreservingInstanceData(
+			final IInterfaceElement oldInterfaceElement) {
+		if (oldInterfaceElement.eContainer() instanceof IInterfaceElement) {
+			return newElement.getInterface().getInterfaceElement(oldInterfaceElement.getBlockRelativePath(), true);
+		}
+		return newElement.getInterface().getInterfaceElement(oldInterfaceElement);
 	}
 
 	protected abstract BlockFBNetworkElement createCopiedFBEntry(final BlockFBNetworkElement srcElement);

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/VarDeclarationFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/VarDeclarationFactory.java
@@ -13,6 +13,7 @@
 package org.eclipse.fordiac.ide.model.helpers;
 
 import org.eclipse.fordiac.ide.model.data.DataType;
+import org.eclipse.fordiac.ide.model.data.ErrorDataType;
 import org.eclipse.fordiac.ide.model.data.StructuredType;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
@@ -22,6 +23,7 @@ public final class VarDeclarationFactory {
 	public static VarDeclaration createVarDecl(final DataType type) {
 		return switch (type) {
 		case final StructuredType structType -> LibraryElementFactory.eINSTANCE.createContainerVarDeclaration();
+		case final ErrorDataType errorType -> LibraryElementFactory.eINSTANCE.createContainerVarDeclaration();
 		default -> LibraryElementFactory.eINSTANCE.createVarDeclaration();
 
 		};

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/ConfigurableFBManagement.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/ConfigurableFBManagement.java
@@ -24,6 +24,7 @@ import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.model.LibraryElementTags;
 import org.eclipse.fordiac.ide.model.data.DataType;
+import org.eclipse.fordiac.ide.model.data.ErrorDataType;
 import org.eclipse.fordiac.ide.model.data.StructuredType;
 import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes.ElementaryTypes;
 import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
@@ -59,10 +60,9 @@ public final class ConfigurableFBManagement {
 	private static void updateMoveFbConfiguration(final ConfigurableFB fb) {
 		// if data type exists, set it as the data type of the input/output data pin
 		if (fb.getDataType() != null && fb.getInterface() != null) {
-			if ((fb.getDataType() instanceof StructuredType
-					&& !(fb.getInterface().getInputVars().get(0) instanceof ContainerVarDeclaration))
-					|| (!(fb.getDataType() instanceof StructuredType)
-							&& fb.getInterface().getInputVars().get(0) instanceof ContainerVarDeclaration)) {
+			final boolean requiresContainerPin = isContainerPinType(fb.getDataType());
+			final boolean hasContainerPin = fb.getInterface().getInputVars().get(0) instanceof ContainerVarDeclaration;
+			if (requiresContainerPin != hasContainerPin) {
 				// the pin type is not matching convert it
 				convertMoveFBPinTypes(fb);
 			} else {
@@ -74,6 +74,10 @@ public final class ConfigurableFBManagement {
 		}
 	}
 
+	private static boolean isContainerPinType(final DataType dataType) {
+		return dataType instanceof StructuredType || dataType instanceof ErrorDataType;
+	}
+
 	private static void convertMoveFBPinTypes(final ConfigurableFB fb) {
 		final DataType newDataType = fb.getDataType();
 		fb.getInterface().getInputVars().replaceAll(pin -> createNewMovePin(newDataType, pin));
@@ -82,6 +86,7 @@ public final class ConfigurableFBManagement {
 
 	private static VarDeclaration createNewMovePin(final DataType dataType, final VarDeclaration srcPin) {
 		final VarDeclaration newPin = VarDeclarationFactory.createVarDecl(dataType);
+		copyPinProperties(srcPin, newPin);
 		newPin.setName(srcPin.getName());
 		newPin.setType(dataType);
 		newPin.setIsInput(srcPin.isIsInput());
@@ -95,6 +100,29 @@ public final class ConfigurableFBManagement {
 			}
 		}
 		return newPin;
+	}
+
+	private static void copyPinProperties(final VarDeclaration srcPin, final VarDeclaration newPin) {
+		newPin.setComment(srcPin.getComment());
+		newPin.setArraySize(EcoreUtil.copy(srcPin.getArraySize()));
+		if (srcPin.getValue() != null) {
+			newPin.setValue(EcoreUtil.copy(srcPin.getValue()));
+		}
+		newPin.getAttributes().addAll(EcoreUtil.copyAll(srcPin.getAttributes()));
+		if (srcPin instanceof final ContainerVarDeclaration srcContainerPin
+				&& newPin instanceof final ContainerVarDeclaration newContainerPin) {
+			srcContainerPin.getCachedMembers()
+					.forEach(cachedMember -> newContainerPin.getCachedMembers().add(copyCachedMember(cachedMember)));
+		}
+	}
+
+	private static VarDeclaration copyCachedMember(final VarDeclaration cachedMember) {
+		final VarDeclaration copy = VarDeclarationFactory.createVarDecl(cachedMember.getType());
+		copy.setName(cachedMember.getName());
+		copy.setType(cachedMember.getType());
+		copy.setIsInput(cachedMember.isIsInput());
+		copyPinProperties(cachedMember, copy);
+		return copy;
 	}
 
 	static void loadFbConfiguration(final ConfigurableFB fb, final String attributeName, final String typeName) {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/ContainerVarDeclarationAnnotations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/ContainerVarDeclarationAnnotations.java
@@ -29,6 +29,8 @@ import org.eclipse.emf.common.util.DiagnosticChain;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.fordiac.ide.model.Messages;
+import org.eclipse.fordiac.ide.model.data.DataType;
+import org.eclipse.fordiac.ide.model.data.ErrorDataType;
 import org.eclipse.fordiac.ide.model.data.StructuredType;
 import org.eclipse.fordiac.ide.model.errormarker.FordiacMarkerHelper;
 import org.eclipse.fordiac.ide.model.helpers.VarDeclarationFactory;
@@ -67,22 +69,35 @@ public class ContainerVarDeclarationAnnotations {
 			return null;
 		}
 
-		final VarDeclaration memVar = getMember(contVarDeclaration, memberName);
-
-		if (memVar == null) {
+		final DataType memberType = getMemberType(contVarDeclaration, memberName);
+		if (memberType == null) {
 			return null;
 		}
 
-		final VarDeclaration newVisibleMember = VarDeclarationFactory.createVarDecl(memVar.getType());
+		final VarDeclaration newVisibleMember = VarDeclarationFactory.createVarDecl(memberType);
 		newVisibleMember.setName(memberName);
-		newVisibleMember.setType(memVar.getType());
-		setArraySize(newVisibleMember, getArraySize(memVar));
+		newVisibleMember.setType(memberType);
+		final VarDeclaration memVar = getMember(contVarDeclaration, memberName);
+		if (memVar != null) {
+			setArraySize(newVisibleMember, getArraySize(memVar));
+		}
 		newVisibleMember.setIsInput(contVarDeclaration.isIsInput());
 		insertNewVisibleMember(contVarDeclaration, newVisibleMember);
 		if (newVisibleMember.isIsInput()) {
 			newVisibleMember.setValue(LibraryElementFactory.eINSTANCE.createValue());
 		}
 		return newVisibleMember;
+	}
+
+	private static DataType getMemberType(final ContainerVarDeclaration contVarDeclaration, final String memberName) {
+		final VarDeclaration memVar = getMember(contVarDeclaration, memberName);
+		if (memVar != null) {
+			return memVar.getType();
+		}
+		if (contVarDeclaration.getType() instanceof final ErrorDataType errorDataType) {
+			return errorDataType;
+		}
+		return null;
 	}
 
 	private static VarDeclaration getMember(final ContainerVarDeclaration structVarDeclarationImpl,


### PR DESCRIPTION
Use the new full type name when updating dependencies after a TypeEntry rename.
Using the old name during a data type move can create a transient missing
datatype and reconfigure configurable FBs with an error type, dropping member
access pins.