### PR TITLE
Fix cast exception for call argument types in ST core scope provider

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/ExpressionAnnotations.xtend
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/impl/ExpressionAnnotations.xtend
@@ -154,7 +154,7 @@ final package class ExpressionAnnotations {
 		switch (feature : expr.feature) {
 			STStandardFunction:
 				feature.javaMethod.inferReturnTypeFromDataTypes([switch (type: expr.expectedType) { DataType: type }], [
-					expr.parameters.map[resultType].filter(DataType).toList
+					expr.parameters.map[switch (type:resultType) { DataType: type }].toList
 				])
 			default:
 				getDeclaredResultType(expr)

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/util/STCoreUtil.xtend
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.model/src/org/eclipse/fordiac/ide/structuredtextcore/stcore/util/STCoreUtil.xtend
@@ -477,7 +477,7 @@ final class STCoreUtil {
 	def static List<? extends ITypedElement> computeInputParameters(ICallable callable,
 		Iterable<STCallArgument> arguments) {
 		if (callable instanceof STStandardFunction)
-			callable.javaMethod.inferParameterVariables(arguments.map[resultType].filter(DataType).toList, true)
+			callable.javaMethod.inferParameterVariables(arguments.map[switch (type:resultType) { DataType: type }].toList, true)
 		else
 			callable.inputParameters
 	}
@@ -485,7 +485,7 @@ final class STCoreUtil {
 	def static List<? extends ITypedElement> computeOutputParameters(ICallable callable,
 		Iterable<STCallArgument> arguments) {
 		if (callable instanceof STStandardFunction)
-			callable.javaMethod.inferParameterVariables(arguments.map[resultType].filter(DataType).toList, false)
+			callable.javaMethod.inferParameterVariables(arguments.map[switch (type:resultType) { DataType: type }].toList, false)
 		else
 			callable.outputParameters
 	}

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/scoping/STCoreScopeProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/scoping/STCoreScopeProvider.java
@@ -24,7 +24,6 @@ package org.eclipse.fordiac.ide.structuredtextcore.scoping;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -152,8 +151,8 @@ public class STCoreScopeProvider extends AbstractSTCoreScopeProvider {
 			}
 			if (context instanceof final STFeatureExpression expression && expression.isCall()) {
 				final List<DataType> argumentTypes = expression.getParameters().stream()
-						.map(STCallArgument::getDeclaredResultType).map(DataType.class::cast)
-						.map(type -> Objects.requireNonNullElse(type, GenericTypes.ANY)).toList();
+						.map(STCallArgument::getDeclaredResultType)
+						.map(type -> type instanceof final DataType dt ? dt : GenericTypes.ANY).toList();
 				return new STStandardFunctionScope(
 						filterScope(super.getScope(context, reference), this::isApplicableForFeatureReference),
 						standardFunctionProvider, argumentTypes, true);


### PR DESCRIPTION
The declared type of a call argument can also be a non-data type, which caused a class cast exception when looking for standard functions. This checks if the argument is a data type and falls back to ANY otherwise.

The call arguments were also sometimes filtered for data types, discarding non-data types. This resulted in a lookup with the wrong number of arguments.