### PR TITLE
Add type rename button to Type Info section

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/TypeInfoSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/TypeInfoSection.java
@@ -22,21 +22,36 @@ import org.eclipse.fordiac.ide.gef.widgets.PackageInfoWidget;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeCommentCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.FunctionFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
+import org.eclipse.fordiac.ide.typemanagement.Messages;
+import org.eclipse.fordiac.ide.typemanagement.refactoring.TypeRefactoringHelper;
 import org.eclipse.fordiac.ide.ui.FordiacMessages;
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.layout.GridLayoutFactory;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
-import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.eclipse.ui.views.properties.tabbed.TabbedPropertySheetPage;
 
 /** Properties tab which shows the FB type information of the selected FB */
 public abstract class TypeInfoSection extends AbstractDoubleColumnSection {
 
+	private static final String RENAME_ELEMENT_ICON = "icons/full/etool16/tricks.png"; //$NON-NLS-1$
+
 	private PackageInfoWidget typeInfo;
 
 	private Text fbTypeNameText;
 	private Text commentText;
+	private Button renameTypeButton;
+	private Image renameTypeImage;
 
 	private final Adapter typeInfoAdapter = new EContentAdapter() {
 		@Override
@@ -66,17 +81,48 @@ public abstract class TypeInfoSection extends AbstractDoubleColumnSection {
 
 	private void createTypeAndCommentSection(final Composite parent) {
 		final Composite composite = getWidgetFactory().createComposite(parent);
-		composite.setLayout(new GridLayout(2, false));
+		GridLayoutFactory.fillDefaults().numColumns(3).equalWidth(false).applyTo(composite);
 		composite.setLayoutData(new GridData(SWT.FILL, 0, true, false));
-		getWidgetFactory().createCLabel(composite, FordiacMessages.TypeName + ":"); //$NON-NLS-1$
+		renameTypeButton = getWidgetFactory().createButton(composite, null, SWT.PUSH);
+		renameTypeButton.setToolTipText(Messages.RenameType_Name);
+		renameTypeButton.setImage(getRenameTypeImage());
+		renameTypeButton.addDisposeListener(e -> disposeRenameTypeImage());
+		renameTypeButton.addSelectionListener(SelectionListener.widgetSelectedAdapter(ev -> openTypeRefactoring()));
+		GridDataFactory.swtDefaults().align(SWT.LEFT, SWT.CENTER).applyTo(renameTypeButton);
+		getWidgetFactory().createLabel(composite, FordiacMessages.TypeName + ":"); //$NON-NLS-1$
 		fbTypeNameText = createGroupText(composite, false);
-		getWidgetFactory().createCLabel(composite, FordiacMessages.Comment + ":"); //$NON-NLS-1$
+		fbTypeNameText.setEnabled(true);
+		final Label commentLabel = getWidgetFactory().createLabel(composite, FordiacMessages.Comment + ":"); //$NON-NLS-1$
+		GridDataFactory.swtDefaults().align(SWT.RIGHT, SWT.CENTER).span(2, 1).applyTo(commentLabel);
 		commentText = createGroupText(composite, true);
 		commentText.addModifyListener(e -> executeCommand(new ChangeCommentCommand(getType(), commentText.getText())));
 	}
 
+	private Image getRenameTypeImage() {
+		if (renameTypeImage == null) {
+			final ImageDescriptor imageDescriptor = AbstractUIPlugin.imageDescriptorFromPlugin(PlatformUI.PLUGIN_ID,
+					RENAME_ELEMENT_ICON);
+			if (imageDescriptor != null) {
+				renameTypeImage = imageDescriptor.createImage();
+			}
+		}
+		return renameTypeImage;
+	}
+
+	private void disposeRenameTypeImage() {
+		if (renameTypeImage != null && !renameTypeImage.isDisposed()) {
+			renameTypeImage.dispose();
+		}
+		renameTypeImage = null;
+	}
+
+	private void openTypeRefactoring() {
+		TypeRefactoringHelper.openRenameResourceWizard(getType().getTypeEntry(), fbTypeNameText.getShell());
+	}
+
 	@Override
 	public void setInputCode() {
+		renameTypeButton.setEnabled(false);
 		commentText.setEnabled(false);
 		typeInfo.setEnabled(false);
 	}
@@ -84,6 +130,7 @@ public abstract class TypeInfoSection extends AbstractDoubleColumnSection {
 	@Override
 	protected void performRefresh() {
 		fbTypeNameText.setText(getType().getName() != null ? getType().getName() : ""); //$NON-NLS-1$
+		renameTypeButton.setEnabled(canRenameType());
 		commentText.setText(getType().getComment() != null ? getType().getComment() : ""); //$NON-NLS-1$
 		commentText.setEditable(!(getType() instanceof FunctionFBType));
 		typeInfo.refresh();
@@ -108,6 +155,11 @@ public abstract class TypeInfoSection extends AbstractDoubleColumnSection {
 		if (getType() != null && getType().getIdentification() != null) {
 			getType().getIdentification().eAdapters().remove(typeInfoAdapter);
 		}
+	}
+
+	private boolean canRenameType() {
+		final TypeEntry typeEntry = getType().getTypeEntry();
+		return typeEntry != null && typeEntry.getFile() != null && typeEntry.getFile().exists();
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/TypeRefactoringHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/TypeRefactoringHelper.java
@@ -16,6 +16,7 @@ import java.text.MessageFormat;
 import java.util.List;
 
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
 import org.eclipse.fordiac.ide.model.search.types.BlockTypeInstanceSearch;
@@ -24,6 +25,10 @@ import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
 import org.eclipse.fordiac.ide.typemanagement.Messages;
 import org.eclipse.fordiac.ide.typemanagement.refactoring.edit.DataTypeEditBuilder;
 import org.eclipse.fordiac.ide.typemanagement.refactoring.move.MoveTypeModelEdit;
+import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
+import org.eclipse.ltk.ui.refactoring.RefactoringWizardOpenOperation;
+import org.eclipse.ltk.ui.refactoring.resource.RenameResourceWizard;
+import org.eclipse.swt.widgets.Shell;
 
 public final class TypeRefactoringHelper {
 
@@ -31,6 +36,25 @@ public final class TypeRefactoringHelper {
 			final String newPackageName) {
 		modelEdits.add(new MoveTypeModelEdit(newPackageName,
 				MessageFormat.format(Messages.MoveTypeToPackage_RenamePackageTo, newPackageName), typeEntry.getURI()));
+	}
+
+	public static void openRenameResourceWizard(final TypeEntry typeEntry, final Shell shell) {
+		if (typeEntry == null || typeEntry.getFile() == null) {
+			return;
+		}
+
+		try {
+			RefactoringUtil.saveAllAndBuild();
+			final RenameResourceWizard wizard = new RenameResourceWizard(typeEntry.getFile());
+			final RefactoringWizardOpenOperation openOperation = new RefactoringWizardOpenOperation(wizard);
+			openOperation.run(shell, Messages.RenameType_Name);
+		} catch (final OperationCanceledException e) {
+			// ignore
+		} catch (final InterruptedException e) {
+			Thread.currentThread().interrupt();
+		} catch (final Exception e) {
+			FordiacLogHelper.logError("Error during type rename refactoring", e); //$NON-NLS-1$
+		}
 	}
 
 	public static void addModelEditsForMovedType(final List<ModelEdit<?>> modelEdits, final TypeEntry typeEntry,


### PR DESCRIPTION
Adds a rename action next to the type name in the Type Info section.

The new magic-wand button opens the standard type rename refactoring flow, so renaming from the properties view behaves like renaming the type file from the explorer: the file, type name, and references are updated through the existing refactoring participants.

Also makes the displayed type name selectable, so users can copy it directly from the properties view.