### PR TITLE
Fix missing type name update during refresh in type entry

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/impl/AbstractTypeEntryImpl.java
@@ -524,7 +524,9 @@ public abstract class AbstractTypeEntryImpl extends ConcurrentNotifierImpl imple
 		// check content changed
 		if (isFileContentChanged()) {
 			// load type name
-			loadTypeNameFromFile();
+			final String typeName = loadTypeNameFromFile();
+			// update type name
+			notifications = basicSetFullTypeName(typeName, notifications);
 			// clear cached type
 			notifications = basicSetType(null, notifications);
 			// also notify changed contents


### PR DESCRIPTION
The type name was loaded but not updated during a refresh in the type entry. This could also lead to incorrect duplicate type errors when changing the type name outside of 4diac IDE, such as via version control.