### PR TITLE
Fix duplicate/stale errors from type resource in ST resource with query

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/resource/STCoreResource.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/resource/STCoreResource.java
@@ -101,8 +101,11 @@ public class STCoreResource extends LibraryElementXtextResource implements STRes
 			addInternalLibraryElement(libraryElement);
 			// add errors and warnings from type resource
 			// has to be done _after_ super.doLoad, because that clears them
-			getErrors().addAll(typeResource.getErrors());
-			getWarnings().addAll(typeResource.getWarnings());
+			// skip if uri has query to avoid duplicate errors and warnings from type
+			if (!uri.hasQuery()) {
+				getErrors().addAll(typeResource.getErrors());
+				getWarnings().addAll(typeResource.getWarnings());
+			}
 		}
 	}
 


### PR DESCRIPTION
The ST resource propagates errors and warnings from chain loading the type resource. In case the ST resorce URI has a query (e.g., for initial values and array sizes), this can propagate duplicate or stale errors and warnings from the type resource. This skips propagating errors and warnings from the type resource when the ST resource URI has a query.