### PR TITLE
Clear standard libraries during p2 updates

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.library/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.library/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,
+ org.eclipse.equinox.p2.operations,
  org.eclipse.ltk.core.refactoring,
  org.eclipse.gef,
  org.eclipse.ui,

--- a/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/LibraryManager.java
+++ b/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/LibraryManager.java
@@ -39,6 +39,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -61,7 +63,10 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.URIUtil;
+import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.jobs.JobChangeAdapter;
+import org.eclipse.equinox.p2.operations.IProfileChangeJob;
 import org.eclipse.fordiac.ide.library.download.DownloadResult;
 import org.eclipse.fordiac.ide.library.download.IArchiveDownloader;
 import org.eclipse.fordiac.ide.library.model.library.Manifest;
@@ -82,6 +87,8 @@ import org.osgi.framework.VersionRange;
 public enum LibraryManager {
 
 	INSTANCE;
+
+	private static final String UPDATE_JOB_NAME = "Updating Software"; //$NON-NLS-1$
 
 	public static final String LIB_TYPELIB_FOLDER_NAME = "typelib"; //$NON-NLS-1$
 	public static final String PACKAGE_DOWNLOAD_DIRECTORY = ".download"; //$NON-NLS-1$
@@ -116,7 +123,8 @@ public enum LibraryManager {
 			VersionRange.RIGHT_CLOSED);
 
 	private WatchService watchService;
-	private final HashMap<String, List<LibraryRecord>> stdlibraries = new HashMap<>();
+	private final AtomicBoolean standardLibraryResolutionEnabled = new AtomicBoolean(true);
+	private final Map<String, List<LibraryRecord>> stdlibraries = new ConcurrentHashMap<>();
 	private final HashMap<String, List<LibraryRecord>> libraries = new HashMap<>();
 
 	public static final Object FAMILY_FORDIAC_LIBRARY = new Object();
@@ -149,6 +157,26 @@ public enum LibraryManager {
 		}
 
 		LibraryPermission.setLibReadOnly(standardLibraryPath);
+		initP2UpdateListener();
+	}
+
+	private void initP2UpdateListener() {
+		Job.getJobManager().addJobChangeListener(new JobChangeAdapter() {
+			@Override
+			public void aboutToRun(final IJobChangeEvent event) {
+				if (isUpdateProvisioningJob(event.getJob())) {
+					standardLibraryResolutionEnabled.set(false);
+				}
+			}
+
+			@Override
+			public void done(final IJobChangeEvent event) {
+				if (isUpdateProvisioningJob(event.getJob())) {
+					standardLibraryResolutionEnabled.set(true);
+				}
+			}
+
+		});
 	}
 
 	/**
@@ -602,6 +630,10 @@ public enum LibraryManager {
 	 */
 	public void resolveDependencies(final IProject project, final Manifest projectManifest,
 			final IProgressMonitor monitor) throws OperationCanceledException, CoreException {
+
+		if (!standardLibraryResolutionEnabled.get()) {
+			return;
+		}
 
 		final LibraryManagerData libManagerData = LibraryManagerData.init();
 
@@ -1063,6 +1095,10 @@ public enum LibraryManager {
 	private static Stream<Version> getAvailableVersions(final Map<String, List<LibraryRecord>> lib,
 			final String symbolicName) {
 		return lib.getOrDefault(symbolicName, Collections.emptyList()).stream().map(LibraryRecord::version);
+	}
+
+	private static boolean isUpdateProvisioningJob(final Job job) {
+		return job instanceof IProfileChangeJob && UPDATE_JOB_NAME.equals(job.getName());
 	}
 
 }


### PR DESCRIPTION
Clear standard libraries during p2 updates

During a p2 update, automatic builds can still resolve standard library
dependencies from the product typelibrary. On Windows this can keep files open
while p2 tries to back up/remove them, causing the update to fail.

This clears the standard library cache when the p2 update job starts, so the
builder skips standard library resolution until the updated IDE is restarted.