### PR TITLE
Add attribute to device type to allow filter of available Profiles

### DIFF
--- a/data/typelibrary/core-3.0.0/typelib/SupportedProfiles.atp
+++ b/data/typelibrary/core-3.0.0/typelib/SupportedProfiles.atp
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AttributeDeclaration Name="SupportedProfiles" Comment="Comma-separated list of communication profiles a device type supports (first entry is the default)">
+	<Identification Standard="61499-1" Description="Copyright (c) 2026 Contributors to the Eclipse Foundation&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Version="1.0" Author="Pedro Ricardo" Date="2026-07-17" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="eclipse4diac::core">
+	</CompilerInfo>
+	<DirectlyDerivedType BaseType="STRING" InitialValue="''" Comment="Comma-separated list of supported communication profiles (first entry is the default)"/>
+	<Attribute Name="TARGET" Value="(AutomationSystem:=FALSE,Application:=FALSE,GlobalConstant:=FALSE,Connection:=FALSE,Comment:=FALSE,Group:=FALSE,Link:=FALSE,ServiceSequence:=FALSE,FBType:=FALSE,SubAppType:=FALSE,DeviceType:=TRUE,ResourceType:=FALSE,SegmentType:=FALSE,DataType:=FALSE,AttributeDeclaration:=FALSE,FB:=FALSE,TypedSubApp:=FALSE,UntypedSubApp:=FALSE,Device:=FALSE,Resource:=FALSE,Segment:=FALSE,DataTypeMember:=FALSE,InstanceEvent:=FALSE,InstanceVarDecl:=FALSE,InstanceAdapter:=FALSE,TypeEvent:=FALSE,TypeVarDecl:=FALSE,TypeAdapter:=FALSE,Untyped_SubAppEvent:=FALSE,Untyped_SubAppVarDecl:=FALSE,Untyped_SubAppAdapter:=FALSE)"/>
+</AttributeDeclaration>

--- a/data/typelibrary/system-3.0.0/MANIFEST.MF
+++ b/data/typelibrary/system-3.0.0/MANIFEST.MF
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="platform:/resource/org.eclipse.fordiac.ide.library.model/model/library.xsd" Scope="Library">
     <Dependencies>
+        <Required SymbolicName="core" Version="3.0.0"/>
         <Required SymbolicName="events" Version="3.0.0"/>
     </Dependencies>
     <Product Name="System" SymbolicName="system" Comment="Standard Library - System Configuration Components">

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/DEVImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/DEVImporter.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2008, 2009, 2011 - 2017  Profactor GmbH, TU Wien ACIN, fortiss GmbH
- * 				 2020 Johannes Kepler University Linz
+ * Copyright (c) 2008  Profactor GmbH, TU Wien ACIN, fortiss GmbH, 
+ *                                Johannes Kepler University Linz, Aimirim STI
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,6 +13,7 @@
  *    - initial API and implementation and/or initial documentation
  *  Alois Zoitl - Changed XML parsing to Staxx cursor interface for improved
  *  			  parsing performance
+ *  Pedro Ricardo - Added parsing of the SupportedProfiles attribute
  ********************************************************************************/
 package org.eclipse.fordiac.ide.model.dataimport;
 
@@ -24,9 +25,11 @@ import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.stream.XMLStreamException;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.fordiac.ide.model.LibraryElementTags;
+import org.eclipse.fordiac.ide.model.dataimport.exceptions.TypeImportException;
 import org.eclipse.fordiac.ide.model.libraryElement.DeviceType;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
@@ -146,10 +149,13 @@ public class DEVImporter extends TypeImporter {
 
 	}
 
-	private void parseDeviceTypeAttribute() {
+	private void parseDeviceTypeAttribute() throws XMLStreamException, TypeImportException {
 		if (isProfileAttribute()) {
 			parseProfile();
+		} else {
+			parseGenericAttributeNode(getElement());
 		}
+		proceedToEndElementNamed(LibraryElementTags.ATTRIBUTE_ELEMENT);
 	}
 
 	private void parseProfile() {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/DeviceProfileHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/helpers/DeviceProfileHelper.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Aimirim STI
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Pedro Ricardo - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.model.helpers;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
+import org.eclipse.fordiac.ide.model.libraryElement.ConfigurableObject;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
+import org.eclipse.fordiac.ide.model.value.StringValueConverter;
+
+/** 
+ * Helper for the 'SupportedProfiles' attribute that a device type may
+ * declare in its type file (.dev) to restrict the set of communication profiles
+ * available for its devices. */
+public final class DeviceProfileHelper {
+
+	/**
+	 * Return the comma separated list of communication profiles.
+     * Blank or missing attribute means no restrictions */
+	public static List<String> getSupportedProfiles(final ConfigurableObject object) {
+		if (object == null) {
+			return Collections.emptyList();
+		}
+		Attribute attribute = object.getAttribute(TypeLibraryTags.SUPPORTED_PROFILES_ATTRIBUTE_FULL_NAME);
+		// Add a fallback search for the attribute to mirror TypeHash example
+		if (attribute == null) {
+			attribute = object.getAttribute(TypeLibraryTags.SUPPORTED_PROFILES_ATTRIBUTE_NAME);
+		}
+		if (attribute == null || attribute.getValue() == null || attribute.getValue().isBlank()) {
+			return Collections.emptyList();
+		}
+		return Arrays.stream(decodeValue(attribute.getValue()).split(",")) //$NON-NLS-1$
+				.map(String::trim).filter(profile -> !profile.isEmpty()).toList();
+	}
+
+	/**
+     * Attribute value is stored as STRING literal */
+	private static String decodeValue(final String value) {
+		try {
+			return StringValueConverter.INSTANCE.toValue(value.trim());
+		} catch (final IllegalArgumentException e) {
+			return value;
+		}
+	}
+
+	private DeviceProfileHelper() {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/TypeLibraryTags.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/TypeLibraryTags.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2014 fortiss GmbH
+ * Copyright (c) 2014 fortiss GmbH, Aimirim STI
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -11,6 +11,7 @@
  *  Waldemar Eisenmenger
  *    - initial API and implementation and/or initial documentation
  *  Daniel Lindhuber - Added system type file ending
+ *  Pedro Ricardo - Added SupportedProfiles attribute tags
  ********************************************************************************/
 package org.eclipse.fordiac.ide.model.typelibrary;
 
@@ -83,6 +84,9 @@ public final class TypeLibraryTags {
 
 	public static final String TYPE_HASH_ATTRIBUTE_NAME = "TypeHash"; //$NON-NLS-1$
 	public static final String TYPE_HASH_ATTRIBUTE_FULL_NAME = "eclipse4diac::core::TypeHash"; //$NON-NLS-1$
+
+	public static final String SUPPORTED_PROFILES_ATTRIBUTE_NAME = "SupportedProfiles"; //$NON-NLS-1$
+	public static final String SUPPORTED_PROFILES_ATTRIBUTE_FULL_NAME = "eclipse4diac::core::SupportedProfiles"; //$NON-NLS-1$
 
 	private TypeLibraryTags() {
 		throw new UnsupportedOperationException("Helper class TypeLibraryTags can not be instantiated."); //$NON-NLS-1$

--- a/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/commands/DeviceCreateCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/commands/DeviceCreateCommand.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008 - 2017 Profactor GbmH, TU Wien ACIN, fortiss GmbH
- * 				 2019 Johannes Keppler University Linz
+ * Copyright (c) 2008  Profactor GbmH, TU Wien ACIN, fortiss GmbH,
+ *                                Johannes Keppler University Linz, Aimirim STI
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -11,7 +11,10 @@
  * Contributors:
  *   Gerhard Ebenhofer, Alois Zoitl, Gerd Kainz, Monika Wenger, Kiril Dorofeev
  *     - initial API and implementation and/or initial documentation
- *   Alois Zoitl - removed editor check from canUndo
+ *   Alois Zoitl 
+ *     - removed editor check from canUndo
+ *   Pedro Ricardo
+ *     - set default profile as the first supported
  *******************************************************************************/
 package org.eclipse.fordiac.ide.systemconfiguration.commands;
 
@@ -20,12 +23,15 @@ import java.util.List;
 
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.fordiac.ide.deployment.interactors.DeviceManagementInteractorFactory;
 import org.eclipse.fordiac.ide.model.AttributeInheritMode;
 import org.eclipse.fordiac.ide.model.CoordinateConverter;
 import org.eclipse.fordiac.ide.model.NameRepository;
 import org.eclipse.fordiac.ide.model.dataimport.CommonElementImporter;
+import org.eclipse.fordiac.ide.model.helpers.DeviceProfileHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.Color;
 import org.eclipse.fordiac.ide.model.libraryElement.Device;
+import org.eclipse.fordiac.ide.model.libraryElement.DeviceType;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.Position;
 import org.eclipse.fordiac.ide.model.libraryElement.Resource;
@@ -83,14 +89,29 @@ public class DeviceCreateCommand extends Command {
 	}
 
 	private void setDeviceProfile() {
-		String profile;
-		if ((null != device.getType().getProfile()) && !"".equals(device.getType().getProfile())) { //$NON-NLS-1$
-			profile = device.getType().getProfile();
-		} else {
-			profile = Platform.getPreferencesService().getString(UIPreferenceConstants.FORDIAC_UI_PREFERENCES_ID,
-					UIPreferenceConstants.P_DEFAULT_COMPLIANCE_PROFILE, "", null); //$NON-NLS-1$
+		final DeviceType type = device.getType();
+		String profile = getDefaultSupportedProfile(type);
+		if (profile == null) {
+			if ((type.getProfile() != null) && !type.getProfile().isEmpty()) {
+				profile = type.getProfile();
+			} else {
+				profile = Platform.getPreferencesService().getString(UIPreferenceConstants.FORDIAC_UI_PREFERENCES_ID,
+						UIPreferenceConstants.P_DEFAULT_COMPLIANCE_PROFILE, "", null); //$NON-NLS-1$
+			}
 		}
 		device.setProfile(profile);
+	}
+
+	/* Return the first of 'SupportedProfiles' attribute if declared,
+     * else returns null to enable fallback to previous behaviour. */
+	private static String getDefaultSupportedProfile(final DeviceType type) {
+		final List<String> supportedProfiles = DeviceProfileHelper.getSupportedProfiles(type);
+		if (supportedProfiles.isEmpty()) {
+			return null;
+		}
+		final List<String> availableProfiles = DeviceManagementInteractorFactory.INSTANCE.getAvailableProfileNames();
+		return supportedProfiles.stream().filter(availableProfiles::contains).findFirst()
+				.orElseGet(() -> supportedProfiles.get(0));
 	}
 
 	protected void createDevice() {

--- a/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/properties/DeviceSection.java
+++ b/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/properties/DeviceSection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 fortiss GmbH, Johannes Kepler University
+ * Copyright (c) 2017 fortiss GmbH, Johannes Kepler University, Aimirim STI
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,15 +12,20 @@
  *      - initial API and implementation and/or initial documentation
  *    Bianca Wiesmayr
  *      - merged two DeviceInterfaceSection plus Abstract Class into DeviceSection
- *   Alois Zoitl - fixed layout, reduced code duplication
+ *    Alois Zoitl 
+ *      - fixed layout, reduced code duplication
+ *    Pedro Ricardo
+ *      - Added available profiles filter
  *******************************************************************************/
 package org.eclipse.fordiac.ide.systemconfiguration.properties;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.fordiac.ide.deployment.interactors.DeviceManagementInteractorFactory;
 import org.eclipse.fordiac.ide.gef.commands.ChangeProfileCommand;
 import org.eclipse.fordiac.ide.gef.properties.AbstractInterfaceSection;
+import org.eclipse.fordiac.ide.model.helpers.DeviceProfileHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.Device;
 import org.eclipse.fordiac.ide.systemconfiguration.Messages;
 import org.eclipse.fordiac.ide.ui.widget.ComboBoxWidgetFactory;
@@ -30,23 +35,25 @@ import org.eclipse.swt.custom.CCombo;
 import org.eclipse.swt.widgets.Composite;
 
 public class DeviceSection extends AbstractInterfaceSection {
-	private static String[] profileNames;
+	private static List<String> availableProfileNames;
 	private CCombo profile;
 
 	@Override
 	protected void performRefresh() {
 		super.performRefresh();
-		setProfile();
+		final Device device = (Device) getType();
+		if (device == null) {
+			return;
+		}
+		profile.setItems(getSelectableProfiles(device));
+		setProfile(device);
 	}
 
-	private void setProfile() {
-		int i = 0;
-		for (final String p : profile.getItems()) {
-			if (p.equals(((Device) getType()).getProfile())) {
-				profile.select(i);
-				break;
-			}
-			i++;
+	private void setProfile(final Device device) {
+		final String currentProfile = device.getProfile() != null ? device.getProfile() : ""; //$NON-NLS-1$
+		final int index = profile.indexOf(currentProfile);
+		if (index >= 0) {
+			profile.select(index);
 		}
 	}
 
@@ -72,14 +79,31 @@ public class DeviceSection extends AbstractInterfaceSection {
 			refresh();
 			addContentAdapter();
 		});
-		profile.setItems(getAvailableProfileNames());
 	}
 
-	protected static String[] getAvailableProfileNames() {
-		if (null == profileNames) {
-			final List<String> newProfileNames = DeviceManagementInteractorFactory.INSTANCE.getAvailableProfileNames();
-			profileNames = newProfileNames.toArray(new String[newProfileNames.size()]);
+	/** Filter the globally available profiles with the list of allowed profiles 
+     * for the given device via 'SupportedProfiles' attribute. Returns all profiles if
+     * the attribute is not there. */
+	private static String[] getSelectableProfiles(final Device device) {
+		final List<String> available = getAvailableProfileNames();
+		final List<String> supported = DeviceProfileHelper.getSupportedProfiles(device.getType());
+		final List<String> selectable = new ArrayList<>();
+		if (supported.isEmpty()) {
+			selectable.addAll(available);
+		} else {
+			supported.stream().filter(available::contains).forEach(selectable::add);
 		}
-		return profileNames;
+		final String currentProfile = device.getProfile();
+		if (currentProfile != null && !currentProfile.isEmpty() && !selectable.contains(currentProfile)) {
+			selectable.add(currentProfile);
+		}
+		return selectable.toArray(new String[0]);
+	}
+
+	private static List<String> getAvailableProfileNames() {
+		if (availableProfileNames == null) {
+			availableProfileNames = DeviceManagementInteractorFactory.INSTANCE.getAvailableProfileNames();
+		}
+		return availableProfileNames;
 	}
 }


### PR DESCRIPTION
This Merge Request implements #699 as I undestood it was suggested.
It adds a new attribute `<Attribute Name="eclipse4diac::core::SupportedProfiles" />` to be parsed in device files (`.dev`). This attribute value is a comma separated list written as `STRING` type (single quoted), i.e. `Value="'HOLOBLOC,DynamicTypeLoad'"` 

If the attribute does not exist or if it's empty it fall back to the previous allow all behaviour. Otherwise the values written in the attribute are used to filter the `DeviceManagementInteractorFactory.INSTANCE.getAvailableProfileNames()` list.

I used the `TypeHash` attribute as an example for adding this new `SupportedProfiles` one. I hope it is a good example.

I haven't commited changes to the `data/typelibrary/system-3.0.0/typelib/devices` directly. In my point of view we can add those where it is convenient after the first review.

In order to see this implementation in action add the following line to a device file. This example here filters out the `FBDK2` from the available Profiles in FORTE_PC device.
```diff
--- a/data/typelibrary/system-3.0.0/typelib/devices/FORTE_PC.dev
+++ b/data/typelibrary/system-3.0.0/typelib/devices/FORTE_PC.dev
@@ -5,4 +5,5 @@
   <VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2015-10-31" Remarks="Initial version" />
   <CompilerInfo packageName="iec61499::system"/>
   <VarDeclaration Name="MGR_ID" Type="WSTRING" InitialValue="&#34;localhost:61499&#34;" Comment="Device manager socket ID" />  
+  <Attribute Name="eclipse4diac::core::SupportedProfiles" Value="'HOLOBLOC,OPC UA,DynamicTypeLoad,Interpreter'"/>
 </DeviceType>
```