### PR TITLE
Add type management tests for copy, nested struct rename, and connection repair

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.typemanagement/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/META-INF/MANIFEST.MF
@@ -34,6 +34,8 @@ Export-Package: org.eclipse.fordiac.ide.typemanagement,
  org.eclipse.fordiac.ide.typemanagement.navigator,
  org.eclipse.fordiac.ide.typemanagement.preferences,
  org.eclipse.fordiac.ide.typemanagement.refactoring,
+ org.eclipse.fordiac.ide.typemanagement.refactoring.connection.commands;
+  x-friends:="org.eclipse.fordiac.ide.typemanagement.tests",
  org.eclipse.fordiac.ide.typemanagement.refactoring.copy,
  org.eclipse.fordiac.ide.typemanagement.refactoring.edit,
  org.eclipse.fordiac.ide.typemanagement.refactoring.rename,

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/CircularStructTest/.project
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/CircularStructTest/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>CircularStructTest</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.fordiac.ide.library.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.fordiac.ide.export.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.fordiac.ide.systemmanagement.FordiacNature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/CircularStructTest/Type Library/mypackage/CycleA.dtp
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/CircularStructTest/Type Library/mypackage/CycleA.dtp
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DataType Name="CycleA" Comment="">
+	<Identification Standard="61499-1">
+	</Identification>
+	<VersionInfo Version="1.0" Author="Dimitrios Kalligaridis" Date="2026-07-21">
+	</VersionInfo>
+	<CompilerInfo packageName="mypackage">
+	</CompilerInfo>
+	<StructuredType>
+		<VarDeclaration Name="b" Type="mypackage::CycleB" Comment=""/>
+	</StructuredType>
+</DataType>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/CircularStructTest/Type Library/mypackage/CycleB.dtp
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/CircularStructTest/Type Library/mypackage/CycleB.dtp
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DataType Name="CycleB" Comment="">
+	<Identification Standard="61499-1">
+	</Identification>
+	<VersionInfo Version="1.0" Author="Dimitrios Kalligaridis" Date="2026-07-21">
+	</VersionInfo>
+	<CompilerInfo packageName="mypackage">
+	</CompilerInfo>
+	<StructuredType>
+		<VarDeclaration Name="a" Type="mypackage::CycleA" Comment=""/>
+	</StructuredType>
+</DataType>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/ConnectionRepairTest/.project
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/ConnectionRepairTest/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>ConnectionRepairTest</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.fordiac.ide.library.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.fordiac.ide.export.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.fordiac.ide.systemmanagement.FordiacNature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/ConnectionRepairTest/ConnectionRepairTest.sys
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/ConnectionRepairTest/ConnectionRepairTest.sys
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<System Name="ConnectionRepairTest" Comment="">
+	<VersionInfo Version="1.0" Author="Dimitrios Kalligaridis" Date="2026-07-21">
+	</VersionInfo>
+	<Application Name="App" Comment="">
+		<SubAppNetwork>
+			<FB Name="Producer" Type="RepairProducer" Comment="" x="500.0" y="500.0">
+			</FB>
+			<FB Name="Consumer" Type="RepairConsumer" Comment="" x="2500.0" y="500.0">
+			</FB>
+			<EventConnections>
+				<Connection Source="Producer.CNF" Destination="Consumer.REQ" Comment=""/>
+			</EventConnections>
+			<DataConnections>
+				<Connection Source="Producer.OUT.missing" Destination="Consumer.DI" Comment=""/>
+			</DataConnections>
+		</SubAppNetwork>
+	</Application>
+</System>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/ConnectionRepairTest/Type Library/RepairConsumer.fbt
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/ConnectionRepairTest/Type Library/RepairConsumer.fbt
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="RepairConsumer" Comment="Simple FB with one algorithm">
+	<Identification Standard="61499-1">
+	</Identification>
+	<VersionInfo Version="1.0" Author="Dimitrios Kalligaridis" Date="2026-07-21">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="DI"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="DI" Type="BOOL"/>
+		</InputVars>
+	</InterfaceList>
+	<SimpleFB>
+		<ECState Name="REQ">
+			<ECAction Algorithm="REQ" Output="CNF"/>
+		</ECState>
+		<Algorithm Name="REQ">
+			<ST><![CDATA[]]></ST>
+		</Algorithm>
+	</SimpleFB>
+</FBType>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/ConnectionRepairTest/Type Library/RepairProducer.fbt
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/ConnectionRepairTest/Type Library/RepairProducer.fbt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="RepairProducer" Comment="">
+	<Identification Standard="61499-2">
+	</Identification>
+	<VersionInfo Version="1.0" Author="Dimitrios Kalligaridis" Date="2026-07-21">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment=""/>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="mypackage::RepairStruct" Comment=""/>
+		</OutputVars>
+	</InterfaceList>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="">
+	</Service>
+</FBType>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/ConnectionRepairTest/Type Library/mypackage/RepairStruct.dtp
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/ConnectionRepairTest/Type Library/mypackage/RepairStruct.dtp
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DataType Name="RepairStruct" Comment="">
+	<Identification Standard="61499-1">
+	</Identification>
+	<VersionInfo Version="1.0" Author="Dimitrios Kalligaridis" Date="2026-07-21">
+	</VersionInfo>
+	<CompilerInfo packageName="mypackage">
+	</CompilerInfo>
+	<StructuredType>
+		<VarDeclaration Name="keep" Type="BOOL" Comment=""/>
+		<VarDeclaration Name="other" Type="BOOL" Comment=""/>
+	</StructuredType>
+</DataType>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/NestedStructRenameTest/.project
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/NestedStructRenameTest/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>NestedStructRenameTest</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.fordiac.ide.library.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.fordiac.ide.export.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.fordiac.ide.systemmanagement.FordiacNature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/NestedStructRenameTest/NestedStructRenameTest.sys
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/NestedStructRenameTest/NestedStructRenameTest.sys
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<System Name="NestedStructRenameTest" Comment="">
+	<VersionInfo Version="1.0" Author="Dimitrios Kalligaridis" Date="2026-07-21">
+	</VersionInfo>
+	<Application Name="App" Comment="">
+		<SubAppNetwork>
+			<FB Name="Producer" Type="RootProducer" Comment="" x="500.0" y="500.0">
+				<Parameter Name="OUT.middle.leaf.A" Value="">
+					<Attribute Name="Visible" Value="true"/>
+					<Attribute Name="TestAttribute" Type="STRING" Value="42"/>
+				</Parameter>
+			</FB>
+			<FB Name="Consumer" Type="RootConsumer" Comment="" x="2500.0" y="500.0">
+				<Parameter Name="DI.middle.leaf.A" Value="">
+					<Attribute Name="Visible" Value="true"/>
+				</Parameter>
+			</FB>
+			<EventConnections>
+				<Connection Source="Producer.CNF" Destination="Consumer.REQ" Comment=""/>
+			</EventConnections>
+			<DataConnections>
+				<Connection Source="Producer.OUT.middle.leaf.A" Destination="Consumer.DI.middle.leaf.A" Comment=""/>
+			</DataConnections>
+		</SubAppNetwork>
+	</Application>
+</System>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/NestedStructRenameTest/Type Library/RootConsumer.fbt
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/NestedStructRenameTest/Type Library/RootConsumer.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="RootConsumer" Comment="Simple FB with one algorithm">
+	<Identification Standard="61499-1">
+	</Identification>
+	<VersionInfo Version="1.0" Author="Dimitrios Kalligaridis" Date="2026-07-21">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="DI"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="DO1"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="DI" Type="mypackage::Root"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="DO1" Type="mypackage::Root"/>
+		</OutputVars>
+	</InterfaceList>
+	<SimpleFB>
+		<ECState Name="REQ">
+			<ECAction Algorithm="REQ" Output="CNF"/>
+		</ECState>
+		<Algorithm Name="REQ">
+			<ST><![CDATA[]]></ST>
+		</Algorithm>
+	</SimpleFB>
+</FBType>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/NestedStructRenameTest/Type Library/RootProducer.fbt
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/NestedStructRenameTest/Type Library/RootProducer.fbt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="RootProducer" Comment="">
+	<Identification Standard="61499-2">
+	</Identification>
+	<VersionInfo Version="1.0" Author="Dimitrios Kalligaridis" Date="2026-07-21">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment=""/>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="mypackage::Root" Comment=""/>
+		</OutputVars>
+	</InterfaceList>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="">
+	</Service>
+</FBType>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/NestedStructRenameTest/Type Library/mypackage/Leaf.dtp
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/NestedStructRenameTest/Type Library/mypackage/Leaf.dtp
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DataType Name="Leaf" Comment="">
+	<Identification Standard="61499-1">
+	</Identification>
+	<VersionInfo Version="1.0" Author="Dimitrios Kalligaridis" Date="2026-07-21">
+	</VersionInfo>
+	<CompilerInfo packageName="mypackage">
+	</CompilerInfo>
+	<StructuredType>
+		<VarDeclaration Name="A" Type="BOOL" Comment=""/>
+		<VarDeclaration Name="B" Type="BOOL" Comment=""/>
+	</StructuredType>
+</DataType>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/NestedStructRenameTest/Type Library/mypackage/Middle.dtp
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/NestedStructRenameTest/Type Library/mypackage/Middle.dtp
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DataType Name="Middle" Comment="">
+	<Identification Standard="61499-1">
+	</Identification>
+	<VersionInfo Version="1.0" Author="Dimitrios Kalligaridis" Date="2026-07-21">
+	</VersionInfo>
+	<CompilerInfo packageName="mypackage">
+	</CompilerInfo>
+	<StructuredType>
+		<VarDeclaration Name="leaf" Type="mypackage::Leaf" Comment=""/>
+		<VarDeclaration Name="flag" Type="BOOL" Comment=""/>
+	</StructuredType>
+</DataType>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/NestedStructRenameTest/Type Library/mypackage/Root.dtp
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/NestedStructRenameTest/Type Library/mypackage/Root.dtp
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DataType Name="Root" Comment="">
+	<Identification Standard="61499-1">
+	</Identification>
+	<VersionInfo Version="1.0" Author="Dimitrios Kalligaridis" Date="2026-07-21">
+	</VersionInfo>
+	<CompilerInfo packageName="mypackage">
+	</CompilerInfo>
+	<StructuredType>
+		<VarDeclaration Name="middle" Type="mypackage::Middle" Comment=""/>
+		<VarDeclaration Name="id" Type="BOOL" Comment=""/>
+	</StructuredType>
+</DataType>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/CircularStructValidationTest.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/CircularStructValidationTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Dimitrios Kalligaridis
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Dimitrios Kalligaridis - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.tests;
+
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.CONVERT;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.CORE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.IEC_61131_3;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
+import org.eclipse.fordiac.ide.systemmanagement.SystemManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Documents that a circular struct member reference is not validated: CycleA
+ * references CycleB and CycleB references CycleA, yet both load without error.
+ */
+class CircularStructValidationTest {
+
+	private static final String PROJECT_NAME = "CircularStructTest"; //$NON-NLS-1$
+	private static final String PROJECT_PATH = "data/CircularStructTest"; //$NON-NLS-1$
+	private static final String CYCLE_A_FILE = "Type Library/mypackage/CycleA.dtp"; //$NON-NLS-1$
+	private static final String CYCLE_B_FILE = "Type Library/mypackage/CycleB.dtp"; //$NON-NLS-1$
+
+	private IProject project;
+	private TypeLibrary typeLibrary;
+
+	@BeforeAll
+	static void preloadSystemManager() {
+		SystemManager.INSTANCE.name();
+	}
+
+	@BeforeEach
+	void loadFixture() throws Exception {
+		project = RefactoringTestSupport.importProjectIntoWorkspace(PROJECT_NAME, PROJECT_PATH);
+		RefactoringTestSupport.linkStandardLibraries(project, CORE, CONVERT, IEC_61131_3);
+		typeLibrary = TypeLibraryManager.INSTANCE.getTypeLibrary(project);
+	}
+
+	@AfterEach
+	void disposeFixture() throws Exception {
+		RefactoringTestSupport.deleteProject(project);
+	}
+
+	@Test
+	@Disabled("The datatype editor does not validate circular struct member references: CycleA references " //$NON-NLS-1$
+			+ "CycleB and CycleB references CycleA, yet both load without an error. Re-enable once circular " //$NON-NLS-1$
+			+ "references are reported as errors, see https://github.com/eclipse-4diac/4diac-ide/issues/2792") //$NON-NLS-1$
+	void circularStructReference_isReportedAsError() throws Exception {
+		assertTrue(typeLibrary.getTypeEntry(file(CYCLE_A_FILE)).hasError());
+		assertTrue(typeLibrary.getTypeEntry(file(CYCLE_B_FILE)).hasError());
+	}
+
+	private IFile file(final String projectRelativePath) {
+		return project.getFile(projectRelativePath);
+	}
+}

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/ConnectionRepairTest.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/ConnectionRepairTest.java
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Dimitrios Kalligaridis
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Dimitrios Kalligaridis - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.tests;
+
+import static org.eclipse.fordiac.ide.typemanagement.tests.ConnectionRepairTestFixture.APPLICATION_NAME;
+import static org.eclipse.fordiac.ide.typemanagement.tests.ConnectionRepairTestFixture.CONSUMER_INPUT_PIN;
+import static org.eclipse.fordiac.ide.typemanagement.tests.ConnectionRepairTestFixture.CONSUMER_INSTANCE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.ConnectionRepairTestFixture.PRODUCER_INSTANCE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.ConnectionRepairTestFixture.PROJECT_NAME;
+import static org.eclipse.fordiac.ide.typemanagement.tests.ConnectionRepairTestFixture.PROJECT_PATH;
+import static org.eclipse.fordiac.ide.typemanagement.tests.ConnectionRepairTestFixture.REPAIR_STRUCT;
+import static org.eclipse.fordiac.ide.typemanagement.tests.ConnectionRepairTestFixture.REPAIR_STRUCT_MEMBER;
+import static org.eclipse.fordiac.ide.typemanagement.tests.ConnectionRepairTestFixture.STRUCT_DEMUX_TYPE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.ConnectionRepairTestFixture.SYSTEM_FILE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.CONVERT;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.CORE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.IEC_61131_3;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.fordiac.ide.model.data.StructuredType;
+import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
+import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.Connection;
+import org.eclipse.fordiac.ide.model.libraryElement.ErrorMarkerInterface;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
+import org.eclipse.fordiac.ide.systemmanagement.SystemManager;
+import org.eclipse.fordiac.ide.typemanagement.refactoring.connection.commands.RepairBrokenConnectionCommand;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Repairs a struct-member connection left broken after the struct dropped the
+ * member, driving RepairBrokenConnectionCommand the way the Repair Broken
+ * Connection handler does but without the wizard or command stack.
+ */
+class ConnectionRepairTest {
+
+	private IProject project;
+	private TypeLibrary typeLibrary;
+
+	@BeforeAll
+	static void preloadSystemManager() {
+		SystemManager.INSTANCE.name();
+	}
+
+	@BeforeEach
+	void loadFixture() throws Exception {
+		project = RefactoringTestSupport.importProjectIntoWorkspace(PROJECT_NAME, PROJECT_PATH);
+		RefactoringTestSupport.linkStandardLibraries(project, CORE, CONVERT, IEC_61131_3);
+		typeLibrary = TypeLibraryManager.INSTANCE.getTypeLibrary(project);
+	}
+
+	@AfterEach
+	void disposeFixture() throws Exception {
+		RefactoringTestSupport.deleteProject(project);
+	}
+
+	@Test
+	void repairBrokenConnection_removesTheErrorMarker() throws Exception {
+		assertEquals(1, producerErrorMarkers().size());
+
+		repairBrokenConnection();
+
+		assertTrue(producerErrorMarkers().isEmpty());
+		assertFalse(typeLibrary.getTypeEntry(file(SYSTEM_FILE)).hasError());
+	}
+
+	@Test
+	void repairBrokenConnection_reconnectsConsumerThroughInsertedStructDemux() throws Exception {
+		assertTrue(structDemuxInstances().isEmpty());
+
+		repairBrokenConnection();
+
+		assertEquals(1, structDemuxInstances().size());
+		final IInterfaceElement consumerSource = consumerInputSource();
+		assertEquals(REPAIR_STRUCT_MEMBER, consumerSource.getName());
+		assertEquals(STRUCT_DEMUX_TYPE, consumerSource.getBlockFBNetworkElement().getTypeName());
+	}
+
+	private void repairBrokenConnection() {
+		final ErrorMarkerInterface marker = producerErrorMarkers().get(0);
+		final Connection broken = marker.getOutputConnections().get(0);
+		final StructuredType struct = typeLibrary.getDataTypeLibrary().getStructuredType(REPAIR_STRUCT);
+		final RepairBrokenConnectionCommand command = new RepairBrokenConnectionCommand(broken, !marker.isIsInput(),
+				struct, REPAIR_STRUCT_MEMBER);
+		assertTrue(command.canExecute());
+		command.execute();
+	}
+
+	private List<ErrorMarkerInterface> producerErrorMarkers() {
+		return instance(PRODUCER_INSTANCE).getInterface().getErrorMarker();
+	}
+
+	private List<FBNetworkElement> structDemuxInstances() {
+		return applicationNetworkElements().stream().filter(e -> STRUCT_DEMUX_TYPE.equals(e.getTypeName())).toList();
+	}
+
+	private IInterfaceElement consumerInputSource() {
+		final VarDeclaration input = instance(CONSUMER_INSTANCE).getInterface().getInputVars().stream()
+				.filter(v -> CONSUMER_INPUT_PIN.equals(v.getName())).findFirst().orElseThrow();
+		return input.getInputConnections().get(0).getSource();
+	}
+
+	private BlockFBNetworkElement instance(final String instanceName) {
+		final FBNetworkElement element = applicationNetworkElements().stream()
+				.filter(e -> instanceName.equals(e.getName())).findFirst().orElseThrow();
+		return (BlockFBNetworkElement) element;
+	}
+
+	private List<FBNetworkElement> applicationNetworkElements() {
+		final AutomationSystem system = (AutomationSystem) typeLibrary.getTypeEntry(file(SYSTEM_FILE)).getType();
+		return system.getApplicationNamed(APPLICATION_NAME).getFBNetwork().getNetworkElements();
+	}
+
+	private IFile file(final String projectRelativePath) {
+		return project.getFile(projectRelativePath);
+	}
+}

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/ConnectionRepairTestFixture.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/ConnectionRepairTestFixture.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Dimitrios Kalligaridis
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Dimitrios Kalligaridis - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.tests;
+
+/**
+ * Coordinates of the ConnectionRepairTest fixture under data: a system whose
+ * single data connection references a struct member that the struct no longer
+ * declares, so it loads with a broken (error-marker) source pin to repair.
+ */
+public final class ConnectionRepairTestFixture {
+
+	public static final String PROJECT_NAME = "ConnectionRepairTest"; //$NON-NLS-1$
+	public static final String PROJECT_PATH = "data/ConnectionRepairTest"; //$NON-NLS-1$
+	public static final String SYSTEM_FILE = "ConnectionRepairTest.sys"; //$NON-NLS-1$
+	public static final String APPLICATION_NAME = "App"; //$NON-NLS-1$
+
+	public static final String REPAIR_STRUCT = "mypackage::RepairStruct"; //$NON-NLS-1$
+	/** Surviving struct member the repair routes the connection through. */
+	public static final String REPAIR_STRUCT_MEMBER = "keep"; //$NON-NLS-1$
+	public static final String STRUCT_DEMUX_TYPE = "STRUCT_DEMUX"; //$NON-NLS-1$
+
+	public static final String PRODUCER_INSTANCE = "Producer"; //$NON-NLS-1$
+	public static final String CONSUMER_INSTANCE = "Consumer"; //$NON-NLS-1$
+	public static final String CONSUMER_INPUT_PIN = "DI"; //$NON-NLS-1$
+
+	private ConnectionRepairTestFixture() {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/FBTypeCopyTest.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/FBTypeCopyTest.java
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Dimitrios Kalligaridis
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Dimitrios Kalligaridis - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.tests;
+
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.CONVERT;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.CORE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.IEC_61131_3;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.APPLICATION_NAME;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.INNER_STRUCT;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.PRODUCER_OUT_PIN;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.PRODUCER_TYPE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.PROJECT_NAME;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.PROJECT_PATH;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StructRenameTestFixture.SYSTEM_FILE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
+import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.FBType;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
+import org.eclipse.fordiac.ide.systemmanagement.SystemManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Copies the StructProducer FB type into another package and checks that the
+ * copy is a new, independent type entry that leaves the original and its
+ * instance untouched.
+ */
+class FBTypeCopyTest {
+
+	private static final String TARGET_PACKAGE_FOLDER = "Type Library/otherpackage"; //$NON-NLS-1$
+	private static final String PRODUCER_FILE = "Type Library/StructProducer.fbt"; //$NON-NLS-1$
+	private static final String COPIED_PRODUCER_FILE = "Type Library/otherpackage/StructProducer.fbt"; //$NON-NLS-1$
+	private static final String COPIED_PRODUCER_TYPE = "otherpackage::StructProducer"; //$NON-NLS-1$
+	private static final String PRODUCER_INSTANCE = "Producer"; //$NON-NLS-1$
+
+	private IProject project;
+	private TypeLibrary typeLibrary;
+
+	@BeforeAll
+	static void preloadSystemManager() {
+		SystemManager.INSTANCE.name();
+	}
+
+	@BeforeEach
+	void loadFixture() throws Exception {
+		project = RefactoringTestSupport.importProjectIntoWorkspace(PROJECT_NAME, PROJECT_PATH);
+		RefactoringTestSupport.linkStandardLibraries(project, CORE, CONVERT, IEC_61131_3);
+		typeLibrary = TypeLibraryManager.INSTANCE.getTypeLibrary(project);
+	}
+
+	@AfterEach
+	void disposeFixture() throws Exception {
+		RefactoringTestSupport.deleteProject(project);
+	}
+
+	@Test
+	void copyStructProducer_createsCopyFileAndKeepsOriginalFile() throws Exception {
+		assertTrue(file(PRODUCER_FILE).exists());
+		assertFalse(file(COPIED_PRODUCER_FILE).exists());
+
+		copyProducerToTargetPackage();
+
+		assertTrue(file(PRODUCER_FILE).exists());
+		assertTrue(file(COPIED_PRODUCER_FILE).exists());
+	}
+
+	@Test
+	void copyStructProducer_copyIsNewIndependentTypeEntry() throws Exception {
+		assertEntryTypeName(file(PRODUCER_FILE), PRODUCER_TYPE);
+
+		copyProducerToTargetPackage();
+
+		// The copy is its own entry under the target package, and the original entry
+		// keeps its name, so the two never alias the same type.
+		assertEntryTypeName(file(COPIED_PRODUCER_FILE), COPIED_PRODUCER_TYPE);
+		assertEntryTypeName(file(PRODUCER_FILE), PRODUCER_TYPE);
+	}
+
+	@Test
+	void copyStructProducer_leavesProducerInstanceOnOriginalType() throws Exception {
+		assertEquals(PRODUCER_TYPE, producerInstanceType());
+
+		copyProducerToTargetPackage();
+
+		// Unlike a move, a copy must not repoint the existing instance onto the copy.
+		assertEquals(PRODUCER_TYPE, producerInstanceType());
+	}
+
+	@Test
+	void copyStructProducer_copyKeepsStructInterfaceReference() throws Exception {
+		copyProducerToTargetPackage();
+
+		assertEquals(INNER_STRUCT, copyOutPinTypeName());
+	}
+
+	private void copyProducerToTargetPackage() throws Exception {
+		final IFolder destination = project.getFolder(TARGET_PACKAGE_FOLDER);
+		if (!destination.exists()) {
+			destination.create(IResource.FORCE, true, new NullProgressMonitor());
+		}
+		RefactoringTestSupport.performCopy(new IResource[] { file(PRODUCER_FILE) }, destination);
+	}
+
+	private String copyOutPinTypeName() {
+		final FBType copy = (FBType) typeLibrary.getTypeEntry(file(COPIED_PRODUCER_FILE)).getType();
+		final VarDeclaration pin = copy.getInterfaceList().getOutputVars().stream()
+				.filter(v -> PRODUCER_OUT_PIN.equals(v.getName())).findFirst().orElseThrow();
+		return PackageNameHelper.getFullTypeName(pin.getType());
+	}
+
+	private String producerInstanceType() {
+		final AutomationSystem system = (AutomationSystem) typeLibrary.getTypeEntry(file(SYSTEM_FILE)).getType();
+		final FBNetworkElement producer = system.getApplicationNamed(APPLICATION_NAME).getFBNetwork()
+				.getNetworkElements().stream().filter(e -> PRODUCER_INSTANCE.equals(e.getName())).findFirst()
+				.orElseThrow();
+		return producer.getFullTypeName();
+	}
+
+	private void assertEntryTypeName(final IFile typeFile, final String expectedFullTypeName) {
+		final TypeEntry entry = typeLibrary.getTypeEntry(typeFile);
+		assertTrue(typeFile.exists());
+		assertFalse(entry.hasError());
+		assertEquals(expectedFullTypeName, entry.getFullTypeName());
+	}
+
+	private IFile file(final String projectRelativePath) {
+		return project.getFile(projectRelativePath);
+	}
+}

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/NestedStructRenameTest.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/NestedStructRenameTest.java
@@ -1,0 +1,196 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Dimitrios Kalligaridis
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Dimitrios Kalligaridis - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.tests;
+
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedStructRenameTestFixture.APPLICATION_NAME;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedStructRenameTestFixture.LEAF_STRUCT;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedStructRenameTestFixture.LEAF_STRUCT_FILE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedStructRenameTestFixture.LEAF_STRUCT_RENAMED;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedStructRenameTestFixture.MIDDLE_LEAF_MEMBER;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedStructRenameTestFixture.MIDDLE_STRUCT;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedStructRenameTestFixture.MIDDLE_STRUCT_FILE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedStructRenameTestFixture.PRODUCER_INSTANCE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedStructRenameTestFixture.PRODUCER_OUT_PIN;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedStructRenameTestFixture.PROJECT_NAME;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedStructRenameTestFixture.PROJECT_PATH;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedStructRenameTestFixture.ROOT_MIDDLE_MEMBER;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedStructRenameTestFixture.ROOT_STRUCT;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedStructRenameTestFixture.ROOT_STRUCT_FILE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.NestedStructRenameTestFixture.SYSTEM_FILE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.CONVERT;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.CORE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.IEC_61131_3;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.fordiac.ide.model.data.StructuredType;
+import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
+import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
+import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
+import org.eclipse.fordiac.ide.systemmanagement.SystemManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Renames the innermost struct of a Root -> Middle -> Leaf hierarchy and checks
+ * that the change reaches the referencing struct two levels up and the connected
+ * Root-typed instance below it.
+ */
+class NestedStructRenameTest {
+
+	private static final String NEW_LEAF_FILE_NAME = "LeafRenamed.dtp"; //$NON-NLS-1$
+	private static final String RENAMED_LEAF_FILE = "Type Library/mypackage/LeafRenamed.dtp"; //$NON-NLS-1$
+
+	private static final String LEAF_MEMBER = "A"; //$NON-NLS-1$
+	private static final String LEAF_MEMBER_RENAMED = "ARenamed"; //$NON-NLS-1$
+	private static final String CUSTOM_ATTRIBUTE = "TestAttribute"; //$NON-NLS-1$
+	private static final String CUSTOM_ATTRIBUTE_VALUE = "42"; //$NON-NLS-1$
+
+	private IProject project;
+	private TypeLibrary typeLibrary;
+
+	@BeforeAll
+	static void preloadSystemManager() {
+		SystemManager.INSTANCE.name();
+	}
+
+	@BeforeEach
+	void loadFixture() throws Exception {
+		project = RefactoringTestSupport.importProjectIntoWorkspace(PROJECT_NAME, PROJECT_PATH);
+		RefactoringTestSupport.linkStandardLibraries(project, CORE, CONVERT, IEC_61131_3);
+		typeLibrary = TypeLibraryManager.INSTANCE.getTypeLibrary(project);
+	}
+
+	@AfterEach
+	void disposeFixture() throws Exception {
+		RefactoringTestSupport.deleteProject(project);
+	}
+
+	@Test
+	void renameLeafStruct_updatesMiddleMemberReference() throws Exception {
+		assertEquals(LEAF_STRUCT, memberTypeName(MIDDLE_STRUCT, MIDDLE_LEAF_MEMBER));
+		assertEntryTypeName(file(LEAF_STRUCT_FILE), LEAF_STRUCT);
+		assertEntryTypeName(file(MIDDLE_STRUCT_FILE), MIDDLE_STRUCT);
+
+		renameLeafStruct();
+
+		assertEquals(LEAF_STRUCT_RENAMED, memberTypeName(MIDDLE_STRUCT, MIDDLE_LEAF_MEMBER));
+		assertEntryTypeName(file(RENAMED_LEAF_FILE), LEAF_STRUCT_RENAMED);
+		assertEntryTypeName(file(MIDDLE_STRUCT_FILE), MIDDLE_STRUCT);
+	}
+
+	@Test
+	void renameLeafStruct_keepsRootTypedInstanceResolvable() throws Exception {
+		// Root's name does not change, but its transitive Leaf reference does; the
+		// instance pin stays typed Root and the Root entry keeps resolving through it.
+		assertEquals(MIDDLE_STRUCT, memberTypeName(ROOT_STRUCT, ROOT_MIDDLE_MEMBER));
+		assertEquals(ROOT_STRUCT, producerOutPinTypeName());
+		assertEntryTypeName(file(ROOT_STRUCT_FILE), ROOT_STRUCT);
+
+		renameLeafStruct();
+
+		assertEquals(ROOT_STRUCT, producerOutPinTypeName());
+		assertEntryTypeName(file(ROOT_STRUCT_FILE), ROOT_STRUCT);
+		assertFalse(typeLibrary.getTypeEntry(file(SYSTEM_FILE)).hasError());
+	}
+
+	@Test
+	@Disabled("Renaming a struct member is not propagated to a nested (multi-level) expanded instance pin: the " //$NON-NLS-1$
+			+ "deep pin keeps the old member name, becomes an unresolved (ANY) error-marker pin, and its custom " //$NON-NLS-1$
+			+ "attribute is lost. One-level expanded pins are preserved since #2651; re-enable when nested " //$NON-NLS-1$
+			+ "expanded pins follow the member rename too, see " //$NON-NLS-1$
+			+ "https://github.com/eclipse-4diac/4diac-ide/issues/2646") //$NON-NLS-1$
+	void renameLeafStructMember_preservesDeeplyExpandedPinAttribute() throws Exception {
+		assertEquals(CUSTOM_ATTRIBUTE_VALUE, expandedLeafMemberAttribute(LEAF_MEMBER));
+
+		RefactoringTestSupport.performElementRename(leafMemberURI(LEAF_MEMBER), LEAF_MEMBER_RENAMED);
+
+		assertEquals(CUSTOM_ATTRIBUTE_VALUE, expandedLeafMemberAttribute(LEAF_MEMBER_RENAMED));
+	}
+
+	private void renameLeafStruct() throws Exception {
+		RefactoringTestSupport.performRename(file(LEAF_STRUCT_FILE), NEW_LEAF_FILE_NAME);
+	}
+
+	private String memberTypeName(final String structName, final String memberName) {
+		return PackageNameHelper.getFullTypeName(structMember(structName, memberName).getType());
+	}
+
+	private String producerOutPinTypeName() {
+		final VarDeclaration pin = producer().getInterface().getOutputVars().stream()
+				.filter(v -> PRODUCER_OUT_PIN.equals(v.getName())).findFirst().orElseThrow();
+		return PackageNameHelper.getFullTypeName(pin.getType());
+	}
+
+	private String expandedLeafMemberAttribute(final String leafMemberName) {
+		final IInterfaceElement pin = producer().getInterface()
+				.getInterfaceElement(List.of(PRODUCER_OUT_PIN, ROOT_MIDDLE_MEMBER, MIDDLE_LEAF_MEMBER, leafMemberName));
+		// Fail on the missing pin instead of returning null, so a lost attribute
+		// cannot be confused with a member pin that the rename never created.
+		assertNotNull(pin, () -> PRODUCER_OUT_PIN + "." + ROOT_MIDDLE_MEMBER + "." + MIDDLE_LEAF_MEMBER + "." //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				+ leafMemberName + " does not exist"); //$NON-NLS-1$
+		return pin.getAttributeValue(CUSTOM_ATTRIBUTE);
+	}
+
+	private URI leafMemberURI(final String memberName) {
+		return EcoreUtil.getURI(structMember(LEAF_STRUCT, memberName));
+	}
+
+	private VarDeclaration structMember(final String structName, final String memberName) {
+		return structuredType(structName).getMemberVariables().stream().filter(m -> memberName.equals(m.getName()))
+				.findFirst().orElseThrow();
+	}
+
+	private StructuredType structuredType(final String qualifiedName) {
+		return typeLibrary.getDataTypeLibrary().getStructuredType(qualifiedName);
+	}
+
+	private BlockFBNetworkElement producer() {
+		final FBNetworkElement element = system().getApplicationNamed(APPLICATION_NAME).getFBNetwork()
+				.getNetworkElements().stream().filter(e -> PRODUCER_INSTANCE.equals(e.getName())).findFirst()
+				.orElseThrow();
+		return assertInstanceOf(BlockFBNetworkElement.class, element);
+	}
+
+	private AutomationSystem system() {
+		return (AutomationSystem) typeLibrary.getTypeEntry(file(SYSTEM_FILE)).getType();
+	}
+
+	private void assertEntryTypeName(final IFile typeFile, final String expectedFullTypeName) {
+		final TypeEntry entry = typeLibrary.getTypeEntry(typeFile);
+		assertNotNull(entry);
+		assertFalse(entry.hasError());
+		assertEquals(expectedFullTypeName, entry.getFullTypeName());
+	}
+
+	private IFile file(final String projectRelativePath) {
+		return project.getFile(projectRelativePath);
+	}
+}

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/NestedStructRenameTestFixture.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/NestedStructRenameTestFixture.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Dimitrios Kalligaridis
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Dimitrios Kalligaridis - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.tests;
+
+/**
+ * Coordinates of the NestedStructRenameTest fixture under data: a three-level
+ * Root -> Middle -> Leaf struct hierarchy with a connected, expanded Root-typed
+ * instance, referenced by the nested struct rename test.
+ */
+public final class NestedStructRenameTestFixture {
+
+	public static final String PROJECT_NAME = "NestedStructRenameTest"; //$NON-NLS-1$
+	public static final String PROJECT_PATH = "data/NestedStructRenameTest"; //$NON-NLS-1$
+	public static final String SYSTEM_FILE = "NestedStructRenameTest.sys"; //$NON-NLS-1$
+	public static final String APPLICATION_NAME = "App"; //$NON-NLS-1$
+
+	public static final String LEAF_STRUCT_FILE = "Type Library/mypackage/Leaf.dtp"; //$NON-NLS-1$
+	public static final String MIDDLE_STRUCT_FILE = "Type Library/mypackage/Middle.dtp"; //$NON-NLS-1$
+	public static final String ROOT_STRUCT_FILE = "Type Library/mypackage/Root.dtp"; //$NON-NLS-1$
+
+	public static final String LEAF_STRUCT = "mypackage::Leaf"; //$NON-NLS-1$
+	public static final String LEAF_STRUCT_RENAMED = "mypackage::LeafRenamed"; //$NON-NLS-1$
+	public static final String MIDDLE_STRUCT = "mypackage::Middle"; //$NON-NLS-1$
+	public static final String ROOT_STRUCT = "mypackage::Root"; //$NON-NLS-1$
+
+	/** Member of Root typed Middle. */
+	public static final String ROOT_MIDDLE_MEMBER = "middle"; //$NON-NLS-1$
+	/** Member of Middle typed Leaf. */
+	public static final String MIDDLE_LEAF_MEMBER = "leaf"; //$NON-NLS-1$
+
+	public static final String PRODUCER_TYPE = "RootProducer"; //$NON-NLS-1$
+	public static final String PRODUCER_INSTANCE = "Producer"; //$NON-NLS-1$
+	public static final String PRODUCER_OUT_PIN = "OUT"; //$NON-NLS-1$
+
+	private NestedStructRenameTestFixture() {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/RefactoringTestSupport.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/RefactoringTestSupport.java
@@ -50,6 +50,7 @@ import org.eclipse.ltk.core.refactoring.Refactoring;
 import org.eclipse.ltk.core.refactoring.RefactoringCore;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 import org.eclipse.ltk.core.refactoring.participants.RenameRefactoring;
+import org.eclipse.ltk.core.refactoring.resource.CopyResourcesDescriptor;
 import org.eclipse.ltk.core.refactoring.resource.DeleteResourcesDescriptor;
 import org.eclipse.ltk.core.refactoring.resource.MoveResourcesDescriptor;
 import org.eclipse.ltk.core.refactoring.resource.RenameResourceDescriptor;
@@ -141,6 +142,23 @@ public final class RefactoringTestSupport {
 		final MoveResourcesDescriptor descriptor = new MoveResourcesDescriptor();
 		descriptor.setResourcesToMove(new IResource[] { file });
 		descriptor.setDestination(destination);
+		return performRefactoring(descriptor.createRefactoring(new RefactoringStatus()));
+	}
+
+	/**
+	 * Copy the given resources into the destination container through the same LTK
+	 * copy refactoring the System Explorer paste uses, including CopyTypeParticipant
+	 * package updates. A copy into a fresh destination never asks how to resolve a
+	 * name clash.
+	 */
+	public static Change performCopy(final IResource[] files, final IContainer destination) throws CoreException {
+		final CopyResourcesDescriptor descriptor = new CopyResourcesDescriptor();
+		descriptor.setResources(files);
+		final IPath[] destinations = new IPath[files.length];
+		for (int i = 0; i < files.length; i++) {
+			destinations[i] = destination.getFullPath().append(files[i].getName());
+		}
+		descriptor.setDestinationPaths(destinations);
 		return performRefactoring(descriptor.createRefactoring(new RefactoringStatus()));
 	}
 

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/StructRenameSystemCascadeTest.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/StructRenameSystemCascadeTest.java
@@ -58,7 +58,6 @@ import org.eclipse.fordiac.ide.systemmanagement.SystemManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class StructRenameSystemCascadeTest {
@@ -164,8 +163,6 @@ class StructRenameSystemCascadeTest {
 	}
 
 	@Test
-	@Disabled("Custom attributes on expanded struct member pins are lost when the member is renamed, re-enable " //$NON-NLS-1$
-			+ "when https://github.com/eclipse-4diac/4diac-ide/issues/2646 is fixed")
 	void renameStructMember_preservesCustomPinAttribute() throws Exception {
 		assertEquals(CUSTOM_ATTRIBUTE_VALUE, producerOutMemberAttribute(MEMBER));
 


### PR DESCRIPTION
Adds headless tests for the copy, connection repair, and nested struct rename refactorings. Copying an FB type into another package yields a new independent type entry and leaves the original type and its instance unchanged. Renaming a leaf struct type propagates up a nested Root, Middle, Leaf hierarchy to the referencing struct and the connected Root typed instance. After a struct drops a member, the resulting broken struct member connection is repaired through an inserted STRUCT_DEMUX.

Renaming a leaf struct member is added as a disabled test, since it is not propagated to nested multi level expanded instance pins (#2646). A disabled test also records that the datatype editor does not validate circular struct references (#1091). It also re-enables the one level renameStructMember_preservesCustomPinAttribute test, which #2651 fixed.

Exports org.eclipse.fordiac.ide.typemanagement.refactoring.connection.commands so the repair command is reachable from the test bundle