### PR TITLE
Removed Unnecessary Suppress Warnings in AsciiDoc Editor

### DIFF
--- a/features/org.eclipse.fordiac.ide.experimental.feature/feature.xml
+++ b/features/org.eclipse.fordiac.ide.experimental.feature/feature.xml
@@ -38,7 +38,7 @@
       <import plugin="org.eclipse.mylyn.wikitext.asciidoc"/>
       <import plugin="org.eclipse.mylyn.wikitext.asciidoc.ui"/>
       <import plugin="org.eclipse.mylyn.wikitext.ui"/>
-      <import plugin="org.eclipse.mylyn.wikitext.ui.source"/>
+      <import plugin="org.eclipse.mylyn.wikitext.html"/>
    </requires>
 
    <plugin

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.asciidoc/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.asciidoc/META-INF/MANIFEST.MF
@@ -25,6 +25,7 @@ Import-Package: org.eclipse.core.expressions,
  org.eclipse.fordiac.ide.ui,
  org.eclipse.fordiac.ide.ui.imageprovider,
  org.eclipse.mylyn.wikitext.asciidoc,
+ org.eclipse.mylyn.wikitext.html,
  org.eclipse.mylyn.wikitext.parser,
  org.eclipse.mylyn.wikitext.parser.builder,
  org.eclipse.mylyn.wikitext.parser.markup

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.asciidoc/src/org/eclipse/fordiac/ide/fbtypeeditor/asciidoc/editors/AsciiDocPreviewTypeEditorPage.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.asciidoc/src/org/eclipse/fordiac/ide/fbtypeeditor/asciidoc/editors/AsciiDocPreviewTypeEditorPage.java
@@ -29,8 +29,8 @@ import org.eclipse.fordiac.ide.typeeditor.ITypeEditorPage;
 import org.eclipse.fordiac.ide.ui.imageprovider.FordiacImage;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.mylyn.wikitext.asciidoc.AsciiDocLanguage;
+import org.eclipse.mylyn.wikitext.html.HtmlLanguage;
 import org.eclipse.mylyn.wikitext.parser.MarkupParser;
-import org.eclipse.mylyn.wikitext.parser.builder.HtmlDocumentBuilder;
 import org.eclipse.mylyn.wikitext.parser.markup.MarkupLanguage;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.browser.Browser;
@@ -177,7 +177,7 @@ public class AsciiDocPreviewTypeEditorPage extends EditorPart implements ITypeEd
 
 	private MarkupParser createParser(final StringWriter writer) {
 		final MarkupParser parser = new MarkupParser(createLanguage());
-		parser.setBuilder(new HtmlDocumentBuilder(writer));
+		parser.setBuilder(new HtmlLanguage().createDocumentBuilder(writer));
 		return parser;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.asciidoc/src/org/eclipse/fordiac/ide/fbtypeeditor/asciidoc/phrase/FbtMacroPatternElement.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.asciidoc/src/org/eclipse/fordiac/ide/fbtypeeditor/asciidoc/phrase/FbtMacroPatternElement.java
@@ -16,7 +16,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.mylyn.wikitext.parser.markup.PatternBasedElement;
 import org.eclipse.mylyn.wikitext.parser.markup.PatternBasedElementProcessor;
 
-@SuppressWarnings("restriction")
 public class FbtMacroPatternElement extends PatternBasedElement {
 
 	private final LibraryElement target;

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.asciidoc/src/org/eclipse/fordiac/ide/fbtypeeditor/asciidoc/phrase/FbtMacroProcessor.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.asciidoc/src/org/eclipse/fordiac/ide/fbtypeeditor/asciidoc/phrase/FbtMacroProcessor.java
@@ -26,7 +26,6 @@ import org.eclipse.mylyn.wikitext.parser.DocumentBuilder.SpanType;
 import org.eclipse.mylyn.wikitext.parser.LinkAttributes;
 import org.eclipse.mylyn.wikitext.parser.markup.PatternBasedElementProcessor;
 
-@SuppressWarnings("restriction")
 public class FbtMacroProcessor extends PatternBasedElementProcessor {
 
 	public static final String FBT_TYPE_ENTRY_URI = "fbt-entry://"; //$NON-NLS-1$


### PR DESCRIPTION
With the new Eclipse Mylyn Wikitext API suppress warnings are not needed anymore. For HTML preview we can now use HTML language further reducing Eclipse Mylyn Wikitext internal API usage.