### PR TITLE
fix: Correct the order of adapter list creation in interface export

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/AbstractBlockTypeExporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataexport/AbstractBlockTypeExporter.java
@@ -79,8 +79,8 @@ public abstract class AbstractBlockTypeExporter extends AbstractTypeExporter {
 		addEventList(interfaceList.getEventOutputs(), getEventOutputsElementName());
 		addVarList(interfaceList.getInputVars(), LibraryElementTags.INPUT_VARS_ELEMENT);
 		addVarList(interfaceList.getOutputVars(), LibraryElementTags.OUTPUT_VARS_ELEMENT);
-		createAdapterList(interfaceList.getPlugs(), LibraryElementTags.PLUGS_ELEMENT);
 		createAdapterList(interfaceList.getSockets(), LibraryElementTags.SOCKETS_ELEMENT);
+		createAdapterList(interfaceList.getPlugs(), LibraryElementTags.PLUGS_ELEMENT);
 		addVarList(interfaceList.getInOutVars(), LibraryElementTags.INOUT_VARS_ELEMENT);
 		addEndElement();
 	}


### PR DESCRIPTION
Adjust the order of 'createAdapterList' method calls to maintain consistency with the expected sequence for exporting interface lists.

https://github.com/franz-hoepfinger-4diac-org/4diac-ide/pull/19
solves eclipse-4diac#2634

