### PR TITLE
Move Library Preference page to library ui plugin

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.library.ui/plugin.properties
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/plugin.properties
@@ -48,7 +48,11 @@ LibrarySourceBuilder_name=Name:
 LibrarySourceBuilder_path=Path: 
 LibrarySourceBuilder_sym_name=Symbolic name: 
 LibrarySourceBuilder_uri=URI: 
-LibrarySourceBuilder_version=Version: 
+LibrarySourceBuilder_version=Version:
+
+PreferenceForceLoad=Force load explicit project dependencies
+PreferenceLoadingGroup=Library Loading
+
 UnifiedLibraryImportWizardPage_Available_Libraries=Available Libraries
 UnifiedLibraryImportWizardPage_brows=Browse and import libraries from workspace, file system, or GitLab.
 UnifiedLibraryImportWizardPage_config=Configure GitLab endpoints in Preferences.

--- a/plugins/org.eclipse.fordiac.ide.library.ui/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/plugin.xml
@@ -158,5 +158,31 @@
          </command>
       </menuContribution>
    </extension>
-
+   <extension
+         point="org.eclipse.ui.preferencePages">
+      <page
+            category="org.eclipse.fordiac.ide.preferences.FordiacPreferencePage"
+            class="org.eclipse.fordiac.ide.library.ui.preferences.LibraryPreferencePage"
+            id="org.eclipse.fordiac.ide.library.preferences.LibraryPreferences"
+            name="Library">
+      </page>
+   </extension>
+   <extension
+         point="org.eclipse.ui.propertyPages">
+      <page
+            category="org.eclipse.fordiac.ide.properties.FordiacPropertyPage"
+            class="org.eclipse.fordiac.ide.library.ui.preferences.LibraryPreferencePage"
+            id="org.eclipse.fordiac.ide.library.properties.LibraryPreferences"
+            name="Library">
+         <enabledWhen>
+            <adapt
+                  type="org.eclipse.core.resources.IProject">
+               <test
+                     property="org.eclipse.core.resources.projectNature"
+                     value="org.eclipse.fordiac.ide.systemmanagement.FordiacNature">
+               </test>
+            </adapt>
+         </enabledWhen>
+      </page>
+   </extension>
 </plugin>

--- a/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/Messages.java
@@ -71,6 +71,9 @@ public class Messages extends NLS {
 
 	public static String LibrarySourceBuilder_version;
 
+	public static String PreferenceForceLoad;
+	public static String PreferenceLoadingGroup;
+
 	public static String UnifiedLibraryImportWizardPage_Available_Libraries;
 
 	public static String UnifiedLibraryImportWizardPage_brows;

--- a/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/preferences/LibraryPreferencePage.java
+++ b/plugins/org.eclipse.fordiac.ide.library.ui/src/org/eclipse/fordiac/ide/library/ui/preferences/LibraryPreferencePage.java
@@ -10,9 +10,10 @@
  * Contributors:
  *   Patrick Aigner - initial API and implementation and/or initial documentation
  *******************************************************************************/
-package org.eclipse.fordiac.ide.library.preferences;
+package org.eclipse.fordiac.ide.library.ui.preferences;
 
-import org.eclipse.fordiac.ide.library.Messages;
+import org.eclipse.fordiac.ide.library.preferences.LibraryPreferenceConstants;
+import org.eclipse.fordiac.ide.library.ui.Messages;
 import org.eclipse.fordiac.ide.ui.preferences.FordiacPropertyPreferencePage;
 import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.swt.SWT;

--- a/plugins/org.eclipse.fordiac.ide.library/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.library/META-INF/MANIFEST.MF
@@ -10,7 +10,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,
  org.eclipse.equinox.p2.operations,
  org.eclipse.ltk.core.refactoring,
- org.eclipse.ui,
  org.eclipse.fordiac.ide.library.model,
  org.eclipse.fordiac.ide.model,
  org.eclipse.fordiac.ide.ui,
@@ -19,4 +18,5 @@ Require-Bundle: org.eclipse.core.runtime,
  org.osgi.service.event
 Export-Package: org.eclipse.fordiac.ide.library,
  org.eclipse.fordiac.ide.library.download,
+ org.eclipse.fordiac.ide.library.preferences,
  org.eclipse.fordiac.ide.library.provider

--- a/plugins/org.eclipse.fordiac.ide.library/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.library/plugin.xml
@@ -19,31 +19,4 @@
             class="org.eclipse.fordiac.ide.library.preferences.PreferenceInitializer">
       </initializer>
    </extension>
-   <extension
-         point="org.eclipse.ui.preferencePages">
-      <page
-            category="org.eclipse.fordiac.ide.preferences.FordiacPreferencePage"
-            class="org.eclipse.fordiac.ide.library.preferences.LibraryPreferencePage"
-            id="org.eclipse.fordiac.ide.library.preferences.LibraryPreferences"
-            name="Library">
-      </page>
-   </extension>
-   <extension
-         point="org.eclipse.ui.propertyPages">
-      <page
-            category="org.eclipse.fordiac.ide.properties.FordiacPropertyPage"
-            class="org.eclipse.fordiac.ide.library.preferences.LibraryPreferencePage"
-            id="org.eclipse.fordiac.ide.library.properties.LibraryPreferences"
-            name="Library">
-         <enabledWhen>
-            <adapt
-                  type="org.eclipse.core.resources.IProject">
-               <test
-                     property="org.eclipse.core.resources.projectNature"
-                     value="org.eclipse.fordiac.ide.systemmanagement.FordiacNature">
-               </test>
-            </adapt>
-         </enabledWhen>
-      </page>
-   </extension>
 </plugin>

--- a/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/Messages.java
@@ -69,9 +69,6 @@ public class Messages extends NLS {
 
 	public static String LibraryManager_UpdateLibraryPackage;
 
-	public static String PreferenceForceLoad;
-	public static String PreferenceLoadingGroup;
-
 	public static String DownloadNullResult;
 	public static String DownloadUnexpectedError;
 

--- a/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/messages.properties
+++ b/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/messages.properties
@@ -46,8 +46,5 @@ LibraryManager_UnresolvableDependencies=Build aborted due to unresolvable depend
 LibraryManager_BrokenLink=Build aborted due to broken links. Fix links and perform a clean build.
 LibraryManager_UpdateLibraryPackage=Update Library package: {0} = {1}
 
-PreferenceForceLoad=Force load explicit project dependencies
-PreferenceLoadingGroup=Library Loading
-
 DownloadNullResult=Null result
 DownloadUnexpectedError=Unexpected Error


### PR DESCRIPTION
In order to have no ui dependencies in the library plugin the library preference page is moved to the library ui plugin.