### PR TITLE
Allow disabling automatic inito in sifb

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/ServiceInterfaceFBTypeDefaultInterpreter.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/ServiceInterfaceFBTypeDefaultInterpreter.java
@@ -10,6 +10,12 @@ public class ServiceInterfaceFBTypeDefaultInterpreter {
 
 	private final EventOccurrence eventOccurrence;
 
+	private static boolean outputInitO = true;
+
+	public static void setOutputInitO(final boolean outputInitO) {
+		ServiceInterfaceFBTypeDefaultInterpreter.outputInitO = outputInitO;
+	}
+
 	public ServiceInterfaceFBTypeDefaultInterpreter(final EventOccurrence eventOccurrence) {
 		this.eventOccurrence = eventOccurrence;
 	}
@@ -17,11 +23,12 @@ public class ServiceInterfaceFBTypeDefaultInterpreter {
 	public EList<EventOccurrence> run(final ServiceInterfaceFBTypeRuntime fbTypeRuntime) {
 		// TODO this should probably be replaced by an extensible structure with
 		// simulators to also cover other SIFB functionalities.
-		if (this.eventOccurrence.getEvent().getName().equals("INIT")) { //$NON-NLS-1$
+		if (outputInitO && this.eventOccurrence.getEvent().getName().equals("INIT")) { //$NON-NLS-1$
 			final var outputEvent = InterfacePinUtils.findEventInInterface(fbTypeRuntime.getModel(), "INITO"); //$NON-NLS-1$
 			return ECollections
 					.asEList(Utils.createOutputEventOccurrence(fbTypeRuntime, outputEvent, fbTypeRuntime.getModel()));
 		}
+
 		// not supported
 		return ECollections.emptyEList();
 	}

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/mm/EventManagerProcessor.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/mm/EventManagerProcessor.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.fordiac.ide.fb.interpreter.DefaultRunFBType;
+import org.eclipse.fordiac.ide.fb.interpreter.ServiceInterfaceFBTypeDefaultInterpreter;
 import org.eclipse.fordiac.ide.fb.interpreter.OpSem.EventManager;
 import org.eclipse.fordiac.ide.fb.interpreter.OpSem.EventOccurrence;
 import org.eclipse.fordiac.ide.fb.interpreter.OpSem.FBNetworkRuntime;
@@ -69,6 +70,7 @@ public class EventManagerProcessor {
 		this.eventManager = eventManager;
 		this.networkRuntime = networkRuntime;
 		DefaultRunFBType.clearCaches();
+		ServiceInterfaceFBTypeDefaultInterpreter.setOutputInitO(false);
 	}
 
 	public int getEventCounter() {

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/mm/EventManagerUtils.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/mm/EventManagerUtils.java
@@ -22,6 +22,7 @@ import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fordiac.ide.fb.interpreter.DefaultRunFBType;
+import org.eclipse.fordiac.ide.fb.interpreter.ServiceInterfaceFBTypeDefaultInterpreter;
 import org.eclipse.fordiac.ide.fb.interpreter.OpSem.EventManager;
 import org.eclipse.fordiac.ide.fb.interpreter.OpSem.EventOccurrence;
 import org.eclipse.fordiac.ide.fb.interpreter.OpSem.FBRuntimeAbstract;
@@ -48,6 +49,7 @@ public final class EventManagerUtils {
 
 	private static void processInternal(final EventManager eventManager, final boolean network) {
 		DefaultRunFBType.clearCaches();
+		ServiceInterfaceFBTypeDefaultInterpreter.setOutputInitO(true);
 		final var transactions = eventManager.getTransactions();
 		long time = eventManager.getStartTime();
 


### PR DESCRIPTION
The SIFB interpreter has currently an automatic INITO output when INIT is triggered. For replay debugging this is not desired as the actual INITO event is replayed if it was actually there.

It's not a nice solution, but at least it allows some flexibility. 