### PR TITLE
Add FB type rename tests across nested subapplications

### DIFF
--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/FBTypeDeleteNestedSubAppTest/Type Library/mypackage/MyBlock.fbt
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/FBTypeDeleteNestedSubAppTest/Type Library/mypackage/MyBlock.fbt
@@ -4,6 +4,8 @@
 	</Identification>
 	<VersionInfo Version="1.0" Author="Dimitrios Kalligaridis" Date="2026-06-15">
 	</VersionInfo>
+	<CompilerInfo packageName="mypackage">
+	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
 			<Event Name="REQ" Type="Event" Comment="">

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/FBTypeDeleteNestedSubAppTest.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/FBTypeDeleteNestedSubAppTest.java
@@ -40,7 +40,7 @@ class FBTypeDeleteNestedSubAppTest {
 	private static final String FB_FILE = "Type Library/mypackage/MyBlock.fbt"; //$NON-NLS-1$
 	private static final String SYSTEM_FILE = "FBTypeDeleteNestedSubAppTest.sys"; //$NON-NLS-1$
 
-	private static final String MY_BLOCK_TYPE_NAME = "MyBlock"; //$NON-NLS-1$
+	private static final String MY_BLOCK_TYPE_NAME = "mypackage::MyBlock"; //$NON-NLS-1$
 
 	private static final String APPLICATION_NAME = "App"; //$NON-NLS-1$
 	private static final String TOP_INSTANCE = "TopInstance"; //$NON-NLS-1$

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/FBTypeDeleteNestedSubAppTest.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/FBTypeDeleteNestedSubAppTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2026
+ * Copyright (c) 2026 Dimitrios Kalligaridis
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,17 +12,40 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.typemanagement.tests;
 
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedSubAppTestFixture.APPLICATION_NAME;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedSubAppTestFixture.CONTAINER_SUBAPP;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedSubAppTestFixture.DEEPLY_NESTED_INSTANCE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedSubAppTestFixture.DEEPLY_NESTED_INSTANCE_SINK;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedSubAppTestFixture.DEEP_CONTAINER_SUBAPP;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedSubAppTestFixture.MY_BLOCK;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedSubAppTestFixture.MY_BLOCK_FILE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedSubAppTestFixture.NESTED_INSTANCE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedSubAppTestFixture.NESTED_INSTANCE_SINK;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedSubAppTestFixture.PROJECT_NAME;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedSubAppTestFixture.PROJECT_PATH;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedSubAppTestFixture.SYSTEM_FILE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedSubAppTestFixture.TOP_INSTANCE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedSubAppTestFixture.TOP_INSTANCE_SINK;
 import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.CORE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
+import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.Connection;
+import org.eclipse.fordiac.ide.model.libraryElement.FB;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.UntypedSubApp;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
@@ -34,20 +57,14 @@ import org.junit.jupiter.api.Test;
 
 class FBTypeDeleteNestedSubAppTest {
 
-	private static final String PROJECT_NAME = "FBTypeDeleteNestedSubAppTest"; //$NON-NLS-1$
-	private static final String PROJECT_PATH = "data/FBTypeDeleteNestedSubAppTest"; //$NON-NLS-1$
+	private static final Set<String> MY_BLOCK_INSTANCES = Set.of(TOP_INSTANCE, TOP_INSTANCE_SINK, NESTED_INSTANCE,
+			NESTED_INSTANCE_SINK, DEEPLY_NESTED_INSTANCE, DEEPLY_NESTED_INSTANCE_SINK);
 
-	private static final String FB_FILE = "Type Library/mypackage/MyBlock.fbt"; //$NON-NLS-1$
-	private static final String SYSTEM_FILE = "FBTypeDeleteNestedSubAppTest.sys"; //$NON-NLS-1$
-
-	private static final String MY_BLOCK_TYPE_NAME = "mypackage::MyBlock"; //$NON-NLS-1$
-
-	private static final String APPLICATION_NAME = "App"; //$NON-NLS-1$
-	private static final String TOP_INSTANCE = "TopInstance"; //$NON-NLS-1$
-	private static final String CONTAINER_SUBAPP = "Container"; //$NON-NLS-1$
-	private static final String NESTED_INSTANCE = "NestedInstance"; //$NON-NLS-1$
-	private static final String DEEP_CONTAINER_SUBAPP = "DeepContainer"; //$NON-NLS-1$
-	private static final String DEEPLY_NESTED_INSTANCE = "DeeplyNestedInstance"; //$NON-NLS-1$
+	private static final Set<String> INSTANCE_CONNECTIONS = Set.of("TopInstance.CNF -> TopInstanceSink.REQ", //$NON-NLS-1$
+			"TopInstance.DO -> TopInstanceSink.DI", "NestedInstance.CNF -> NestedInstanceSink.REQ", //$NON-NLS-1$ //$NON-NLS-2$
+			"NestedInstance.DO -> NestedInstanceSink.DI", //$NON-NLS-1$
+			"DeeplyNestedInstance.CNF -> DeeplyNestedInstanceSink.REQ", //$NON-NLS-1$
+			"DeeplyNestedInstance.DO -> DeeplyNestedInstanceSink.DI"); //$NON-NLS-1$
 
 	private IProject project;
 	private TypeLibrary typeLibrary;
@@ -71,53 +88,72 @@ class FBTypeDeleteNestedSubAppTest {
 
 	@Test
 	void deleteMyBlock_removesItFromWorkspace() throws Exception {
-		assertTrue(file(FB_FILE).exists());
+		assertTrue(file(MY_BLOCK_FILE).exists());
 
 		deleteMyBlock();
 
-		assertFalse(file(FB_FILE).exists());
+		assertFalse(file(MY_BLOCK_FILE).exists());
 	}
 
 	@Test
 	void deleteMyBlock_clearsItFromTypeLibrary() throws Exception {
-		assertNotNull(typeLibrary.getFBTypeEntry(MY_BLOCK_TYPE_NAME));
+		assertNotNull(typeLibrary.getFBTypeEntry(MY_BLOCK));
 
 		deleteMyBlock();
 
-		assertNull(typeLibrary.getFBTypeEntry(MY_BLOCK_TYPE_NAME));
+		assertNull(typeLibrary.getFBTypeEntry(MY_BLOCK));
 	}
 
 	@Test
-	void deleteMyBlock_leavesAllNestedSubAppInstancesStructurallyIntact() throws Exception {
-		findInstance(TOP_INSTANCE);
-		findInstance(CONTAINER_SUBAPP, NESTED_INSTANCE);
-		findInstance(CONTAINER_SUBAPP, DEEP_CONTAINER_SUBAPP, DEEPLY_NESTED_INSTANCE);
+	void deleteMyBlock_keepsInstancesAndConnectionsAtEveryNestingLevel() throws Exception {
+		assertEquals(MY_BLOCK_INSTANCES, myBlockInstanceNames());
+		assertEquals(INSTANCE_CONNECTIONS, connectionNames());
 
 		deleteMyBlock();
 
-		// DeleteTypeRefactoringParticipant only removes internal FBs whose
-		// container is a BaseFBType, so System FB instances at every nesting
-		// level remain in place; findInstance throws if any is missing.
-		findInstance(TOP_INSTANCE);
-		findInstance(CONTAINER_SUBAPP, NESTED_INSTANCE);
-		findInstance(CONTAINER_SUBAPP, DEEP_CONTAINER_SUBAPP, DEEPLY_NESTED_INSTANCE);
+		// DeleteTypeRefactoringParticipant only removes internal FBs whose container is
+		// a BaseFBType, so the instances in the application and the connections between
+		// them stay untouched on every nesting level.
+		assertEquals(MY_BLOCK_INSTANCES, myBlockInstanceNames());
+		assertEquals(INSTANCE_CONNECTIONS, connectionNames());
 	}
 
 	private void deleteMyBlock() throws Exception {
-		RefactoringTestSupport.performDelete(file(FB_FILE));
+		RefactoringTestSupport.performDelete(file(MY_BLOCK_FILE));
+	}
+
+	private Set<String> myBlockInstanceNames() {
+		return networksAtEveryNestingLevel().flatMap(network -> network.getNetworkElements().stream())
+				.filter(FB.class::isInstance).map(FBNetworkElement::getName).collect(Collectors.toSet());
+	}
+
+	private Set<String> connectionNames() {
+		return networksAtEveryNestingLevel()
+				.flatMap(network -> Stream.concat(network.getEventConnections().stream(),
+						network.getDataConnections().stream()))
+				.map(FBTypeDeleteNestedSubAppTest::connectionName).collect(Collectors.toSet());
+	}
+
+	private Stream<FBNetwork> networksAtEveryNestingLevel() {
+		return Stream.of(system().getApplicationNamed(APPLICATION_NAME).getFBNetwork(),
+				subAppNetwork(CONTAINER_SUBAPP), subAppNetwork(CONTAINER_SUBAPP, DEEP_CONTAINER_SUBAPP));
+	}
+
+	private FBNetwork subAppNetwork(final String... namePath) {
+		return ((UntypedSubApp) findInstance(namePath)).getSubAppNetwork();
+	}
+
+	private static String connectionName(final Connection connection) {
+		return endpointName(connection.getSource()) + " -> " + endpointName(connection.getDestination()); //$NON-NLS-1$
+	}
+
+	private static String endpointName(final IInterfaceElement pin) {
+		final BlockFBNetworkElement block = pin.getBlockFBNetworkElement();
+		return block.getName() + "." + pin.getRelativeName(block); //$NON-NLS-1$
 	}
 
 	private FBNetworkElement findInstance(final String... namePath) {
-		FBNetwork network = system().getApplicationNamed(APPLICATION_NAME).getFBNetwork();
-		for (int i = 0; i < namePath.length - 1; i++) {
-			final String subAppName = namePath[i];
-			final UntypedSubApp subApp = (UntypedSubApp) network.getNetworkElements().stream()
-					.filter(element -> subAppName.equals(element.getName())).findFirst().orElseThrow();
-			network = subApp.getSubAppNetwork();
-		}
-		final String instanceName = namePath[namePath.length - 1];
-		return network.getNetworkElements().stream().filter(element -> instanceName.equals(element.getName()))
-				.findFirst().orElseThrow();
+		return RefactoringTestSupport.findInstance(system(), APPLICATION_NAME, namePath);
 	}
 
 	private AutomationSystem system() {

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/FBTypeRenameNestedSubAppTest.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/FBTypeRenameNestedSubAppTest.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Dimitrios Kalligaridis
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Dimitrios Kalligaridis - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.tests;
+
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedSubAppTestFixture.APPLICATION_NAME;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedSubAppTestFixture.CONTAINER_SUBAPP;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedSubAppTestFixture.DEEPLY_NESTED_INSTANCE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedSubAppTestFixture.DEEP_CONTAINER_SUBAPP;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedSubAppTestFixture.MY_BLOCK;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedSubAppTestFixture.MY_BLOCK_FILE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedSubAppTestFixture.NESTED_INSTANCE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedSubAppTestFixture.PROJECT_NAME;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedSubAppTestFixture.PROJECT_PATH;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedSubAppTestFixture.SYSTEM_FILE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedSubAppTestFixture.TOP_INSTANCE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.CORE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
+import org.eclipse.fordiac.ide.systemmanagement.SystemManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class FBTypeRenameNestedSubAppTest {
+
+	private static final String RENAMED_FB_FILE = "Type Library/mypackage/MyBlockRenamed.fbt"; //$NON-NLS-1$
+	private static final String NEW_FB_FILE_NAME = "MyBlockRenamed.fbt"; //$NON-NLS-1$
+	private static final String MY_BLOCK_RENAMED = "mypackage::MyBlockRenamed"; //$NON-NLS-1$
+
+	private IProject project;
+	private TypeLibrary typeLibrary;
+
+	@BeforeAll
+	static void preloadSystemManager() {
+		SystemManager.INSTANCE.name();
+	}
+
+	@BeforeEach
+	void loadFixture() throws Exception {
+		RefactoringTestSupport.flushUndoHistory();
+		project = RefactoringTestSupport.importProjectIntoWorkspace(PROJECT_NAME, PROJECT_PATH);
+		RefactoringTestSupport.linkStandardLibraries(project, CORE);
+		typeLibrary = TypeLibraryManager.INSTANCE.getTypeLibrary(project);
+	}
+
+	@AfterEach
+	void disposeFixture() throws Exception {
+		RefactoringTestSupport.deleteProject(project);
+	}
+
+	@Test
+	void renameMyBlock_repointsInstancesAtEveryNestingLevel() throws Exception {
+		assertInstanceTypeNamesAtEveryNestingLevel(MY_BLOCK);
+
+		renameMyBlock();
+
+		assertInstanceTypeNamesAtEveryNestingLevel(MY_BLOCK_RENAMED);
+	}
+
+	@Test
+	void renameMyBlock_undoRedoRoundTrip() throws Exception {
+		renameMyBlock();
+		assertRenamedState();
+
+		RefactoringTestSupport.undoLastRefactoring();
+		assertOriginalState();
+
+		RefactoringTestSupport.redoLastRefactoring();
+		assertRenamedState();
+	}
+
+	private void assertRenamedState() {
+		assertFalse(file(MY_BLOCK_FILE).exists());
+		assertTrue(file(RENAMED_FB_FILE).exists());
+		assertInstanceTypeNamesAtEveryNestingLevel(MY_BLOCK_RENAMED);
+	}
+
+	private void assertOriginalState() {
+		assertTrue(file(MY_BLOCK_FILE).exists());
+		assertFalse(file(RENAMED_FB_FILE).exists());
+		assertInstanceTypeNamesAtEveryNestingLevel(MY_BLOCK);
+	}
+
+	private void assertInstanceTypeNamesAtEveryNestingLevel(final String expectedFullTypeName) {
+		assertEquals(expectedFullTypeName, findInstance(TOP_INSTANCE).getFullTypeName());
+		assertEquals(expectedFullTypeName, findInstance(CONTAINER_SUBAPP, NESTED_INSTANCE).getFullTypeName());
+		assertEquals(expectedFullTypeName,
+				findInstance(CONTAINER_SUBAPP, DEEP_CONTAINER_SUBAPP, DEEPLY_NESTED_INSTANCE).getFullTypeName());
+	}
+
+	private void renameMyBlock() throws Exception {
+		RefactoringTestSupport.performRename(file(MY_BLOCK_FILE), NEW_FB_FILE_NAME);
+	}
+
+	private FBNetworkElement findInstance(final String... namePath) {
+		return RefactoringTestSupport.findInstance(system(), APPLICATION_NAME, namePath);
+	}
+
+	private AutomationSystem system() {
+		return (AutomationSystem) typeLibrary.getTypeEntry(file(SYSTEM_FILE)).getType();
+	}
+
+	private IFile file(final String projectRelativePath) {
+		return project.getFile(projectRelativePath);
+	}
+}

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/NestedSubAppTestFixture.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/NestedSubAppTestFixture.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Dimitrios Kalligaridis
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Dimitrios Kalligaridis - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.tests;
+
+/**
+ * Coordinates of the shared FBTypeDeleteNestedSubAppTest fixture under data,
+ * where MyBlock is instanced at three nesting levels, referenced by the FB type
+ * delete and rename tests.
+ */
+public final class NestedSubAppTestFixture {
+
+	public static final String PROJECT_NAME = "FBTypeDeleteNestedSubAppTest"; //$NON-NLS-1$
+	public static final String PROJECT_PATH = "data/FBTypeDeleteNestedSubAppTest"; //$NON-NLS-1$
+	public static final String SYSTEM_FILE = "FBTypeDeleteNestedSubAppTest.sys"; //$NON-NLS-1$
+	public static final String APPLICATION_NAME = "App"; //$NON-NLS-1$
+
+	public static final String MY_BLOCK_FILE = "Type Library/mypackage/MyBlock.fbt"; //$NON-NLS-1$
+	public static final String MY_BLOCK = "mypackage::MyBlock"; //$NON-NLS-1$
+
+	public static final String TOP_INSTANCE = "TopInstance"; //$NON-NLS-1$
+	public static final String CONTAINER_SUBAPP = "Container"; //$NON-NLS-1$
+	public static final String NESTED_INSTANCE = "NestedInstance"; //$NON-NLS-1$
+	public static final String DEEP_CONTAINER_SUBAPP = "DeepContainer"; //$NON-NLS-1$
+	public static final String DEEPLY_NESTED_INSTANCE = "DeeplyNestedInstance"; //$NON-NLS-1$
+	public static final String TOP_INSTANCE_SINK = "TopInstanceSink"; //$NON-NLS-1$
+	public static final String NESTED_INSTANCE_SINK = "NestedInstanceSink"; //$NON-NLS-1$
+	public static final String DEEPLY_NESTED_INSTANCE_SINK = "DeeplyNestedInstanceSink"; //$NON-NLS-1$
+
+	private NestedSubAppTestFixture() {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/RefactoringTestSupport.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/RefactoringTestSupport.java
@@ -34,6 +34,10 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.fordiac.ide.library.LibraryManager;
+import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.UntypedSubApp;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 import org.eclipse.fordiac.ide.typemanagement.refactoring.rename.RenameElementRefactoringProcessor;
@@ -149,6 +153,21 @@ public final class RefactoringTestSupport {
 		return performRefactoring(new RenameRefactoring(new RenameElementRefactoringProcessor(elementURI, newName)));
 	}
 
+	/**
+	 * Run only the rename condition check and return its status. performRename
+	 * cannot be used for the negative cases because CreateChangeOperation drops a
+	 * fatal status instead of surfacing it.
+	 */
+	public static RefactoringStatus checkRenameConditions(final IFile file, final String newName) throws CoreException {
+		final RenameResourceDescriptor descriptor = new RenameResourceDescriptor();
+		descriptor.setResourcePath(file.getFullPath());
+		descriptor.setNewName(newName);
+		final CheckConditionsOperation check = new CheckConditionsOperation(
+				descriptor.createRefactoring(new RefactoringStatus()), CheckConditionsOperation.ALL_CONDITIONS);
+		check.run(new NullProgressMonitor());
+		return check.getStatus();
+	}
+
 	private static Change performRefactoring(final Refactoring refactoring) throws CoreException {
 		final CreateChangeOperation create = new CreateChangeOperation(
 				new CheckConditionsOperation(refactoring, CheckConditionsOperation.ALL_CONDITIONS),
@@ -176,6 +195,21 @@ public final class RefactoringTestSupport {
 	 */
 	public static void flushUndoHistory() {
 		RefactoringCore.getUndoManager().flush();
+	}
+
+	/** Walk from the application network through the named subapps to an FB instance. */
+	public static FBNetworkElement findInstance(final AutomationSystem system, final String applicationName,
+			final String... namePath) {
+		FBNetwork network = system.getApplicationNamed(applicationName).getFBNetwork();
+		for (int i = 0; i < namePath.length - 1; i++) {
+			final String subAppName = namePath[i];
+			final UntypedSubApp subApp = (UntypedSubApp) network.getNetworkElements().stream()
+					.filter(element -> subAppName.equals(element.getName())).findFirst().orElseThrow();
+			network = subApp.getSubAppNetwork();
+		}
+		final String instanceName = namePath[namePath.length - 1];
+		return network.getNetworkElements().stream().filter(element -> instanceName.equals(element.getName()))
+				.findFirst().orElseThrow();
 	}
 
 	// The undo manager is the global RefactoringCore singleton; a permissive query

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/RenameTypeErrorConditionsTest.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/RenameTypeErrorConditionsTest.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Dimitrios Kalligaridis
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Dimitrios Kalligaridis - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.tests;
+
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.CONVERT;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.CORE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.IEC_61131_3;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.INNER_STRUCT_FILE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.PROJECT_NAME;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.PROJECT_PATH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.fordiac.ide.model.IdentifierVerifier;
+import org.eclipse.fordiac.ide.systemmanagement.SystemManager;
+import org.eclipse.fordiac.ide.typemanagement.refactoring.rename.RenameElementRefactoringProcessor;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RenameTypeErrorConditionsTest {
+
+	private static final String EXISTING_TYPE_FILE_NAME = "OuterStruct.dtp"; //$NON-NLS-1$
+	private static final String FILE_EXISTS_MESSAGE = "File already exists!"; //$NON-NLS-1$
+	private static final String RESERVED_NAME = "ADD"; //$NON-NLS-1$
+	private static final String RESERVED_TYPE_FILE_NAME = "ADD.dtp"; //$NON-NLS-1$
+
+	private IProject project;
+
+	@BeforeAll
+	static void preloadSystemManager() {
+		SystemManager.INSTANCE.name();
+	}
+
+	@BeforeEach
+	void loadFixture() throws Exception {
+		project = RefactoringTestSupport.importProjectIntoWorkspace(PROJECT_NAME, PROJECT_PATH);
+		RefactoringTestSupport.linkStandardLibraries(project, CORE, CONVERT, IEC_61131_3);
+	}
+
+	@AfterEach
+	void disposeFixture() throws Exception {
+		RefactoringTestSupport.deleteProject(project);
+	}
+
+	@Test
+	void renameToExistingFileName_yieldsFatalStatus() throws Exception {
+		final RefactoringStatus status = RefactoringTestSupport.checkRenameConditions(file(INNER_STRUCT_FILE),
+				EXISTING_TYPE_FILE_NAME);
+
+		assertTrue(status.hasFatalError());
+		assertTrue(Stream.of(status.getEntries()).anyMatch(entry -> FILE_EXISTS_MESSAGE.equals(entry.getMessage())));
+	}
+
+	@Test
+	void renameToReservedKeyword_processorFlagsFatalStatus() throws Exception {
+		final RenameElementRefactoringProcessor processor = new RenameElementRefactoringProcessor(
+				URI.createPlatformResourceURI(file(INNER_STRUCT_FILE).getFullPath().toString(), true), RESERVED_NAME);
+
+		final RefactoringStatus status = processor.checkInitialConditions(new NullProgressMonitor());
+
+		assertTrue(status.hasFatalError());
+		assertEquals(IdentifierVerifier.verifyIdentifier(RESERVED_NAME).orElseThrow(),
+				status.getEntryWithHighestSeverity().getMessage());
+	}
+
+	@Test
+	void renameFileToReservedKeyword_isNotFlaggedByFileRename() throws Exception {
+		// The file rename path checks only the file ending and name collisions, so a
+		// reserved keyword is rejected through the model rename processor, not here.
+		final RefactoringStatus status = RefactoringTestSupport.checkRenameConditions(file(INNER_STRUCT_FILE),
+				RESERVED_TYPE_FILE_NAME);
+
+		assertFalse(status.hasFatalError());
+	}
+
+	private IFile file(final String projectRelativePath) {
+		return project.getFile(projectRelativePath);
+	}
+}


### PR DESCRIPTION
Adds headless tests for FB type rename. Renaming an FB type repoints its instances across nested subapplications; the tests cover the cascade with an undo/redo round trip, the fatal status when renaming to an existing file name, and the reserved keyword check in the rename element processor. Also fixes the MyBlock fixture, which was missing its package name attribute, so its instances never actually resolved to the type and no test caught it.