### PR TITLE
Group codeql actions in dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
       interval: "weekly"
     labels:
       - "Github Action Dependencies"
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action*"
   - package-ecosystem: maven
     directory: /
     schedule:


### PR DESCRIPTION
Group codeql actions in dependabot updates to avoid version mismatch errors and unnecessary pull requests.