### PR TITLE
Refactor ECC state breakpoints to use target factory

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.debug.ui/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.debug.ui/plugin.xml
@@ -94,6 +94,23 @@
 				type="org.eclipse.debug.internal.ui.viewers.model.provisional.IViewActionProvider">
 			</adapter>
 		</factory>
+		<factory
+			adaptableType="org.eclipse.fordiac.ide.debug.EvaluatorDebugVariable"
+			class="org.eclipse.fordiac.ide.debug.ui.EvaluatorWatchExpressionFactory">
+			<adapter
+				type="org.eclipse.debug.ui.actions.IWatchExpressionFactoryAdapter">
+			</adapter>
+		</factory>
+		<factory
+           class="org.eclipse.fordiac.ide.debug.ui.breakpoint.ToggleModelBreakpointsTargetExtension"
+           adaptableType="org.eclipse.fordiac.ide.model.libraryElement.ECState">
+           <adapter type="org.eclipse.debug.ui.actions.IToggleBreakpointsTarget"/>
+        </factory>
+        <factory
+          class="org.eclipse.fordiac.ide.debug.ui.breakpoint.ToggleModelBreakpointsTargetExtension"
+          adaptableType="org.eclipse.fordiac.ide.debug.ui.breakpoint.ECStateEditPart">
+         <adapter type="org.eclipse.debug.ui.actions.IToggleBreakpointsTarget"/>
+        </factory>
 	</extension>
 	<extension
 		point="org.eclipse.ui.views">
@@ -134,16 +151,6 @@
 			id="org.eclipse.fordiac.ide.debug.ui.preferences.FordiacDebugPreferencePage"
 			name="%FordiacDebugPreferencePage.name">
 		</page>
-	</extension>
-	<extension
-		point="org.eclipse.core.runtime.adapters">
-		<factory
-			adaptableType="org.eclipse.fordiac.ide.debug.EvaluatorDebugVariable"
-			class="org.eclipse.fordiac.ide.debug.ui.EvaluatorWatchExpressionFactory">
-			<adapter
-				type="org.eclipse.debug.ui.actions.IWatchExpressionFactoryAdapter">
-			</adapter>
-		</factory>
 	</extension>
 	<extension
 		point="org.eclipse.ui.commands">
@@ -217,6 +224,17 @@
 				</with>
 			</activeWhen>
 		</handler>
+		<handler
+			class="org.eclipse.fordiac.ide.debug.ui.handler.ToggleModelBreakpointHandler"
+			commandId="org.eclipse.debug.ui.commands.ToggleBreakpoint">
+			<activeWhen>
+				<with variable="selection">
+					<iterate ifEmpty="false" operator="or">
+						<adapt type="org.eclipse.fordiac.ide.model.libraryElement.ECState"/>
+					</iterate>
+				</with>
+			</activeWhen>
+		</handler>
 	</extension>
 	<extension
 		point="org.eclipse.ui.bindings">
@@ -255,6 +273,16 @@
 				</visibleWhen>
 			</command>
 		</menuContribution>
+		<menuContribution
+			locationURI="popup:org.eclipse.ui.popup.any?after=additions">
+			<command
+				commandId="org.eclipse.debug.ui.commands.ToggleBreakpoint"
+				style="push">
+				<visibleWhen
+					checkEnabled="true">
+				</visibleWhen>
+			</command>
+		</menuContribution>
 	</extension>
 	<extension
 		point="org.eclipse.debug.ui.variableValueEditors">
@@ -262,5 +290,18 @@
 			class="org.eclipse.fordiac.ide.debug.ui.editor.EvaluatorVariableValueEditor"
 			modelId="org.eclipse.fordiac.ide.debug.model">
 		</variableValueEditor>
+	</extension>
+	<extension point="org.eclipse.debug.ui.toggleBreakpointsTargetFactories">
+		<toggleTargetFactory
+			id="org.eclipse.fordiac.ide.debug.ui.toggleModelBreakpointTarget"
+			class="org.eclipse.fordiac.ide.debug.ui.breakpoint.EvaluatorToggleBreakpointsTargetFactory">
+			<enablement>
+				<with variable="selection">
+					<iterate ifEmpty="false" operator="or">
+						<adapt type="org.eclipse.fordiac.ide.model.libraryElement.ECState"/>
+					</iterate>
+				</with>
+			</enablement>
+		</toggleTargetFactory>
 	</extension>
 </plugin>

--- a/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/breakpoint/EvaluatorToggleBreakpointsTargetFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/breakpoint/EvaluatorToggleBreakpointsTargetFactory.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vikash Kumar
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Vikash Kumar - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.debug.ui.breakpoint;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.eclipse.debug.ui.actions.IToggleBreakpointsTarget;
+import org.eclipse.debug.ui.actions.IToggleBreakpointsTargetFactory;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.ui.IWorkbenchPart;
+
+public class EvaluatorToggleBreakpointsTargetFactory implements IToggleBreakpointsTargetFactory {
+
+	private static final String TARGET_ID = "org.eclipse.fordiac.ide.debug.ui.toggleModelBreakpointTarget"; //$NON-NLS-1$
+
+	@Override
+	public Set<String> getToggleTargets(final IWorkbenchPart part, final ISelection selection) {
+		if (new ToggleModelBreakpointsTargetExtension().canToggleBreakpoints(part, selection)) {
+			return Collections.singleton(TARGET_ID);
+		}
+		return Collections.emptySet();
+	}
+
+	@Override
+	public String getDefaultToggleTarget(final IWorkbenchPart part, final ISelection selection) {
+		if (new ToggleModelBreakpointsTargetExtension().canToggleBreakpoints(part, selection)) {
+			return TARGET_ID;
+		}
+		return null;
+	}
+
+	@Override
+	public IToggleBreakpointsTarget createToggleTarget(final String targetID) {
+		if (TARGET_ID.equals(targetID)) {
+			return new ToggleModelBreakpointsTargetExtension();
+		}
+		return null;
+	}
+
+	@Override
+	public String getToggleTargetName(final String targetID) {
+		return "ECC State Breakpoint"; //$NON-NLS-1$
+	}
+
+	@Override
+	public String getToggleTargetDescription(final String targetID) {
+		return "Toggle breakpoint on ECC state"; //$NON-NLS-1$
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/breakpoint/ToggleModelBreakpointsTargetExtension.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/breakpoint/ToggleModelBreakpointsTargetExtension.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vikash Kumar sinha
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Vikash Kumar sinha - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.debug.ui.breakpoint;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.Adapters;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.model.IBreakpoint;
+import org.eclipse.debug.ui.actions.IToggleBreakpointsTargetExtension;
+import org.eclipse.fordiac.ide.debug.breakpoint.EvaluatorModelBreakpoint;
+import org.eclipse.fordiac.ide.model.libraryElement.ECState;
+import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IWorkbenchPart;
+
+public class ToggleModelBreakpointsTargetExtension implements IToggleBreakpointsTargetExtension {
+
+	@Override
+	public boolean canToggleBreakpoints(final IWorkbenchPart part, final ISelection selection) {
+		return getSelectedElement(selection) != null;
+	}
+
+	@Override
+	public void toggleBreakpoints(final IWorkbenchPart part, final ISelection selection) throws CoreException {
+		final INamedElement element = getSelectedElement(selection);
+		if (element == null) {
+			return;
+		}
+		final var manager = DebugPlugin.getDefault().getBreakpointManager();
+		for (final IBreakpoint bp : manager.getBreakpoints(EvaluatorModelBreakpoint.DEBUG_MODEL)) {
+			if (bp instanceof final EvaluatorModelBreakpoint modelBp
+					&& modelBp.getQualifiedName().equals(element.getQualifiedName())) {
+				manager.removeBreakpoint(modelBp, true);
+				return;
+			}
+		}
+		IResource resource = null;
+		if (part instanceof final IEditorPart editorPart) {
+			resource = editorPart.getEditorInput().getAdapter(IFile.class);
+		}
+		if (resource == null) {
+			return;
+		}
+		manager.addBreakpoint(new EvaluatorModelBreakpoint(resource, element));
+	}
+
+	@Override
+	public boolean canToggleLineBreakpoints(final IWorkbenchPart part, final ISelection selection) {
+		return false;
+	}
+
+	@Override
+	public void toggleLineBreakpoints(final IWorkbenchPart part, final ISelection selection) throws CoreException {
+		// not supported
+	}
+
+	@Override
+	public boolean canToggleMethodBreakpoints(final IWorkbenchPart part, final ISelection selection) {
+		return false;
+	}
+
+	@Override
+	public void toggleMethodBreakpoints(final IWorkbenchPart part, final ISelection selection) throws CoreException {
+		// not supported
+	}
+
+	@Override
+	public boolean canToggleWatchpoints(final IWorkbenchPart part, final ISelection selection) {
+		return false;
+	}
+
+	@Override
+	public void toggleWatchpoints(final IWorkbenchPart part, final ISelection selection) throws CoreException {
+		// not supported
+	}
+
+	private static INamedElement getSelectedElement(final ISelection selection) {
+		if (selection instanceof final IStructuredSelection structured) {
+			final Object first = structured.getFirstElement();
+			return Adapters.adapt(first, ECState.class);
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
Added toggleBreakpointsTargetFactories extension in plugin.xml and created the new EvaluatorToggleBreakpointsTargetFactory class Removed old adapter factory code and EditPart dependency from the existing class