### PR TITLE
Fix writing of fake time to device in deployment evaluator

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.deployment.eval/src/org/eclipse/fordiac/ide/deployment/eval/fb/DeploymentFBNetworkElementEvaluator.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.eval/src/org/eclipse/fordiac/ide/deployment/eval/fb/DeploymentFBNetworkElementEvaluator.java
@@ -111,9 +111,13 @@ public abstract class DeploymentFBNetworkElementEvaluator<T extends FBType, I ex
 		prepare();
 		try {
 			writeVariables();
+			// write fake time to device *before* triggering event, so the triggered event
+			// executes with the current time of the evaluator
+			sharedState.writeDeviceParameter(FAKE_TIME_DEV_PARAM_NAME, StandardFunctions.NOW_MONOTONIC().toString());
 			if (triggerEvent(instanceEvent)) {
-				sharedState.writeDeviceParameter(FAKE_TIME_DEV_PARAM_NAME,
-						StandardFunctions.NOW_MONOTONIC().toString());
+				// ~~~~~
+				// event is executing asynchronously on device until pollWatches() returns
+				// ~~~~~
 				pollWatches();
 			}
 			update(getVariables().values());


### PR DESCRIPTION
The deployment evaluator was writing the fake time to the device after triggering the event. This meant that the event was executing with the previous time or even while the time was being changed.

This changes the order to write the fake time *before* triggering the event, so that the event is guaranteed to execute with the current time of the evaluator.