### PR TITLE
[Replay Debugging] Fix deletion commands and wire undo/redo

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/plugin.xml
@@ -213,7 +213,7 @@
     <!-- Delete Timeline — shown for both Timeline and Event selection -->
       <command commandId="org.eclipse.fordiac.ide.debug.replaydebugging.ui.deleteTimeline"
                label="%command.delete_timeline_label">
-        <visibleWhen checkEnabled="false">
+        <visibleWhen checkEnabled="true">
           <with variable="selection">
             <iterate ifEmpty="false">
               <or>

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/CommonConstants.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/CommonConstants.java
@@ -26,6 +26,8 @@ public class CommonConstants {
 	public static final String ADD_TO_COMPARISON_REQUEST = "AddToComparison"; //$NON-NLS-1$
 	public static final String REMOVE_FROM_COMPARISON_REQUEST = "RemoveFromComparison"; //$NON-NLS-1$
 
+	public static final String SELECTED_EVENT_POSITION = "SelectedEventPosition"; //$NON-NLS-1$
+
 	public static final String ADD_EDIT_EVENT_COMMENT_REQUEST = "AddEditEventComment"; //$NON-NLS-1$
 	public static final String ADD_EDIT_EVENT_COMMENT_DATA = "AddEditEventCommentData"; //$NON-NLS-1$
 	public static final String REMOVE_EVENT_COMMENT_REQUEST = "RemoveEventComment"; //$NON-NLS-1$

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/ReplayDebuggingView.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/ReplayDebuggingView.java
@@ -23,12 +23,17 @@ import org.eclipse.gef.DefaultEditDomain;
 import org.eclipse.gef.GraphicalViewer;
 import org.eclipse.gef.MouseWheelHandler;
 import org.eclipse.gef.MouseWheelZoomHandler;
+import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.gef.editparts.ScalableRootEditPart;
+import org.eclipse.gef.ui.actions.RedoAction;
+import org.eclipse.gef.ui.actions.UndoAction;
 import org.eclipse.gef.ui.parts.ScrollingGraphicalViewer;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Menu;
+import org.eclipse.ui.IActionBars;
+import org.eclipse.ui.actions.ActionFactory;
 import org.eclipse.ui.contexts.IContextService;
 import org.eclipse.ui.part.ViewPart;
 
@@ -67,6 +72,20 @@ public class ReplayDebuggingView extends ViewPart implements IReplayNavigatorReg
 
 		getSite().getService(IContextService.class)
 				.activateContext("org.eclipse.fordiac.ide.debug.replaydebugging.context"); //$NON-NLS-1$
+
+		// Wire undo/redo to the workbench
+		final UndoAction undoAction = new UndoAction(this);
+		final RedoAction redoAction = new RedoAction(this);
+
+		final IActionBars bars = getViewSite().getActionBars();
+		bars.setGlobalActionHandler(ActionFactory.UNDO.getId(), undoAction);
+		bars.setGlobalActionHandler(ActionFactory.REDO.getId(), redoAction);
+
+		viewer.getEditDomain().getCommandStack().addCommandStackListener(e -> {
+			undoAction.update();
+			redoAction.update();
+			bars.updateActionBars();
+		});
 
 		ReplayNavigatorManager.getDefault().addListener(this);
 		SelectionService.getDefault().install(getSite().getPage());
@@ -114,6 +133,9 @@ public class ReplayDebuggingView extends ViewPart implements IReplayNavigatorReg
 	public <T> T getAdapter(final Class<T> adapter) {
 		if (adapter == GraphicalViewer.class) {
 			return adapter.cast(viewer);
+		}
+		if (adapter == CommandStack.class) {
+			return adapter.cast(viewer.getEditDomain().getCommandStack());
 		}
 		return super.getAdapter(adapter);
 	}

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/command/AddEditEventCommentCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/command/AddEditEventCommentCommand.java
@@ -38,7 +38,11 @@ public class AddEditEventCommentCommand extends Command {
 
 	@Override
 	public void undo() {
-		CommentsHandler.getInstance().setComment(eventPosition, previousComment); // restore prior comment
+		if (previousComment == null) {
+			CommentsHandler.getInstance().removeComment(eventPosition);
+		} else {
+			CommentsHandler.getInstance().setComment(eventPosition, previousComment); // restore prior comment
+		}
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/command/AddEditTimelineCommentCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/command/AddEditTimelineCommentCommand.java
@@ -38,7 +38,11 @@ public class AddEditTimelineCommentCommand extends Command {
 
 	@Override
 	public void undo() {
-		CommentsHandler.getInstance().setComment(timeline, previousComment); // restore prior comment
+		if (previousComment == null) {
+			CommentsHandler.getInstance().removeComment(timeline);
+		} else {
+			CommentsHandler.getInstance().setComment(timeline, previousComment); // restore prior comment
+		}
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/command/DeleteEventsCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/command/DeleteEventsCommand.java
@@ -29,11 +29,15 @@ public class DeleteEventsCommand extends Command {
 	private final Timeline timeline;
 	private final int eventIndex;
 	private List<EventChange> eventChanges; // Store event data for undo
+	private final int spawningIndex;
+	private final Timeline parentTimeline;
 
 	public DeleteEventsCommand(final Timeline timeline, final int eventIndex) {
 		super(Messages.DeleteEventsCommand_Label);
 		this.timeline = timeline;
 		this.eventIndex = eventIndex;
+		parentTimeline = timeline.getParentTimeline();
+		spawningIndex = (parentTimeline != null) ? parentTimeline.getSpawnedTimelineEventNumber(timeline) : -1;
 	}
 
 	@Override
@@ -45,6 +49,10 @@ public class DeleteEventsCommand extends Command {
 
 	@Override
 	public void undo() {
+		// the timeline was removed from the parent, so we need to re-add it
+		if ((eventIndex == 0) && (parentTimeline != null)) {
+			parentTimeline.addSpawnedTimeline(timeline, spawningIndex);
+		}
 		// Restore the event with its previous data
 		for (final var eventChange : eventChanges) {
 			timeline.addEventChange(eventChange.newValues());

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/EventMarkerEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/EventMarkerEditPart.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.fordiac.ide.debug.replaydebugging.core.ReplayNavigator.EventPosition;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.CommonConstants;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.command.DeleteEventsCommand;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.figure.EventMarkerFigure;
@@ -93,6 +94,18 @@ public class EventMarkerEditPart extends AbstractGraphicalEditPart
 			}
 		});
 
+		installEditPolicy(CommonConstants.COMPARISON_POLICY, new AbstractEditPolicy() {
+			@Override
+			public Command getCommand(final Request request) {
+				if (CommonConstants.ADD_TO_COMPARISON_REQUEST.equals(request.getType())
+						|| CommonConstants.REMOVE_FROM_COMPARISON_REQUEST.equals(request.getType())) {
+					request.getExtendedData().put(CommonConstants.SELECTED_EVENT_POSITION,
+							new EventPosition(getModel().getParentTimeline().getTimeline(), getModel().getIndex()));
+				}
+				return null;
+			}
+		});
+
 	}
 
 	@Override
@@ -113,11 +126,14 @@ public class EventMarkerEditPart extends AbstractGraphicalEditPart
 		figure.repaint();
 	}
 
-	private void safeRefresh() {
+	private void safeRefresh(final boolean reveal) {
 		final Display display = getViewer().getControl().getDisplay();
 		display.asyncExec(() -> {
 			if (isActive()) {
 				refreshVisuals();
+				if (getModel().getIsCurrentEvent() && reveal) {
+					getViewer().reveal(this);
+				}
 			}
 		});
 	}
@@ -164,7 +180,9 @@ public class EventMarkerEditPart extends AbstractGraphicalEditPart
 	@Override
 	public void propertyChange(final PropertyChangeEvent evt) {
 		if (evt.getPropertyName().equals(EventMarker.PROPERTY_EVENT_CHANGED)) {
-			safeRefresh();
+			safeRefresh(false);
+		} else if (evt.getPropertyName().equals(EventMarker.PROPERTY_IS_CURRENT_CHANGED)) {
+			safeRefresh(true);
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/ResourceEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/editpart/ResourceEditPart.java
@@ -16,6 +16,7 @@ package org.eclipse.fordiac.ide.debug.replaydebugging.ui.editpart;
 import java.util.List;
 
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.fordiac.ide.debug.replaydebugging.core.ReplayNavigator.EventPosition;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.CommentsHandler;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.CommonConstants;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.command.AddToComparisonCommand;
@@ -26,8 +27,10 @@ import org.eclipse.fordiac.ide.debug.replaydebugging.ui.command.MoveUpCommand;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.command.RemoveFromComparisonCommand;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.figure.NameStackedFigure;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.model.Resource;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.Request;
+import org.eclipse.gef.RequestConstants;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.editparts.AbstractGraphicalEditPart;
 import org.eclipse.gef.editpolicies.AbstractEditPolicy;
@@ -63,6 +66,15 @@ public class ResourceEditPart extends AbstractGraphicalEditPart {
 	}
 
 	@Override
+	public EditPart getTargetEditPart(final Request request) {
+		if (RequestConstants.REQ_SELECTION.equals(request.getType())) {
+			return getEditPartFromCurrentEventPosition();
+		}
+
+		return super.getTargetEditPart(request);
+	}
+
+	@Override
 	protected void createEditPolicies() {
 		installEditPolicy(EditPolicy.SELECTION_FEEDBACK_ROLE, new NonResizableEditPolicy());
 		installEditPolicy(CommonConstants.NAVIGATION_POLICY, new AbstractEditPolicy() {
@@ -85,17 +97,61 @@ public class ResourceEditPart extends AbstractGraphicalEditPart {
 			@Override
 			public Command getCommand(final Request request) {
 				if (CommonConstants.ADD_TO_COMPARISON_REQUEST.equals(request.getType())) {
-					return new AddToComparisonCommand(getModel().getReplayNavigator(),
-							getModel().getReplayNavigator().getCurrentEventPosition(), CommentsHandler.getInstance()
-									.getComment(getModel().getReplayNavigator().getCurrentEventPosition()));
+					var eventPosition = (EventPosition) request.getExtendedData()
+							.get(CommonConstants.SELECTED_EVENT_POSITION);
+					if (eventPosition == null) {
+						eventPosition = getModel().getReplayNavigator().getCurrentEventPosition();
+					}
+
+					return new AddToComparisonCommand(getModel().getReplayNavigator(), eventPosition,
+							CommentsHandler.getInstance().getComment(eventPosition));
 				}
 				if (CommonConstants.REMOVE_FROM_COMPARISON_REQUEST.equals(request.getType())) {
-					return new RemoveFromComparisonCommand(getModel().getReplayNavigator().getCurrentEventPosition());
+					var eventPosition = (EventPosition) request.getExtendedData()
+							.get(CommonConstants.SELECTED_EVENT_POSITION);
+					if (eventPosition == null) {
+						eventPosition = getModel().getReplayNavigator().getCurrentEventPosition();
+					}
+					return new RemoveFromComparisonCommand(eventPosition);
 				}
 				return null;
 			}
 		});
+	}
 
+	private EditPart getEditPartFromCurrentEventPosition() {
+		final var currentEventPosition = getModel().getReplayNavigator().getCurrentEventPosition();
+		return getEventMarkerEditPart(getTimelineEditPart(currentEventPosition, this), currentEventPosition);
+	}
+
+	private static TimelineEditPart getTimelineEditPart(final EventPosition currentEventPosition,
+			final EditPart sourceEditPart) {
+		for (final Object child : sourceEditPart.getChildren()) {
+			if (child instanceof final TimelineEditPart tep) {
+				if (currentEventPosition.timeline() == tep.getModel().getTimeline()) {
+					return tep;
+				}
+				final var possibleEditPart = getTimelineEditPart(currentEventPosition, tep);
+				if (possibleEditPart != null) {
+					return possibleEditPart;
+				}
+			}
+		}
+		return null;
+	}
+
+	private static EditPart getEventMarkerEditPart(final TimelineEditPart sourceEditPart,
+			final EventPosition currentEventPosition) {
+		if (sourceEditPart == null) {
+			return null;
+		}
+		for (final Object child : sourceEditPart.getChildren()) {
+			if ((child instanceof final EventMarkerEditPart ep)
+					&& currentEventPosition.eventNumber() == ep.getModel().getIndex()) {
+				return ep;
+			}
+		}
+		return null;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/EventMarkerFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/EventMarkerFigure.java
@@ -46,7 +46,9 @@ public class EventMarkerFigure extends Figure {
 
 			@Override
 			public void mousePressed(final MouseEvent me) {
-				notifyListeners();
+				if (me.button == 1) { // left-click only
+					notifyListeners();
+				}
 			}
 
 			@Override

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/TimelineWithChildrenFigure.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/TimelineWithChildrenFigure.java
@@ -99,7 +99,7 @@ public class TimelineWithChildrenFigure extends Figure {
 		final Dimension timelineSize = lineFigure.getPreferredSize();
 		final Dimension contentSize = childrenFigure.getPreferredSize();
 
-		final int width = Math.max(startPosition * CommonFigureConstants.MARKER_SIZE + timelineSize.width,
+		final int width = Math.max(startPosition * CommonFigureConstants.TOTAL_MARKER_SPACE + timelineSize.width,
 				contentSize.width);
 		final int height = timelineSize.height + contentSize.height + SPACING_BETWEEN_TIMELINES;
 

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/handlers/DeleteTimelineHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/handlers/DeleteTimelineHandler.java
@@ -29,6 +29,7 @@ import org.eclipse.core.commands.AbstractHandler;
  *******************************************************************************/
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.fordiac.ide.debug.replaydebugging.core.Timeline;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.CommonConstants;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.editpart.EventMarkerEditPart;
 import org.eclipse.fordiac.ide.debug.replaydebugging.ui.editpart.TimelineEditPart;
@@ -49,8 +50,22 @@ public class DeleteTimelineHandler extends AbstractHandler {
 	public void setEnabled(final Object evaluationContext) {
 		final Object selection = HandlerUtil.getVariable(evaluationContext, ISources.ACTIVE_CURRENT_SELECTION_NAME);
 		if (selection instanceof final IStructuredSelection s) {
-			final Object first = s.getFirstElement();
-			setBaseEnabled(first instanceof TimelineEditPart || first instanceof EventMarkerEditPart);
+			if (s.isEmpty()) {
+				setBaseEnabled(false);
+				return;
+			}
+			Timeline parentTimeline = null;
+			switch (s.getFirstElement()) {
+			case final EventMarkerEditPart eventMarkerEditPart ->
+				parentTimeline = eventMarkerEditPart.getModel().getParentTimeline().getTimeline().getParentTimeline();
+			case final TimelineEditPart timelineEditPart -> parentTimeline = timelineEditPart.getModel().getTimeline();
+			default -> {
+				// parentTimeline already set to null
+			}
+			}
+
+			setBaseEnabled(parentTimeline != null);
+
 		}
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/model/EventMarker.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/model/EventMarker.java
@@ -32,6 +32,8 @@ public class EventMarker {
 
 	public static final String PROPERTY_EVENT_CHANGED = "eventChanged"; //$NON-NLS-1$
 
+	public static final String PROPERTY_IS_CURRENT_CHANGED = "isCurrentChanged"; //$NON-NLS-1$
+
 	private final PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(this);
 
 	public EventMarker(final int index, final TimelineModel parentTimeline, final Consumer<Integer> eventSelected) {
@@ -72,7 +74,7 @@ public class EventMarker {
 
 	public void setIsCurrentEvent(final boolean isCurrentEvent) {
 		this.isCurrentEvent = isCurrentEvent;
-		propertyChangeSupport.firePropertyChange(PROPERTY_EVENT_CHANGED, null, null);
+		propertyChangeSupport.firePropertyChange(PROPERTY_IS_CURRENT_CHANGED, null, null);
 	}
 
 	public boolean getValid() {

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/core/ReplayNavigator.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/core/ReplayNavigator.java
@@ -409,11 +409,13 @@ public class ReplayNavigator implements Timeline.StructureListener {
 				changedValues.putAll(temp.getInitialStateAtLeavingTimeline());
 				currentEventPosition = new EventPosition(timeline.getParentTimeline(),
 						timeline.getParentTimeline().getSpawnedTimelineEventNumber(timeline));
-				timeline.getParentTimeline().removeSpawnedTimeline(timeline);
 			} else {
 				currentEventPosition = new EventPosition(timeline, removedStartEventIndex - 1);
 			}
 			updateCache(changedValues);
+		}
+		if (removedStartEventIndex == 0) {
+			timeline.getParentTimeline().removeSpawnedTimeline(timeline);
 		}
 		maxEventNumber = rootTimeline.getTotalMaxEventNumber();
 	}

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/core/Timeline.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/core/Timeline.java
@@ -102,9 +102,9 @@ public class Timeline {
 		final var toRemove = eventChanges.subList(eventNumber, eventChanges.size());
 
 		// remove mapping from datapoints to event numbers
-		for (var i = eventNumber; i < eventChanges.size(); i++) {
+		for (var i = 0; i < eventChanges.size() - eventNumber; i++) {
 			for (final var datapointChange : toRemove.get(i).newValues()) {
-				eventsWhereDatapointsChange.get(datapointChange.datapoint()).remove(Integer.valueOf(i));
+				eventsWhereDatapointsChange.get(datapointChange.datapoint()).remove(Integer.valueOf(i + eventNumber));
 			}
 		}
 
@@ -284,13 +284,15 @@ public class Timeline {
 	}
 
 	private void notifyRemoveEvents(final int removedStartEventIndex, final List<EventChange> removedChanges) {
-		for (final var listener : structureListeners) {
+		// defense copy when removing events, as listeners might remove timelines and
+		// thus modify the list of listeners while we are notifying
+		for (final var listener : new HashSet<>(structureListeners)) {
 			listener.eventsRemoved(this, removedStartEventIndex, removedChanges);
 		}
 	}
 
 	private void notifyRemovedSpawnedTimeline(final Timeline removedTimeline, final int spawnedAtEventNumber) {
-		for (final var listener : structureListeners) {
+		for (final var listener : new HashSet<>(structureListeners)) {
 			listener.timelineRemoved(this, removedTimeline, spawnedAtEventNumber);
 		}
 	}


### PR DESCRIPTION
- Commands related to deleting (events, timelines, or comments) are fixed 
- When a resource is selected, the selection is redirected to the current event. This allow an easier handling of commands. Related to this, some commands require the information of the current event, so this is handle by the eventMarker edit part and pass to the parent.
- Reveal the current event in case is out of the view (when navigating for example)
- Wire undo/redo commands
