### PR TITLE
Avoid unnecessary marker update jobs and cleanup marker updates

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/builder/LibraryBuilder.java
+++ b/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/builder/LibraryBuilder.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.library.builder;
 
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -39,7 +38,6 @@ import org.eclipse.fordiac.ide.library.Messages;
 import org.eclipse.fordiac.ide.library.model.library.Manifest;
 import org.eclipse.fordiac.ide.library.model.util.ManifestHelper;
 import org.eclipse.fordiac.ide.model.errormarker.FordiacErrorMarker;
-import org.eclipse.fordiac.ide.model.errormarker.FordiacMarkerHelper;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 
 public class LibraryBuilder extends IncrementalProjectBuilder {
@@ -78,20 +76,24 @@ public class LibraryBuilder extends IncrementalProjectBuilder {
 
 	@Override
 	protected void clean(final IProgressMonitor monitor) throws CoreException {
-		final SubMonitor progress = SubMonitor.convert(monitor, Messages.LibraryBuilder_CleaningLibrary, 2);
+		final SubMonitor progress = SubMonitor.convert(monitor, Messages.LibraryBuilder_CleaningLibrary,
+				LibraryManager.LIBRARY_FOLDERS.size() + 1);
 
 		// clean manifest library marker
-		FordiacMarkerHelper.updateMarkers(getProject().getFile(LibraryManager.MANIFEST),
-				FordiacErrorMarker.LIBRARY_MARKER, Collections.emptyList(), true);
+		final IFile manifestFile = getProject().getFile(LibraryManager.MANIFEST);
+		if (manifestFile.exists()) {
+			manifestFile.deleteMarkers(FordiacErrorMarker.LIBRARY_MARKER, true, IResource.DEPTH_ZERO);
+		}
 		progress.worked(1);
 
 		// clean broken link markers
-		LibraryManager.LIBRARY_FOLDERS.stream().map(name -> getProject().getFolder(name))
-				.forEach(folder -> FordiacMarkerHelper.updateMarkers(folder, FordiacErrorMarker.LIBRARY_MARKER,
-						Collections.emptyList(), true));
-		progress.worked(1);
-
-		SubMonitor.done(monitor);
+		for (final String name : LibraryManager.LIBRARY_FOLDERS) {
+			final IFolder folder = getProject().getFolder(name);
+			if (folder.exists()) {
+				folder.deleteMarkers(FordiacErrorMarker.LIBRARY_MARKER, true, IResource.DEPTH_ONE);
+			}
+			progress.worked(1);
+		}
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/UtilityMarkerHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/UtilityMarkerHelper.java
@@ -50,7 +50,7 @@ public class UtilityMarkerHelper {
 	}
 
 	public static void deleteElementMarker(final String markerId, final IResource resource) {
-		FordiacMarkerHelper.updateMarkers(resource, markerId, List.of(), true);
+		FordiacMarkerHelper.updateMarkers(resource, markerId, List.of());
 	}
 
 	public static void setMarkedElement(final String markerId, final EObject target) {
@@ -62,7 +62,7 @@ public class UtilityMarkerHelper {
 
 		final ErrorMarkerBuilder markerBuilder = ErrorMarkerBuilder.createErrorMarkerBuilder(markerId).setType(markerId)
 				.setTarget(target).setSeverity(IMarker.SEVERITY_INFO);
-		FordiacMarkerHelper.updateMarkers(resource, markerId, List.of(markerBuilder), true);
+		FordiacMarkerHelper.updateMarkers(resource, markerId, List.of(markerBuilder));
 	}
 
 	private UtilityMarkerHelper() {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/errormarker/FordiacMarkerHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/errormarker/FordiacMarkerHelper.java
@@ -258,6 +258,11 @@ public final class FordiacMarkerHelper {
 	}
 
 	public static void updateMarkers(final IResource resource, final String type,
+			final List<ErrorMarkerBuilder> builders) {
+		updateMarkers(resource, type, builders, false);
+	}
+
+	public static void updateMarkers(final IResource resource, final String type,
 			final List<ErrorMarkerBuilder> builders, final boolean force) {
 		if (resource != null && resource.isAccessible()
 				&& (force || errorMarkersNeedsUpdate(resource, type, builders))) {
@@ -289,7 +294,7 @@ public final class FordiacMarkerHelper {
 	private static void updateMarkersInWorkspace(final IResource resource, final String type,
 			final List<ErrorMarkerBuilder> builders) {
 		try {
-			resource.deleteMarkers(type, true, IResource.DEPTH_INFINITE);
+			resource.deleteMarkers(type, true, IResource.DEPTH_ZERO);
 			for (final var builder : builders) {
 				builder.createMarker(resource);
 			}
@@ -314,7 +319,7 @@ public final class FordiacMarkerHelper {
 	private static boolean errorMarkersNeedsUpdate(final IResource resource, final String type,
 			final List<ErrorMarkerBuilder> builders) {
 		try {
-			return !builders.isEmpty() || resource.findMarkers(type, true, IResource.DEPTH_INFINITE).length != 0;
+			return !builders.isEmpty() || resource.findMarkers(type, true, IResource.DEPTH_ZERO).length != 0;
 		} catch (final CoreException e) {
 			FordiacLogHelper.logWarning("Couldn't determine marker state of resoruce: " + resource.getName(), e); //$NON-NLS-1$
 

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/TypeLibrary.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/TypeLibrary.java
@@ -632,7 +632,8 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 
 	private void disposeReferencedProjects() {
 		for (final IProject referencedProject : referencedProjects) {
-			final TypeLibrary referencedTypeLibrary = TypeLibraryManager.INSTANCE.getTypeLibraryIfPresent(referencedProject);
+			final TypeLibrary referencedTypeLibrary = TypeLibraryManager.INSTANCE
+					.getTypeLibraryIfPresent(referencedProject);
 			if (referencedTypeLibrary != null) {
 				referencedTypeLibrary.eAdapters().remove(typeLibraryAdapter);
 			}
@@ -701,15 +702,16 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 
 	private void createTypeLibraryMarker(final IResource resource, final String message) {
 		if (resource != null && project.equals(resource.getProject())) {
-			FordiacMarkerHelper.createMarkers(resource, List.of(ErrorMarkerBuilder.createErrorMarkerBuilder(message)
-					.setType(FordiacErrorMarker.TYPE_LIBRARY_MARKER)));
+			FordiacMarkerHelper.updateMarkers(resource, FordiacErrorMarker.TYPE_LIBRARY_MARKER,
+					List.of(ErrorMarkerBuilder.createErrorMarkerBuilder(message)
+							.setType(FordiacErrorMarker.TYPE_LIBRARY_MARKER)));
 		}
 	}
 
 	private void deleteTypeLibraryMarkers(final IResource resource) {
 		if (resource != null && project.equals(resource.getProject())) {
-			FordiacMarkerHelper.updateMarkers(resource, FordiacErrorMarker.TYPE_LIBRARY_MARKER, Collections.emptyList(),
-					true);
+			FordiacMarkerHelper.updateMarkers(resource, FordiacErrorMarker.TYPE_LIBRARY_MARKER,
+					Collections.emptyList());
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/nature/FordiacNature.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/nature/FordiacNature.java
@@ -180,7 +180,7 @@ public class FordiacNature implements IProjectNature {
 					.setCode(WRONG_BUILDER_ORDER));
 		}
 
-		FordiacMarkerHelper.updateMarkers(project, FordiacErrorMarker.PROJECT_CONFIGURATION_MARKER, builders, true);
+		FordiacMarkerHelper.updateMarkers(project, FordiacErrorMarker.PROJECT_CONFIGURATION_MARKER, builders);
 	}
 
 	public boolean hasExportBuilderCommand() throws CoreException {

--- a/tests/org.eclipse.fordiac.ide.test.library/src/org/eclipse/fordiac/ide/test/library/LibraryImportTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.library/src/org/eclipse/fordiac/ide/test/library/LibraryImportTest.java
@@ -17,12 +17,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.net.URI;
 import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
@@ -41,7 +41,6 @@ import org.eclipse.fordiac.ide.library.download.IArchiveDownloader;
 import org.eclipse.fordiac.ide.library.model.library.Manifest;
 import org.eclipse.fordiac.ide.library.model.util.ManifestHelper;
 import org.eclipse.fordiac.ide.model.errormarker.FordiacErrorMarker;
-import org.eclipse.fordiac.ide.model.errormarker.FordiacMarkerHelper;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 import org.eclipse.fordiac.ide.systemmanagement.SystemManager;
@@ -107,9 +106,10 @@ class LibraryImportTest {
 			manifest.getDependencies().getRequired().clear();
 			ManifestHelper.saveManifest(manifest);
 		}
-		FordiacMarkerHelper.updateMarkers(project.getFile(LibraryManager.MANIFEST), FordiacErrorMarker.LIBRARY_MARKER,
-				Collections.emptyList(), true);
-		Job.getJobManager().join(FordiacMarkerHelper.FAMILY_FORDIAC_MARKER, null);
+		final IFile manifestFile = project.getFile(LibraryManager.MANIFEST);
+		if (manifestFile.exists()) {
+			manifestFile.deleteMarkers(FordiacErrorMarker.LIBRARY_MARKER, false, IResource.DEPTH_ZERO);
+		}
 		project.getFolder(TypeLibraryTags.STANDARD_LIB_FOLDER_NAME).accept(resource -> {
 			if (resource instanceof final IFolder folder) {
 				if (folder.getName().equals(TypeLibraryTags.STANDARD_LIB_FOLDER_NAME)) {


### PR DESCRIPTION
This avoids unnecessary workspace jobs by not forcing an update where possible, particularly when adding types in the type library. It also avoids creating duplicate type library markers.

Furthermore, it directly uses `IResource.deleteMarkers` in builders, where we are guaranteed to hold a workspace lock, and only updates current resources without its children.