### PR TITLE
Add struct and FB type delete tests with nested SubApp fixture

### DIFF
--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/FBTypeDeleteNestedSubAppTest/.project
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/FBTypeDeleteNestedSubAppTest/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>FBTypeDeleteNestedSubAppTest</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.fordiac.ide.library.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.fordiac.ide.export.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.fordiac.ide.systemmanagement.FordiacNature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/FBTypeDeleteNestedSubAppTest/FBTypeDeleteNestedSubAppTest.sys
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/FBTypeDeleteNestedSubAppTest/FBTypeDeleteNestedSubAppTest.sys
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<System Name="FBTypeDeleteNestedSubAppTest" Comment="">
+	<VersionInfo Version="1.0" Author="Dimitrios Kalligaridis" Date="2026-06-15">
+	</VersionInfo>
+	<Application Name="App" Comment="">
+		<SubAppNetwork>
+			<FB Name="TopInstance" Type="mypackage::MyBlock" Comment="" x="500.0" y="500.0">
+			</FB>
+			<FB Name="TopInstanceSink" Type="mypackage::MyBlock" Comment="" x="500.0" y="1500.0">
+			</FB>
+			<SubApp Name="Container" Comment="" x="1500.0" y="500.0">
+				<SubAppInterfaceList>
+				</SubAppInterfaceList>
+				<SubAppNetwork>
+					<FB Name="NestedInstance" Type="mypackage::MyBlock" Comment="" x="500.0" y="500.0">
+					</FB>
+					<FB Name="NestedInstanceSink" Type="mypackage::MyBlock" Comment="" x="500.0" y="1500.0">
+					</FB>
+					<SubApp Name="DeepContainer" Comment="" x="1500.0" y="500.0">
+						<SubAppInterfaceList>
+						</SubAppInterfaceList>
+						<SubAppNetwork>
+							<FB Name="DeeplyNestedInstance" Type="mypackage::MyBlock" Comment="" x="500.0" y="500.0">
+							</FB>
+							<FB Name="DeeplyNestedInstanceSink" Type="mypackage::MyBlock" Comment="" x="500.0" y="1500.0">
+							</FB>
+							<EventConnections>
+								<Connection Comment="" Source="DeeplyNestedInstance.CNF" Destination="DeeplyNestedInstanceSink.REQ" dx1="250.0" dx2="0.0" dy="0.0"/>
+							</EventConnections>
+							<DataConnections>
+								<Connection Comment="" Source="DeeplyNestedInstance.DO" Destination="DeeplyNestedInstanceSink.DI" dx1="250.0" dx2="0.0" dy="0.0"/>
+							</DataConnections>
+						</SubAppNetwork>
+					</SubApp>
+					<EventConnections>
+						<Connection Comment="" Source="NestedInstance.CNF" Destination="NestedInstanceSink.REQ" dx1="250.0" dx2="0.0" dy="0.0"/>
+					</EventConnections>
+					<DataConnections>
+						<Connection Comment="" Source="NestedInstance.DO" Destination="NestedInstanceSink.DI" dx1="250.0" dx2="0.0" dy="0.0"/>
+					</DataConnections>
+				</SubAppNetwork>
+			</SubApp>
+			<EventConnections>
+				<Connection Comment="" Source="TopInstance.CNF" Destination="TopInstanceSink.REQ" dx1="250.0" dx2="0.0" dy="0.0"/>
+			</EventConnections>
+			<DataConnections>
+				<Connection Comment="" Source="TopInstance.DO" Destination="TopInstanceSink.DI" dx1="250.0" dx2="0.0" dy="0.0"/>
+			</DataConnections>
+		</SubAppNetwork>
+	</Application>
+</System>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/FBTypeDeleteNestedSubAppTest/Type Library/mypackage/MyBlock.fbt
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/FBTypeDeleteNestedSubAppTest/Type Library/mypackage/MyBlock.fbt
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="MyBlock" Comment="">
+	<Identification Standard="61499-2">
+	</Identification>
+	<VersionInfo Version="1.0" Author="Dimitrios Kalligaridis" Date="2026-06-15">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="">
+				<With Var="DI"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="">
+				<With Var="DO"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="DI" Type="mypackage::MyStruct" Comment=""/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="DO" Type="mypackage::MyStruct" Comment=""/>
+		</OutputVars>
+	</InterfaceList>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="">
+	</Service>
+</FBType>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/FBTypeDeleteNestedSubAppTest/Type Library/mypackage/MyStruct.dtp
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/FBTypeDeleteNestedSubAppTest/Type Library/mypackage/MyStruct.dtp
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DataType Name="MyStruct" Comment="">
+	<Identification Standard="61499-1">
+	</Identification>
+	<VersionInfo Version="1.0" Author="Dimitrios Kalligaridis" Date="2026-06-15">
+	</VersionInfo>
+	<CompilerInfo packageName="mypackage">
+	</CompilerInfo>
+	<StructuredType>
+		<VarDeclaration Name="A" Type="BOOL" Comment=""/>
+		<VarDeclaration Name="B" Type="BOOL" Comment=""/>
+	</StructuredType>
+</DataType>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/FBTypeDeleteNestedSubAppTest.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/FBTypeDeleteNestedSubAppTest.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2026
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Dimitrios Kalligaridis - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.tests;
+
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.CORE;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.UntypedSubApp;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
+import org.eclipse.fordiac.ide.systemmanagement.SystemManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class FBTypeDeleteNestedSubAppTest {
+
+	private static final String PROJECT_NAME = "FBTypeDeleteNestedSubAppTest"; //$NON-NLS-1$
+	private static final String PROJECT_PATH = "data/FBTypeDeleteNestedSubAppTest"; //$NON-NLS-1$
+
+	private static final String FB_FILE = "Type Library/mypackage/MyBlock.fbt"; //$NON-NLS-1$
+	private static final String SYSTEM_FILE = "FBTypeDeleteNestedSubAppTest.sys"; //$NON-NLS-1$
+
+	private static final String MY_BLOCK_TYPE_NAME = "MyBlock"; //$NON-NLS-1$
+
+	private static final String APPLICATION_NAME = "App"; //$NON-NLS-1$
+	private static final String TOP_INSTANCE = "TopInstance"; //$NON-NLS-1$
+	private static final String CONTAINER_SUBAPP = "Container"; //$NON-NLS-1$
+	private static final String NESTED_INSTANCE = "NestedInstance"; //$NON-NLS-1$
+	private static final String DEEP_CONTAINER_SUBAPP = "DeepContainer"; //$NON-NLS-1$
+	private static final String DEEPLY_NESTED_INSTANCE = "DeeplyNestedInstance"; //$NON-NLS-1$
+
+	private IProject project;
+	private TypeLibrary typeLibrary;
+
+	@BeforeAll
+	static void preloadSystemManager() {
+		SystemManager.INSTANCE.name();
+	}
+
+	@BeforeEach
+	void loadFixture() throws Exception {
+		project = RefactoringTestSupport.importProjectIntoWorkspace(PROJECT_NAME, PROJECT_PATH);
+		RefactoringTestSupport.linkStandardLibraries(project, CORE);
+		typeLibrary = TypeLibraryManager.INSTANCE.getTypeLibrary(project);
+	}
+
+	@AfterEach
+	void disposeFixture() throws Exception {
+		RefactoringTestSupport.deleteProject(project);
+	}
+
+	@Test
+	void deleteMyBlock_removesItFromWorkspace() throws Exception {
+		assertTrue(file(FB_FILE).exists());
+
+		deleteMyBlock();
+
+		assertFalse(file(FB_FILE).exists());
+	}
+
+	@Test
+	void deleteMyBlock_clearsItFromTypeLibrary() throws Exception {
+		assertNotNull(typeLibrary.getFBTypeEntry(MY_BLOCK_TYPE_NAME));
+
+		deleteMyBlock();
+
+		assertNull(typeLibrary.getFBTypeEntry(MY_BLOCK_TYPE_NAME));
+	}
+
+	@Test
+	void deleteMyBlock_leavesAllNestedSubAppInstancesStructurallyIntact() throws Exception {
+		findInstance(TOP_INSTANCE);
+		findInstance(CONTAINER_SUBAPP, NESTED_INSTANCE);
+		findInstance(CONTAINER_SUBAPP, DEEP_CONTAINER_SUBAPP, DEEPLY_NESTED_INSTANCE);
+
+		deleteMyBlock();
+
+		// DeleteTypeRefactoringParticipant only removes internal FBs whose
+		// container is a BaseFBType, so System FB instances at every nesting
+		// level remain in place; findInstance throws if any is missing.
+		findInstance(TOP_INSTANCE);
+		findInstance(CONTAINER_SUBAPP, NESTED_INSTANCE);
+		findInstance(CONTAINER_SUBAPP, DEEP_CONTAINER_SUBAPP, DEEPLY_NESTED_INSTANCE);
+	}
+
+	private void deleteMyBlock() throws Exception {
+		RefactoringTestSupport.performDelete(file(FB_FILE));
+	}
+
+	private FBNetworkElement findInstance(final String... namePath) {
+		FBNetwork network = system().getApplicationNamed(APPLICATION_NAME).getFBNetwork();
+		for (int i = 0; i < namePath.length - 1; i++) {
+			final String subAppName = namePath[i];
+			final UntypedSubApp subApp = (UntypedSubApp) network.getNetworkElements().stream()
+					.filter(element -> subAppName.equals(element.getName())).findFirst().orElseThrow();
+			network = subApp.getSubAppNetwork();
+		}
+		final String instanceName = namePath[namePath.length - 1];
+		return network.getNetworkElements().stream().filter(element -> instanceName.equals(element.getName()))
+				.findFirst().orElseThrow();
+	}
+
+	private AutomationSystem system() {
+		return (AutomationSystem) typeLibrary.getTypeEntry(file(SYSTEM_FILE)).getType();
+	}
+
+	private IFile file(final String projectRelativePath) {
+		return project.getFile(projectRelativePath);
+	}
+}

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/RefactoringTestSupport.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/RefactoringTestSupport.java
@@ -41,6 +41,7 @@ import org.eclipse.ltk.core.refactoring.PerformChangeOperation;
 import org.eclipse.ltk.core.refactoring.Refactoring;
 import org.eclipse.ltk.core.refactoring.RefactoringCore;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+import org.eclipse.ltk.core.refactoring.resource.DeleteResourcesDescriptor;
 import org.eclipse.ltk.core.refactoring.resource.RenameResourceDescriptor;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
@@ -117,6 +118,22 @@ public final class RefactoringTestSupport {
 		final RenameResourceDescriptor descriptor = new RenameResourceDescriptor();
 		descriptor.setResourcePath(file.getFullPath());
 		descriptor.setNewName(newName);
+
+		final RefactoringStatus status = new RefactoringStatus();
+		final Refactoring refactoring = descriptor.createRefactoring(status);
+
+		final CreateChangeOperation create = new CreateChangeOperation(
+				new CheckConditionsOperation(refactoring, CheckConditionsOperation.ALL_CONDITIONS),
+				RefactoringStatus.FATAL);
+		final PerformChangeOperation perform = new PerformChangeOperation(create);
+		perform.setUndoManager(RefactoringCore.getUndoManager(), refactoring.getName());
+		ResourcesPlugin.getWorkspace().run(perform, new NullProgressMonitor());
+		return perform.getUndoChange();
+	}
+
+	public static Change performDelete(final IFile file) throws CoreException {
+		final DeleteResourcesDescriptor descriptor = new DeleteResourcesDescriptor();
+		descriptor.setResourcePaths(new IPath[] { file.getFullPath() });
 
 		final RefactoringStatus status = new RefactoringStatus();
 		final Refactoring refactoring = descriptor.createRefactoring(status);

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/StructDataTypeDeleteTest.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/StructDataTypeDeleteTest.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (c) 2026
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Dimitrios Kalligaridis - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.tests;
+
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.CONVERT;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.CORE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.IEC_61131_3;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.INNER_STRUCT;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.INNER_STRUCT_FILE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.OUTER_STRUCT;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.PROJECT_NAME;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.PROJECT_PATH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.fordiac.ide.model.data.ErrorDataType;
+import org.eclipse.fordiac.ide.model.data.StructuredType;
+import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes.GenericTypes;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
+import org.eclipse.fordiac.ide.systemmanagement.SystemManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class StructDataTypeDeleteTest {
+
+	private IProject project;
+	private TypeLibrary typeLibrary;
+
+	@BeforeAll
+	static void preloadSystemManager() {
+		SystemManager.INSTANCE.name();
+	}
+
+	@BeforeEach
+	void loadFixture() throws Exception {
+		project = RefactoringTestSupport.importProjectIntoWorkspace(PROJECT_NAME, PROJECT_PATH);
+		RefactoringTestSupport.linkStandardLibraries(project, CORE, CONVERT, IEC_61131_3);
+		typeLibrary = TypeLibraryManager.INSTANCE.getTypeLibrary(project);
+	}
+
+	@AfterEach
+	void disposeFixture() throws Exception {
+		RefactoringTestSupport.deleteProject(project);
+	}
+
+	@Test
+	void deleteInnerStruct_removesItFromWorkspace() throws Exception {
+		assertTrue(file(INNER_STRUCT_FILE).exists());
+
+		deleteInnerStruct();
+
+		assertFalse(file(INNER_STRUCT_FILE).exists());
+	}
+
+	@Test
+	void deleteInnerStruct_clearsItFromTypeLibrary() throws Exception {
+		assertEquals(INNER_STRUCT, structuredType(INNER_STRUCT).getTypeEntry().getFullTypeName());
+
+		deleteInnerStruct();
+
+		// getStructuredType returns ANY_STRUCT for unknown names instead of null.
+		assertSame(GenericTypes.ANY_STRUCT, structuredType(INNER_STRUCT));
+	}
+
+	@Test
+	void deleteInnerStruct_breaksOuterStructMemberTypeResolution() throws Exception {
+		assertEquals(1, structuredType(OUTER_STRUCT).getMemberVariables().size());
+
+		deleteInnerStruct();
+
+		// The member stays but its type can no longer resolve, so EMF returns
+		// an ErrorDataType placeholder.
+		assertEquals(1, structuredType(OUTER_STRUCT).getMemberVariables().size());
+		assertInstanceOf(ErrorDataType.class,
+				structuredType(OUTER_STRUCT).getMemberVariables().get(0).getType());
+	}
+
+	private void deleteInnerStruct() throws Exception {
+		RefactoringTestSupport.performDelete(file(INNER_STRUCT_FILE));
+	}
+
+	private StructuredType structuredType(final String qualifiedName) {
+		return typeLibrary.getDataTypeLibrary().getStructuredType(qualifiedName);
+	}
+
+	private IFile file(final String projectRelativePath) {
+		return project.getFile(projectRelativePath);
+	}
+}


### PR DESCRIPTION
Adds delete tests for struct data types and FB types.

Struct delete: the .dtp file is removed, the type is gone from the library, and the outer struct member can no longer resolve its type.

FB delete: the .fbt file is removed, the type is gone, and the FB instances stay in place, and the fixture instances a block across three nested subapp levels to check this.

The fixture block is a service interface FB with a struct-typed in/out pin, wired with event and data connections between the instances.