### PR TITLE
Export Build should only export existing files

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/builder/ExportBuilder.java
+++ b/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/builder/ExportBuilder.java
@@ -180,7 +180,7 @@ public class ExportBuilder extends IncrementalProjectBuilder {
 				throw new OperationCanceledException();
 			}
 
-			if ((delta.getResource() instanceof final IFile file) && includeInIncrementalBuild(file)) {
+			if ((delta.getResource() instanceof final IFile file) && file.exists() && includeInIncrementalBuild(file)) {
 				exportElement(monitor, file, context);
 			}
 			return true;


### PR DESCRIPTION
During refactoring we get change notification for the renamed old version of the file which is not existing anymore.