### PR TITLE
Update F_LOWER_BOUND and F_UPPER_BOUND.

### DIFF
--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arrays/F_LOWER_BOUND.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arrays/F_LOWER_BOUND.fbt
@@ -4,7 +4,7 @@
 	</Identification>
 	<VersionInfo Organization="Demmler Andreas Fahrzeugbau" Version="1.0" Author="Franz Höpfinger" Date="2026-01-23" Remarks="Initial Implementation">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::selection">
+	<CompilerInfo packageName="iec61131::arrays">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -26,5 +26,15 @@
 			<VarDeclaration Name="OUT" Type="ANY_INT" Comment="lowest index of the Dimension"/>
 		</OutputVars>
 	</InterfaceList>
+	<SimpleFB>
+		<ECState Name="REQ">
+			<ECAction Algorithm="REQ" Output="CNF"/>
+		</ECState>
+		<Algorithm Name="REQ">
+			<ST><![CDATA[
+OUT := LOWER_BOUND(ARR, DIM);
+]]></ST>
+		</Algorithm>
+	</SimpleFB>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arrays/F_UPPER_BOUND.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arrays/F_UPPER_BOUND.fbt
@@ -4,7 +4,7 @@
 	</Identification>
 	<VersionInfo Organization="Demmler Andreas Fahrzeugbau" Version="1.0" Author="Franz Höpfinger" Date="2026-01-23" Remarks="Initial Implementation">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::selection">
+	<CompilerInfo packageName="iec61131::arrays">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -26,5 +26,15 @@
 			<VarDeclaration Name="OUT" Type="ANY_INT" Comment="highest index of the Dimension"/>
 		</OutputVars>
 	</InterfaceList>
+	<SimpleFB>
+		<ECState Name="REQ">
+			<ECAction Algorithm="REQ" Output="CNF"/>
+		</ECState>
+		<Algorithm Name="REQ">
+			<ST><![CDATA[
+OUT := UPPER_BOUND(ARR, DIM);
+]]></ST>
+		</Algorithm>
+	</SimpleFB>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>


### PR DESCRIPTION
### Update F_LOWER_BOUND and F_UPPER_BOUND.

- Add algorithms as Simple FB
- Move them into arrays package (package and folder)


it does not need changes on the C++ side, as  `DEFINE_FIRMWARE_FB(FORTE_F_LOWER_BOUND, "iec61131::arrays::F_LOWER_BOUND"_STRID, TypeHash)` is already present in FORTE. 

References: 

- https://github.com/franz-hoepfinger-4diac-org/4diac-ide/pull/14
- https://github.com/eclipse-4diac/4diac-ide/pull/2373
- https://github.com/eclipse-4diac/4diac-ide/pull/2332
- https://github.com/eclipse-4diac/4diac-ide/pull/2046
- https://github.com/eclipse-4diac/4diac-forte/pull/844
- https://github.com/eclipse-4diac/4diac-forte/pull/911



