### PR TITLE
Handle correct refresh for empty MemberAccessViewers

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/MemberAccessViewer.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/MemberAccessViewer.java
@@ -76,8 +76,11 @@ class MemberAccessViewer {
 	}
 
 	public void updateVisibility() {
-		updateVisibility(block.getInterface().getAllInterfaceElements().filter(
-				ie -> ie instanceof final VarDeclaration vardecl && ie.isIsInput() == input && !vardecl.isInOutVar()));
+		if (block != null) {
+			updateVisibility(block.getInterface().getAllInterfaceElements()
+					.filter(ie -> ie instanceof final VarDeclaration vardecl && ie.isIsInput() == input
+							&& !vardecl.isInOutVar()));
+		}
 	}
 
 	private void updateVisibility(final Stream<IInterfaceElement> vars) {


### PR DESCRIPTION
MemerAccessViewers currently are empty for typed subapps. Visibility updates didn't correctly consider this.