### PR TITLE
Correct variable comment to match event output behavior

### DIFF
--- a/data/typelibrary/events-3.0.0/typelib/E_SWITCH.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_SWITCH.fbt
@@ -18,7 +18,7 @@
       <Event Comment="Output, switched from EI when G=1" Name="EO1" Type="Event"/>
     </EventOutputs>
     <InputVars>
-      <VarDeclaration Comment="Switch EI to EI0 when G=0, to EI1 when G=1 " Name="G" Type="BOOL"/>
+      <VarDeclaration Comment="Switch EI to EO0 when G=0, to EO1 when G=1 " Name="G" Type="BOOL"/>
     </InputVars>
     <OutputVars/>
   </InterfaceList>


### PR DESCRIPTION
Updates the comment for variable "G" to accurately reflect the switching behavior of event outputs in the interface definition.

fixes: https://github.com/eclipse-4diac/4diac-ide/issues/2509

Review Log: https://github.com/franz-hoepfinger-4diac-org/4diac-ide/pull/15
