### PR TITLE
Add missing permission to allow access to actions cache

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -10,6 +10,7 @@ jobs:
   close-issues:
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       issues: write
       pull-requests: write
     steps:


### PR DESCRIPTION
The `actions/stale` action requires the `actions: write` permission to access the actions cache, so that it does not always process only the first `operations-per-run` (default 30) items[^1].

[^1]: see also https://github.com/actions/stale/pull/1248