### PR TITLE
Store sparse struct and array initial value diffs in edit value dialog

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/VarConfigurationSection.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/properties/VarConfigurationSection.java
@@ -26,7 +26,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.application.Messages;
 import org.eclipse.fordiac.ide.gef.nat.DefaultImportCopyPasteLayerConfiguration;
-import org.eclipse.fordiac.ide.gef.nat.InitialValueGenericEditorConfiguration;
+import org.eclipse.fordiac.ide.gef.nat.InitialValueVariableEditorConfiguration;
 import org.eclipse.fordiac.ide.gef.nat.InitialValueTypedElementAccessor;
 import org.eclipse.fordiac.ide.gef.nat.VarDeclarationColumnAccessor;
 import org.eclipse.fordiac.ide.gef.nat.VarDeclarationConfigLabelAccumulator;
@@ -122,7 +122,7 @@ public class VarConfigurationSection extends AbstractSection {
 						VarDeclarationTableColumn.DEFAULT_EDITABLE));
 
 		inputTable.addConfiguration(new CheckBoxConfigurationNebula());
-		inputTable.addConfiguration(new InitialValueGenericEditorConfiguration<>(inputDataProvider,
+		inputTable.addConfiguration(new InitialValueVariableEditorConfiguration<>(inputDataProvider,
 				new InitialValueTypedElementAccessor<VarDeclaration>() {
 					@Override
 					public LibraryElement getContext(final VarDeclaration element) {

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/dialogs/InitialValueVariableDialog.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/dialogs/InitialValueVariableDialog.java
@@ -1,0 +1,176 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Michael Oberlehner - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.gef.dialogs;
+
+import java.lang.reflect.InvocationTargetException;
+import java.text.MessageFormat;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.eclipse.core.runtime.Status;
+import org.eclipse.fordiac.ide.gef.Messages;
+import org.eclipse.fordiac.ide.gef.widgets.InitialValueVariableWidget;
+import org.eclipse.fordiac.ide.gef.widgets.VariableWidget;
+import org.eclipse.fordiac.ide.model.data.DirectlyDerivedType;
+import org.eclipse.fordiac.ide.model.eval.variable.ArrayVariable;
+import org.eclipse.fordiac.ide.model.eval.variable.StructVariable;
+import org.eclipse.fordiac.ide.model.eval.variable.Variable;
+import org.eclipse.fordiac.ide.model.eval.variable.VariableOperations;
+import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
+import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.jface.dialogs.ErrorDialog;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.PlatformUI;
+
+public class InitialValueVariableDialog extends VariableDialog {
+
+	private final Variable<?> baseVariable;
+	private final Set<Variable<?>> explicitlyInitialized;
+
+	protected InitialValueVariableDialog(final Shell shell, final String title, final Variable<?> variable,
+			final Variable<?> baseVariable, final Set<Variable<?>> explicitlyInitialized) {
+		super(shell, title, List.of(variable));
+		this.baseVariable = baseVariable;
+		this.explicitlyInitialized = explicitlyInitialized;
+	}
+
+	@Override
+	protected VariableWidget createVariableWidget() {
+		return new InitialValueVariableWidget(List.of(baseVariable), explicitlyInitialized);
+	}
+
+	public static Optional<String> open(final Shell shell, final ITypedElement element, final String initialValue) {
+		return open(shell, Messages.VariableDialog_DefaultTitle, element, initialValue);
+	}
+
+	public static Optional<String> open(final Shell shell, final String title, final ITypedElement element,
+			final String initialValue) {
+		final Variable<?>[] variable = new Variable[1];
+		final Variable<?>[] baseVariable = new Variable[1];
+		final Set<Variable<?>> explicitlyInitialized = Collections.newSetFromMap(new IdentityHashMap<>());
+		try {
+			PlatformUI.getWorkbench().getProgressService().busyCursorWhile(monitor -> {
+				variable[0] = newDialogVariable(element, getDialogInitialValue(element, initialValue),
+						explicitlyInitialized);
+				baseVariable[0] = newBaseVariable(element);
+			});
+		} catch (final InvocationTargetException e) {
+			ErrorDialog.openError(shell, title, null,
+					Status.error(MessageFormat.format(Messages.VariableDialog_ValueError, element.getQualifiedName()),
+							e.getTargetException()));
+			return Optional.empty();
+		} catch (final InterruptedException e) {
+			Thread.currentThread().interrupt();
+			return Optional.empty();
+		}
+
+		final InitialValueVariableDialog dialog = new InitialValueVariableDialog(shell, title, variable[0],
+				baseVariable[0], explicitlyInitialized);
+		if (dialog.open() == OK) {
+			return Optional.of(toExplicitInitialValue(variable[0],
+					((InitialValueVariableWidget) dialog.getVariableWidget())::isExplicitInitialValue));
+		}
+		return Optional.empty();
+	}
+
+	private static Variable<?> newDialogVariable(final ITypedElement element, final String initialValue,
+			final Set<Variable<?>> explicitlyInitialized) {
+		return switch (element) {
+		case final VarDeclaration varDeclaration ->
+			VariableOperations.newVariable(varDeclaration, initialValue, explicitlyInitialized);
+		case final Attribute attribute ->
+			VariableOperations.newVariable(attribute, initialValue, explicitlyInitialized);
+		case final DirectlyDerivedType directlyDerivedType ->
+			VariableOperations.newVariable(directlyDerivedType, initialValue, explicitlyInitialized);
+		default -> VariableOperations.newVariable(element, initialValue);
+		};
+	}
+
+	private static Variable<?> newBaseVariable(final ITypedElement element) {
+		return switch (element) {
+		case final VarDeclaration varDeclaration ->
+			VariableOperations.newVariableWithoutDeclaredInitialValue(varDeclaration);
+		case final Attribute attribute -> VariableOperations.newVariable(attribute.getName(), attribute.getType());
+		case final DirectlyDerivedType directlyDerivedType ->
+			VariableOperations.newVariable(directlyDerivedType.getName(), directlyDerivedType.getBaseType());
+		default -> VariableOperations.newVariable(element, null);
+		};
+	}
+
+	protected static String toExplicitInitialValue(final Variable<?> variable,
+			final Predicate<Variable<?>> explicitInitialValuePredicate) {
+		return switch (variable) {
+		case final StructVariable structVariable ->
+			toExplicitStructInitialValue(structVariable, explicitInitialValuePredicate);
+		case final ArrayVariable arrayVariable ->
+			toExplicitArrayInitialValue(arrayVariable, explicitInitialValuePredicate);
+		default -> explicitInitialValuePredicate.test(variable) ? variable.toString() : ""; //$NON-NLS-1$
+		};
+	}
+
+	private static String toExplicitStructInitialValue(final StructVariable variable,
+			final Predicate<Variable<?>> explicitInitialValuePredicate) {
+		final String members = variable.getMembers().values().stream()
+				.map(member -> toExplicitStructMemberInitialValue(member, explicitInitialValuePredicate))
+				.filter(Predicate.not(String::isEmpty)).collect(Collectors.joining(", ")); //$NON-NLS-1$
+		return members.isEmpty() ? "" : '(' + members + ')'; //$NON-NLS-1$
+	}
+
+	private static String toExplicitStructMemberInitialValue(final Variable<?> member,
+			final Predicate<Variable<?>> explicitInitialValuePredicate) {
+		final String value = toExplicitInitialValue(member, explicitInitialValuePredicate);
+		return value.isEmpty() ? "" : member.getName() + " := " + value; //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	private static String toExplicitArrayInitialValue(final ArrayVariable variable,
+			final Predicate<Variable<?>> explicitInitialValuePredicate) {
+		final List<Variable<?>> elements = variable.getElements();
+		final List<String> explicitValues = elements.stream()
+				.map(element -> toExplicitInitialValue(element, explicitInitialValuePredicate)).toList();
+		final int lastExplicitIndex = IntStream.range(0, explicitValues.size())
+				.filter(index -> !explicitValues.get(index).isEmpty()).max().orElse(-1);
+		if (lastExplicitIndex < 0) {
+			return ""; //$NON-NLS-1$
+		}
+
+		return IntStream.rangeClosed(0, lastExplicitIndex)
+				.mapToObj(index -> explicitValues.get(index).isEmpty() ? elements.get(index).toString()
+						: explicitValues.get(index))
+				.collect(Collectors.joining(", ", "[", "]")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+	}
+
+	private static String getDialogInitialValue(final ITypedElement element, final String initialValue) {
+		final String declaredInitialValue = switch (element) {
+		case final VarDeclaration varDeclaration -> VariableOperations.getDeclaredInitialValue(varDeclaration);
+		case final Attribute attribute -> attribute.getValue();
+		case final DirectlyDerivedType directlyDerivedType -> directlyDerivedType.getInitialValue();
+		default -> null;
+		};
+		if (initialValue == null) {
+			return declaredInitialValue;
+		}
+		if (declaredInitialValue == null
+				&& Objects.equals(initialValue, VariableOperations.newVariable(element).toString())) {
+			return null;
+		}
+		return initialValue;
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/dialogs/VariableDialog.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/dialogs/VariableDialog.java
@@ -39,21 +39,30 @@ public class VariableDialog extends Dialog {
 
 	private final String title;
 	private final List<Variable<?>> variables;
-	private final VariableWidget variableWidget;
+	private VariableWidget variableWidget;
 
 	protected VariableDialog(final Shell shell, final String title, final List<Variable<?>> variables) {
 		super(shell);
 		this.title = title;
 		this.variables = variables;
-		variableWidget = new VariableWidget();
 	}
 
 	@Override
 	protected Control createDialogArea(final Composite parent) {
+		variableWidget = createVariableWidget();
 		final Composite control = variableWidget.createWidget(parent);
 		GridDataFactory.fillDefaults().grab(true, true).applyTo(control);
 		variableWidget.setInput(variables);
 		return control;
+	}
+
+	@SuppressWarnings("static-method")
+	protected VariableWidget createVariableWidget() {
+		return new VariableWidget();
+	}
+
+	protected VariableWidget getVariableWidget() {
+		return variableWidget;
 	}
 
 	@Override
@@ -135,7 +144,7 @@ public class VariableDialog extends Dialog {
 			throws InvocationTargetException, InterruptedException {
 		final Variable<?>[] result = new Variable[1];
 		PlatformUI.getWorkbench().getProgressService()
-				.busyCursorWhile(moniotr -> result[0] = VariableOperations.newVariable(element, initialValue));
+				.busyCursorWhile(monitor -> result[0] = VariableOperations.newVariable(element, initialValue));
 		return result[0];
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/InitialValueStructuredCellEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/InitialValueStructuredCellEditor.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.gef.editparts;
 
+import java.util.Optional;
+
 import org.eclipse.fordiac.ide.gef.dialogs.VariableDialog;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.ui.FordiacMessages;
@@ -24,6 +26,7 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
 
 public class InitialValueStructuredCellEditor extends InitialValueCellEditor {
 
@@ -60,11 +63,15 @@ public class InitialValueStructuredCellEditor extends InitialValueCellEditor {
 		try {
 			variableDialogOpen = true;
 			final String initialValue = FordiacMessages.ValueTooLarge.equals(text.getText()) ? null : text.getText();
-			VariableDialog.open(getControl().getShell(), getVarDeclaration(), initialValue).ifPresent(text::setText);
+			openVariableDialog(getControl().getShell(), initialValue).ifPresent(text::setText);
 		} finally {
 			textControl.forceFocus();
 			variableDialogOpen = false;
 		}
+	}
+
+	protected Optional<String> openVariableDialog(final Shell shell, final String initialValue) {
+		return VariableDialog.open(shell, getVarDeclaration(), initialValue);
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/InitialValueVariableDirectEditManager.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/InitialValueVariableDirectEditManager.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Michael Oberlehner - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.gef.editparts;
+
+import org.eclipse.fordiac.ide.model.data.StructuredType;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.gef.GraphicalEditPart;
+import org.eclipse.gef.tools.CellEditorLocator;
+import org.eclipse.jface.viewers.CellEditor;
+import org.eclipse.swt.widgets.Composite;
+
+public class InitialValueVariableDirectEditManager extends InitialValueDirectEditManager {
+
+	private final VarDeclaration varDeclaration;
+
+	public InitialValueVariableDirectEditManager(final GraphicalEditPart source, final CellEditorLocator locator,
+			final VarDeclaration varDeclaration, final String initialValue) {
+		super(source, locator, varDeclaration, initialValue);
+		this.varDeclaration = varDeclaration;
+	}
+
+	@Override
+	protected CellEditor createCellEditorOn(final Composite composite) {
+		if (varDeclaration.getType() instanceof StructuredType || varDeclaration.isArray()) {
+			return new InitialValueVariableStructuredCellEditor(composite, varDeclaration);
+		}
+		return super.createCellEditorOn(composite);
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/InitialValueVariableStructuredCellEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/InitialValueVariableStructuredCellEditor.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Michael Oberlehner - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.gef.editparts;
+
+import java.util.Optional;
+
+import org.eclipse.fordiac.ide.gef.dialogs.InitialValueVariableDialog;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Shell;
+
+public class InitialValueVariableStructuredCellEditor extends InitialValueStructuredCellEditor {
+
+	public InitialValueVariableStructuredCellEditor(final Composite parent, final VarDeclaration varDeclaration) {
+		super(parent, varDeclaration);
+	}
+
+	public InitialValueVariableStructuredCellEditor(final Composite parent, final VarDeclaration varDeclaration,
+			final int style) {
+		super(parent, varDeclaration, style);
+	}
+
+	@Override
+	protected Optional<String> openVariableDialog(final Shell shell, final String initialValue) {
+		return InitialValueVariableDialog.open(shell, getVarDeclaration(), initialValue);
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/ValueEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/editparts/ValueEditPart.java
@@ -375,7 +375,7 @@ public class ValueEditPart extends AbstractGraphicalEditPart implements NodeEdit
 	public DirectEditManager createDirectEditManager() {
 		final IInterfaceElement interfaceElement = getIInterfaceElement();
 		if (interfaceElement instanceof final VarDeclaration varDecl) {
-			return new InitialValueDirectEditManager(this, new FigureCellEditorLocator(getFigure()), varDecl,
+			return new InitialValueVariableDirectEditManager(this, new FigureCellEditorLocator(getFigure()), varDecl,
 					getDirectEditInitialValue());
 		}
 		return new LabelDirectEditManager(this, getFigure());

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/DefaultCellUpdateDataCommandHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/DefaultCellUpdateDataCommandHandler.java
@@ -53,4 +53,9 @@ public class DefaultCellUpdateDataCommandHandler extends UpdateDataCommandHandle
 			return false;
 		}
 	}
+
+	public static void register(final DataLayer dataLayer) {
+		dataLayer.unregisterCommandHandler(UpdateDataCommand.class);
+		dataLayer.registerCommandHandler(new DefaultCellUpdateDataCommandHandler(dataLayer));
+	}
 }

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/InitialValueGenericEditorConfiguration.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/InitialValueGenericEditorConfiguration.java
@@ -35,8 +35,19 @@ public class InitialValueGenericEditorConfiguration<T> extends AbstractRegistryC
 	public void configureRegistry(final IConfigRegistry configRegistry) {
 		configRegistry.registerConfigAttribute(EditConfigAttributes.CELL_EDITOR,
 				new InitialValueCellEditor<>(dataProvider, elementAccessor), DisplayMode.EDIT, INITIAL_VALUE_CELL);
-		configRegistry.registerConfigAttribute(EditConfigAttributes.CELL_EDITOR,
-				new InitialValueStructuredCellEditor<>(dataProvider, elementAccessor), DisplayMode.EDIT,
-				INITIAL_VALUE_STRUCTURED_CELL);
+		configRegistry.registerConfigAttribute(EditConfigAttributes.CELL_EDITOR, createStructuredCellEditor(),
+				DisplayMode.EDIT, INITIAL_VALUE_STRUCTURED_CELL);
+	}
+
+	protected InitialValueStructuredCellEditor<T> createStructuredCellEditor() {
+		return new InitialValueStructuredCellEditor<>(dataProvider, elementAccessor);
+	}
+
+	protected IRowDataProvider<? extends T> getDataProvider() {
+		return dataProvider;
+	}
+
+	protected InitialValueStructuredElementAccessor<T> getElementAccessor() {
+		return elementAccessor;
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/InitialValueStructuredCellEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/InitialValueStructuredCellEditor.java
@@ -12,7 +12,10 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.gef.nat;
 
+import java.util.Optional;
+
 import org.eclipse.fordiac.ide.gef.dialogs.VariableDialog;
+import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement;
 import org.eclipse.fordiac.ide.ui.FordiacMessages;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
@@ -27,6 +30,7 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
 
 public class InitialValueStructuredCellEditor<T> extends InitialValueCellEditor<T> {
 
@@ -68,14 +72,18 @@ public class InitialValueStructuredCellEditor<T> extends InitialValueCellEditor<
 		try {
 			final String initialValue = FordiacMessages.ValueTooLarge.equals(getEditorValue()) ? null
 					: getEditorValue();
-			VariableDialog
-					.open(composite.getShell(), getElementAccessor().getReferenceElement(getRowObject()), initialValue)
-					.ifPresent(this::setEditorValue);
+			openVariableDialog(composite.getShell(), getElementAccessor().getReferenceElement(getRowObject()),
+					initialValue).ifPresent(this::setEditorValue);
 		} finally {
 			if (textControl != null && !textControl.isDisposed()) {
 				textControl.forceFocus();
 			}
 		}
+	}
+
+	protected Optional<String> openVariableDialog(final Shell shell, final ITypedElement element,
+			final String initialValue) {
+		return VariableDialog.open(shell, element, initialValue);
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/InitialValueVariableConfigLabelAccumulator.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/InitialValueVariableConfigLabelAccumulator.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Michael Oberlehner - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.gef.nat;
+
+import java.util.function.Predicate;
+
+import org.eclipse.fordiac.ide.model.eval.variable.Variable;
+import org.eclipse.fordiac.ide.ui.widget.nattable.NatTableWidgetFactory;
+import org.eclipse.nebula.widgets.nattable.data.IRowDataProvider;
+import org.eclipse.nebula.widgets.nattable.layer.LabelStack;
+
+public class InitialValueVariableConfigLabelAccumulator extends VariableConfigLabelAccumulator {
+
+	private final IRowDataProvider<Variable<?>> dataProvider;
+	private final Predicate<Variable<?>> inheritedValuePredicate;
+
+	public InitialValueVariableConfigLabelAccumulator(final IRowDataProvider<Variable<?>> dataProvider,
+			final Predicate<Variable<?>> inheritedValuePredicate) {
+		this.dataProvider = dataProvider;
+		this.inheritedValuePredicate = inheritedValuePredicate;
+	}
+
+	@Override
+	public void accumulateConfigLabels(final LabelStack configLabels, final int columnPosition, final int rowPosition) {
+		super.accumulateConfigLabels(configLabels, columnPosition, rowPosition);
+		if (getColumns().get(columnPosition) == VariableTableColumn.VALUE
+				&& inheritedValuePredicate.test(dataProvider.getRowObject(rowPosition))) {
+			configLabels.addLabelOnTop(NatTableWidgetFactory.DEFAULT_CELL);
+		}
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/InitialValueVariableDataLayer.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/InitialValueVariableDataLayer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Martin Erich Jobst
+ * Copyright (c) 2026 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -8,19 +8,17 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *   Martin Jobst - initial API and implementation and/or initial documentation
+ *   Michael Oberlehner - initial API and implementation and/or initial documentation
  *******************************************************************************/
 package org.eclipse.fordiac.ide.gef.nat;
 
-import java.util.List;
-
-import org.eclipse.fordiac.ide.ui.widget.nattable.ColumnCachingDataLayer;
 import org.eclipse.nebula.widgets.nattable.data.IDataProvider;
+import org.eclipse.nebula.widgets.nattable.layer.DataLayer;
 
-public class VarDeclarationDataLayer extends ColumnCachingDataLayer<VarDeclarationTableColumn> {
+public class InitialValueVariableDataLayer extends DataLayer {
 
-	public VarDeclarationDataLayer(final IDataProvider dataProvider, final List<VarDeclarationTableColumn> columns) {
-		super(dataProvider, columns, VarDeclarationTableColumn.INITIAL_VALUE);
+	public InitialValueVariableDataLayer(final IDataProvider dataProvider) {
+		super(dataProvider);
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/InitialValueVariableEditorConfiguration.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/InitialValueVariableEditorConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Martin Erich Jobst
+ * Copyright (c) 2026 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -8,21 +8,21 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *   Martin Jobst - initial API and implementation and/or initial documentation
+ *   Michael Oberlehner - initial API and implementation and/or initial documentation
  *******************************************************************************/
 package org.eclipse.fordiac.ide.gef.nat;
 
-import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement;
 import org.eclipse.nebula.widgets.nattable.data.IRowDataProvider;
 
-public class InitialValueEditorConfiguration extends InitialValueGenericEditorConfiguration<ITypedElement> {
+public class InitialValueVariableEditorConfiguration<T> extends InitialValueGenericEditorConfiguration<T> {
 
-	public InitialValueEditorConfiguration(final IRowDataProvider<? extends ITypedElement> dataProvider) {
-		super(dataProvider, InitialValueTypedElementAccessor.INSTANCE);
+	public InitialValueVariableEditorConfiguration(final IRowDataProvider<? extends T> dataProvider,
+			final InitialValueStructuredElementAccessor<T> elementAccessor) {
+		super(dataProvider, elementAccessor);
 	}
 
 	@Override
-	protected InitialValueStructuredCellEditor<ITypedElement> createStructuredCellEditor() {
+	protected InitialValueStructuredCellEditor<T> createStructuredCellEditor() {
 		return new InitialValueVariableStructuredCellEditor<>(getDataProvider(), getElementAccessor());
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/InitialValueVariableStructuredCellEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/nat/InitialValueVariableStructuredCellEditor.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Michael Oberlehner - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.gef.nat;
+
+import java.util.Optional;
+
+import org.eclipse.fordiac.ide.gef.dialogs.InitialValueVariableDialog;
+import org.eclipse.fordiac.ide.model.libraryElement.ITypedElement;
+import org.eclipse.nebula.widgets.nattable.data.IRowDataProvider;
+import org.eclipse.swt.widgets.Shell;
+
+public class InitialValueVariableStructuredCellEditor<T> extends InitialValueStructuredCellEditor<T> {
+
+	public InitialValueVariableStructuredCellEditor(final IRowDataProvider<? extends T> dataProvider,
+			final InitialValueStructuredElementAccessor<T> elementAccessor) {
+		super(dataProvider, elementAccessor);
+	}
+
+	public InitialValueVariableStructuredCellEditor(final IRowDataProvider<? extends T> dataProvider,
+			final InitialValueStructuredElementAccessor<T> elementAccessor, final boolean moveSelectionOnEnter) {
+		super(dataProvider, elementAccessor, moveSelectionOnEnter);
+	}
+
+	@Override
+	protected Optional<String> openVariableDialog(final Shell shell, final ITypedElement element,
+			final String initialValue) {
+		return InitialValueVariableDialog.open(shell, element, initialValue);
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/widgets/InitialValueVariableWidget.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/widgets/InitialValueVariableWidget.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Michael Oberlehner - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.gef.widgets;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import org.eclipse.fordiac.ide.gef.nat.InitialValueVariableConfigLabelAccumulator;
+import org.eclipse.fordiac.ide.gef.nat.InitialValueVariableDataLayer;
+import org.eclipse.fordiac.ide.gef.nat.VariableTreeData;
+import org.eclipse.fordiac.ide.model.eval.value.ValueOperations;
+import org.eclipse.fordiac.ide.model.eval.variable.Variable;
+import org.eclipse.nebula.widgets.nattable.layer.DataLayer;
+import org.eclipse.nebula.widgets.nattable.layer.cell.IConfigLabelAccumulator;
+
+public class InitialValueVariableWidget extends VariableWidget {
+
+	private final List<Variable<?>> baseVariables;
+	private final Set<Variable<?>> explicitInitialValueVariables;
+	private Map<Variable<?>, Variable<?>> baseVariableMap = Map.of();
+
+	public InitialValueVariableWidget(final List<Variable<?>> baseVariables,
+			final Set<Variable<?>> explicitInitialValueVariables) {
+		this.baseVariables = List.copyOf(baseVariables);
+		this.explicitInitialValueVariables = Collections.newSetFromMap(new IdentityHashMap<>());
+		this.explicitInitialValueVariables.addAll(explicitInitialValueVariables);
+	}
+
+	public boolean isExplicitInitialValue(final Variable<?> variable) {
+		return explicitInitialValueVariables.contains(variable);
+	}
+
+	@Override
+	protected DataLayer createDataLayer(final VariableTreeData dataProvider) {
+		return new InitialValueVariableDataLayer(dataProvider);
+	}
+
+	@Override
+	protected IConfigLabelAccumulator createConfigLabelAccumulator(final VariableTreeData dataProvider) {
+		return new InitialValueVariableConfigLabelAccumulator(dataProvider, this::isInheritedValue);
+	}
+
+	@Override
+	protected void setVariableInput(final List<Variable<?>> variables) {
+		super.setVariableInput(variables);
+		baseVariableMap = mapBaseVariables(variables, baseVariables);
+	}
+
+	@Override
+	protected void handleVariableModified(final Variable<?> variable, final String oldValue, final String newValue) {
+		updateExplicitInitialValue(variable, oldValue, newValue);
+		getTable().refresh();
+	}
+
+	private boolean isInheritedValue(final Variable<?> variable) {
+		return isBaseValue(variable) && !hasExplicitInitialValue(variable);
+	}
+
+	private boolean isBaseValue(final Variable<?> variable) {
+		final Variable<?> baseVariable = baseVariableMap.get(variable);
+		return baseVariable != null && ValueOperations.equals(baseVariable.getValue(), variable.getValue());
+	}
+
+	private void updateExplicitInitialValue(final Variable<?> variable, final String oldValue, final String newValue) {
+		if (!baseVariableMap.containsKey(variable)) {
+			return;
+		}
+		if (!isBaseValue(variable) || Objects.equals(oldValue, newValue)) {
+			markExplicitInitialValue(variable);
+		} else {
+			clearExplicitInitialValue(variable);
+		}
+	}
+
+	private void markExplicitInitialValue(final Variable<?> variable) {
+		final List<Variable<?>> children = variable.getChildren().toList();
+		if (children.isEmpty()) {
+			explicitInitialValueVariables.add(variable);
+		} else {
+			children.forEach(this::markExplicitInitialValue);
+		}
+	}
+
+	private void clearExplicitInitialValue(final Variable<?> variable) {
+		explicitInitialValueVariables.remove(variable);
+		variable.getChildren().forEach(this::clearExplicitInitialValue);
+	}
+
+	private boolean hasExplicitInitialValue(final Variable<?> variable) {
+		return explicitInitialValueVariables.contains(variable)
+				|| variable.getChildren().anyMatch(this::hasExplicitInitialValue);
+	}
+
+	private static Map<Variable<?>, Variable<?>> mapBaseVariables(final List<Variable<?>> variables,
+			final List<Variable<?>> baseVariables) {
+		final Map<Variable<?>, Variable<?>> result = new HashMap<>();
+		for (int i = 0; i < variables.size() && i < baseVariables.size(); i++) {
+			mapBaseVariable(variables.get(i), baseVariables.get(i), result);
+		}
+		return Map.copyOf(result);
+	}
+
+	private static void mapBaseVariable(final Variable<?> variable, final Variable<?> baseVariable,
+			final Map<Variable<?>, Variable<?>> result) {
+		result.put(variable, baseVariable);
+		variable.getChildren().forEach(child -> getBaseChild(baseVariable, child)
+				.ifPresent(baseChild -> mapBaseVariable(child, baseChild, result)));
+	}
+
+	private static Optional<Variable<?>> getBaseChild(final Variable<?> baseVariable, final Variable<?> child) {
+		return baseVariable.getChildren().filter(baseChild -> Objects.equals(baseChild.getName(), child.getName()))
+				.findFirst();
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/widgets/InitialValueVariableWidget.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/widgets/InitialValueVariableWidget.java
@@ -40,6 +40,7 @@ public class InitialValueVariableWidget extends VariableWidget {
 		this.baseVariables = List.copyOf(baseVariables);
 		this.explicitInitialValueVariables = Collections.newSetFromMap(new IdentityHashMap<>());
 		this.explicitInitialValueVariables.addAll(explicitInitialValueVariables);
+		addVariableModificationListener(this::handleVariableModified);
 	}
 
 	public boolean isExplicitInitialValue(final Variable<?> variable) {
@@ -62,8 +63,7 @@ public class InitialValueVariableWidget extends VariableWidget {
 		baseVariableMap = mapBaseVariables(variables, baseVariables);
 	}
 
-	@Override
-	protected void handleVariableModified(final Variable<?> variable, final String oldValue, final String newValue) {
+	private void handleVariableModified(final Variable<?> variable, final String oldValue, final String newValue) {
 		updateExplicitInitialValue(variable, oldValue, newValue);
 		getTable().refresh();
 	}

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/widgets/VariableWidget.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/widgets/VariableWidget.java
@@ -123,11 +123,6 @@ public class VariableWidget {
 		return new VariableConfigLabelAccumulator();
 	}
 
-	@SuppressWarnings("unused")
-	protected void handleVariableModified(final Variable<?> variable, final String oldValue, final String newValue) {
-		// subclasses may react to variable modifications
-	}
-
 	protected NatTable getTable() {
 		return table;
 	}
@@ -137,7 +132,6 @@ public class VariableWidget {
 			final Variable<?> variable = data.getRowObject(dataUpdateEvent.getRowPosition());
 			final String oldValue = Objects.toString(dataUpdateEvent.getOldValue(), NULL_DEFAULT);
 			final String newValue = Objects.toString(dataUpdateEvent.getNewValue(), NULL_DEFAULT);
-			handleVariableModified(variable, oldValue, newValue);
 			modificationListeners.forEach(listener -> listener.variableModified(variable, oldValue, newValue));
 		}
 	}

--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/widgets/VariableWidget.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/widgets/VariableWidget.java
@@ -35,6 +35,7 @@ import org.eclipse.nebula.widgets.nattable.NatTable;
 import org.eclipse.nebula.widgets.nattable.config.IEditableRule;
 import org.eclipse.nebula.widgets.nattable.edit.event.DataUpdateEvent;
 import org.eclipse.nebula.widgets.nattable.layer.DataLayer;
+import org.eclipse.nebula.widgets.nattable.layer.cell.IConfigLabelAccumulator;
 import org.eclipse.nebula.widgets.nattable.layer.event.ILayerEvent;
 import org.eclipse.nebula.widgets.nattable.tree.command.TreeCollapseAllCommand;
 import org.eclipse.nebula.widgets.nattable.tree.command.TreeExpandAllCommand;
@@ -63,8 +64,8 @@ public class VariableWidget {
 		GridLayoutFactory.swtDefaults().applyTo(buttonPanel);
 
 		data = new VariableTreeData(new VariableColumnAccessor());
-		final DataLayer dataLayer = new DataLayer(data);
-		dataLayer.setConfigLabelAccumulator(new VariableConfigLabelAccumulator());
+		final DataLayer dataLayer = createDataLayer(data);
+		dataLayer.setConfigLabelAccumulator(createConfigLabelAccumulator(data));
 		dataLayer.addLayerListener(this::handleDataLayerEvent);
 		table = NatTableWidgetFactory.createTreeNatTable(composite, dataLayer, data,
 				new NatTableColumnProvider<>(VariableTableColumn.DEFAULT_COLUMNS),
@@ -90,7 +91,15 @@ public class VariableWidget {
 	}
 
 	public void setInput(final List<Variable<?>> variables) {
+		setVariableInput(variables);
+		refreshTable(variables);
+	}
+
+	protected void setVariableInput(final List<Variable<?>> variables) {
 		data.setInput(variables);
+	}
+
+	private void refreshTable(final List<Variable<?>> variables) {
 		table.refresh();
 		table.doCommand(new TreeCollapseAllCommand());
 		if (variables.size() == 1) {
@@ -106,11 +115,29 @@ public class VariableWidget {
 		modificationListeners.remove(listener);
 	}
 
+	protected DataLayer createDataLayer(final VariableTreeData dataProvider) {
+		return new DataLayer(dataProvider);
+	}
+
+	protected IConfigLabelAccumulator createConfigLabelAccumulator(final VariableTreeData dataProvider) {
+		return new VariableConfigLabelAccumulator();
+	}
+
+	@SuppressWarnings("unused")
+	protected void handleVariableModified(final Variable<?> variable, final String oldValue, final String newValue) {
+		// subclasses may react to variable modifications
+	}
+
+	protected NatTable getTable() {
+		return table;
+	}
+
 	private void handleDataLayerEvent(final ILayerEvent event) {
 		if (event instanceof final DataUpdateEvent dataUpdateEvent) {
 			final Variable<?> variable = data.getRowObject(dataUpdateEvent.getRowPosition());
 			final String oldValue = Objects.toString(dataUpdateEvent.getOldValue(), NULL_DEFAULT);
 			final String newValue = Objects.toString(dataUpdateEvent.getNewValue(), NULL_DEFAULT);
+			handleVariableModified(variable, oldValue, newValue);
 			modificationListeners.forEach(listener -> listener.variableModified(variable, oldValue, newValue));
 		}
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.eval.st/src/org/eclipse/fordiac/ide/model/eval/st/AttributeEvaluator.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval.st/src/org/eclipse/fordiac/ide/model/eval/st/AttributeEvaluator.java
@@ -84,12 +84,26 @@ public class AttributeEvaluator extends StructuredTextEvaluator implements Varia
 
 	@Override
 	public Variable<?> evaluateVariable() throws EvaluatorException, InterruptedException {
+		return doEvaluateVariable(null);
+	}
+
+	@Override
+	public Variable<?> evaluateVariable(final Set<Variable<?>> explicitlyInitialized)
+			throws EvaluatorException, InterruptedException {
+		return doEvaluateVariable(explicitlyInitialized);
+	}
+
+	private Variable<?> doEvaluateVariable(final Set<Variable<?>> explicitlyInitialized)
+			throws EvaluatorException, InterruptedException {
 		prepare();
 		final Variable<?> result = VariableOperations.newVariable(attribute.getName(), evaluateResultType());
 		if (parseResult != null && parseResult.getInitializerExpression() != null) {
-			evaluateInitializerExpression(result, trap(parseResult).getInitializerExpression());
+			evaluateInitializerExpression(result, trap(parseResult).getInitializerExpression(), explicitlyInitialized);
 		} else if (attribute.getType() instanceof InternalDataType && attribute.getValue() != null) {
 			result.setValue(ValueOperations.wrapValue(attribute.getValue(), result.getType()));
+			if (explicitlyInitialized != null) {
+				explicitlyInitialized.add(result);
+			}
 		}
 		return result;
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.eval.st/src/org/eclipse/fordiac/ide/model/eval/st/DirectlyDerivedTypeEvaluator.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval.st/src/org/eclipse/fordiac/ide/model/eval/st/DirectlyDerivedTypeEvaluator.java
@@ -81,10 +81,21 @@ public class DirectlyDerivedTypeEvaluator extends StructuredTextEvaluator implem
 
 	@Override
 	public Variable<?> evaluateVariable() throws EvaluatorException, InterruptedException {
+		return doEvaluateVariable(null);
+	}
+
+	@Override
+	public Variable<?> evaluateVariable(final Set<Variable<?>> explicitlyInitialized)
+			throws EvaluatorException, InterruptedException {
+		return doEvaluateVariable(explicitlyInitialized);
+	}
+
+	private Variable<?> doEvaluateVariable(final Set<Variable<?>> explicitlyInitialized)
+			throws EvaluatorException, InterruptedException {
 		prepare();
 		final Variable<?> result = VariableOperations.newVariable(directlyDerivedType.getName(), evaluateResultType());
 		if (parseResult != null && parseResult.getInitializerExpression() != null) {
-			evaluateInitializerExpression(result, trap(parseResult).getInitializerExpression());
+			evaluateInitializerExpression(result, trap(parseResult).getInitializerExpression(), explicitlyInitialized);
 		}
 		return result;
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.eval.st/src/org/eclipse/fordiac/ide/model/eval/st/ECTransitionEvaluator.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval.st/src/org/eclipse/fordiac/ide/model/eval/st/ECTransitionEvaluator.java
@@ -93,6 +93,12 @@ public class ECTransitionEvaluator extends StructuredTextEvaluator implements Va
 	}
 
 	@Override
+	public Variable<?> evaluateVariable(final Set<Variable<?>> explicitlyInitialized)
+			throws EvaluatorException, InterruptedException {
+		return evaluateVariable();
+	}
+
+	@Override
 	public boolean validateVariable(final List<String> errors, final List<String> warnings, final List<String> infos)
 			throws EvaluatorException, InterruptedException {
 		if (VariableOperations.hasConditionExpression(transition)) {

--- a/plugins/org.eclipse.fordiac.ide.model.eval.st/src/org/eclipse/fordiac/ide/model/eval/st/StructuredTextEvaluator.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval.st/src/org/eclipse/fordiac/ide/model/eval/st/StructuredTextEvaluator.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -250,26 +251,47 @@ public abstract class StructuredTextEvaluator extends AbstractEvaluator {
 
 	protected Variable<?> evaluateInitializerExpression(final Variable<?> variable,
 			final STInitializerExpression expression) throws EvaluatorException, InterruptedException {
+		return evaluateInitializerExpression(variable, expression, null);
+	}
+
+	protected Variable<?> evaluateInitializerExpression(final Variable<?> variable,
+			final STInitializerExpression expression, final Set<Variable<?>> explicitlyInitialized)
+			throws EvaluatorException, InterruptedException {
 		return switch (expression) {
 		case null -> variable;
 		case final STElementaryInitializerExpression elementaryInitializerExpression ->
-			evaluateInitializerExpression(variable, elementaryInitializerExpression);
+			evaluateInitializerExpression(variable, elementaryInitializerExpression, explicitlyInitialized);
 		case final STArrayInitializerExpression arrayInitializerExpression ->
-			evaluateInitializerExpression(variable, arrayInitializerExpression);
+			evaluateInitializerExpression(variable, arrayInitializerExpression, explicitlyInitialized);
 		case final STStructInitializerExpression structInitializerExpression ->
-			evaluateInitializerExpression(variable, structInitializerExpression);
+			evaluateInitializerExpression(variable, structInitializerExpression, explicitlyInitialized);
 		default -> throw createUnsupportedOperationException(expression);
 		};
 	}
 
 	protected Variable<?> evaluateInitializerExpression(final Variable<?> variable,
 			final STElementaryInitializerExpression expression) throws EvaluatorException, InterruptedException {
+		return evaluateInitializerExpression(variable, expression, null);
+	}
+
+	protected Variable<?> evaluateInitializerExpression(final Variable<?> variable,
+			final STElementaryInitializerExpression expression, final Set<Variable<?>> explicitlyInitialized)
+			throws EvaluatorException, InterruptedException {
 		variable.setValue(evaluateExpression(expression.getValue()));
+		if (explicitlyInitialized != null) {
+			explicitlyInitialized.add(variable);
+		}
 		return variable;
 	}
 
 	protected Variable<?> evaluateInitializerExpression(final Variable<?> variable,
 			final STArrayInitializerExpression expression) throws EvaluatorException, InterruptedException {
+		return evaluateInitializerExpression(variable, expression, null);
+	}
+
+	protected Variable<?> evaluateInitializerExpression(final Variable<?> variable,
+			final STArrayInitializerExpression expression, final Set<Variable<?>> explicitlyInitialized)
+			throws EvaluatorException, InterruptedException {
 		if (variable instanceof GenericVariable) {
 			variable.setValue(new ArrayValue((ArrayType) expression.getResultType()));
 		}
@@ -281,7 +303,8 @@ public abstract class StructuredTextEvaluator extends AbstractEvaluator {
 				if (index >= size) {
 					return variable; // ignore excess initializers
 				}
-				evaluateInitializerExpression(value.getRaw(index), singleArrayInitElement.getInitExpression());
+				evaluateInitializerExpression(value.getRaw(index), singleArrayInitElement.getInitExpression(),
+					explicitlyInitialized);
 				index++;
 			} else if (elem instanceof final STRepeatArrayInitElement repeatArrayInitElement) {
 				final int count = repeatArrayInitElement.getRepetitions().intValueExact();
@@ -290,7 +313,7 @@ public abstract class StructuredTextEvaluator extends AbstractEvaluator {
 						if (index >= size) {
 							return variable; // ignore excess initializers
 						}
-						evaluateInitializerExpression(value.getRaw(index), initElement);
+						evaluateInitializerExpression(value.getRaw(index), initElement, explicitlyInitialized);
 						index++;
 					}
 				}
@@ -301,12 +324,19 @@ public abstract class StructuredTextEvaluator extends AbstractEvaluator {
 
 	protected Variable<?> evaluateInitializerExpression(final Variable<?> variable,
 			final STStructInitializerExpression expression) throws EvaluatorException, InterruptedException {
+		return evaluateInitializerExpression(variable, expression, null);
+	}
+
+	protected Variable<?> evaluateInitializerExpression(final Variable<?> variable,
+			final STStructInitializerExpression expression, final Set<Variable<?>> explicitlyInitialized)
+			throws EvaluatorException, InterruptedException {
 		if (variable instanceof GenericVariable) {
 			variable.setValue(new StructValue((StructuredType) expression.getResultType()));
 		}
 		final StructValue value = (StructValue) variable.getValue();
 		for (final STStructInitElement elem : expression.getValues()) {
-			evaluateInitializerExpression(value.get(elem.getVariable().getName()), elem.getValue());
+			evaluateInitializerExpression(value.get(elem.getVariable().getName()), elem.getValue(),
+				explicitlyInitialized);
 		}
 		return variable;
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.eval.st/src/org/eclipse/fordiac/ide/model/eval/st/VarDeclarationEvaluator.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval.st/src/org/eclipse/fordiac/ide/model/eval/st/VarDeclarationEvaluator.java
@@ -116,10 +116,21 @@ public class VarDeclarationEvaluator extends StructuredTextEvaluator implements 
 
 	@Override
 	public Variable<?> evaluateVariable() throws EvaluatorException, InterruptedException {
+		return doEvaluateVariable(null);
+	}
+
+	@Override
+	public Variable<?> evaluateVariable(final Set<Variable<?>> explicitlyInitialized)
+			throws EvaluatorException, InterruptedException {
+		return doEvaluateVariable(explicitlyInitialized);
+	}
+
+	private Variable<?> doEvaluateVariable(final Set<Variable<?>> explicitlyInitialized)
+			throws EvaluatorException, InterruptedException {
 		prepareInitialValue();
-		final Variable<?> result = VariableOperations.newVariable(varDeclaration.getName(), evaluateResultType());
+		final Variable<?> result = VariableOperations.newVariableWithoutDeclaredInitialValue(varDeclaration);
 		if (parseResult != null && parseResult.getInitializerExpression() != null) {
-			evaluateInitializerExpression(result, trap(parseResult).getInitializerExpression());
+			evaluateInitializerExpression(result, trap(parseResult).getInitializerExpression(), explicitlyInitialized);
 		}
 		return result;
 	}

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/VariableEvaluator.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/VariableEvaluator.java
@@ -13,6 +13,7 @@
 package org.eclipse.fordiac.ide.model.eval.variable;
 
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.fordiac.ide.model.eval.Evaluator;
 import org.eclipse.fordiac.ide.model.eval.EvaluatorException;
@@ -27,6 +28,17 @@ public interface VariableEvaluator extends Evaluator {
 	 * @throws InterruptedException if the evaluation was interrupted
 	 */
 	Variable<?> evaluateVariable() throws EvaluatorException, InterruptedException;
+
+	/**
+	 * Evaluate a variable and collect the variables which are explicitly initialized.
+	 *
+	 * @param explicitlyInitialized The variables which are explicitly initialized
+	 * @return The resulting variable
+	 * @throws EvaluatorException   if an exception occurred during evaluation
+	 * @throws InterruptedException if the evaluation was interrupted
+	 */
+	Variable<?> evaluateVariable(Set<Variable<?>> explicitlyInitialized)
+			throws EvaluatorException, InterruptedException;
 
 	/**
 	 * Validate a variable

--- a/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/VariableOperations.java
+++ b/plugins/org.eclipse.fordiac.ide.model.eval/src/org/eclipse/fordiac/ide/model/eval/variable/VariableOperations.java
@@ -161,19 +161,55 @@ public final class VariableOperations {
 		return newVariable(varDeclaration.getName(), evaluateResultType(varDeclaration));
 	}
 
-	private static Value doEvaluateValue(final VarDeclaration varDeclaration)
-			throws EvaluatorException, InterruptedException {
+	public static Variable<?> newVariableWithoutDeclaredInitialValue(final VarDeclaration varDeclaration)
+			throws EvaluatorException {
+		if (hasInheritedInitialValue(varDeclaration)) {
+			try (EvaluatorCache cache = EvaluatorCache.open()) {
+				final VarDeclaration typeVariable = varDeclaration.findInTypeInterface();
+				return newVariable(varDeclaration.getName(), evaluateResultType(varDeclaration),
+						cache.computeInitialValueIfAbsent(typeVariable, VariableOperations::doEvaluateValue));
+			} catch (final InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+		}
+		return newVariable(varDeclaration.getName(), evaluateResultType(varDeclaration));
+	}
+
+	private static Variable<?> doEvaluateVariable(final VarDeclaration varDeclaration,
+			final Set<Variable<?>> explicitlyInitialized) throws EvaluatorException, InterruptedException {
 		final Evaluator evaluator = EvaluatorFactory.createEvaluator(varDeclaration, VarDeclaration.class, null,
 				Collections.emptySet(), null);
-		if (evaluator instanceof VariableEvaluator) {
-			return evaluator.evaluate();
+		if (evaluator instanceof final VariableEvaluator variableEvaluator) {
+			return evaluateVariable(variableEvaluator, explicitlyInitialized);
 		}
 		throw new UnsupportedOperationException(Messages.VariableOperations_NoEvaluatorForVarDeclaration);
 	}
 
+	private static Variable<?> evaluateVariable(final VariableEvaluator evaluator,
+			final Set<Variable<?>> explicitlyInitialized) throws EvaluatorException, InterruptedException {
+		return explicitlyInitialized != null ? evaluator.evaluateVariable(explicitlyInitialized)
+				: evaluator.evaluateVariable();
+	}
+
+	private static Value doEvaluateValue(final VarDeclaration varDeclaration)
+			throws EvaluatorException, InterruptedException {
+		return doEvaluateVariable(varDeclaration, null).getValue();
+	}
+
 	public static Variable<?> newVariable(final VarDeclaration varDeclaration, final String initialValue)
 			throws EvaluatorException {
-		return newVariable(withValue(varDeclaration, initialValue));
+		return newVariable(varDeclaration, initialValue, null);
+	}
+
+	public static Variable<?> newVariable(final VarDeclaration varDeclaration, final String initialValue,
+			final Set<Variable<?>> explicitlyInitialized) throws EvaluatorException {
+		final VarDeclaration declaration = withValue(varDeclaration, initialValue);
+		try {
+			return doEvaluateVariable(declaration, explicitlyInitialized);
+		} catch (final InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+		return newVariable(declaration.getName(), evaluateResultType(declaration));
 	}
 
 	public static Variable<?> newVariable(final VarDeclaration varDeclaration, final Value value)
@@ -203,7 +239,26 @@ public final class VariableOperations {
 
 	public static Variable<?> newVariable(final Attribute attribute, final String initialValue)
 			throws EvaluatorException {
-		return newVariable(withValue(attribute, initialValue));
+		return newVariable(attribute, initialValue, null);
+	}
+
+	public static Variable<?> newVariable(final Attribute attribute, final String initialValue,
+			final Set<Variable<?>> explicitlyInitialized) throws EvaluatorException {
+		final Attribute declaration = withValue(attribute, initialValue);
+		if (!hasValue(declaration)) {
+			return newVariable(declaration.getName(), declaration.getType());
+		}
+		try {
+			final Evaluator evaluator = EvaluatorFactory.createEvaluator(declaration, Attribute.class, null,
+					Collections.emptySet(), null);
+			if (evaluator instanceof final VariableEvaluator variableEvaluator) {
+				return evaluateVariable(variableEvaluator, explicitlyInitialized);
+			}
+			throw new UnsupportedOperationException(Messages.VariableOperations_NoEvaluatorForAttribute);
+		} catch (final InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+		return newVariable(declaration.getName(), declaration.getType());
 	}
 
 	public static Variable<?> newVariable(final DirectlyDerivedType type) throws EvaluatorException {
@@ -224,7 +279,26 @@ public final class VariableOperations {
 
 	public static Variable<?> newVariable(final DirectlyDerivedType type, final String initialValue)
 			throws EvaluatorException {
-		return newVariable(withValue(type, initialValue));
+		return newVariable(type, initialValue, null);
+	}
+
+	public static Variable<?> newVariable(final DirectlyDerivedType type, final String initialValue,
+			final Set<Variable<?>> explicitlyInitialized) throws EvaluatorException {
+		final DirectlyDerivedType declaration = withValue(type, initialValue);
+		if (!hasInitialValue(declaration)) {
+			return newVariable(declaration.getName(), declaration.getBaseType());
+		}
+		try {
+			final Evaluator evaluator = EvaluatorFactory.createEvaluator(declaration, DirectlyDerivedType.class, null,
+					Collections.emptySet(), null);
+			if (evaluator instanceof final VariableEvaluator variableEvaluator) {
+				return evaluateVariable(variableEvaluator, explicitlyInitialized);
+			}
+			throw new UnsupportedOperationException(Messages.VariableOperations_NoEvaluatorForDirectlyDerivedType);
+		} catch (final InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+		return newVariable(declaration.getName(), declaration.getBaseType());
 	}
 
 	public static LibraryElement evaluateResultType(final VarDeclaration decl) throws EvaluatorException {

--- a/tests/org.eclipse.fordiac.ide.test.model.eval/src/org/eclipse/fordiac/ide/test/model/eval/variable/VariableOperationExplicitInitialValueTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model.eval/src/org/eclipse/fordiac/ide/test/model/eval/variable/VariableOperationExplicitInitialValueTest.java
@@ -1,0 +1,227 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Michael Oberlehner - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.test.model.eval.variable;
+
+import static org.eclipse.fordiac.ide.model.eval.value.BoolValue.toBoolValue;
+import static org.eclipse.fordiac.ide.model.eval.value.DIntValue.toDIntValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.emf.ecore.resource.impl.ResourceImpl;
+import org.eclipse.fordiac.ide.model.data.DataFactory;
+import org.eclipse.fordiac.ide.model.data.DirectlyDerivedType;
+import org.eclipse.fordiac.ide.model.data.StructuredType;
+import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes.ElementaryTypes;
+import org.eclipse.fordiac.ide.model.eval.EvaluatorException;
+import org.eclipse.fordiac.ide.model.eval.st.ECTransitionEvaluator;
+import org.eclipse.fordiac.ide.model.eval.variable.ArrayVariable;
+import org.eclipse.fordiac.ide.model.eval.variable.StructVariable;
+import org.eclipse.fordiac.ide.model.eval.variable.Variable;
+import org.eclipse.fordiac.ide.model.eval.variable.VariableOperations;
+import org.eclipse.fordiac.ide.model.helpers.ArraySizeHelper;
+import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
+import org.eclipse.fordiac.ide.model.libraryElement.FB;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
+import org.eclipse.fordiac.ide.model.libraryElement.SimpleFBType;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
+import org.eclipse.fordiac.ide.test.model.eval.AbstractEvaluatorTest;
+import org.eclipse.fordiac.ide.test.model.typelibrary.DataTypeEntryMock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings({ "static-method", "nls" })
+class VariableOperationExplicitInitialValueTest extends AbstractEvaluatorTest {
+
+	private VarDeclaration nestedArrayDeclaration;
+
+	@BeforeEach
+	void setup() {
+		final StructuredType innerInnerType = newInnerInnerBoolStructType("TestExplicitInnerInnerStruct");
+		final StructuredType innerType = newInnerBoolStructType("TestExplicitInnerStruct", innerInnerType);
+		nestedArrayDeclaration = newArrayInstanceDeclaration("TestExplicitNestedArrayFB",
+				"TestExplicitNestedArrayInstance", "DI_ARRAY", innerType, "0..1", null);
+	}
+
+	@Test
+	void testCollectsExplicitNestedArrayMember() {
+		final Set<Variable<?>> explicitlyInitialized = newIdentitySet();
+		final Variable<?> variable = VariableOperations.newVariable(nestedArrayDeclaration,
+				"[(VAR15 := (VAR8 := TRUE))]", explicitlyInitialized);
+		final Variable<?> explicitMember = getMember(getMember(getElement(variable, 0), "VAR15"), "VAR8");
+
+		assertEquals(toBoolValue(true), explicitMember.getValue());
+		assertEquals(toBoolValue(false), getMember(getMember(getElement(variable, 0), "VAR15"), "VAR9").getValue());
+		assertEquals(toBoolValue(false), getMember(getMember(getElement(variable, 1), "VAR15"), "VAR8").getValue());
+		assertTrue(explicitlyInitialized.contains(explicitMember));
+	}
+
+	@Test
+	void testCollectsExplicitFalseNestedArrayMemberEqualToBaseValue() {
+		final Set<Variable<?>> explicitlyInitialized = newIdentitySet();
+		final Variable<?> variable = VariableOperations.newVariable(nestedArrayDeclaration,
+				"[(VAR15 := (VAR8 := FALSE))]", explicitlyInitialized);
+		final Variable<?> member = getMember(getMember(getElement(variable, 0), "VAR15"), "VAR8");
+
+		assertEquals(toBoolValue(false), member.getValue());
+		assertTrue(explicitlyInitialized.contains(member));
+	}
+
+	@Test
+	void testCollectsExplicitStructMember() {
+		final StructuredType structType = newStructuredType("TestExplicitStruct",
+				List.of(newVarDeclaration("a", ElementaryTypes.DINT, false, "17"),
+						newVarDeclaration("b", ElementaryTypes.DINT, false, "4")));
+		final VarDeclaration declaration = newVarDeclaration("DI", structType, true, "(a := 17)");
+		final Set<Variable<?>> explicitlyInitialized = newIdentitySet();
+
+		final Variable<?> variable = VariableOperations.newVariable(declaration, "(a := 17)", explicitlyInitialized);
+		final Variable<?> memberA = getMember(variable, "a");
+		final Variable<?> memberB = getMember(variable, "b");
+
+		assertEquals(toDIntValue(17), memberA.getValue());
+		assertTrue(explicitlyInitialized.contains(memberA));
+		assertFalse(explicitlyInitialized.contains(memberB));
+	}
+
+	@Test
+	void testInheritedInitialValueDoesNotBecomeExplicit() {
+		final StructuredType structType = newResolvableStructuredType("TestInheritedStruct",
+				List.of(newVarDeclaration("a", ElementaryTypes.DINT, false),
+						newVarDeclaration("b", ElementaryTypes.DINT, false)));
+		final VarDeclaration typeDeclaration = newVarDeclaration("DI", structType, true, "(a := 17)");
+		final VarDeclaration instanceDeclaration = newInstanceDeclaration("TestInheritedFB", "TestInheritedInstance",
+				typeDeclaration);
+		final Set<Variable<?>> explicitlyInitialized = newIdentitySet();
+
+		final Variable<?> variable = VariableOperations.newVariable(instanceDeclaration, null, explicitlyInitialized);
+
+		assertEquals(toDIntValue(17), getMember(variable, "a").getValue());
+		assertTrue(explicitlyInitialized.isEmpty());
+	}
+
+	@Test
+	void testCollectsExplicitAttributeStructMember() {
+		final Attribute attribute = newAttribute(
+				newAttributeDeclaration("TestExplicitStructAttribute",
+						List.of(newVarDeclaration("a", ElementaryTypes.DINT, false),
+								newVarDeclaration("b", ElementaryTypes.DINT, false))),
+				"(a := 17)");
+		final Set<Variable<?>> explicitlyInitialized = newIdentitySet();
+
+		final Variable<?> variable = VariableOperations.newVariable(attribute, "(a := 17)", explicitlyInitialized);
+
+		assertEquals(toDIntValue(17), getMember(variable, "a").getValue());
+		assertTrue(explicitlyInitialized.contains(getMember(variable, "a")));
+		assertFalse(explicitlyInitialized.contains(getMember(variable, "b")));
+	}
+
+	@Test
+	void testCollectsExplicitDirectlyDerivedValue() {
+		final DirectlyDerivedType derivedType = newDirectlyDerivedType("TestExplicitDerivedType",
+				ElementaryTypes.DINT, null);
+		final Set<Variable<?>> explicitlyInitialized = newIdentitySet();
+
+		final Variable<?> variable = VariableOperations.newVariable(derivedType, "17", explicitlyInitialized);
+
+		assertEquals(toDIntValue(17), variable.getValue());
+		assertTrue(explicitlyInitialized.contains(variable));
+	}
+
+	@Test
+	void testECTransitionLeavesExplicitlyInitializedVariablesUnchanged()
+			throws EvaluatorException, InterruptedException {
+		final Set<Variable<?>> explicitlyInitialized = newIdentitySet();
+		final Variable<?> initializedVariable = VariableOperations.newVariable("initialized", ElementaryTypes.BOOL);
+		explicitlyInitialized.add(initializedVariable);
+		final ECTransitionEvaluator evaluator = new ECTransitionEvaluator(
+				LibraryElementFactory.eINSTANCE.createECTransition(), null, Collections.emptySet(), null);
+
+		evaluator.evaluateVariable(explicitlyInitialized);
+
+		assertEquals(1, explicitlyInitialized.size());
+		assertTrue(explicitlyInitialized.contains(initializedVariable));
+	}
+
+	private static VarDeclaration newArrayInstanceDeclaration(final String fbTypeName, final String instanceName,
+			final String variableName, final StructuredType elementType, final String arraySize,
+			final String initialValue) {
+		final VarDeclaration typeDeclaration = initialValue == null ? newVarDeclaration(variableName, elementType, true)
+				: newVarDeclaration(variableName, elementType, true, initialValue);
+		ArraySizeHelper.setArraySize(typeDeclaration, arraySize);
+		return newInstanceDeclaration(fbTypeName, instanceName, typeDeclaration);
+	}
+
+	private static VarDeclaration newInstanceDeclaration(final String fbTypeName, final String instanceName,
+			final VarDeclaration typeDeclaration) {
+		final SimpleFBType fbType = newSimpleFBType(fbTypeName, List.of(typeDeclaration));
+		final FB fb = newResourceBackedFB(instanceName, fbType);
+		return fb.getInterface().getVariable(typeDeclaration.getName());
+	}
+
+	private static StructuredType newResolvableStructuredType(final String name, final List<VarDeclaration> vars) {
+		final StructuredType structType = DataFactory.eINSTANCE.createStructuredType();
+		structType.setName(name);
+		structType.getMemberVariables().addAll(vars);
+		final DataTypeEntryMock typeEntry = new DataTypeEntryMock(structType, typeLib,
+				project.getFile(name + TypeLibraryTags.DATA_TYPE_FILE_ENDING_WITH_DOT));
+		structType.setTypeEntry(typeEntry);
+		typeLib.addTypeEntry(typeEntry);
+		new ResourceImpl(typeEntry.getURI()).getContents().add(structType);
+		return structType;
+	}
+
+	private static FB newResourceBackedFB(final String instanceName, final SimpleFBType instanceType) {
+		final FB fb = newFB(instanceName, instanceType);
+		if (instanceType.eResource() != null) {
+			new ResourceImpl(instanceType.eResource().getURI()).getContents().add(fb);
+		}
+		return fb;
+	}
+
+	private static Variable<?> getMember(final Variable<?> variable, final String name) {
+		return ((StructVariable) variable).getMembers().get(name);
+	}
+
+	private static Variable<?> getElement(final Variable<?> variable, final int index) {
+		return ((ArrayVariable) variable).getValue().get(index);
+	}
+
+	private static Set<Variable<?>> newIdentitySet() {
+		return Collections.newSetFromMap(new IdentityHashMap<>());
+	}
+
+	private static StructuredType newInnerInnerBoolStructType(final String name) {
+		final List<VarDeclaration> members = new ArrayList<>();
+		for (int i = 1; i <= 13; i++) {
+			members.add(newVarDeclaration("VAR" + i, ElementaryTypes.BOOL, false));
+		}
+		return newResolvableStructuredType(name, members);
+	}
+
+	private static StructuredType newInnerBoolStructType(final String name, final StructuredType innerInnerType) {
+		final List<VarDeclaration> members = new ArrayList<>();
+		for (int i = 1; i <= 23; i++) {
+			members.add(i == 15 ? newVarDeclaration("VAR15", innerInnerType, false)
+					: newVarDeclaration("VAR" + i, ElementaryTypes.BOOL, false));
+		}
+		return newResolvableStructuredType(name, members);
+	}
+}

--- a/tests/org.eclipse.fordiac.ide.test.ui/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.fordiac.ide.test.ui/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Automatic-Module-Name: org.eclipse.fordiac.ide.test.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Import-Package: org.eclipse.core.runtime,
  org.eclipse.draw2d.geometry,
+ org.eclipse.fordiac.ide.model.eval.variable,
  org.eclipse.ui.internal.views.properties.tabbed.view,
  org.eclipse.ui.views.properties.tabbed,
  org.junit.jupiter.api;version="[6.0.0,7.0.0)",

--- a/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/gef/dialogs/InitialValueVariableDialogTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.ui/src/org/eclipse/fordiac/ide/test/ui/gef/dialogs/InitialValueVariableDialogTest.java
@@ -1,0 +1,159 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Michael Oberlehner - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.test.ui.gef.dialogs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.eclipse.fordiac.ide.gef.dialogs.InitialValueVariableDialog;
+import org.eclipse.fordiac.ide.model.data.DataFactory;
+import org.eclipse.fordiac.ide.model.data.DataType;
+import org.eclipse.fordiac.ide.model.data.StructuredType;
+import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes.ElementaryTypes;
+import org.eclipse.fordiac.ide.model.eval.variable.ArrayVariable;
+import org.eclipse.fordiac.ide.model.eval.variable.StructVariable;
+import org.eclipse.fordiac.ide.model.eval.variable.Variable;
+import org.eclipse.fordiac.ide.model.helpers.ArraySizeHelper;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings({ "static-method", "nls" })
+class InitialValueVariableDialogTest {
+
+	@Test
+	void testSerializesOnlyExplicitStructMembers() {
+		final StructVariable variable = newStructVariable("DI", newStructType("TestStruct",
+				newMember("a", ElementaryTypes.BOOL), newMember("b", ElementaryTypes.BOOL)));
+		final Variable<?> memberA = variable.getMembers().get("a");
+		final Variable<?> memberB = variable.getMembers().get("b");
+		memberA.setValue("TRUE");
+		memberB.setValue("TRUE");
+
+		assertEquals("(a := TRUE)", serialize(variable, Set.of(memberA)::contains));
+	}
+
+	@Test
+	void testSerializesExplicitFalseEqualToDefaultValue() {
+		final StructVariable variable = newStructVariable("DI", newStructType("TestExplicitFalseStruct",
+				newMember("a", ElementaryTypes.BOOL), newMember("b", ElementaryTypes.BOOL)));
+		final Variable<?> memberA = variable.getMembers().get("a");
+
+		assertEquals("(a := FALSE)", serialize(variable, Set.of(memberA)::contains));
+	}
+
+	@Test
+	void testSerializesNestedExplicitStructMember() {
+		final StructuredType innerType = newStructType("TestInnerStruct", newMember("flag", ElementaryTypes.BOOL),
+				newMember("other", ElementaryTypes.BOOL));
+		final StructVariable variable = newStructVariable("DI",
+				newStructType("TestOuterStruct", newMember("inner", innerType), newMember("flag", ElementaryTypes.BOOL)));
+		final Variable<?> explicitMember = ((StructVariable) variable.getMembers().get("inner")).getMembers().get("flag");
+
+		assertEquals("(inner := (flag := FALSE))", serialize(variable, Set.of(explicitMember)::contains));
+	}
+
+	@Test
+	void testSerializesArrayThroughLastExplicitElement() {
+		final StructuredType elementType = newStructType("TestArrayElement", newMember("x", ElementaryTypes.DINT),
+				newMember("y", ElementaryTypes.DINT));
+		final ArrayVariable variable = new ArrayVariable("DI_ARRAY",
+				ArrayVariable.newArrayType(elementType, ArrayVariable.newSubrange(0, 2)));
+		setStructValues(getElement(variable, 0), "10", "11");
+		setStructValues(getElement(variable, 1), "20", "21");
+		setStructValues(getElement(variable, 2), "42", "31");
+		final Variable<?> explicitMember = getElement(variable, 2).getMembers().get("x");
+
+		assertEquals("[(x := 10, y := 11), (x := 20, y := 21), (x := 42)]",
+				serialize(variable, Set.of(explicitMember)::contains));
+	}
+
+	@Test
+	void testSerializesNestedExplicitArrayMemberThroughLastExplicitElement() {
+		final StructuredType innerType = newStructType("TestNestedArrayInnerStruct",
+				newMember("flag", ElementaryTypes.BOOL), newMember("other", ElementaryTypes.BOOL));
+		final StructuredType elementType = newStructType("TestNestedArrayElementStruct",
+				newMember("inner", innerType));
+		final StructVariable variable = newStructVariable("DI",
+				newStructType("TestNestedArrayOuterStruct", newArrayMember("items", elementType, "0..2")));
+		final ArrayVariable array = (ArrayVariable) variable.getMembers().get("items");
+		final String firstElement = array.getElements().get(0).toString();
+		final String secondElement = array.getElements().get(1).toString();
+		final Variable<?> explicitMember = ((StructVariable) getElement(array, 2).getMembers().get("inner")).getMembers()
+				.get("flag");
+
+		assertEquals("(items := [" + firstElement + ", " + secondElement + ", (inner := (flag := FALSE))])",
+				serialize(variable, Set.of(explicitMember)::contains));
+	}
+
+	@Test
+	void testReturnsEmptyInitialValueWithoutExplicitMembers() {
+		final StructVariable variable = newStructVariable("DI",
+				newStructType("TestInheritedStruct", newMember("a", ElementaryTypes.BOOL)));
+		variable.getMembers().get("a").setValue("TRUE");
+
+		assertEquals("", serialize(variable, unused -> false));
+	}
+
+	private static String serialize(final Variable<?> variable, final Predicate<Variable<?>> explicitPredicate) {
+		return TestInitialValueVariableDialog.serialize(variable, explicitPredicate);
+	}
+
+	private static StructVariable newStructVariable(final String name, final StructuredType type) {
+		return new StructVariable(name, type);
+	}
+
+	private static StructuredType newStructType(final String name, final VarDeclaration... members) {
+		final StructuredType type = DataFactory.eINSTANCE.createStructuredType();
+		type.setName(name);
+		type.getMemberVariables().addAll(List.of(members));
+		return type;
+	}
+
+	private static VarDeclaration newMember(final String name, final DataType type) {
+		final VarDeclaration member = LibraryElementFactory.eINSTANCE.createVarDeclaration();
+		member.setName(name);
+		member.setType(type);
+		return member;
+	}
+
+	private static VarDeclaration newArrayMember(final String name, final DataType type, final String arraySize) {
+		final VarDeclaration member = newMember(name, type);
+		ArraySizeHelper.setArraySize(member, arraySize);
+		return member;
+	}
+
+	private static StructVariable getElement(final ArrayVariable variable, final int index) {
+		return (StructVariable) variable.getElements().get(index);
+	}
+
+	private static void setStructValues(final StructVariable variable, final String x, final String y) {
+		variable.getMembers().get("x").setValue(x);
+		variable.getMembers().get("y").setValue(y);
+	}
+
+	private static final class TestInitialValueVariableDialog extends InitialValueVariableDialog {
+
+		private TestInitialValueVariableDialog() {
+			super(null, null, null, null, Set.of());
+		}
+
+		private static String serialize(final Variable<?> variable,
+				final Predicate<Variable<?>> explicitPredicate) {
+			return toExplicitInitialValue(variable, explicitPredicate);
+		}
+	}
+}


### PR DESCRIPTION
This change updates the edit value dialog for structured initial values so that only changed values are stored, while inherited/default values remain visible in the UI.