### PR TITLE
Fixed column order for InternalVarsSection

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/InternalVarsSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/InternalVarsSection.java
@@ -81,7 +81,7 @@ public class InternalVarsSection extends AbstractInternalVarsSection {
 
 	@Override
 	public void createNatTable(final Composite composite) {
-		final var columns = VarDeclarationTableColumn.defaultColumnsWithPrepended(VarDeclarationTableColumn.RETAIN);
+		final var columns = VarDeclarationTableColumn.defaultColumnsWith(VarDeclarationTableColumn.RETAIN);
 		provider = new ChangeableListDataProvider<>(new VarDeclarationColumnAccessor(this, columns));
 		final DataLayer dataLayer = new VarDeclarationDataLayer(provider, columns);
 		final VarDeclarationConfigLabelAccumulator acc = new VarDeclarationConfigLabelAccumulator(provider,


### PR DESCRIPTION
Retain was first but should be the last column.