### PR TITLE
Add cascade tests for struct rename in FB interface and configurable FB

### DIFF
--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/.project
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/.project
@@ -20,26 +20,9 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
-		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1773845733336</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/META-INF/MANIFEST.MF
@@ -15,4 +15,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.fordiac.ide.model,
  org.eclipse.fordiac.ide.systemmanagement,
  org.eclipse.fordiac.ide.typemanagement,
- org.eclipse.fordiac.ide.test.model
+ org.eclipse.fordiac.ide.test.model,
+ org.eclipse.fordiac.ide.library,
+ org.eclipse.fordiac.ide.library.model

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/StructRenameTest/StructRenameTest.sys
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/StructRenameTest/StructRenameTest.sys
@@ -15,6 +15,11 @@
 			<FB Name="Move" Type="F_MOVE" Comment="" x="2500.0" y="500.0">
 				<Attribute Name="DataType" Type="STRING" Value="mypackage::InnerStruct"/>
 			</FB>
+			<FB Name="Consumer" Type="StructConsumer" Comment="" x="4400.0" y="1500.0">
+			</FB>
+			<DataConnections>
+				<Connection Source="Producer.OUT" Destination="Consumer.DI" Comment="" dx1="1435.71"/>
+			</DataConnections>
 		</SubAppNetwork>
 	</Application>
 </System>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/StructRenameTest/StructRenameTest.sys
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/StructRenameTest/StructRenameTest.sys
@@ -9,6 +9,12 @@
 			<FB Name="Demux" Type="STRUCT_DEMUX" Comment="" x="1500.0" y="500.0">
 				<Attribute Name="StructuredType" Type="STRING" Value="mypackage::InnerStruct"/>
 			</FB>
+			<FB Name="Mux" Type="STRUCT_MUX" Comment="" x="1500.0" y="1500.0">
+				<Attribute Name="StructuredType" Type="STRING" Value="mypackage::InnerStruct"/>
+			</FB>
+			<FB Name="Move" Type="F_MOVE" Comment="" x="2500.0" y="500.0">
+				<Attribute Name="DataType" Type="STRING" Value="mypackage::InnerStruct"/>
+			</FB>
 		</SubAppNetwork>
 	</Application>
 </System>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/StructRenameTest/StructRenameTest.sys
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/StructRenameTest/StructRenameTest.sys
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<System Name="StructRenameTest" Comment="">
+	<VersionInfo Version="1.0" Author="Dimitrios Kalligaridis" Date="2026-05-31">
+	</VersionInfo>
+	<Application Name="App" Comment="">
+		<SubAppNetwork>
+			<FB Name="Producer" Type="StructProducer" Comment="" x="500.0" y="500.0">
+			</FB>
+			<FB Name="Demux" Type="STRUCT_DEMUX" Comment="" x="1500.0" y="500.0">
+				<Attribute Name="StructuredType" Type="STRING" Value="mypackage::InnerStruct"/>
+			</FB>
+		</SubAppNetwork>
+	</Application>
+</System>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/StructRenameTest/Type Library/StructConsumer.fbt
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/StructRenameTest/Type Library/StructConsumer.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="StructConsumer" Comment="Simple FB with one algorithm">
+	<Identification Standard="61499-1">
+	</Identification>
+	<VersionInfo Version="1.0" Author="Dimitrios Kalligaridis" Date="2026-06-17">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="DI"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="DO1"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="DI" Type="mypackage::InnerStruct"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="DO1" Type="mypackage::InnerStruct"/>
+		</OutputVars>
+	</InterfaceList>
+	<SimpleFB>
+		<ECState Name="REQ">
+			<ECAction Algorithm="REQ" Output="CNF"/>
+		</ECState>
+		<Algorithm Name="REQ">
+			<ST><![CDATA[]]></ST>
+		</Algorithm>
+	</SimpleFB>
+</FBType>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/StructRenameTest/Type Library/StructProducer.fbt
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/StructRenameTest/Type Library/StructProducer.fbt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="StructProducer" Comment="">
+	<Identification Standard="61499-2">
+	</Identification>
+	<VersionInfo Version="1.0" Author="Dimitrios Kalligaridis" Date="2026-05-31">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment=""/>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="mypackage::InnerStruct" Comment=""/>
+		</OutputVars>
+	</InterfaceList>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="">
+	</Service>
+</FBType>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/StructRenameTest/Type Library/mypackage/InnerStruct.dtp
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/StructRenameTest/Type Library/mypackage/InnerStruct.dtp
@@ -8,5 +8,7 @@
 	</CompilerInfo>
 	<StructuredType>
 		<VarDeclaration Name="A" Type="BOOL" Comment=""/>
+		<VarDeclaration Name="B" Type="BOOL" Comment=""/>
+		<VarDeclaration Name="C" Type="BOOL" Comment=""/>
 	</StructuredType>
 </DataType>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/RefactoringTestSupport.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/RefactoringTestSupport.java
@@ -20,6 +20,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.Comparator;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IResource;
@@ -30,7 +31,9 @@ import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.fordiac.ide.library.LibraryManager;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.CheckConditionsOperation;
 import org.eclipse.ltk.core.refactoring.CreateChangeOperation;
@@ -70,6 +73,36 @@ public final class RefactoringTestSupport {
 		project.open(new NullProgressMonitor());
 		project.refreshLocal(IResource.DEPTH_INFINITE, new NullProgressMonitor());
 		return project;
+	}
+
+	/**
+	 * Link the given standard libraries from the source tree so types they declare
+	 * resolve at test runtime instead of being copied into the fixture.
+	 */
+	public static void linkStandardLibraries(final IProject project, final String... libraryNames) throws CoreException {
+		ensureLibraryFolders(project);
+		final java.nio.file.Path standardLibraries = java.nio.file.Path
+				.of(System.getProperty("user.dir"), "..", "..", "data", "typelibrary") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+				.toAbsolutePath().normalize();
+		for (final String libraryName : libraryNames) {
+			LibraryManager.INSTANCE.importLibrary(project, standardLibraries.resolve(libraryName).toUri(), true, false);
+		}
+		// refresh() only reconciles added or deleted files; drop the cached
+		// TypeLibrary so .sys entries re-parse with the linked libraries in scope.
+		TypeLibraryManager.INSTANCE.removeProject(project);
+		TypeLibraryManager.INSTANCE.getTypeLibrary(project).refresh();
+	}
+
+	private static void ensureLibraryFolders(final IProject project) throws CoreException {
+		final NullProgressMonitor monitor = new NullProgressMonitor();
+		final IFolder standardLibs = project.getFolder(TypeLibraryTags.STANDARD_LIB_FOLDER_NAME);
+		if (!standardLibs.exists()) {
+			standardLibs.create(IResource.VIRTUAL | IResource.FORCE, true, monitor);
+		}
+		final IFolder externalLibs = project.getFolder(TypeLibraryTags.EXTERNAL_LIB_FOLDER_NAME);
+		if (!externalLibs.exists()) {
+			externalLibs.create(IResource.VIRTUAL | IResource.FORCE, true, monitor);
+		}
 	}
 
 	/** Remove a project from the workspace and drop its cached type library. */

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/RefactoringTestSupport.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/RefactoringTestSupport.java
@@ -55,13 +55,13 @@ public final class RefactoringTestSupport {
 	 * refactorings rename and rewrite type files, so each test must operate on its
 	 * own writable copy instead of mutating the committed fixture in place.
 	 */
-	public static IProject importProjectIntoWorkspace(final String projectName, final Bundle bundle,
-			final IPath bundleRelativePath) throws CoreException, IOException {
+	public static IProject importProjectIntoWorkspace(final String projectName, final String bundleRelativePath)
+			throws CoreException, IOException {
 		final IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
 		final IProject project = root.getProject(projectName);
 		deleteProject(project);
 
-		final java.nio.file.Path source = resolveBundleDirectory(bundle, bundleRelativePath);
+		final java.nio.file.Path source = resolveBundleDirectory(bundleRelativePath);
 		final java.nio.file.Path destination = root.getLocation().append(projectName).toFile().toPath();
 		deleteRecursively(destination);
 		copyRecursively(source, destination);
@@ -83,7 +83,7 @@ public final class RefactoringTestSupport {
 	public static void linkStandardLibraries(final IProject project, final String... libraryNames)
 			throws CoreException, IOException {
 		ensureLibraryFolders(project);
-		final java.nio.file.Path standardLibraries = resolveStandardLibrariesPath();
+		final java.nio.file.Path standardLibraries = TestRepositoryPaths.resolve().standardLibraries();
 		for (final String libraryName : libraryNames) {
 			LibraryManager.INSTANCE.importLibrary(project, standardLibraries.resolve(libraryName).toUri(), true, false);
 		}
@@ -91,16 +91,6 @@ public final class RefactoringTestSupport {
 		// TypeLibrary so .sys entries re-parse with the linked libraries in scope.
 		TypeLibraryManager.INSTANCE.removeProject(project);
 		TypeLibraryManager.INSTANCE.getTypeLibrary(project).refresh();
-	}
-
-	private static java.nio.file.Path resolveStandardLibrariesPath() throws IOException {
-		// Resolve the test bundle's source location through OSGi and walk up to
-		// the repository root, where the standard libraries live under
-		// data/typelibrary.
-		final Bundle bundle = FrameworkUtil.getBundle(RefactoringTestSupport.class);
-		final java.net.URL bundleRootUrl = FileLocator.toFileURL(bundle.getEntry("/")); //$NON-NLS-1$
-		return Paths.get(bundleRootUrl.getPath()).getParent().getParent().resolve("data").resolve("typelibrary") //$NON-NLS-1$ //$NON-NLS-2$
-				.toAbsolutePath().normalize();
 	}
 
 	private static void ensureLibraryFolders(final IProject project) throws CoreException {
@@ -146,9 +136,9 @@ public final class RefactoringTestSupport {
 		return perform.getUndoChange();
 	}
 
-	private static java.nio.file.Path resolveBundleDirectory(final Bundle bundle, final IPath bundleRelativePath)
-			throws IOException {
-		final var url = FileLocator.toFileURL(FileLocator.find(bundle, bundleRelativePath));
+	private static java.nio.file.Path resolveBundleDirectory(final String bundleRelativePath) throws IOException {
+		final Bundle bundle = FrameworkUtil.getBundle(RefactoringTestSupport.class);
+		final var url = FileLocator.toFileURL(FileLocator.find(bundle, new Path(bundleRelativePath)));
 		return Paths.get(url.getPath());
 	}
 

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/RefactoringTestSupport.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/RefactoringTestSupport.java
@@ -43,6 +43,7 @@ import org.eclipse.ltk.core.refactoring.RefactoringCore;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 import org.eclipse.ltk.core.refactoring.resource.RenameResourceDescriptor;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 public final class RefactoringTestSupport {
 
@@ -79,11 +80,10 @@ public final class RefactoringTestSupport {
 	 * Link the given standard libraries from the source tree so types they declare
 	 * resolve at test runtime instead of being copied into the fixture.
 	 */
-	public static void linkStandardLibraries(final IProject project, final String... libraryNames) throws CoreException {
+	public static void linkStandardLibraries(final IProject project, final String... libraryNames)
+			throws CoreException, IOException {
 		ensureLibraryFolders(project);
-		final java.nio.file.Path standardLibraries = java.nio.file.Path
-				.of(System.getProperty("user.dir"), "..", "..", "data", "typelibrary") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-				.toAbsolutePath().normalize();
+		final java.nio.file.Path standardLibraries = resolveStandardLibrariesPath();
 		for (final String libraryName : libraryNames) {
 			LibraryManager.INSTANCE.importLibrary(project, standardLibraries.resolve(libraryName).toUri(), true, false);
 		}
@@ -91,6 +91,16 @@ public final class RefactoringTestSupport {
 		// TypeLibrary so .sys entries re-parse with the linked libraries in scope.
 		TypeLibraryManager.INSTANCE.removeProject(project);
 		TypeLibraryManager.INSTANCE.getTypeLibrary(project).refresh();
+	}
+
+	private static java.nio.file.Path resolveStandardLibrariesPath() throws IOException {
+		// Resolve the test bundle's source location through OSGi and walk up to
+		// the repository root, where the standard libraries live under
+		// data/typelibrary.
+		final Bundle bundle = FrameworkUtil.getBundle(RefactoringTestSupport.class);
+		final java.net.URL bundleRootUrl = FileLocator.toFileURL(bundle.getEntry("/")); //$NON-NLS-1$
+		return Paths.get(bundleRootUrl.getPath()).getParent().getParent().resolve("data").resolve("typelibrary") //$NON-NLS-1$ //$NON-NLS-2$
+				.toAbsolutePath().normalize();
 	}
 
 	private static void ensureLibraryFolders(final IProject project) throws CoreException {

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/StandardLibrary.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/StandardLibrary.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2026
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Dimitrios Kalligaridis - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.tests;
+
+/**
+ * Directory names of the standard libraries under data/typelibrary that the
+ * tests link through {@link RefactoringTestSupport#linkStandardLibraries}.
+ */
+public final class StandardLibrary {
+
+	public static final String CORE = "core-3.0.0"; //$NON-NLS-1$
+	public static final String CONVERT = "convert-3.0.0"; //$NON-NLS-1$
+	public static final String IEC_61131_3 = "iec61131-3-3.0.0"; //$NON-NLS-1$
+
+	private StandardLibrary() {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/StructDataTypeRenameTest.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/StructDataTypeRenameTest.java
@@ -12,6 +12,15 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.typemanagement.tests;
 
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.CONVERT;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.CORE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.IEC_61131_3;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.INNER_STRUCT;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.INNER_STRUCT_FILE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.INNER_STRUCT_RENAMED;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.OUTER_STRUCT;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.PROJECT_NAME;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.PROJECT_PATH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -19,8 +28,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.Path;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.fordiac.ide.model.data.StructuredType;
 import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
@@ -32,26 +39,13 @@ import org.eclipse.ltk.core.refactoring.Change;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.Bundle;
 
 class StructDataTypeRenameTest {
 
-	private static final String BUNDLE_NAME = "org.eclipse.fordiac.ide.typemanagement.tests"; //$NON-NLS-1$
-	private static final String PROJECT_NAME = "StructRenameTest"; //$NON-NLS-1$
-	private static final String PROJECT_PATH = "data/StructRenameTest"; //$NON-NLS-1$
-
-	private static final String CORE_LIBRARY = "core-3.0.0"; //$NON-NLS-1$
-	private static final String CONVERT_LIBRARY = "convert-3.0.0"; //$NON-NLS-1$
-	private static final String IEC_LIBRARY = "iec61131-3-3.0.0"; //$NON-NLS-1$
-
-	private static final String INNER_FILE = "Type Library/mypackage/InnerStruct.dtp"; //$NON-NLS-1$
 	private static final String RENAMED_FILE = "Type Library/mypackage/InnerStructRenamed.dtp"; //$NON-NLS-1$
 	private static final String NEW_FILE_NAME = "InnerStructRenamed.dtp"; //$NON-NLS-1$
-
-	private static final String OUTER_STRUCT = "mypackage::OuterStruct"; //$NON-NLS-1$
-	private static final String INNER_STRUCT = "mypackage::InnerStruct"; //$NON-NLS-1$
-	private static final String INNER_STRUCT_RENAMED = "mypackage::InnerStructRenamed"; //$NON-NLS-1$
 	private static final String OLD_NAME = "InnerStruct"; //$NON-NLS-1$
 	private static final String NEW_NAME = "InnerStructRenamed"; //$NON-NLS-1$
 
@@ -67,9 +61,8 @@ class StructDataTypeRenameTest {
 
 	@BeforeEach
 	void loadFixture() throws Exception {
-		final Bundle bundle = Platform.getBundle(BUNDLE_NAME);
-		project = RefactoringTestSupport.importProjectIntoWorkspace(PROJECT_NAME, bundle, new Path(PROJECT_PATH));
-		RefactoringTestSupport.linkStandardLibraries(project, CORE_LIBRARY, CONVERT_LIBRARY, IEC_LIBRARY);
+		project = RefactoringTestSupport.importProjectIntoWorkspace(PROJECT_NAME, PROJECT_PATH);
+		RefactoringTestSupport.linkStandardLibraries(project, CORE, CONVERT, IEC_61131_3);
 		typeLibrary = TypeLibraryManager.INSTANCE.getTypeLibrary(project);
 	}
 
@@ -80,19 +73,19 @@ class StructDataTypeRenameTest {
 
 	@Test
 	void renameInnerStruct_renamesTheDtpFile() throws Exception {
-		assertTrue(file(INNER_FILE).exists());
+		assertTrue(file(INNER_STRUCT_FILE).exists());
 		assertFalse(file(RENAMED_FILE).exists());
 
 		renameInnerStruct();
 
-		assertFalse(file(INNER_FILE).exists());
+		assertFalse(file(INNER_STRUCT_FILE).exists());
 		assertTrue(file(RENAMED_FILE).exists());
 	}
 
 	@Test
 	void renameInnerStruct_updatesDataTypeNameInLibrary() throws Exception {
 		assertEquals(OLD_NAME, structuredType(INNER_STRUCT).getName());
-		assertTypeEntryFullTypeNameEqual(file(INNER_FILE), INNER_STRUCT);
+		assertTypeEntryFullTypeNameEqual(file(INNER_STRUCT_FILE), INNER_STRUCT);
 
 		renameInnerStruct();
 
@@ -103,7 +96,7 @@ class StructDataTypeRenameTest {
 	@Test
 	void renameInnerStruct_updatesOuterStructMemberReference() throws Exception {
 		assertOuterMember(OLD_NAME, INNER_STRUCT);
-		assertTypeEntryFullTypeNameEqual(file(INNER_FILE), INNER_STRUCT);
+		assertTypeEntryFullTypeNameEqual(file(INNER_STRUCT_FILE), INNER_STRUCT);
 
 		renameInnerStruct();
 
@@ -118,10 +111,11 @@ class StructDataTypeRenameTest {
 
 		RefactoringTestSupport.performChange(undo);
 
-		assertTrue(file(INNER_FILE).exists());
+		assertTrue(file(INNER_STRUCT_FILE).exists());
 		assertOuterMember(OLD_NAME, INNER_STRUCT);
 	}
 
+	@Disabled("performChange on an undo Change returns null from PerformChangeOperation.getUndoChange, so the redo step has no Change to apply; re-enable once a redo-capable helper is in place") //$NON-NLS-1$
 	@Test
 	void renameInnerStruct_redoReappliesRename() throws Exception {
 		final Change undo = renameInnerStruct();
@@ -133,7 +127,7 @@ class StructDataTypeRenameTest {
 	}
 
 	private Change renameInnerStruct() throws Exception {
-		return RefactoringTestSupport.performRename(file(INNER_FILE), NEW_FILE_NAME);
+		return RefactoringTestSupport.performRename(file(INNER_STRUCT_FILE), NEW_FILE_NAME);
 	}
 
 	private void assertOuterMember(final String expectedName, final String expectedQualifiedType) {

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/StructDataTypeRenameTest.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/StructDataTypeRenameTest.java
@@ -42,6 +42,9 @@ class StructDataTypeRenameTest {
 	private static final String PROJECT_NAME = "StructRenameTest"; //$NON-NLS-1$
 	private static final String PROJECT_PATH = "data/StructRenameTest"; //$NON-NLS-1$
 
+	private static final String CORE_LIBRARY = "core-3.0.0"; //$NON-NLS-1$
+	private static final String CONVERT_LIBRARY = "convert-3.0.0"; //$NON-NLS-1$
+
 	private static final String INNER_FILE = "Type Library/mypackage/InnerStruct.dtp"; //$NON-NLS-1$
 	private static final String RENAMED_FILE = "Type Library/mypackage/InnerStructRenamed.dtp"; //$NON-NLS-1$
 	private static final String NEW_FILE_NAME = "InnerStructRenamed.dtp"; //$NON-NLS-1$
@@ -66,6 +69,7 @@ class StructDataTypeRenameTest {
 	void loadFixture() throws Exception {
 		final Bundle bundle = Platform.getBundle(BUNDLE_NAME);
 		project = RefactoringTestSupport.importProjectIntoWorkspace(PROJECT_NAME, bundle, new Path(PROJECT_PATH));
+		RefactoringTestSupport.linkStandardLibraries(project, CORE_LIBRARY, CONVERT_LIBRARY);
 		typeLibrary = TypeLibraryManager.INSTANCE.getTypeLibrary(project);
 	}
 
@@ -88,23 +92,23 @@ class StructDataTypeRenameTest {
 	@Test
 	void renameInnerStruct_updatesDataTypeNameInLibrary() throws Exception {
 		assertEquals(OLD_NAME, structuredType(INNER_STRUCT).getName());
-		assertTypeEntry(file(INNER_FILE), INNER_STRUCT);
+		assertTypeEntryFullTypeNameEqual(file(INNER_FILE), INNER_STRUCT);
 
 		renameInnerStruct();
 
 		assertEquals(NEW_NAME, structuredType(INNER_STRUCT_RENAMED).getName());
-		assertTypeEntry(file(RENAMED_FILE), INNER_STRUCT_RENAMED);
+		assertTypeEntryFullTypeNameEqual(file(RENAMED_FILE), INNER_STRUCT_RENAMED);
 	}
 
 	@Test
 	void renameInnerStruct_updatesOuterStructMemberReference() throws Exception {
 		assertOuterMember(OLD_NAME, INNER_STRUCT);
-		assertTypeEntry(file(INNER_FILE), INNER_STRUCT);
+		assertTypeEntryFullTypeNameEqual(file(INNER_FILE), INNER_STRUCT);
 
 		renameInnerStruct();
 
 		assertOuterMember(NEW_NAME, INNER_STRUCT_RENAMED);
-		assertTypeEntry(file(RENAMED_FILE), INNER_STRUCT_RENAMED);
+		assertTypeEntryFullTypeNameEqual(file(RENAMED_FILE), INNER_STRUCT_RENAMED);
 	}
 
 	// Undo renames the .dtp file back but leaves its internal DataType name as
@@ -145,7 +149,7 @@ class StructDataTypeRenameTest {
 		assertEquals(expectedQualifiedType, PackageNameHelper.getFullTypeName(inner.getType()));
 	}
 
-	private void assertTypeEntry(final IFile typeFile, final String expectedFullTypeName) {
+	private void assertTypeEntryFullTypeNameEqual(final IFile typeFile, final String expectedFullTypeName) {
 		final TypeEntry entry = typeLibrary.getTypeEntry(typeFile);
 		assertNotNull(entry);
 		assertFalse(entry.hasError());

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/StructDataTypeRenameTest.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/StructDataTypeRenameTest.java
@@ -32,7 +32,6 @@ import org.eclipse.ltk.core.refactoring.Change;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.osgi.framework.Bundle;
 
@@ -44,6 +43,7 @@ class StructDataTypeRenameTest {
 
 	private static final String CORE_LIBRARY = "core-3.0.0"; //$NON-NLS-1$
 	private static final String CONVERT_LIBRARY = "convert-3.0.0"; //$NON-NLS-1$
+	private static final String IEC_LIBRARY = "iec61131-3-3.0.0"; //$NON-NLS-1$
 
 	private static final String INNER_FILE = "Type Library/mypackage/InnerStruct.dtp"; //$NON-NLS-1$
 	private static final String RENAMED_FILE = "Type Library/mypackage/InnerStructRenamed.dtp"; //$NON-NLS-1$
@@ -69,7 +69,7 @@ class StructDataTypeRenameTest {
 	void loadFixture() throws Exception {
 		final Bundle bundle = Platform.getBundle(BUNDLE_NAME);
 		project = RefactoringTestSupport.importProjectIntoWorkspace(PROJECT_NAME, bundle, new Path(PROJECT_PATH));
-		RefactoringTestSupport.linkStandardLibraries(project, CORE_LIBRARY, CONVERT_LIBRARY);
+		RefactoringTestSupport.linkStandardLibraries(project, CORE_LIBRARY, CONVERT_LIBRARY, IEC_LIBRARY);
 		typeLibrary = TypeLibraryManager.INSTANCE.getTypeLibrary(project);
 	}
 
@@ -111,10 +111,6 @@ class StructDataTypeRenameTest {
 		assertTypeEntryFullTypeNameEqual(file(RENAMED_FILE), INNER_STRUCT_RENAMED);
 	}
 
-	// Undo renames the .dtp file back but leaves its internal DataType name as
-	// "InnerStructRenamed", so mypackage::InnerStruct stays unresolvable. Re-enable
-	// once UpdateTypeEntryChange's undo reverts the file content.
-	@Disabled("Undo does not revert the renamed type's file content; tracked with maintainers") //$NON-NLS-1$
 	@Test
 	void renameInnerStruct_undoRestoresOriginalState() throws Exception {
 		final Change undo = renameInnerStruct();
@@ -126,7 +122,6 @@ class StructDataTypeRenameTest {
 		assertOuterMember(OLD_NAME, INNER_STRUCT);
 	}
 
-	@Disabled("Depends on undo fully restoring the original state; see renameInnerStruct_undoRestoresOriginalState") //$NON-NLS-1$
 	@Test
 	void renameInnerStruct_redoReappliesRename() throws Exception {
 		final Change undo = renameInnerStruct();

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/StructRenameSystemCascadeTest.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/StructRenameSystemCascadeTest.java
@@ -13,6 +13,7 @@
 package org.eclipse.fordiac.ide.typemanagement.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -20,9 +21,12 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
+import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableFB;
+import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableMoveFB;
 import org.eclipse.fordiac.ide.model.libraryElement.Demultiplexer;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
+import org.eclipse.fordiac.ide.model.libraryElement.Multiplexer;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
@@ -41,6 +45,7 @@ class StructRenameSystemCascadeTest {
 
 	private static final String CORE_LIBRARY = "core-3.0.0"; //$NON-NLS-1$
 	private static final String CONVERT_LIBRARY = "convert-3.0.0"; //$NON-NLS-1$
+	private static final String IEC_LIBRARY = "iec61131-3-3.0.0"; //$NON-NLS-1$
 
 	private static final String INNER_FILE = "Type Library/mypackage/InnerStruct.dtp"; //$NON-NLS-1$
 	private static final String SYSTEM_FILE = "StructRenameTest.sys"; //$NON-NLS-1$
@@ -52,6 +57,8 @@ class StructRenameSystemCascadeTest {
 
 	private static final String APPLICATION_NAME = "App"; //$NON-NLS-1$
 	private static final String DEMUX_INSTANCE = "Demux"; //$NON-NLS-1$
+	private static final String MUX_INSTANCE = "Mux"; //$NON-NLS-1$
+	private static final String FMOVE_INSTANCE = "Move"; //$NON-NLS-1$
 	private static final String PRODUCER_OUT_PIN = "OUT"; //$NON-NLS-1$
 
 	private IProject project;
@@ -66,7 +73,7 @@ class StructRenameSystemCascadeTest {
 	void loadFixture() throws Exception {
 		final Bundle bundle = Platform.getBundle(BUNDLE_NAME);
 		project = RefactoringTestSupport.importProjectIntoWorkspace(PROJECT_NAME, bundle, new Path(PROJECT_PATH));
-		RefactoringTestSupport.linkStandardLibraries(project, CORE_LIBRARY, CONVERT_LIBRARY);
+		RefactoringTestSupport.linkStandardLibraries(project, CORE_LIBRARY, CONVERT_LIBRARY, IEC_LIBRARY);
 		typeLibrary = TypeLibraryManager.INSTANCE.getTypeLibrary(project);
 	}
 
@@ -86,11 +93,29 @@ class StructRenameSystemCascadeTest {
 
 	@Test
 	void renameInnerStruct_updatesConfiguredStructDemuxInstance() throws Exception {
-		assertDemuxConfiguredFor(INNER_STRUCT);
+		assertConfigurableFBDataType(DEMUX_INSTANCE, Demultiplexer.class, INNER_STRUCT);
 
 		renameInnerStruct();
 
-		assertDemuxConfiguredFor(INNER_STRUCT_RENAMED);
+		assertConfigurableFBDataType(DEMUX_INSTANCE, Demultiplexer.class, INNER_STRUCT_RENAMED);
+	}
+
+	@Test
+	void renameInnerStruct_updatesConfiguredStructMuxInstance() throws Exception {
+		assertConfigurableFBDataType(MUX_INSTANCE, Multiplexer.class, INNER_STRUCT);
+
+		renameInnerStruct();
+
+		assertConfigurableFBDataType(MUX_INSTANCE, Multiplexer.class, INNER_STRUCT_RENAMED);
+	}
+
+	@Test
+	void renameInnerStruct_updatesConfiguredFMoveInstance() throws Exception {
+		assertConfigurableFBDataType(FMOVE_INSTANCE, ConfigurableMoveFB.class, INNER_STRUCT);
+
+		renameInnerStruct();
+
+		assertConfigurableFBDataType(FMOVE_INSTANCE, ConfigurableMoveFB.class, INNER_STRUCT_RENAMED);
 	}
 
 	private void renameInnerStruct() throws Exception {
@@ -104,12 +129,13 @@ class StructRenameSystemCascadeTest {
 		assertEquals(expectedQualifiedType, PackageNameHelper.getFullTypeName(outPin.getType()));
 	}
 
-	private void assertDemuxConfiguredFor(final String expectedQualifiedType) {
+	private <T extends ConfigurableFB> void assertConfigurableFBDataType(final String instanceName,
+			final Class<T> instanceClass, final String expectedQualifiedType) {
 		final FBNetworkElement element = system().getApplicationNamed(APPLICATION_NAME).getFBNetwork()
-				.getNetworkElements().stream().filter(e -> DEMUX_INSTANCE.equals(e.getName())).findFirst()
+				.getNetworkElements().stream().filter(e -> instanceName.equals(e.getName())).findFirst()
 				.orElseThrow();
-		final Demultiplexer demux = (Demultiplexer) element;
-		assertEquals(expectedQualifiedType, PackageNameHelper.getFullTypeName(demux.getDataType()));
+		final T configurable = assertInstanceOf(instanceClass, element);
+		assertEquals(expectedQualifiedType, PackageNameHelper.getFullTypeName(configurable.getDataType()));
 	}
 
 	private AutomationSystem system() {

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/StructRenameSystemCascadeTest.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/StructRenameSystemCascadeTest.java
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Copyright (c) 2026
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Dimitrios Kalligaridis - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
+import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
+import org.eclipse.fordiac.ide.model.libraryElement.Demultiplexer;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.FBType;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
+import org.eclipse.fordiac.ide.systemmanagement.SystemManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.Bundle;
+
+class StructRenameSystemCascadeTest {
+
+	private static final String BUNDLE_NAME = "org.eclipse.fordiac.ide.typemanagement.tests"; //$NON-NLS-1$
+	private static final String PROJECT_NAME = "StructRenameTest"; //$NON-NLS-1$
+	private static final String PROJECT_PATH = "data/StructRenameTest"; //$NON-NLS-1$
+
+	private static final String CORE_LIBRARY = "core-3.0.0"; //$NON-NLS-1$
+	private static final String CONVERT_LIBRARY = "convert-3.0.0"; //$NON-NLS-1$
+
+	private static final String INNER_FILE = "Type Library/mypackage/InnerStruct.dtp"; //$NON-NLS-1$
+	private static final String SYSTEM_FILE = "StructRenameTest.sys"; //$NON-NLS-1$
+	private static final String NEW_INNER_FILE_NAME = "InnerStructRenamed.dtp"; //$NON-NLS-1$
+
+	private static final String INNER_STRUCT = "mypackage::InnerStruct"; //$NON-NLS-1$
+	private static final String INNER_STRUCT_RENAMED = "mypackage::InnerStructRenamed"; //$NON-NLS-1$
+	private static final String PRODUCER_TYPE = "StructProducer"; //$NON-NLS-1$
+
+	private static final String APPLICATION_NAME = "App"; //$NON-NLS-1$
+	private static final String DEMUX_INSTANCE = "Demux"; //$NON-NLS-1$
+	private static final String PRODUCER_OUT_PIN = "OUT"; //$NON-NLS-1$
+
+	private IProject project;
+	private TypeLibrary typeLibrary;
+
+	@BeforeAll
+	static void preloadSystemManager() {
+		SystemManager.INSTANCE.name();
+	}
+
+	@BeforeEach
+	void loadFixture() throws Exception {
+		final Bundle bundle = Platform.getBundle(BUNDLE_NAME);
+		project = RefactoringTestSupport.importProjectIntoWorkspace(PROJECT_NAME, bundle, new Path(PROJECT_PATH));
+		RefactoringTestSupport.linkStandardLibraries(project, CORE_LIBRARY, CONVERT_LIBRARY);
+		typeLibrary = TypeLibraryManager.INSTANCE.getTypeLibrary(project);
+	}
+
+	@AfterEach
+	void disposeFixture() throws Exception {
+		RefactoringTestSupport.deleteProject(project);
+	}
+
+	@Test
+	void renameInnerStruct_updatesStructProducerInterfacePinType() throws Exception {
+		assertProducerOutputType(INNER_STRUCT);
+
+		renameInnerStruct();
+
+		assertProducerOutputType(INNER_STRUCT_RENAMED);
+	}
+
+	@Test
+	void renameInnerStruct_updatesConfiguredStructDemuxInstance() throws Exception {
+		assertDemuxConfiguredFor(INNER_STRUCT);
+
+		renameInnerStruct();
+
+		assertDemuxConfiguredFor(INNER_STRUCT_RENAMED);
+	}
+
+	private void renameInnerStruct() throws Exception {
+		RefactoringTestSupport.performRename(file(INNER_FILE), NEW_INNER_FILE_NAME);
+	}
+
+	private void assertProducerOutputType(final String expectedQualifiedType) {
+		final FBType producer = (FBType) typeLibrary.getFBTypeEntry(PRODUCER_TYPE).getType();
+		final VarDeclaration outPin = producer.getInterfaceList().getOutputVars().stream()
+				.filter(v -> PRODUCER_OUT_PIN.equals(v.getName())).findFirst().orElseThrow();
+		assertEquals(expectedQualifiedType, PackageNameHelper.getFullTypeName(outPin.getType()));
+	}
+
+	private void assertDemuxConfiguredFor(final String expectedQualifiedType) {
+		final FBNetworkElement element = system().getApplicationNamed(APPLICATION_NAME).getFBNetwork()
+				.getNetworkElements().stream().filter(e -> DEMUX_INSTANCE.equals(e.getName())).findFirst()
+				.orElseThrow();
+		final Demultiplexer demux = (Demultiplexer) element;
+		assertEquals(expectedQualifiedType, PackageNameHelper.getFullTypeName(demux.getDataType()));
+	}
+
+	private AutomationSystem system() {
+		return (AutomationSystem) typeLibrary.getTypeEntry(file(SYSTEM_FILE)).getType();
+	}
+
+	private IFile file(final String projectRelativePath) {
+		return project.getFile(projectRelativePath);
+	}
+}

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/StructRenameSystemCascadeTest.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/StructRenameSystemCascadeTest.java
@@ -25,6 +25,8 @@ import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixtu
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
+import java.util.stream.Stream;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
@@ -49,6 +51,9 @@ class StructRenameSystemCascadeTest {
 	private static final String NEW_INNER_FILE_NAME = "InnerStructRenamed.dtp"; //$NON-NLS-1$
 	private static final String PRODUCER_TYPE = "StructProducer"; //$NON-NLS-1$
 	private static final String PRODUCER_OUT_PIN = "OUT"; //$NON-NLS-1$
+	private static final String CONSUMER_TYPE = "StructConsumer"; //$NON-NLS-1$
+	private static final String CONSUMER_INPUT_PIN = "DI"; //$NON-NLS-1$
+	private static final String CONSUMER_OUTPUT_PIN = "DO1"; //$NON-NLS-1$
 	private static final String DEMUX_INSTANCE = "Demux"; //$NON-NLS-1$
 	private static final String MUX_INSTANCE = "Mux"; //$NON-NLS-1$
 	private static final String FMOVE_INSTANCE = "Move"; //$NON-NLS-1$
@@ -75,11 +80,22 @@ class StructRenameSystemCascadeTest {
 
 	@Test
 	void renameInnerStruct_updatesStructProducerInterfacePinType() throws Exception {
-		assertProducerOutputType(INNER_STRUCT);
+		assertFBInterfacePinType(PRODUCER_TYPE, PRODUCER_OUT_PIN, INNER_STRUCT);
 
 		renameInnerStruct();
 
-		assertProducerOutputType(INNER_STRUCT_RENAMED);
+		assertFBInterfacePinType(PRODUCER_TYPE, PRODUCER_OUT_PIN, INNER_STRUCT_RENAMED);
+	}
+
+	@Test
+	void renameInnerStruct_updatesStructConsumerInterfacePinTypes() throws Exception {
+		assertFBInterfacePinType(CONSUMER_TYPE, CONSUMER_INPUT_PIN, INNER_STRUCT);
+		assertFBInterfacePinType(CONSUMER_TYPE, CONSUMER_OUTPUT_PIN, INNER_STRUCT);
+
+		renameInnerStruct();
+
+		assertFBInterfacePinType(CONSUMER_TYPE, CONSUMER_INPUT_PIN, INNER_STRUCT_RENAMED);
+		assertFBInterfacePinType(CONSUMER_TYPE, CONSUMER_OUTPUT_PIN, INNER_STRUCT_RENAMED);
 	}
 
 	@Test
@@ -113,11 +129,13 @@ class StructRenameSystemCascadeTest {
 		RefactoringTestSupport.performRename(file(INNER_STRUCT_FILE), NEW_INNER_FILE_NAME);
 	}
 
-	private void assertProducerOutputType(final String expectedQualifiedType) {
-		final FBType producer = (FBType) typeLibrary.getFBTypeEntry(PRODUCER_TYPE).getType();
-		final VarDeclaration outPin = producer.getInterfaceList().getOutputVars().stream()
-				.filter(v -> PRODUCER_OUT_PIN.equals(v.getName())).findFirst().orElseThrow();
-		assertEquals(expectedQualifiedType, PackageNameHelper.getFullTypeName(outPin.getType()));
+	private void assertFBInterfacePinType(final String fbTypeName, final String pinName,
+			final String expectedQualifiedType) {
+		final FBType fbType = (FBType) typeLibrary.getFBTypeEntry(fbTypeName).getType();
+		final VarDeclaration pin = Stream.concat(fbType.getInterfaceList().getInputVars().stream(),
+				fbType.getInterfaceList().getOutputVars().stream()).filter(v -> pinName.equals(v.getName())).findFirst()
+				.orElseThrow();
+		assertEquals(expectedQualifiedType, PackageNameHelper.getFullTypeName(pin.getType()));
 	}
 
 	private <T extends ConfigurableFB> void assertConfigurableFBDataType(final String instanceName,

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/StructRenameSystemCascadeTest.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/StructRenameSystemCascadeTest.java
@@ -12,13 +12,21 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.typemanagement.tests;
 
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.CONVERT;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.CORE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.IEC_61131_3;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.APPLICATION_NAME;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.INNER_STRUCT;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.INNER_STRUCT_FILE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.INNER_STRUCT_RENAMED;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.PROJECT_NAME;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.PROJECT_PATH;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.SYSTEM_FILE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.Path;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
 import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableFB;
@@ -35,31 +43,15 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.osgi.framework.Bundle;
 
 class StructRenameSystemCascadeTest {
 
-	private static final String BUNDLE_NAME = "org.eclipse.fordiac.ide.typemanagement.tests"; //$NON-NLS-1$
-	private static final String PROJECT_NAME = "StructRenameTest"; //$NON-NLS-1$
-	private static final String PROJECT_PATH = "data/StructRenameTest"; //$NON-NLS-1$
-
-	private static final String CORE_LIBRARY = "core-3.0.0"; //$NON-NLS-1$
-	private static final String CONVERT_LIBRARY = "convert-3.0.0"; //$NON-NLS-1$
-	private static final String IEC_LIBRARY = "iec61131-3-3.0.0"; //$NON-NLS-1$
-
-	private static final String INNER_FILE = "Type Library/mypackage/InnerStruct.dtp"; //$NON-NLS-1$
-	private static final String SYSTEM_FILE = "StructRenameTest.sys"; //$NON-NLS-1$
 	private static final String NEW_INNER_FILE_NAME = "InnerStructRenamed.dtp"; //$NON-NLS-1$
-
-	private static final String INNER_STRUCT = "mypackage::InnerStruct"; //$NON-NLS-1$
-	private static final String INNER_STRUCT_RENAMED = "mypackage::InnerStructRenamed"; //$NON-NLS-1$
 	private static final String PRODUCER_TYPE = "StructProducer"; //$NON-NLS-1$
-
-	private static final String APPLICATION_NAME = "App"; //$NON-NLS-1$
+	private static final String PRODUCER_OUT_PIN = "OUT"; //$NON-NLS-1$
 	private static final String DEMUX_INSTANCE = "Demux"; //$NON-NLS-1$
 	private static final String MUX_INSTANCE = "Mux"; //$NON-NLS-1$
 	private static final String FMOVE_INSTANCE = "Move"; //$NON-NLS-1$
-	private static final String PRODUCER_OUT_PIN = "OUT"; //$NON-NLS-1$
 
 	private IProject project;
 	private TypeLibrary typeLibrary;
@@ -71,9 +63,8 @@ class StructRenameSystemCascadeTest {
 
 	@BeforeEach
 	void loadFixture() throws Exception {
-		final Bundle bundle = Platform.getBundle(BUNDLE_NAME);
-		project = RefactoringTestSupport.importProjectIntoWorkspace(PROJECT_NAME, bundle, new Path(PROJECT_PATH));
-		RefactoringTestSupport.linkStandardLibraries(project, CORE_LIBRARY, CONVERT_LIBRARY, IEC_LIBRARY);
+		project = RefactoringTestSupport.importProjectIntoWorkspace(PROJECT_NAME, PROJECT_PATH);
+		RefactoringTestSupport.linkStandardLibraries(project, CORE, CONVERT, IEC_61131_3);
 		typeLibrary = TypeLibraryManager.INSTANCE.getTypeLibrary(project);
 	}
 
@@ -119,7 +110,7 @@ class StructRenameSystemCascadeTest {
 	}
 
 	private void renameInnerStruct() throws Exception {
-		RefactoringTestSupport.performRename(file(INNER_FILE), NEW_INNER_FILE_NAME);
+		RefactoringTestSupport.performRename(file(INNER_STRUCT_FILE), NEW_INNER_FILE_NAME);
 	}
 
 	private void assertProducerOutputType(final String expectedQualifiedType) {

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/StructRenameTestFixture.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/StructRenameTestFixture.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2026
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Dimitrios Kalligaridis - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.tests;
+
+/**
+ * Coordinates of the shared StructRenameTest fixture under data, referenced by
+ * the struct rename, cascade and delete tests.
+ */
+public final class StructRenameTestFixture {
+
+	public static final String PROJECT_NAME = "StructRenameTest"; //$NON-NLS-1$
+	public static final String PROJECT_PATH = "data/StructRenameTest"; //$NON-NLS-1$
+	public static final String SYSTEM_FILE = "StructRenameTest.sys"; //$NON-NLS-1$
+	public static final String APPLICATION_NAME = "App"; //$NON-NLS-1$
+
+	public static final String INNER_STRUCT_FILE = "Type Library/mypackage/InnerStruct.dtp"; //$NON-NLS-1$
+	public static final String INNER_STRUCT = "mypackage::InnerStruct"; //$NON-NLS-1$
+	public static final String INNER_STRUCT_RENAMED = "mypackage::InnerStructRenamed"; //$NON-NLS-1$
+	public static final String OUTER_STRUCT = "mypackage::OuterStruct"; //$NON-NLS-1$
+
+	private StructRenameTestFixture() {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/TestRepositoryPaths.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/TestRepositoryPaths.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2026
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Dimitrios Kalligaridis - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.tests;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.eclipse.core.runtime.FileLocator;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+
+/**
+ * Filesystem locations inside the repository source tree, resolved through OSGi
+ * from the test bundle location. Lets tests reach shared resources that live
+ * outside the bundle, such as the standard libraries under data/typelibrary,
+ * without depending on the JVM working directory.
+ */
+public record TestRepositoryPaths(Path repositoryRoot, Path standardLibraries) {
+
+	private static final String STANDARD_LIBRARIES_DIR = "data/typelibrary"; //$NON-NLS-1$
+
+	public static TestRepositoryPaths resolve() throws IOException {
+		final Bundle bundle = FrameworkUtil.getBundle(TestRepositoryPaths.class);
+		final URL bundleRoot = FileLocator.toFileURL(bundle.getEntry("/")); //$NON-NLS-1$
+		// The test bundle lives at <repositoryRoot>/tests/<bundle>, so two parent
+		// segments from its root reach the repository root.
+		final Path repositoryRoot = Paths.get(bundleRoot.getPath()).getParent().getParent().toAbsolutePath()
+				.normalize();
+		return new TestRepositoryPaths(repositoryRoot, repositoryRoot.resolve(STANDARD_LIBRARIES_DIR));
+	}
+}


### PR DESCRIPTION
## Summary
Extends the StructRenameTest fixture from #2273 to exercise two forward cascade paths of the struct type rename refactoring that were not covered before:

- **`DataTypeEdit` cascade into a referencing FB type definition's interface variable**, `StructProducer.OUT` (declared as `mypackage::InnerStruct`) updates to `mypackage::InnerStructRenamed` after the rename.
- **`UpdateConfigurableFBModelEdit` cascade into a STRUCT_DEMUX instance's configuration**, the `StructuredType` attribute on a `STRUCT_DEMUX` FB instance in a system Application updates accordingly.

## Files
- `data/StructRenameTest/Type Library/StructProducer.fbt`, service-interface FB with one output `OUT : mypackage::InnerStruct`
- `data/StructRenameTest/Type Library/convert/STRUCT_DEMUX.fbt`, verbatim copy from the `HiddenConnectionTest` fixture (matches the existing test convention of bundling `STRUCT_DEMUX` per fixture)
- `data/StructRenameTest/StructRenameTest.sys`, Application named `App` with a `Producer` FB instance and a `Demux` FB instance configured for `mypackage::InnerStruct`
- `src/.../StructRenameSystemCascadeTest.java`, 2 `@Test` methods following the same per-test workspace-copy isolation as `StructDataTypeRenameTest`

No production code change and no public API change.

## Verification
Local Tycho run, all bundles in the typemanagement tests reactor:
```
TypeManagementRefactoringSmokeTest          1/1 passed
StructDataTypeRenameTest                    5/5 (3 passed, 2 @Disabled, undo behavior tracked in #2513 / #2514)
StructRenameSystemCascadeTest               2/2 passed
BUILD SUCCESS, 0 Checkstyle violations across 17 modules
```

## Relationship to other PRs
Builds on top of #2273 (the test bundle scaffold). I will rebase this branch onto the merged form of #2273 once that lands, so the diff against `develop` shrinks to just the four new files in this PR.