### PR TITLE
Fix undo of struct type rename leaving .dtp content stale

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/UpdateTypeEntryChange.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/UpdateTypeEntryChange.java
@@ -99,28 +99,30 @@ public class UpdateTypeEntryChange extends Change {
 
 	@Override
 	public Change perform(final IProgressMonitor pm) throws CoreException {
-		final IFile newFile = findNewResource(newName);
-		if (newFile != null && typeEntry != null) {
-			updateTypeEntryByRename(newFile, typeEntry);
-			return new UpdateTypeEntryChange(newFile, typeEntry, oldName, newName);
+		// On the composite undo, the file rename undo has not run yet, so the file is
+		// still at its renamed location; prefer the captured reference when it still
+		// resolves and fall back to the name lookup for the forward path only.
+		final IFile currentFile = file.exists() ? file : findNewResource(newName);
+		if (currentFile != null && typeEntry != null) {
+			updateTypeEntryToName(currentFile, typeEntry, newName);
+			return new UpdateTypeEntryChange(currentFile, typeEntry, oldName, newName);
 		}
 		return null;
 	}
 
-	private static void updateTypeEntryByRename(final IFile newFile, final TypeEntry entry) {
-		final String newTypeName = TypeEntry.getTypeNameFromFile(newFile);
-
-		if (!Objects.equals(newFile, entry.getFile())) {
+	private static void updateTypeEntryToName(final IFile currentFile, final TypeEntry entry,
+			final String targetTypeName) {
+		if (!Objects.equals(currentFile, entry.getFile()) || !Objects.equals(targetTypeName, entry.getTypeName())) {
 			final TypeLibrary typeLibrary = entry.getTypeLibrary();
 			if (typeLibrary != null) {
 				typeLibrary.removeTypeEntry(entry);
 			}
-			entry.setFile(newFile);
+			entry.setFile(currentFile);
 
 			// update type and typeEditable names
 			final LibraryElement type = entry.copyType();
 			if ((null != type)) {
-				type.setName(newTypeName);
+				type.setName(targetTypeName);
 			}
 
 			if (typeLibrary != null) {


### PR DESCRIPTION
## Summary
Fixes #2513.

`UpdateTypeEntryChange#perform` returned an undo change whose `findNewResource(restoredName)` looked up the file at its restored name. During the LTK composite undo, the file rename undo has not yet executed when this change runs, so the lookup returned `null` and the content and library revert were silently skipped. The file was renamed back on disk, but its internal `<DataType Name=...>` kept the renamed value, leaving the persisted model inconsistent and the original qualified type name unresolvable.

## Fix
- Use the captured file reference when it still resolves (the undo case, where the file is still at its renamed location); fall back to `findNewResource` only on the forward path.
- Derive the target type name from the constructor argument instead of from the file's current filename, so the content update writes the correct name regardless of where the file is currently located.

No public API change. ~29 net lines in one file.

## Reproducer
The two undo/redo tests in #2273 demonstrate the bug. They are currently `@Disabled` there; once this lands and is back-merged into `develop`, they will be re-enabled in that PR.

## Verification
Local Tycho build on `3.2.x` with the reproducer tests pulled in and `@Disabled` removed: `Tests run: 5, Failures: 0, Errors: 0, Skipped: 0`, `BUILD SUCCESS`.