### PR TITLE
Apply data output properly in the interpreter network and handle ANY types properly

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/replayer/interpreter/ResourceInterpreterExecutor.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/replayer/interpreter/ResourceInterpreterExecutor.java
@@ -13,9 +13,7 @@
 
 package org.eclipse.fordiac.ide.debug.replaydebugging.replayer.interpreter;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 
@@ -107,18 +105,14 @@ public class ResourceInterpreterExecutor {
 	}
 
 	public void injectEventOutput(final String instanceName, final int eventId, final List<String> outputValues) {
-		final var fb = networkRuntimeInspector.getRealFB(instanceName);
-		final var event = fb.getInterface().getEventOutputs().get(eventId);
 
-		// set outputs
-		final var fbDataOutput = fb.getInterface().getOutputVars();
-		final var dataOutputValues = new HashMap<String, String>();
-		for (int i = 0; i < outputValues.size(); i++) {
-			dataOutputValues.put(fbDataOutput.get(i).getName(), outputValues.get(i));
-		}
+		final var realEvent = networkRuntimeInspector.getRealFB(instanceName).getInterface().getEventOutputs()
+				.get(eventId);
 
-		eventManagerProcessor.injectOutputEvent(fb, event, dataOutputValues);
-		lastInjectedEvent = event;
+		networkRuntimeInspector.applyOutputData(instanceName, outputValues);
+
+		eventManagerProcessor.injectOutputEvent(realEvent);
+		lastInjectedEvent = realEvent;
 	}
 
 	public void injectEvent(final String name) {
@@ -137,7 +131,7 @@ public class ResourceInterpreterExecutor {
 
 		for (final var inputEvent : fb.getInterface().getEventInputs()) {
 			if (inputEvent.getName().equals(eventName)) {
-				eventManagerProcessor.injectInputEvent(fb, inputEvent, Map.of());
+				eventManagerProcessor.injectInputEvent(inputEvent);
 				return;
 			}
 		}

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/watch/WatchFactoryReplay.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging/src/org/eclipse/fordiac/ide/debug/replaydebugging/watch/WatchFactoryReplay.java
@@ -35,8 +35,10 @@ import org.eclipse.fordiac.ide.deployment.debug.watch.IWatch;
 import org.eclipse.fordiac.ide.deployment.debug.watch.SubAppEventWatch;
 import org.eclipse.fordiac.ide.deployment.debug.watch.SubAppVarDeclarationWatch;
 import org.eclipse.fordiac.ide.deployment.debug.watch.VarDeclarationWatch;
+import org.eclipse.fordiac.ide.fb.interpreter.mm.VariableUtils;
 import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes.ElementaryTypes;
 import org.eclipse.fordiac.ide.model.eval.EvaluatorException;
+import org.eclipse.fordiac.ide.model.eval.variable.VariableOperations;
 import org.eclipse.fordiac.ide.model.libraryElement.AdapterDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.AdapterFB;
 import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType;
@@ -146,7 +148,9 @@ public class WatchFactoryReplay {
 	private static class VarDeclarationWatchReplay extends VarDeclarationWatch implements IWatchWithPublicError {
 		public VarDeclarationWatchReplay(final String name, final VarDeclaration varDeclaration,
 				final DeploymentDebugDevice debugTarget) {
-			super(name, varDeclaration, debugTarget);
+			super(VariableOperations.newVariable(name,
+					DeploymentDebugWatchUtils.evaluateWatchType(VariableUtils.getNonAnyVarDeclaration(varDeclaration))),
+					varDeclaration, debugTarget);
 		}
 
 		public VarDeclarationWatchReplay(final String name, final VarDeclaration varDeclaration,

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/VarDeclarationWatch.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/watch/VarDeclarationWatch.java
@@ -24,6 +24,7 @@ import org.eclipse.fordiac.ide.deployment.exceptions.DeploymentException;
 import org.eclipse.fordiac.ide.model.eval.EvaluatorException;
 import org.eclipse.fordiac.ide.model.eval.value.AnyValue;
 import org.eclipse.fordiac.ide.model.eval.value.Value;
+import org.eclipse.fordiac.ide.model.eval.variable.Variable;
 import org.eclipse.fordiac.ide.model.eval.variable.VariableOperations;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.fordiac.ide.model.libraryElement.Resource;
@@ -37,6 +38,11 @@ public class VarDeclarationWatch extends AbstractRuntimeWatch implements IVarDec
 			final DeploymentDebugDevice debugTarget) throws EvaluatorException {
 		super(VariableOperations.newVariable(name, DeploymentDebugWatchUtils.evaluateWatchType(varDeclaration)),
 				varDeclaration, debugTarget);
+	}
+
+	public VarDeclarationWatch(final Variable<?> variable, final VarDeclaration varDeclaration,
+			final DeploymentDebugDevice debugTarget) throws EvaluatorException {
+		super(variable, varDeclaration, debugTarget);
 	}
 
 	public VarDeclarationWatch(final String name, final VarDeclaration varDeclaration, final Resource resource,

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/BasicFBTypeDefaultInterpreter.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/BasicFBTypeDefaultInterpreter.java
@@ -43,7 +43,7 @@ public class BasicFBTypeDefaultInterpreter extends FBTypeWithEvaluatorDefaultInt
 
 	public EList<EventOccurrence> run(final BasicFBTypeRuntime basicFBTypeRuntime) {
 		// Initialization of variables
-		VariableUtils.fBVariableInitialization(basicFBTypeRuntime.getBasicfbtype());
+		VariableUtils.fBVariableInitialization(basicFBTypeRuntime.getBasicfbtype(), null);
 		final var outputEvents = new BasicEList<EventOccurrence>();
 		final var eCC = basicFBTypeRuntime.getBasicfbtype().getECC();
 		// Active State

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/FunctionFBTypeDefaultInterpreter.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/FunctionFBTypeDefaultInterpreter.java
@@ -29,7 +29,7 @@ public class FunctionFBTypeDefaultInterpreter extends FBTypeWithEvaluatorDefault
 			return ECollections.emptyEList();
 		}
 		final FunctionFBType functionFBType = fBTypeRuntime.getFunctionFBType();
-		VariableUtils.fBVariableInitialization(functionFBType);
+		VariableUtils.fBVariableInitialization(functionFBType, null);
 
 		// function types always have exactly 1 output event
 		final Event event = functionFBType.getInterfaceList().getEventOutputs().get(0);

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/SimpleFBTypeDefaultInterpreter.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/SimpleFBTypeDefaultInterpreter.java
@@ -27,7 +27,7 @@ public class SimpleFBTypeDefaultInterpreter extends FBTypeWithEvaluatorDefaultIn
 		}
 		// Initialization of variables
 		final SimpleFBType simpleFBType = simpleFBTypeRuntime.getSimpleFBType();
-		VariableUtils.fBVariableInitialization(simpleFBType);
+		VariableUtils.fBVariableInitialization(simpleFBType, null);
 
 		final var actions = getActions(simpleFBType, eventOccurrence.getEvent().getName());
 		final var outputEvents = new BasicEList<EventOccurrence>(actions.size());

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/api/RuntimeFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/api/RuntimeFactory.java
@@ -14,6 +14,7 @@
 package org.eclipse.fordiac.ide.fb.interpreter.api;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.util.EcoreUtil;
@@ -40,7 +41,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.ServiceInterfaceFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.SimpleFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
 import org.eclipse.fordiac.ide.model.libraryElement.UntypedSubApp;
-import org.eclipse.fordiac.ide.model.libraryElement.Value;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
 
@@ -185,8 +185,8 @@ public final class RuntimeFactory {
 				if (map.get(conn) != null) {
 					return;
 				}
-				final String val = InitialValueHelper.getInitialOrDefaultValue(pin);
-				final Value value = LibraryElementFactory.eINSTANCE.createValue();
+				final String val = InitialValueHelper.getDefaultValue(VariableUtils.getNonAnyValueFromConnection(conn));
+				final var value = LibraryElementFactory.eINSTANCE.createValue();
 				value.setValue(val);
 				map.put(conn, value);
 			}));
@@ -217,7 +217,9 @@ public final class RuntimeFactory {
 			}
 
 			final FBType copiedType = EcoreUtil.copy(networkElement.getType());
-			VariableUtils.initializeFbType(copiedType);
+			VariableUtils.initializeFbType(copiedType,
+					varDeclaration -> getDefaultValueFromNetworkElement(varDeclaration, networkElement));
+
 			final var fbRuntime = RuntimeFactory.createFrom(copiedType);
 			containerRuntime.getTypeRuntimes().put(networkElement, fbRuntime);
 
@@ -233,6 +235,33 @@ public final class RuntimeFactory {
 			}
 
 		});
+	}
+
+	/**
+	 * Given a VarDeclaration from a type, this method looks for the corresponding
+	 * variable in the network element and returns its default value, looking for
+	 * non-Any var declarations on its connections. If no corresponding variable is
+	 * found, it returns the default value of the given VarDeclaration.
+	 */
+	private static String getDefaultValueFromNetworkElement(final VarDeclaration varDeclaration,
+			final BlockFBNetworkElement networkElement) {
+		// find the corresponding variable in the real FB
+		Optional<VarDeclaration> varDeclFromNetworkElement;
+		if (varDeclaration.isIsInput()) {
+			varDeclFromNetworkElement = networkElement.getInterface().getInputVars().stream()
+					.filter(v -> v.getName().equals(varDeclaration.getName())).findFirst();
+
+		} else {
+			varDeclFromNetworkElement = networkElement.getInterface().getOutputVars().stream()
+					.filter(v -> v.getName().equals(varDeclaration.getName())).findFirst();
+		}
+
+		if (!varDeclFromNetworkElement.isPresent()) {
+			return InitialValueHelper.getDefaultValue(varDeclaration);
+		}
+
+		return InitialValueHelper
+				.getDefaultValue(VariableUtils.getNonAnyVarDeclaration(varDeclFromNetworkElement.get()));
 	}
 
 	/**
@@ -256,7 +285,6 @@ public final class RuntimeFactory {
 				map.put(conn, EcoreUtil.copy(value));
 			}
 		});
-
 	}
 
 	public static void setStartState(final FBRuntimeAbstract fbRT, final String startStateName) {

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/mm/EventManagerProcessor.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/mm/EventManagerProcessor.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
@@ -33,7 +32,6 @@ import org.eclipse.fordiac.ide.fb.interpreter.OpSem.FBTransaction;
 import org.eclipse.fordiac.ide.fb.interpreter.OpSem.Transaction;
 import org.eclipse.fordiac.ide.fb.interpreter.api.EventOccFactory;
 import org.eclipse.fordiac.ide.fb.interpreter.api.TransactionFactory;
-import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.Connection;
 import org.eclipse.fordiac.ide.model.libraryElement.Event;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
@@ -146,23 +144,8 @@ public class EventManagerProcessor {
 		}
 	}
 
-	public void injectOutputEvent(final BlockFBNetworkElement fb, final Event event,
-			final Map<String, String> outputValues) {
+	public void injectOutputEvent(final Event event) {
 		DefaultRunFBType.clearCaches();
-		for (final var entry : outputValues.entrySet()) {
-			final var name = entry.getKey();
-			final var value = entry.getValue();
-			// copy output values to the model.
-			for (final var output : fb.getInterface().getOutputVars()) {
-				if (!output.getName().equals(name)) {
-					continue;
-				}
-				final var newValue = LibraryElementFactory.eINSTANCE.createValue();
-				newValue.setValue(value);
-				output.setValue(newValue);
-			}
-		}
-
 		final EList<Transaction> generatedT = new BasicEList<>();
 		for (final Connection conn : event.getOutputConnections()) {
 			final var dest = (Event) conn.getDestination();
@@ -174,23 +157,8 @@ public class EventManagerProcessor {
 		addTransactions(generatedT, true);
 	}
 
-	public void injectInputEvent(final BlockFBNetworkElement fb, final Event event,
-			final Map<String, String> inputValues) {
+	public void injectInputEvent(final Event event) {
 		DefaultRunFBType.clearCaches();
-		for (final var entry : inputValues.entrySet()) {
-			final var name = entry.getKey();
-			final var value = entry.getValue();
-			// copy output values to the model.
-			for (final var input : fb.getInterface().getInputVars()) {
-				if (!input.getName().equals(name)) {
-					continue;
-				}
-				final var newValue = LibraryElementFactory.eINSTANCE.createValue();
-				newValue.setValue(value);
-				input.setValue(newValue);
-			}
-		}
-
 		final EventOccurrence destinationEventOccurence = EventOccFactory.createFrom(event, null);
 		destinationEventOccurence.setParentFB(event.getBlockFBNetworkElement());
 		final Transaction transaction = TransactionFactory.createFrom(destinationEventOccurence);

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/mm/NetworkRuntimeInspector.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/mm/NetworkRuntimeInspector.java
@@ -77,6 +77,24 @@ public class NetworkRuntimeInspector {
 		return realBlockNames.get(name);
 	}
 
+	public void applyOutputData(final String instanceName, final List<String> outputValues) {
+		final var realFB = getRealFB(instanceName);
+		// set output and transfer data in the interpreter network
+		for (int i = 0; i < outputValues.size(); i++) {
+			final var valueToStore = outputValues.get(i);
+			networkRuntimeState.getDataValues().get(realFB.getInterface().getOutputVars().get(i).getQualifiedName()
+					.substring(firstLevelPrefix.length())).setValue(valueToStore);
+
+			final var realOutputPin = InterfacePinUtils.findPinInInterface(realFB,
+					realFB.getInterface().getOutputVars().get(i));
+			realOutputPin.getOutputConnections().forEach(conn -> networkRuntimeState
+					.getConnectionValue(conn.getSource().getQualifiedName().substring(firstLevelPrefix.length()),
+							conn.getDestination().getQualifiedName().substring(firstLevelPrefix.length()))
+					.setValue(valueToStore));
+		}
+
+	}
+
 	public Optional<Event> getRealEvent(final Optional<Event> originalEvent) {
 		if (!originalEvent.isPresent()) {
 			return Optional.empty();

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/mm/NetworkRuntimeInspector.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/mm/NetworkRuntimeInspector.java
@@ -17,6 +17,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.ecore.EObject;
@@ -46,6 +48,8 @@ public class NetworkRuntimeInspector {
 
 	private final String firstLevelPrefix;
 	private final String nameSeparator;
+
+	private static final Pattern TYPE_PREFIX_PATTERN = Pattern.compile("\\G([_a-zA-Z][a-zA-Z_0-9:]*+)#"); //$NON-NLS-1$
 
 	private final NetworkRuntimeState networkRuntimeState = new NetworkRuntimeState();
 
@@ -81,7 +85,13 @@ public class NetworkRuntimeInspector {
 		final var realFB = getRealFB(instanceName);
 		// set output and transfer data in the interpreter network
 		for (int i = 0; i < outputValues.size(); i++) {
-			final var valueToStore = outputValues.get(i);
+			String valueWithoutType = outputValues.get(i);
+			final Matcher matcher = TYPE_PREFIX_PATTERN.matcher(valueWithoutType);
+			// remove type before #
+			if (matcher.lookingAt()) {
+				valueWithoutType = valueWithoutType.substring(matcher.end());
+			}
+			final var valueToStore = valueWithoutType;
 			networkRuntimeState.getDataValues().get(realFB.getInterface().getOutputVars().get(i).getQualifiedName()
 					.substring(firstLevelPrefix.length())).setValue(valueToStore);
 

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/mm/NetworkRuntimeState.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/mm/NetworkRuntimeState.java
@@ -70,4 +70,9 @@ public class NetworkRuntimeState {
 				.map(connectionValues::get).findFirst().orElse(null);
 	}
 
+	public Value getConnectionValue(final String sourceName, final String destinationName) {
+		final var connectionInfo = new ConnectionInfo(sourceName, destinationName);
+		return connectionValues.get(connectionInfo);
+	}
+
 }

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/mm/VariableUtils.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/mm/VariableUtils.java
@@ -14,11 +14,13 @@
 package org.eclipse.fordiac.ide.fb.interpreter.mm;
 
 import java.util.List;
+import java.util.function.Function;
 
 import org.eclipse.fordiac.ide.model.edit.helper.InitialValueHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.AdapterType;
 import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.CompositeFBType;
+import org.eclipse.fordiac.ide.model.libraryElement.Connection;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.FunctionFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
@@ -44,11 +46,80 @@ public final class VariableUtils {
 		setVariable((VarDeclaration) el, ServiceSequenceUtils.removeKeyword(value));
 	}
 
-	public static void initVariable(final VarDeclaration varDeclaration) {
+	public static void initVariable(final VarDeclaration varDeclaration,
+			final Function<VarDeclaration, String> defaultCreation) {
 		// if there is no initial value, we take a default value
 		if ((varDeclaration != null) && isEmptyValue(varDeclaration.getValue())) {
-			setVariable(varDeclaration, InitialValueHelper.getDefaultValue(varDeclaration));
+			setVariable(varDeclaration, defaultCreation == null ? InitialValueHelper.getDefaultValue(varDeclaration)
+					: defaultCreation.apply(varDeclaration));
 		}
+	}
+
+	private static boolean isAny(final IInterfaceElement varDeclaration) {
+		return varDeclaration.getType().getName().startsWith("ANY"); //$NON-NLS-1$
+	}
+
+	/**
+	 * Looks for the a non-ANY interface in a connection, first from the source and
+	 * then from the destination. If both are ANY Types, the source is returned.
+	 */
+	public static IInterfaceElement getNonAnyValueFromConnection(final Connection connection) {
+		if (!isAny(connection.getSource())) {
+			return connection.getSource();
+		}
+		if (!isAny(connection.getDestination())) {
+			return connection.getDestination();
+		}
+		return connection.getSource();
+	}
+
+	/**
+	 * Looks for a non-ANY interface element in the connections of the given
+	 * variable declaration. If the variable is an input, it checks the source of
+	 * the input connection. If it is an output, it checks the destination of the
+	 * output connections. If all connected interfaces are ANY types, it returns
+	 * null.
+	 */
+	private static IInterfaceElement getNonAnyVarFromConnections(final VarDeclaration varDeclaration) {
+		if (varDeclaration.isIsInput()) {
+			// only one input connection allowed, check if the source is not an ANY type
+			if (!isAny(varDeclaration.getInputConnections().get(0).getSource())) {
+				return varDeclaration.getInputConnections().get(0).getSource();
+			}
+
+		} else {
+			// find the first output connection whose destination is not an ANY type
+			for (final var connection : varDeclaration.getOutputConnections()) {
+				if (!isAny(connection.getDestination())) {
+					return connection.getDestination();
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Checks if the given variable declaration is of an ANY type. If it is, it
+	 * looks for a non-ANY type in the connections of the variable declaration. If a
+	 * non-ANY type is found in the connections, a new VarDeclaration is created
+	 * with the same name as the original variable declaration but with the non-ANY
+	 * type.
+	 */
+	public static VarDeclaration getNonAnyVarDeclaration(final VarDeclaration original) {
+		if (!isAny(original)) {
+			return original;
+		}
+
+		final var nonAnyVar = getNonAnyVarFromConnections(original);
+		if (nonAnyVar == null) {
+			// all connections from original are also ANY types
+			return original;
+		}
+
+		final VarDeclaration varDeclaration = LibraryElementFactory.eINSTANCE.createVarDeclaration();
+		varDeclaration.setType(nonAnyVar.getType());
+		varDeclaration.setName(original.getName());
+		return varDeclaration;
 	}
 
 	public static boolean isEmptyValue(final Value value) {
@@ -56,54 +127,58 @@ public final class VariableUtils {
 	}
 
 	// Init all FB Variables
-	public static void fBVariableInitialization(final BaseFBType baseFbType) {
+	public static void fBVariableInitialization(final BaseFBType baseFbType,
+			final Function<VarDeclaration, String> defaultCreation) {
 		initInternalVars(baseFbType);
 		initInternalConstVars(baseFbType);
-		initializeFbType(baseFbType);
+		initializeFbType(baseFbType, defaultCreation);
 	}
 
-	public static void fBVariableInitialization(final CompositeFBType compFBType) {
-		initializeFbType(compFBType);
+	public static void fBVariableInitialization(final CompositeFBType compFBType,
+			final Function<VarDeclaration, String> defaultCreation) {
+		initializeFbType(compFBType, defaultCreation);
 	}
 
-	public static void fBVariableInitialization(final FunctionFBType functionFBType) {
-		initializeFbType(functionFBType);
+	public static void fBVariableInitialization(final FunctionFBType functionFBType,
+			final Function<VarDeclaration, String> defaultCreation) {
+		initializeFbType(functionFBType, defaultCreation);
 	}
 
-	public static void initializeFbType(final FBType fbType) {
-		initInputVars(fbType);
-		initOutputVars(fbType);
-		initPlugs(fbType);
-		initSockets(fbType);
+	public static void initializeFbType(final FBType fbType, final Function<VarDeclaration, String> defaultCreation) {
+		initInputVars(fbType, defaultCreation);
+		initOutputVars(fbType, defaultCreation);
+		initPlugs(fbType, defaultCreation);
+		initSockets(fbType, defaultCreation);
 	}
 
-	private static void initOutputVars(final FBType fbType) {
-		fbType.getInterfaceList().getOutputVars().forEach(VariableUtils::initVariable);
+	private static void initOutputVars(final FBType fbType, final Function<VarDeclaration, String> defaultCreation) {
+		fbType.getInterfaceList().getOutputVars().forEach(outputVar -> initVariable(outputVar, defaultCreation));
 	}
 
-	private static void initInputVars(final FBType fbType) {
-		fbType.getInterfaceList().getInputVars().forEach(VariableUtils::initVariable);
+	private static void initInputVars(final FBType fbType, final Function<VarDeclaration, String> defaultCreation) {
+		fbType.getInterfaceList().getInputVars().forEach(inputVar -> initVariable(inputVar, defaultCreation));
 	}
 
 	private static void initInternalVars(final BaseFBType baseFbType) {
-		baseFbType.getInternalVars().forEach(VariableUtils::initVariable);
+		baseFbType.getInternalVars().forEach(internalVar -> initVariable(internalVar, null));
 	}
 
 	private static void initInternalConstVars(final BaseFBType baseFbType) {
-		baseFbType.getInternalConstVars().forEach(VariableUtils::initVariable);
+		baseFbType.getInternalConstVars().forEach(internalConstVar -> initVariable(internalConstVar, null));
 	}
 
-	private static void initSockets(final FBType fbType) {
-		fbType.getInterfaceList().getSockets().forEach(adp -> initializeAdapter(adp.getType()));
+	private static void initSockets(final FBType fbType, final Function<VarDeclaration, String> defaultCreation) {
+		fbType.getInterfaceList().getSockets().forEach(adp -> initializeAdapter(adp.getType(), defaultCreation));
 	}
 
-	private static void initPlugs(final FBType fbType) {
-		fbType.getInterfaceList().getPlugs().forEach(adp -> initializeAdapter(adp.getType()));
+	private static void initPlugs(final FBType fbType, final Function<VarDeclaration, String> defaultCreation) {
+		fbType.getInterfaceList().getPlugs().forEach(adp -> initializeAdapter(adp.getType(), defaultCreation));
 	}
 
-	private static void initializeAdapter(final AdapterType type) {
-		initInputVars(type);
-		initOutputVars(type);
+	private static void initializeAdapter(final AdapterType type,
+			final Function<VarDeclaration, String> defaultCreation) {
+		initInputVars(type, defaultCreation);
+		initOutputVars(type, defaultCreation);
 	}
 
 	private VariableUtils() {


### PR DESCRIPTION
The data is stored in the interpreter network (types of the FBs). When injecting an event, the data must therefore be copied in to the right DataValues.

This operation also is moved aways from the EventManagerProcessor which shoult take care only of processing events ocurrences

Update: while working on this, I realized that whne you have an ANY_BIT type, for example in AND_2, the interprepreter and the watches were showing `DWORD#16#000000` which is not what the user wants to see. On the interpreter side, this problems came from the recursive creation of runtimes, because the complete state is created at the beginning. In the original usage of the interpreter, the variables are being created when they are needed, which smoothly pass the type from the connection to the input data for example. 

The solution here was to look for non-ANY types from the connections of a Data Input or Output and use that type. For the Watches a similar solution is used, passing a variable with the right type, and the interface element to be watche separately. 