### PR TITLE
Check Dispose Stage in Property Section Refreshes

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AbstractSection.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/properties/AbstractSection.java
@@ -140,7 +140,7 @@ public abstract class AbstractSection extends AbstractPropertySection implements
 	};
 
 	protected final void notifiyRefresh() {
-		if (shouldRefresh()) {
+		if (shouldRefresh() && !parent.isDisposed()) {
 			parent.getDisplay().asyncExec(() -> {
 				if (!parent.isDisposed()) {
 					refresh();
@@ -150,7 +150,7 @@ public abstract class AbstractSection extends AbstractPropertySection implements
 	}
 
 	protected final void notifiyRefreshAnnotations() {
-		if (shouldRefresh()) {
+		if (shouldRefresh() && !parent.isDisposed()) {
 			parent.getDisplay().asyncExec(() -> {
 				if (!parent.isDisposed()) {
 					refreshAnnotations();


### PR DESCRIPTION
Long running operations (e.g., builders) may notify disposed property sheets and accessing their display leads to issues. Therefore a disposed check is added to avoid these problems.

This PR is based on the following stack trace I found in a users log file:
```
org.eclipse.swt.SWTException: Widget is disposed
	at org.eclipse.swt.SWT.error(SWT.java:4934)
	at org.eclipse.swt.SWT.error(SWT.java:4849)
	at org.eclipse.swt.SWT.error(SWT.java:4820)
	at org.eclipse.swt.widgets.Widget.error(Widget.java:510)
	at org.eclipse.swt.widgets.Widget.getDisplay(Widget.java:631)
	at org.eclipse.fordiac.ide.gef.properties.AbstractSection.notifiyRefreshAnnotations(AbstractSection.java:154)
	at org.eclipse.fordiac.ide.gef.properties.AbstractSection.lambda$0(AbstractSection.java:204)
	at org.eclipse.fordiac.ide.model.ui.annotation.AbstractGraphicalAnnotationModel.lambda$0(AbstractGraphicalAnnotationModel.java:49)
	at java.base/java.util.concurrent.ConcurrentHashMap$KeySetView.forEach(Unknown Source)
	at org.eclipse.fordiac.ide.model.ui.annotation.AbstractGraphicalAnnotationModel.fireModelChanged(AbstractGraphicalAnnotationModel.java:49)
	at org.eclipse.fordiac.ide.model.ui.annotation.AbstractGraphicalAnnotationModel.updateAnnotations(AbstractGraphicalAnnotationModel.java:154)
	at org.eclipse.fordiac.ide.model.ui.annotation.ResourceMarkerGraphicalAnnotationModel.refresh(ResourceMarkerGraphicalAnnotationModel.java:56)
	at org.eclipse.fordiac.ide.model.ui.annotation.FordiacMarkerGraphicalAnnotationModel.refresh(FordiacMarkerGraphicalAnnotationModel.java:69)
	at org.eclipse.fordiac.ide.model.ui.validation.ValidationJob.lambda$11(ValidationJob.java:150)
	at org.eclipse.core.runtime.jobs.Job$2.run(Job.java:187)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)
```