### PR TITLE
Move project creation code from SystemManager to ProjectCreator

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/wizard/New4diacProjectWizard.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/wizard/New4diacProjectWizard.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2010 - 2016  Profactor GmbH, TU Wien ACIN, fortiss GmbH
- * 				 2020 Johannes Kepler University Linz
+ * Copyright (c) 2008 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
+ *                    Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -121,10 +121,8 @@ public class New4diacProjectWizard extends Wizard implements INewWizard {
 	 */
 	private void createProject(final IProgressMonitor monitor) {
 		try {
-			final ProjectCreator projectCreator = new ProjectCreator(page.getProjectName(), page.getLocationPath());
-
-			final IProject newProject = projectCreator
-					.createProject(monitor != null ? monitor : new NullProgressMonitor());
+			final IProject newProject = ProjectCreator.of(page.getProjectName(), page.getLocationPath())
+					.create(monitor);
 			libPage.setTargetProject(newProject);
 			final SystemCreator systemCreator = new SystemCreator(newProject, page.getInitialSystemName(),
 					page.getInitialApplicationName());

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/ProjectCreator.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/ProjectCreator.java
@@ -13,21 +13,36 @@
 
 package org.eclipse.fordiac.ide.systemmanagement;
 
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.eclipse.core.resources.ICommand;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.fordiac.ide.library.model.util.ManifestHelper;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
+import org.eclipse.xtext.ui.XtextProjectHelper;
 
 public class ProjectCreator {
 
 	private final String projectName;
 	private final IPath projectLocation;
-	private IProject projectToCreate;
 
-	public ProjectCreator(final String projectName, final IPath projectLocation) {
+	private ProjectCreator(final String projectName, final IPath projectLocation) {
 		this.projectName = projectName;
 		this.projectLocation = projectLocation;
+	}
+
+	public static ProjectCreator of(final String projectName, final IPath projectLocation) {
+		return new ProjectCreator(projectName, projectLocation);
 	}
 
 	/**
@@ -35,15 +50,54 @@ public class ProjectCreator {
 	 *
 	 * @param monitor the monitor
 	 */
-	public IProject createProject(final IProgressMonitor monitor) {
+	public IProject create(final IProgressMonitor monitor) {
 		try {
-			projectToCreate = SystemManager.INSTANCE.createNew4diacProject(projectName, projectLocation, monitor);
+			return createNew4diacProject(monitor);
 		} catch (final CoreException e) {
 			FordiacLogHelper.logError(e.getMessage(), e);
 		} finally {
 			monitor.done();
 		}
-		return projectToCreate;
+		return null;
 
+	}
+
+	private IProject createNew4diacProject(final IProgressMonitor monitor) throws CoreException {
+		final IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+
+		final IProject project = root.getProject(projectName);
+		final IProjectDescription description = ResourcesPlugin.getWorkspace().newProjectDescription(project.getName());
+
+		if (!Platform.getLocation().equals(projectLocation)) {
+			description.setLocation(projectLocation);
+		}
+
+		description.setNatureIds(SystemManager.getNatureIDs());
+
+		final List<ICommand> commands = Stream.of(getBuilderIDs()).map(builder -> {
+			final ICommand command = description.newCommand();
+			command.setBuilderName(builder);
+			return command;
+		}).toList();
+		description.setBuildSpec(commands.toArray(new ICommand[commands.size()]));
+
+		project.create(description, monitor);
+		project.open(monitor);
+
+		project.getFolder(TypeLibraryTags.TYPE_LIB_FOLDER_NAME).create(true, true, monitor);
+		project.getFolder(TypeLibraryTags.STANDARD_LIB_FOLDER_NAME).create(IResource.VIRTUAL | IResource.FORCE, true,
+				monitor);
+		project.getFolder(TypeLibraryTags.EXTERNAL_LIB_FOLDER_NAME).create(IResource.VIRTUAL | IResource.FORCE, true,
+				monitor);
+
+		ManifestHelper.getOrCreateProjectManifest(project);
+
+		project.refreshLocal(IResource.DEPTH_ONE, monitor);
+		return project;
+	}
+
+	private static String[] getBuilderIDs() {
+		return new String[] { SystemManager.FORDIAC_LIBRARY_BUILDER_ID, XtextProjectHelper.BUILDER_ID,
+				SystemManager.FORDIAC_OCL_VALIDATION_BUILDER_ID, SystemManager.FORDIAC_EXPORT_BUILDER_ID };
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/SystemManager.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement/src/org/eclipse/fordiac/ide/systemmanagement/SystemManager.java
@@ -1,8 +1,7 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2026 Profactor GmbH, TU Wien ACIN, AIT, fortiss GmbH,
- *                          Johannes Kepler University Linz,
- *                          Primetals Technologies Austria GmbH,
- *                          Martin Erich Jobst
+ * Copyright (c) 2008 Profactor GmbH, TU Wien ACIN, AIT, fortiss GmbH,
+ *                    Johannes Kepler University Linz,
+ *                    Primetals Technologies Austria GmbH, Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -23,23 +22,13 @@
 package org.eclipse.fordiac.ide.systemmanagement;
 
 import java.text.MessageFormat;
-import java.util.List;
-import java.util.stream.Stream;
 
-import org.eclipse.core.resources.ICommand;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IProjectDescription;
-import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceChangeListener;
-import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.Platform;
-import org.eclipse.fordiac.ide.library.model.util.ManifestHelper;
-import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 import org.eclipse.fordiac.ide.systemmanagement.changelistener.FordiacResourceChangeListener;
 import org.eclipse.fordiac.ide.systemmanagement.nature.FordiacNature;
 import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
@@ -66,8 +55,6 @@ public enum SystemManager {
 
 	private final IResourceChangeListener fordiacListener = new FordiacResourceChangeListener();
 
-	/** The listeners. */
-
 	/** Instantiates a new system manager. */
 	SystemManager() {
 		addFordiacChangeListener();
@@ -80,49 +67,8 @@ public enum SystemManager {
 						&& SystemManager.SYSTEM_FILE_ENDING.equalsIgnoreCase((file).getFileExtension()));
 	}
 
-	@SuppressWarnings("static-method")
-	public IProject createNew4diacProject(final String projectName, final IPath location,
-			final IProgressMonitor monitor) throws CoreException {
-		final IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-
-		final IProject project = root.getProject(projectName);
-		final IProjectDescription description = ResourcesPlugin.getWorkspace().newProjectDescription(project.getName());
-
-		if (!Platform.getLocation().equals(location)) {
-			description.setLocation(location);
-		}
-
-		description.setNatureIds(getNatureIDs());
-
-		final List<ICommand> commands = Stream.of(getBuilderIDs()).map(builder -> {
-			final ICommand command = description.newCommand();
-			command.setBuilderName(builder);
-			return command;
-		}).toList();
-		description.setBuildSpec(commands.toArray(new ICommand[commands.size()]));
-
-		project.create(description, monitor);
-		project.open(monitor);
-
-		project.getFolder(TypeLibraryTags.TYPE_LIB_FOLDER_NAME).create(true, true, monitor);
-		project.getFolder(TypeLibraryTags.STANDARD_LIB_FOLDER_NAME).create(IResource.VIRTUAL | IResource.FORCE, true,
-				monitor);
-		project.getFolder(TypeLibraryTags.EXTERNAL_LIB_FOLDER_NAME).create(IResource.VIRTUAL | IResource.FORCE, true,
-				monitor);
-
-		ManifestHelper.getOrCreateProjectManifest(project);
-
-		project.refreshLocal(IResource.DEPTH_ONE, monitor);
-		return project;
-	}
-
 	public static String[] getNatureIDs() {
 		return new String[] { SystemManager.FORDIAC_PROJECT_NATURE_ID, XtextProjectHelper.NATURE_ID };
-	}
-
-	private static String[] getBuilderIDs() {
-		return new String[] { FORDIAC_LIBRARY_BUILDER_ID, XtextProjectHelper.BUILDER_ID,
-				FORDIAC_OCL_VALIDATION_BUILDER_ID, FORDIAC_EXPORT_BUILDER_ID };
 	}
 
 	public void removeFordiacChangeListener() {

--- a/tests/org.eclipse.fordiac.ide.test.library/src/org/eclipse/fordiac/ide/test/library/LibraryImportTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.library/src/org/eclipse/fordiac/ide/test/library/LibraryImportTest.java
@@ -43,7 +43,7 @@ import org.eclipse.fordiac.ide.library.model.util.ManifestHelper;
 import org.eclipse.fordiac.ide.model.errormarker.FordiacErrorMarker;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
-import org.eclipse.fordiac.ide.systemmanagement.SystemManager;
+import org.eclipse.fordiac.ide.systemmanagement.ProjectCreator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -75,8 +75,9 @@ class LibraryImportTest {
 
 	@BeforeAll
 	static void setupBeforeClass() throws Exception {
-		final IProject proj = SystemManager.INSTANCE.createNew4diacProject(PROJECT,
-				ResourcesPlugin.getWorkspace().getRoot().getLocation().append(PROJECT), new NullProgressMonitor());
+		final IProject proj = ProjectCreator
+				.of(PROJECT, ResourcesPlugin.getWorkspace().getRoot().getLocation().append(PROJECT))
+				.create(new NullProgressMonitor());
 		proj.refreshLocal(IResource.DEPTH_INFINITE, null);
 
 		// extract test libraries


### PR DESCRIPTION
Bring all project creation code into one place. Turn ProjecCreator into a fluid api class.