### PR TITLE
Add common interface for ECState and SimpleECState

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/actions/AddECCActionAction.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/actions/AddECCActionAction.java
@@ -37,9 +37,9 @@ public class AddECCActionAction extends SelectionAction {
 	 */
 	public static final String ADD_ECC_ACTION = "org.eclipse.fordiac.ide.fbtypeeditor.ecc.actions.AddECCActionAction";//$NON-NLS-1$
 
-	private ActionCreationFactory actionFactory = new ActionCreationFactory();
+	private final ActionCreationFactory actionFactory = new ActionCreationFactory();
 
-	public AddECCActionAction(IWorkbenchPart part) {
+	public AddECCActionAction(final IWorkbenchPart part) {
 		super(part);
 		setId(ADD_ECC_ACTION);
 		setText(Messages.ECCActions_AddAction);
@@ -49,7 +49,7 @@ public class AddECCActionAction extends SelectionAction {
 	@Override
 	protected boolean calculateEnabled() {
 		if (1 == getSelectedObjects().size()) {
-			ECState state = getState(getSelectedObjects());
+			final ECState state = getState(getSelectedObjects());
 			if (null != state) {
 				// only allow to add actions if we are not the the initial state
 				return !state.isStartState();
@@ -61,24 +61,21 @@ public class AddECCActionAction extends SelectionAction {
 
 	@Override
 	public void run() {
-		IFBTEditorPart editor = (IFBTEditorPart) getWorkbenchPart();
-		ECAction action = (ECAction) actionFactory.getNewObject();
-		execute(new CreateECActionCommand(action, getState(getSelectedObjects())));
+		final IFBTEditorPart editor = (IFBTEditorPart) getWorkbenchPart();
+		final ECAction action = (ECAction) actionFactory.getNewObject();
+		execute(new CreateECActionCommand<>(action, getState(getSelectedObjects())));
 		editor.outlineSelectionChanged(action);
 	}
 
-	@SuppressWarnings("rawtypes")
-	private static ECState getState(List selectedObjects) {
-		ECState state = null;
-		if (selectedObjects.get(0) instanceof ECStateEditPart) {
-			state = ((ECStateEditPart) selectedObjects.get(0)).getModel();
-		} else if (selectedObjects.get(0) instanceof ECActionAlgorithmEditPart) {
-			ECActionAlgorithmEditPart part = (ECActionAlgorithmEditPart) selectedObjects.get(0);
-			state = part.getAction().getECState();
-		} else if (selectedObjects.get(0) instanceof ECActionOutputEventEditPart) {
-			ECActionOutputEventEditPart part = (ECActionOutputEventEditPart) selectedObjects.get(0);
-			state = part.getAction().getECState();
+	private static ECState getState(final List<Object> selectedObjects) {
+		if (selectedObjects == null || selectedObjects.isEmpty()) {
+			return null;
 		}
-		return state;
+		return switch (selectedObjects.get(0)) {
+		case final ECStateEditPart stateEP -> stateEP.getModel();
+		case final ECActionAlgorithmEditPart algoEP -> algoEP.getAction().getECState();
+		case final ECActionOutputEventEditPart eventEP -> eventEP.getAction().getECState();
+		default -> null;
+		};
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/commands/ChangeAlgorithmCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/commands/ChangeAlgorithmCommand.java
@@ -14,7 +14,7 @@
 package org.eclipse.fordiac.ide.fbtypeeditor.ecc.commands;
 
 import org.eclipse.fordiac.ide.model.libraryElement.Algorithm;
-import org.eclipse.fordiac.ide.model.libraryElement.ECAction;
+import org.eclipse.fordiac.ide.model.libraryElement.BaseECAction;
 import org.eclipse.gef.commands.Command;
 
 /**
@@ -23,7 +23,7 @@ import org.eclipse.gef.commands.Command;
 public class ChangeAlgorithmCommand extends Command {
 
 	/** The ec action. */
-	private final ECAction ecAction;
+	private final BaseECAction ecAction;
 
 	/** The algorithm. */
 	private final String algorithm;
@@ -37,7 +37,7 @@ public class ChangeAlgorithmCommand extends Command {
 	 * @param action    the action
 	 * @param algorithm the algorithm
 	 */
-	public ChangeAlgorithmCommand(final ECAction action, final Algorithm algorithm) {
+	public ChangeAlgorithmCommand(final BaseECAction action, final Algorithm algorithm) {
 		this.ecAction = action;
 		this.algorithm = algorithm == null ? null : algorithm.getName();
 	}

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/commands/ChangeOutputCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/commands/ChangeOutputCommand.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2008, 2009, 2015 Profactor GmbH, fortiss GmbH
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.fbtypeeditor.ecc.commands;
 
-import org.eclipse.fordiac.ide.model.libraryElement.ECAction;
+import org.eclipse.fordiac.ide.model.libraryElement.BaseECAction;
 import org.eclipse.fordiac.ide.model.libraryElement.Event;
 import org.eclipse.gef.commands.Command;
 
@@ -23,7 +23,7 @@ import org.eclipse.gef.commands.Command;
 public class ChangeOutputCommand extends Command {
 
 	/** The ec action. */
-	private final ECAction ecAction;
+	private final BaseECAction ecAction;
 
 	/** The event. */
 	private final Event event;
@@ -33,19 +33,18 @@ public class ChangeOutputCommand extends Command {
 
 	/**
 	 * Instantiates a new change output command.
-	 * 
+	 *
 	 * @param action      the action
 	 * @param outputEvent the output event
 	 */
-	public ChangeOutputCommand(final ECAction action, final Event outputEvent) {
-		super();
+	public ChangeOutputCommand(final BaseECAction action, final Event outputEvent) {
 		this.ecAction = action;
 		this.event = outputEvent;
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.eclipse.gef.commands.Command#execute()
 	 */
 	@Override
@@ -56,7 +55,7 @@ public class ChangeOutputCommand extends Command {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.eclipse.gef.commands.Command#undo()
 	 */
 	@Override
@@ -67,7 +66,7 @@ public class ChangeOutputCommand extends Command {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.eclipse.gef.commands.Command#redo()
 	 */
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/commands/CreateECActionCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/commands/CreateECActionCommand.java
@@ -16,16 +16,15 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.fbtypeeditor.ecc.commands;
 
-import org.eclipse.fordiac.ide.model.libraryElement.ECAction;
-import org.eclipse.fordiac.ide.model.libraryElement.ECState;
+import org.eclipse.fordiac.ide.model.libraryElement.BaseECAction;
+import org.eclipse.fordiac.ide.model.libraryElement.BaseECState;
 import org.eclipse.fordiac.ide.ui.providers.CreationCommand;
 
-public class CreateECActionCommand extends CreationCommand {
-	private final ECAction action;
-	private final ECState parent;
+public class CreateECActionCommand<T extends BaseECAction> extends CreationCommand {
+	private final T action;
+	private final BaseECState<T> parent;
 
-	public CreateECActionCommand(final ECAction action, final ECState parent) {
-		super();
+	public CreateECActionCommand(final T action, final BaseECState<T> parent) {
 		this.action = action;
 		this.parent = parent;
 	}
@@ -37,12 +36,12 @@ public class CreateECActionCommand extends CreationCommand {
 
 	@Override
 	public void undo() {
-		parent.getECAction().remove(action);
+		parent.getECActions().remove(action);
 	}
 
 	@Override
 	public void redo() {
-		parent.getECAction().add(action);
+		parent.getECActions().add(action);
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/commands/DeleteECActionCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/commands/DeleteECActionCommand.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2008, 2009, 2016 Profactor GmbH, fortiss GmbH
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -13,35 +13,35 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.fbtypeeditor.ecc.commands;
 
-import org.eclipse.fordiac.ide.model.libraryElement.ECAction;
-import org.eclipse.fordiac.ide.model.libraryElement.ECState;
+import org.eclipse.fordiac.ide.model.libraryElement.BaseECAction;
+import org.eclipse.fordiac.ide.model.libraryElement.BaseECState;
 import org.eclipse.gef.commands.Command;
 
-public class DeleteECActionCommand extends Command {
-	private final ECAction ecAction;
-	private ECState parent;
+public class DeleteECActionCommand<T extends BaseECAction> extends Command {
+	private final T action;
+	private final BaseECState<T> parent;
 
-	public DeleteECActionCommand(final ECAction ecAction) {
-		this.ecAction = ecAction;
+	public DeleteECActionCommand(final T action, final BaseECState<T> parent) {
+		this.action = action;
+		this.parent = parent;
 	}
 
 	@Override
 	public void execute() {
-		parent = ecAction.getECState();
 		redo();
 	}
 
 	@Override
 	public void undo() {
 		if (null != parent) {
-			parent.getECAction().add(ecAction);
+			parent.getECActions().add(action);
 		}
 	}
 
 	@Override
 	public void redo() {
 		if (null != parent) {
-			parent.getECAction().remove(ecAction);
+			parent.getECActions().remove(action);
 		}
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/commands/DeleteECStateCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/commands/DeleteECStateCommand.java
@@ -44,7 +44,6 @@ public class DeleteECStateCommand extends Command {
 	 * @param state the state
 	 */
 	public DeleteECStateCommand(final ECState state) {
-		super();
 		this.state = state;
 		parent = state.getECC();
 	}
@@ -64,7 +63,8 @@ public class DeleteECStateCommand extends Command {
 	public void execute() {
 
 		deleteActions = new CompoundCommand();
-		state.getECAction().forEach(action -> deleteActions.add(new DeleteECActionCommand(action)));
+		state.getECAction()
+				.forEach(action -> deleteActions.add(new DeleteECActionCommand<>(action, action.getECState())));
 		if (deleteActions.canExecute()) {
 			deleteActions.execute();
 		}

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/contentprovider/ActionContentProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/contentprovider/ActionContentProvider.java
@@ -13,52 +13,63 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.fbtypeeditor.ecc.contentprovider;
 
-import org.eclipse.fordiac.ide.model.libraryElement.BasicFBType;
+import org.eclipse.fordiac.ide.model.libraryElement.BaseECState;
+import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.ECAction;
 import org.eclipse.fordiac.ide.model.libraryElement.ECState;
+import org.eclipse.fordiac.ide.model.libraryElement.SimpleECAction;
 import org.eclipse.jface.viewers.ITreeContentProvider;
 
 public class ActionContentProvider implements ITreeContentProvider {
 	@Override
 	public Object[] getElements(final Object inputElement) {
-		if (inputElement instanceof ECState) {
-			return ((ECState) inputElement).getECAction().toArray();
+		if (inputElement instanceof final BaseECState baseState) {
+			return baseState.getECActions().toArray();
 		}
-		if (inputElement instanceof ECAction) {
-			return ((ECAction) inputElement).getECState().getECC().getBasicFBType().getAlgorithm().toArray();
+		if (inputElement instanceof final ECAction action) {
+			return action.getECState().getECC().getBasicFBType().getAlgorithm().toArray();
+		}
+		if (inputElement instanceof final SimpleECAction simpleAction) {
+			return simpleAction.getSimpleECState().getSimpleFBType().getAlgorithm().toArray();
 		}
 		return new Object[] {};
 	}
 
 	@Override
 	public Object[] getChildren(final Object parentElement) {
-		if (parentElement instanceof ECState && null != ((ECState) parentElement).getECAction()) {
-			return ((ECState) parentElement).getECAction().toArray();
+		if (parentElement instanceof final BaseECState state && null != state.getECActions()) {
+			return state.getECActions().toArray();
 		}
-		if (parentElement instanceof BasicFBType) {
-			return ((BasicFBType) parentElement).getAlgorithm().toArray();
+		if (parentElement instanceof final BaseFBType baseType) {
+			return baseType.getAlgorithm().toArray();
 		}
 		return new Object[0];
 	}
 
 	@Override
 	public Object getParent(final Object element) {
-		if (element instanceof ECState) {
-			return ((ECState) element).getECC();
+		if (element instanceof final ECState state) {
+			return state.getECC();
 		}
-		if ((element instanceof ECAction) && (null != ((ECAction) element).getECState())) {
-			return ((ECAction) element).getECState().getECC().getBasicFBType();
+		if (element instanceof final ECAction action && null != action.getECState()) {
+			return action.getECState().getBaseFBType();
+		}
+		if (element instanceof final SimpleECAction simpleAction && null != simpleAction.getSimpleECState()) {
+			return simpleAction.getSimpleECState().getBaseFBType();
 		}
 		return null;
 	}
 
 	@Override
 	public boolean hasChildren(final Object element) {
-		if (element instanceof ECState) {
-			return !((ECState) element).getECAction().isEmpty();
+		if (element instanceof final BaseECState state) {
+			return !state.getECActions().isEmpty();
 		}
-		if (element instanceof ECAction) {
-			return !((ECAction) element).getECState().getECC().getBasicFBType().getAlgorithm().isEmpty();
+		if (element instanceof final ECAction action) {
+			return !action.getECState().getBaseFBType().getAlgorithm().isEmpty();
+		}
+		if (element instanceof final SimpleECAction simpleAction) {
+			return !simpleAction.getSimpleECState().getBaseFBType().getAlgorithm().isEmpty();
 		}
 		return false;
 	}

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/contentprovider/ECCContentAndLabelProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/contentprovider/ECCContentAndLabelProvider.java
@@ -42,7 +42,7 @@ public final class ECCContentAndLabelProvider {
 	// selecting nothing
 	public static final String ONE_CONDITION = "1"; //$NON-NLS-1$
 
-	public static List<Event> getOutputEvents(final BasicFBType type) {
+	public static List<Event> getOutputEvents(final BaseFBType type) {
 		final List<Event> events = new ArrayList<>();
 		if (null != type) {
 			events.addAll(type.getInterfaceList().getEventOutputs());
@@ -60,7 +60,7 @@ public final class ECCContentAndLabelProvider {
 		return transition.getConditionExpression() != null && transition.getConditionExpression().equals(ONE_CONDITION);
 	}
 
-	public static List<String> getOutputEventNames(final BasicFBType type) {
+	public static List<String> getOutputEventNames(final BaseFBType type) {
 		final List<String> eventNames = new ArrayList<>(getEventNames(getOutputEvents(type)));
 		eventNames.add(EMPTY_FIELD);
 		return eventNames;
@@ -98,7 +98,7 @@ public final class ECCContentAndLabelProvider {
 		return algorithms;
 	}
 
-	public static List<String> getAlgorithmNames(final BasicFBType type) {
+	public static List<String> getAlgorithmNames(final BaseFBType type) {
 		final List<String> algNames = new ArrayList<>(getAlgorithms(type).stream().map(Algorithm::getName).toList());
 		algNames.add(EMPTY_FIELD);
 		return algNames;

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editparts/ECActionAlgorithmEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editparts/ECActionAlgorithmEditPart.java
@@ -132,7 +132,7 @@ public class ECActionAlgorithmEditPart extends AbstractDirectEditableEditPart {
 		installEditPolicy(EditPolicy.COMPONENT_ROLE, new ComponentEditPolicy() {
 			@Override
 			protected Command getDeleteCommand(final GroupRequest request) {
-				return new DeleteECActionCommand(getAction());
+				return new DeleteECActionCommand<>(getAction(), getAction().getECState());
 			}
 		});
 		installEditPolicy(EditPolicy.DIRECT_EDIT_ROLE, new DirectEditPolicy() {

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editparts/ECActionOutputEventEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/editparts/ECActionOutputEventEditPart.java
@@ -142,7 +142,7 @@ public class ECActionOutputEventEditPart extends AbstractDirectEditableEditPart 
 		installEditPolicy(EditPolicy.COMPONENT_ROLE, new ComponentEditPolicy() {
 			@Override
 			protected Command getDeleteCommand(final GroupRequest request) {
-				return new DeleteECActionCommand(getAction());
+				return new DeleteECActionCommand<>(getAction(), getAction().getECState());
 			}
 		});
 		installEditPolicy(EditPolicy.DIRECT_EDIT_ROLE, new DirectEditPolicy() {

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/policies/ECStateLayoutEditPolicy.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/policies/ECStateLayoutEditPolicy.java
@@ -35,16 +35,16 @@ import org.eclipse.gef.requests.CreateRequest;
 
 public class ECStateLayoutEditPolicy extends LayoutEditPolicy {
 	@Override
-	public Command getCommand(Request request) {
-		Object type = request.getType();
+	public Command getCommand(final Request request) {
+		final Object type = request.getType();
 		if (REQ_ALIGN.equals(type) && request instanceof AlignmentRequest) {
 			return getAlignCommand((AlignmentRequest) request);
 		}
 		return super.getCommand(request);
 	}
 
-	protected Command getAlignCommand(AlignmentRequest request) {
-		AlignmentRequest req = new AlignmentRequest(REQ_ALIGN_CHILDREN);
+	protected Command getAlignCommand(final AlignmentRequest request) {
+		final AlignmentRequest req = new AlignmentRequest(REQ_ALIGN_CHILDREN);
 		req.setEditParts(getHost());
 		req.setAlignment(request.getAlignment());
 		req.setAlignmentRectangle(request.getAlignmentRectangle());
@@ -54,20 +54,20 @@ public class ECStateLayoutEditPolicy extends LayoutEditPolicy {
 	@Override
 	protected Command getCreateCommand(final CreateRequest request) {
 		if (request.getNewObjectType().equals(ECAction.class) && getHost().getModel() instanceof ECState) {
-			ECState state = (ECState) getHost().getModel();
+			final ECState state = (ECState) getHost().getModel();
 			if ((null != state) && (!state.isStartState())) {
 				// only create an action when the target is not the initial state
-				return new CreateECActionCommand((ECAction) request.getNewObject(), state);
+				return new CreateECActionCommand<>((ECAction) request.getNewObject(), state);
 			}
 		}
 		return null;
 	}
 
 	@Override
-	protected EditPolicy createChildEditPolicy(EditPart child) {
-		ModifiedNonResizeableEditPolicy editPolicy = new ModifiedNonResizeableEditPolicy(0, new Insets(0)) {
+	protected EditPolicy createChildEditPolicy(final EditPart child) {
+		final ModifiedNonResizeableEditPolicy editPolicy = new ModifiedNonResizeableEditPolicy(0, new Insets(0)) {
 			@Override
-			protected Command getMoveCommand(ChangeBoundsRequest request) {
+			protected Command getMoveCommand(final ChangeBoundsRequest request) {
 				return getActionMoveCommand(request);
 			}
 		};
@@ -76,7 +76,7 @@ public class ECStateLayoutEditPolicy extends LayoutEditPolicy {
 	}
 
 	@Override
-	protected Command getAddCommand(Request generic) {
+	protected Command getAddCommand(final Request generic) {
 		// move actions between states
 		if (generic instanceof ChangeBoundsRequest) {
 			return getActionMoveCommand((ChangeBoundsRequest) generic);
@@ -84,9 +84,9 @@ public class ECStateLayoutEditPolicy extends LayoutEditPolicy {
 		return null;
 	}
 
-	private Command getActionMoveCommand(ChangeBoundsRequest request) {
+	private Command getActionMoveCommand(final ChangeBoundsRequest request) {
 		if (getHost().getModel() instanceof ECState) {
-			ECState targetState = (ECState) getHost().getModel();
+			final ECState targetState = (ECState) getHost().getModel();
 			ECAction action = null;
 			if (!request.getEditParts().isEmpty()) {
 				if (request.getEditParts().get(0) instanceof ECActionAlgorithmEditPart) {
@@ -102,7 +102,7 @@ public class ECStateLayoutEditPolicy extends LayoutEditPolicy {
 	}
 
 	@Override
-	protected Command getMoveChildrenCommand(Request request) {
+	protected Command getMoveChildrenCommand(final Request request) {
 		// we currently can not directly reorder actions of states in the graphics
 		// therefore null is fine here
 		return null;

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/properties/StateSection.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/properties/StateSection.java
@@ -26,6 +26,7 @@ import org.eclipse.fordiac.ide.fbtypeeditor.ecc.widgets.TransitionEditingComposi
 import org.eclipse.fordiac.ide.gef.properties.AbstractSection;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeCommentCommand;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeNameCommand;
+import org.eclipse.fordiac.ide.model.libraryElement.ECAction;
 import org.eclipse.fordiac.ide.model.libraryElement.ECState;
 import org.eclipse.gef.EditPart;
 import org.eclipse.swt.SWT;
@@ -38,7 +39,7 @@ import org.eclipse.ui.views.properties.tabbed.TabbedPropertySheetPage;
 public class StateSection extends AbstractSection {
 	private Text stateNameText;
 	private Text stateCommentText;
-	private ActionEditingComposite actionGroup;
+	private ActionEditingComposite<ECAction> actionGroup;
 	private TransitionEditingComposite transitionGroup;
 
 	@Override
@@ -62,7 +63,7 @@ public class StateSection extends AbstractSection {
 		parent.setLayout(new GridLayout(2, true));
 		createStateNameControls(parent);
 		createStateCommentControls(parent);
-		actionGroup = new ActionEditingComposite(parent, getWidgetFactory(), this);
+		actionGroup = new ActionEditingComposite<>(parent, getWidgetFactory(), this);
 		transitionGroup = new TransitionEditingComposite(parent, getWidgetFactory(), this);
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/widgets/ActionEditingComposite.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.ecc/src/org/eclipse/fordiac/ide/fbtypeeditor/ecc/widgets/ActionEditingComposite.java
@@ -32,11 +32,10 @@ import org.eclipse.fordiac.ide.fbtypeeditor.ecc.contentprovider.ActionContentPro
 import org.eclipse.fordiac.ide.fbtypeeditor.ecc.contentprovider.ECCContentAndLabelProvider;
 import org.eclipse.fordiac.ide.model.commands.change.ChangeActionOrderCommand;
 import org.eclipse.fordiac.ide.model.libraryElement.Algorithm;
-import org.eclipse.fordiac.ide.model.libraryElement.BasicFBType;
-import org.eclipse.fordiac.ide.model.libraryElement.ECAction;
-import org.eclipse.fordiac.ide.model.libraryElement.ECState;
+import org.eclipse.fordiac.ide.model.libraryElement.BaseECAction;
+import org.eclipse.fordiac.ide.model.libraryElement.BaseECState;
+import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.Event;
-import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.ui.widget.AddDeleteReorderListWidget;
 import org.eclipse.fordiac.ide.ui.widget.ComboBoxWidgetFactory;
 import org.eclipse.fordiac.ide.ui.widget.CommandExecutor;
@@ -61,7 +60,7 @@ import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.ui.views.properties.tabbed.TabbedPropertySheetWidgetFactory;
 
-public class ActionEditingComposite {
+public class ActionEditingComposite<T extends BaseECAction> {
 	private static class ActionListLabelProvider extends LabelProvider implements ITableLabelProvider {
 		@Override
 		public Image getColumnImage(final Object element, final int columnIndex) {
@@ -70,7 +69,7 @@ public class ActionEditingComposite {
 
 		@Override
 		public String getColumnText(final Object element, final int columnIndex) {
-			if (element instanceof final ECAction ecAction) {
+			if (element instanceof final BaseECAction ecAction) {
 				switch (columnIndex) {
 				case ACTION_COLUMN_ALGORITHM:
 					return (ecAction.getAlgorithm() != null) ? ecAction.getAlgorithm()
@@ -95,15 +94,15 @@ public class ActionEditingComposite {
 
 		@Override
 		public Object getValue(final Object element, final String property) {
-			final ECAction selectedAction = (ECAction) element;
+			final BaseECAction selectedAction = (BaseECAction) element;
 			return switch (property) {
 			case ACTION_ALGORITHM -> {
-				final List<Algorithm> algorithms = ECCContentAndLabelProvider.getAlgorithms(getBasicFBType());
-				final Algorithm alg = selectedAction.getAlgorithmModel();
+				final List<String> algorithms = ECCContentAndLabelProvider.getAlgorithmNames(getBaseFBType());
+				final String alg = selectedAction.getAlgorithm();
 				yield Integer.valueOf((alg != null) ? algorithms.indexOf(alg) : algorithms.size());
 			}
 			case ACTION_EVENT -> {
-				final List<String> events = ECCContentAndLabelProvider.getOutputEventNames(getBasicFBType());
+				final List<String> events = ECCContentAndLabelProvider.getOutputEventNames(getBaseFBType());
 				final Event oe = selectedAction.getOutput();
 				yield Integer.valueOf(
 						(oe != null) ? events.indexOf(ECCContentAndLabelProvider.getEventName(oe)) : events.size());
@@ -115,18 +114,18 @@ public class ActionEditingComposite {
 		@Override
 		public void modify(final Object element, final String property, final Object value) {
 			final TableItem tableItem = (TableItem) element;
-			final ECAction selectedAction = (ECAction) tableItem.getData();
+			final BaseECAction selectedAction = (BaseECAction) tableItem.getData();
 			final int selected = ((Integer) value).intValue();
 			Command cmd = null;
 
 			switch (property) {
 			case ACTION_ALGORITHM:
-				final List<Algorithm> algorithms = ECCContentAndLabelProvider.getAlgorithms(getBasicFBType());
+				final List<Algorithm> algorithms = ECCContentAndLabelProvider.getAlgorithms(getBaseFBType());
 				final Algorithm alg = (selected < algorithms.size()) ? algorithms.get(selected) : null;
 				cmd = new ChangeAlgorithmCommand(selectedAction, alg);
 				break;
 			case ACTION_EVENT:
-				final List<Event> events = ECCContentAndLabelProvider.getOutputEvents(getBasicFBType());
+				final List<Event> events = ECCContentAndLabelProvider.getOutputEvents(getBaseFBType());
 				final Event ev = ((0 <= selected) && (selected < events.size())) ? events.get(selected) : null;
 				cmd = new ChangeOutputCommand(selectedAction, ev);
 				break;
@@ -153,7 +152,8 @@ public class ActionEditingComposite {
 
 	private CommandStack commandStack;
 	private final CommandExecutor commandExecutor; // the parent section
-	private ECState type;
+
+	private BaseECState<T> type;
 
 	public ActionEditingComposite(final Composite parent, final TabbedPropertySheetWidgetFactory actionWidgetFactory,
 			final CommandExecutor commandExecutor) {
@@ -163,9 +163,9 @@ public class ActionEditingComposite {
 		commandStack = null;
 		type = null;
 		createGroupLayout();
-
 	}
 
+	@SuppressWarnings("unchecked") // we need to cast to (T)
 	private void createGroupLayout() {
 		actionGroup.setLayout(new GridLayout(2, false));
 		actionGroup.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
@@ -178,10 +178,10 @@ public class ActionEditingComposite {
 		actionViewer.setLabelProvider(new ActionListLabelProvider());
 
 		actionMgmButtons.bindToTableViewer(actionViewer, commandExecutor,
-				ref -> new CreateECActionCommand(LibraryElementFactory.eINSTANCE.createECAction(), type),
-				ref -> new DeleteECActionCommand((ECAction) ref),
-				ref -> new ChangeActionOrderCommand(type, (ECAction) ref, true),
-				ref -> new ChangeActionOrderCommand(type, (ECAction) ref, false));
+				ref -> new CreateECActionCommand<>(type.createNewAction(), type),
+				ref -> new DeleteECActionCommand<>((T) ref, type),
+				ref -> new ChangeActionOrderCommand<>(type, (T) ref, true),
+				ref -> new ChangeActionOrderCommand<>(type, (T) ref, false));
 	}
 
 	private void configureActionTableLayout(final Table table) {
@@ -197,7 +197,7 @@ public class ActionEditingComposite {
 	}
 
 	private CellEditor[] createActionViewerCellEditors(final Table table) {
-		final BasicFBType fbType = getBasicFBType();
+		final BaseFBType fbType = getBaseFBType();
 		return new CellEditor[] {
 				ComboBoxWidgetFactory.createComboBoxCellEditor(table,
 						ECCContentAndLabelProvider.getAlgorithmNames(fbType).toArray(new String[0]), SWT.READ_ONLY),
@@ -205,8 +205,8 @@ public class ActionEditingComposite {
 						ECCContentAndLabelProvider.getOutputEventNames(fbType).toArray(new String[0]), SWT.READ_ONLY) };
 	}
 
-	private BasicFBType getBasicFBType() {
-		return type.getECC().getBasicFBType();
+	private BaseFBType getBaseFBType() {
+		return type.getBaseFBType();
 	}
 
 	public void refresh() {
@@ -218,7 +218,7 @@ public class ActionEditingComposite {
 		commandStack = commandStackBuffer;
 	}
 
-	public void setTypeAndCommandStack(final ECState type, final CommandStack commandStack) {
+	public void setTypeAndCommandStack(final BaseECState<T> type, final CommandStack commandStack) {
 		this.type = type;
 		this.commandStack = commandStack;
 

--- a/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeActionOrderCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.model.commands/src/org/eclipse/fordiac/ide/model/commands/change/ChangeActionOrderCommand.java
@@ -15,13 +15,13 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.model.commands.change;
 
-import org.eclipse.fordiac.ide.model.libraryElement.ECAction;
-import org.eclipse.fordiac.ide.model.libraryElement.ECState;
+import org.eclipse.fordiac.ide.model.libraryElement.BaseECAction;
+import org.eclipse.fordiac.ide.model.libraryElement.BaseECState;
 
-public class ChangeActionOrderCommand extends AbstractChangeListElementOrderCommand<ECAction> {
+public class ChangeActionOrderCommand<T extends BaseECAction> extends AbstractChangeListElementOrderCommand<T> {
 
-	public ChangeActionOrderCommand(final ECState state, final ECAction action, final boolean up) {
-		super(action, up, state.getECAction());
+	public ChangeActionOrderCommand(final BaseECState<T> state, final T action, final boolean up) {
+		super(action, up, state.getECActions());
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.model/model/fordiac.genmodel
+++ b/plugins/org.eclipse.fordiac.ide.model/model/fordiac.genmodel
@@ -116,6 +116,13 @@
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference lib.ecore#//BaseECAction/output"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute lib.ecore#//BaseECAction/algorithm"/>
     </genClasses>
+    <genClasses image="false" ecoreClass="lib.ecore#//BaseECState">
+      <genTypeParameters ecoreTypeParameter="lib.ecore#//BaseECState/T"/>
+      <genOperations ecoreOperation="lib.ecore#//BaseECState/getECActions"/>
+      <genOperations ecoreOperation="lib.ecore#//BaseECState/getBaseFBType"/>
+      <genOperations ecoreOperation="lib.ecore#//BaseECState/isStartState"/>
+      <genOperations ecoreOperation="lib.ecore#//BaseECState/createNewAction"/>
+    </genClasses>
     <genClasses ecoreClass="lib.ecore#//BaseFBType">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference lib.ecore#//BaseFBType/internalVars"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference lib.ecore#//BaseFBType/internalConstVars"/>
@@ -417,7 +424,10 @@
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference lib.ecore#//ECState/outTransitions"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference lib.ecore#//ECState/inTransitions"/>
       <genFeatures property="None" notify="false" createChild="false" ecoreFeature="ecore:EReference lib.ecore#//ECState/eCC"/>
+      <genOperations ecoreOperation="lib.ecore#//ECState/getECActions" body="return getECAction();"/>
+      <genOperations ecoreOperation="lib.ecore#//ECState/getBaseFBType" body="return getECC().getBasicFBType();"/>
       <genOperations ecoreOperation="lib.ecore#//ECState/isStartState" body="return org.eclipse.fordiac.ide.model.Annotations.isStartState(this);"/>
+      <genOperations ecoreOperation="lib.ecore#//ECState/createNewAction" body="return LibraryElementFactory.eINSTANCE.createECAction();"/>
     </genClasses>
     <genClasses ecoreClass="lib.ecore#//ECTransition">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute lib.ecore#//ECTransition/comment"/>
@@ -874,6 +884,10 @@
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference lib.ecore#//SimpleECState/simpleECActions"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference lib.ecore#//SimpleECState/inputEvent"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference lib.ecore#//SimpleECState/simpleFBType"/>
+      <genOperations ecoreOperation="lib.ecore#//SimpleECState/getECActions" body="return getSimpleECActions();"/>
+      <genOperations ecoreOperation="lib.ecore#//SimpleECState/getBaseFBType" body="return getSimpleFBType();"/>
+      <genOperations ecoreOperation="lib.ecore#//SimpleECState/isStartState" body="return false;"/>
+      <genOperations ecoreOperation="lib.ecore#//SimpleECState/createNewAction" body="return LibraryElementFactory.eINSTANCE.createSimpleECAction();"/>
     </genClasses>
     <genClasses ecoreClass="lib.ecore#//SimpleFBType">
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference lib.ecore#//SimpleFBType/simpleECStates"/>

--- a/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
+++ b/plugins/org.eclipse.fordiac.ide.model/model/lib.ecore
@@ -205,6 +205,19 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="output" eType="#//Event"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="algorithm" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String"/>
   </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="BaseECState" abstract="true" interface="true">
+    <eTypeParameters name="T">
+      <eBounds eClassifier="#//BaseECAction"/>
+    </eTypeParameters>
+    <eOperations name="getECActions" upperBound="-1">
+      <eGenericType eTypeParameter="#//BaseECState/T"/>
+    </eOperations>
+    <eOperations name="getBaseFBType" eType="#//BaseFBType"/>
+    <eOperations name="isStartState" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Boolean"/>
+    <eOperations name="createNewAction">
+      <eGenericType eTypeParameter="#//BaseECState/T"/>
+    </eOperations>
+  </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="BaseFBType" abstract="true" eSuperTypes="#//FBType">
     <eOperations name="getAlgorithmNamed" lowerBound="1" eType="#//Algorithm">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -1023,10 +1036,25 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="basicFBType" lowerBound="1"
         eType="#//BasicFBType" eOpposite="#//BasicFBType/eCC"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="ECState" eSuperTypes="#//INamedElement #//PositionableElement">
+  <eClassifiers xsi:type="ecore:EClass" name="ECState">
+    <eOperations name="getECActions" upperBound="-1" eType="#//ECAction">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="body" value="return getECAction();"/>
+      </eAnnotations>
+    </eOperations>
+    <eOperations name="getBaseFBType" eType="#//BaseFBType">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="body" value="return getECC().getBasicFBType();"/>
+      </eAnnotations>
+    </eOperations>
     <eOperations name="isStartState" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Boolean">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return org.eclipse.fordiac.ide.model.Annotations.isStartState(this);"/>
+      </eAnnotations>
+    </eOperations>
+    <eOperations name="createNewAction" eType="#//ECAction">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="body" value="return LibraryElementFactory.eINSTANCE.createECAction();"/>
       </eAnnotations>
     </eOperations>
     <eStructuralFeatures xsi:type="ecore:EReference" name="eCAction" upperBound="-1"
@@ -1042,6 +1070,11 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="inTransitions" upperBound="-1"
         eType="#//ECTransition" eOpposite="#//ECTransition/destination"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="eCC" eType="#//ECC" eOpposite="#//ECC/eCState"/>
+    <eGenericSuperTypes eClassifier="#//INamedElement"/>
+    <eGenericSuperTypes eClassifier="#//PositionableElement"/>
+    <eGenericSuperTypes eClassifier="#//BaseECState">
+      <eTypeArguments eClassifier="#//ECAction"/>
+    </eGenericSuperTypes>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ECTransition" eSuperTypes="#//PositionableElement">
     <eOperations name="getConditionText" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
@@ -2327,7 +2360,27 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="simpleECState" lowerBound="1"
         eType="#//SimpleECState" eOpposite="#//SimpleECState/simpleECActions"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="SimpleECState" eSuperTypes="#//INamedElement">
+  <eClassifiers xsi:type="ecore:EClass" name="SimpleECState">
+    <eOperations name="getECActions" upperBound="-1" eType="#//SimpleECAction">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="body" value="return getSimpleECActions();"/>
+      </eAnnotations>
+    </eOperations>
+    <eOperations name="getBaseFBType" eType="#//BaseFBType">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="body" value="return getSimpleFBType();"/>
+      </eAnnotations>
+    </eOperations>
+    <eOperations name="isStartState" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Boolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="body" value="return false;"/>
+      </eAnnotations>
+    </eOperations>
+    <eOperations name="createNewAction" eType="#//SimpleECAction">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="body" value="return LibraryElementFactory.eINSTANCE.createSimpleECAction();"/>
+      </eAnnotations>
+    </eOperations>
     <eStructuralFeatures xsi:type="ecore:EReference" name="simpleECActions" upperBound="-1"
         eType="#//SimpleECAction" containment="true" resolveProxies="false" eOpposite="#//SimpleECAction/simpleECState">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
@@ -2340,6 +2393,10 @@
         eType="#//Event"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="simpleFBType" lowerBound="1"
         eType="#//SimpleFBType" eOpposite="#//SimpleFBType/simpleECStates"/>
+    <eGenericSuperTypes eClassifier="#//INamedElement"/>
+    <eGenericSuperTypes eClassifier="#//BaseECState">
+      <eTypeArguments eClassifier="#//SimpleECAction"/>
+    </eGenericSuperTypes>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="SimpleFBType" eSuperTypes="#//BaseFBType">
     <eOperations name="validateEventUsage" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean">

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/BaseECState.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/BaseECState.java
@@ -1,0 +1,65 @@
+/**
+ * *******************************************************************************
+ * Copyright (c) 2008, 2026 Profactor GmbH, TU Wien ACIN, fortiss GmbH,
+ *                                                       Martin Erich Jobst, Primetals Technologies Austria GmbH
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Gerhard Ebenhofer, Alois Zoitl, Ingo Hegny, Monika Wenger, Martin Jobst
+ *      - initial API and implementation and/or initial documentation
+ * *******************************************************************************
+ */
+package org.eclipse.fordiac.ide.model.libraryElement;
+
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EObject;
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the model object '<em><b>Base EC State</b></em>'.
+ * <!-- end-user-doc -->
+ *
+ *
+ * @see org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage#getBaseECState()
+ * @model interface="true" abstract="true"
+ * @generated
+ */
+public interface BaseECState<T extends BaseECAction> extends EObject {
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @model kind="operation"
+	 * @generated
+	 */
+	EList<T> getECActions();
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @model kind="operation"
+	 * @generated
+	 */
+	BaseFBType getBaseFBType();
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @model kind="operation" dataType="org.eclipse.emf.ecore.xml.type.Boolean"
+	 * @generated
+	 */
+	boolean isStartState();
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @model
+	 * @generated
+	 */
+	T createNewAction();
+} // BaseECState

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/ECState.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/ECState.java
@@ -37,7 +37,7 @@ import org.eclipse.emf.common.util.EList;
  * @model
  * @generated
  */
-public interface ECState extends INamedElement, PositionableElement {
+public interface ECState extends INamedElement, PositionableElement, BaseECState<ECAction> {
 	/**
 	 * Returns the value of the '<em><b>EC Action</b></em>' containment reference list.
 	 * The list contents are of type {@link org.eclipse.fordiac.ide.model.libraryElement.ECAction}.
@@ -108,9 +108,33 @@ public interface ECState extends INamedElement, PositionableElement {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * @model kind="operation"
+	 * @generated
+	 */
+	EList<ECAction> getECActions();
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @model kind="operation"
+	 * @generated
+	 */
+	BaseFBType getBaseFBType();
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
 	 * @model kind="operation" dataType="org.eclipse.emf.ecore.xml.type.Boolean" required="true"
 	 * @generated
 	 */
 	boolean isStartState();
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @model
+	 * @generated
+	 */
+	ECAction createNewAction();
 
 } // ECState

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/LibraryElementPackage.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/LibraryElementPackage.java
@@ -81,7 +81,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getConfigurableObject()
 	 * @generated
 	 */
-	int CONFIGURABLE_OBJECT = 24;
+	int CONFIGURABLE_OBJECT = 25;
 
 	/**
 	 * The feature id for the '<em><b>Attributes</b></em>' containment reference list.
@@ -109,7 +109,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getConnection()
 	 * @generated
 	 */
-	int CONNECTION = 27;
+	int CONNECTION = 28;
 
 	/**
 	 * The feature id for the '<em><b>Attributes</b></em>' containment reference list.
@@ -264,7 +264,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getINamedElement()
 	 * @generated
 	 */
-	int INAMED_ELEMENT = 67;
+	int INAMED_ELEMENT = 68;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -301,7 +301,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getITypedElement()
 	 * @generated
 	 */
-	int ITYPED_ELEMENT = 70;
+	int ITYPED_ELEMENT = 71;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -338,7 +338,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getIInterfaceElement()
 	 * @generated
 	 */
-	int IINTERFACE_ELEMENT = 65;
+	int IINTERFACE_ELEMENT = 66;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -520,7 +520,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getTypedConfigureableObject()
 	 * @generated
 	 */
-	int TYPED_CONFIGUREABLE_OBJECT = 113;
+	int TYPED_CONFIGUREABLE_OBJECT = 114;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -575,7 +575,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getFBNetworkElement()
 	 * @generated
 	 */
-	int FB_NETWORK_ELEMENT = 55;
+	int FB_NETWORK_ELEMENT = 56;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -657,7 +657,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getBlockFBNetworkElement()
 	 * @generated
 	 */
-	int BLOCK_FB_NETWORK_ELEMENT = 13;
+	int BLOCK_FB_NETWORK_ELEMENT = 14;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -748,7 +748,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getFB()
 	 * @generated
 	 */
-	int FB = 53;
+	int FB = 54;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -939,7 +939,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getLibraryElement()
 	 * @generated
 	 */
-	int LIBRARY_ELEMENT = 72;
+	int LIBRARY_ELEMENT = 73;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -1130,7 +1130,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getICallable()
 	 * @generated
 	 */
-	int ICALLABLE = 63;
+	int ICALLABLE = 64;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -1590,6 +1590,25 @@ public interface LibraryElementPackage extends EPackage {
 	int BASE_EC_ACTION_FEATURE_COUNT = 2;
 
 	/**
+	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.BaseECState <em>Base EC State</em>}' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see org.eclipse.fordiac.ide.model.libraryElement.BaseECState
+	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getBaseECState()
+	 * @generated
+	 */
+	int BASE_EC_STATE = 11;
+
+	/**
+	 * The number of structural features of the '<em>Base EC State</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int BASE_EC_STATE_FEATURE_COUNT = 0;
+
+	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.FBTypeImpl <em>FB Type</em>}' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -1597,7 +1616,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getFBType()
 	 * @generated
 	 */
-	int FB_TYPE = 56;
+	int FB_TYPE = 57;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -1697,7 +1716,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getBaseFBType()
 	 * @generated
 	 */
-	int BASE_FB_TYPE = 11;
+	int BASE_FB_TYPE = 12;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -1851,7 +1870,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getBasicFBType()
 	 * @generated
 	 */
-	int BASIC_FB_TYPE = 12;
+	int BASIC_FB_TYPE = 13;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -2014,7 +2033,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getCFBInstance()
 	 * @generated
 	 */
-	int CFB_INSTANCE = 14;
+	int CFB_INSTANCE = 15;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -2114,7 +2133,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getColor()
 	 * @generated
 	 */
-	int COLOR = 15;
+	int COLOR = 16;
 
 	/**
 	 * The feature id for the '<em><b>Red</b></em>' attribute.
@@ -2160,7 +2179,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getColorizableElement()
 	 * @generated
 	 */
-	int COLORIZABLE_ELEMENT = 16;
+	int COLORIZABLE_ELEMENT = 17;
 
 	/**
 	 * The feature id for the '<em><b>Color</b></em>' containment reference.
@@ -2188,7 +2207,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getComment()
 	 * @generated
 	 */
-	int COMMENT = 17;
+	int COMMENT = 18;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -2288,7 +2307,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getCommunicationChannel()
 	 * @generated
 	 */
-	int COMMUNICATION_CHANNEL = 18;
+	int COMMUNICATION_CHANNEL = 19;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -2379,7 +2398,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getCommunicationConfiguration()
 	 * @generated
 	 */
-	int COMMUNICATION_CONFIGURATION = 19;
+	int COMMUNICATION_CONFIGURATION = 20;
 
 	/**
 	 * The number of structural features of the '<em>Communication Configuration</em>' class.
@@ -2398,7 +2417,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getMappingTarget()
 	 * @generated
 	 */
-	int MAPPING_TARGET = 76;
+	int MAPPING_TARGET = 77;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -2435,7 +2454,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getCommunicationMappingTarget()
 	 * @generated
 	 */
-	int COMMUNICATION_MAPPING_TARGET = 20;
+	int COMMUNICATION_MAPPING_TARGET = 21;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -2481,7 +2500,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getCompiler()
 	 * @generated
 	 */
-	int COMPILER = 21;
+	int COMPILER = 22;
 
 	/**
 	 * The feature id for the '<em><b>Language</b></em>' attribute.
@@ -2536,7 +2555,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getCompilerInfo()
 	 * @generated
 	 */
-	int COMPILER_INFO = 22;
+	int COMPILER_INFO = 23;
 
 	/**
 	 * The feature id for the '<em><b>Compiler</b></em>' containment reference list.
@@ -2600,7 +2619,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getCompositeFBType()
 	 * @generated
 	 */
-	int COMPOSITE_FB_TYPE = 23;
+	int COMPOSITE_FB_TYPE = 24;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -2709,7 +2728,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getConfigurableFB()
 	 * @generated
 	 */
-	int CONFIGURABLE_FB = 25;
+	int CONFIGURABLE_FB = 26;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -2809,7 +2828,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getConfigurableMoveFB()
 	 * @generated
 	 */
-	int CONFIGURABLE_MOVE_FB = 26;
+	int CONFIGURABLE_MOVE_FB = 27;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -2909,7 +2928,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getConnectionRoutingData()
 	 * @generated
 	 */
-	int CONNECTION_ROUTING_DATA = 28;
+	int CONNECTION_ROUTING_DATA = 29;
 
 	/**
 	 * The feature id for the '<em><b>Dx1</b></em>' attribute.
@@ -2964,7 +2983,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getDataConnection()
 	 * @generated
 	 */
-	int DATA_CONNECTION = 30;
+	int DATA_CONNECTION = 31;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.StructManipulatorImpl <em>Struct Manipulator</em>}' class.
@@ -2974,7 +2993,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getStructManipulator()
 	 * @generated
 	 */
-	int STRUCT_MANIPULATOR = 105;
+	int STRUCT_MANIPULATOR = 106;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.DemultiplexerImpl <em>Demultiplexer</em>}' class.
@@ -2984,7 +3003,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getDemultiplexer()
 	 * @generated
 	 */
-	int DEMULTIPLEXER = 31;
+	int DEMULTIPLEXER = 32;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.DeviceImpl <em>Device</em>}' class.
@@ -2994,7 +3013,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getDevice()
 	 * @generated
 	 */
-	int DEVICE = 32;
+	int DEVICE = 33;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.DeviceTypeImpl <em>Device Type</em>}' class.
@@ -3004,7 +3023,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getDeviceType()
 	 * @generated
 	 */
-	int DEVICE_TYPE = 33;
+	int DEVICE_TYPE = 34;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.ECActionImpl <em>EC Action</em>}' class.
@@ -3014,7 +3033,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getECAction()
 	 * @generated
 	 */
-	int EC_ACTION = 34;
+	int EC_ACTION = 35;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.ECCImpl <em>ECC</em>}' class.
@@ -3024,7 +3043,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getECC()
 	 * @generated
 	 */
-	int ECC = 35;
+	int ECC = 36;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.ECStateImpl <em>EC State</em>}' class.
@@ -3034,7 +3053,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getECState()
 	 * @generated
 	 */
-	int EC_STATE = 36;
+	int EC_STATE = 37;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.PositionableElementImpl <em>Positionable Element</em>}' class.
@@ -3044,7 +3063,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getPositionableElement()
 	 * @generated
 	 */
-	int POSITIONABLE_ELEMENT = 85;
+	int POSITIONABLE_ELEMENT = 86;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.ECTransitionImpl <em>EC Transition</em>}' class.
@@ -3054,7 +3073,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getECTransition()
 	 * @generated
 	 */
-	int EC_TRANSITION = 37;
+	int EC_TRANSITION = 38;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.ErrorMarkerFBNElementImpl <em>Error Marker FBN Element</em>}' class.
@@ -3064,7 +3083,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getErrorMarkerFBNElement()
 	 * @generated
 	 */
-	int ERROR_MARKER_FBN_ELEMENT = 46;
+	int ERROR_MARKER_FBN_ELEMENT = 47;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.ErrorMarkerInterfaceImpl <em>Error Marker Interface</em>}' class.
@@ -3074,7 +3093,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getErrorMarkerInterface()
 	 * @generated
 	 */
-	int ERROR_MARKER_INTERFACE = 47;
+	int ERROR_MARKER_INTERFACE = 48;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.EventImpl <em>Event</em>}' class.
@@ -3084,7 +3103,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getEvent()
 	 * @generated
 	 */
-	int EVENT = 51;
+	int EVENT = 52;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.EventConnectionImpl <em>Event Connection</em>}' class.
@@ -3094,7 +3113,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getEventConnection()
 	 * @generated
 	 */
-	int EVENT_CONNECTION = 52;
+	int EVENT_CONNECTION = 53;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.FBNetworkImpl <em>FB Network</em>}' class.
@@ -3104,7 +3123,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getFBNetwork()
 	 * @generated
 	 */
-	int FB_NETWORK = 54;
+	int FB_NETWORK = 55;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.FunctionImpl <em>Function</em>}' class.
@@ -3114,7 +3133,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getFunction()
 	 * @generated
 	 */
-	int FUNCTION = 57;
+	int FUNCTION = 58;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.FunctionBodyImpl <em>Function Body</em>}' class.
@@ -3124,7 +3143,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getFunctionBody()
 	 * @generated
 	 */
-	int FUNCTION_BODY = 58;
+	int FUNCTION_BODY = 59;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.FunctionFBTypeImpl <em>Function FB Type</em>}' class.
@@ -3134,7 +3153,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getFunctionFBType()
 	 * @generated
 	 */
-	int FUNCTION_FB_TYPE = 59;
+	int FUNCTION_FB_TYPE = 60;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.GlobalConstantsImpl <em>Global Constants</em>}' class.
@@ -3144,7 +3163,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getGlobalConstants()
 	 * @generated
 	 */
-	int GLOBAL_CONSTANTS = 60;
+	int GLOBAL_CONSTANTS = 61;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.GroupImpl <em>Group</em>}' class.
@@ -3154,7 +3173,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getGroup()
 	 * @generated
 	 */
-	int GROUP = 61;
+	int GROUP = 62;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.HiddenElementImpl <em>Hidden Element</em>}' class.
@@ -3164,7 +3183,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getHiddenElement()
 	 * @generated
 	 */
-	int HIDDEN_ELEMENT = 62;
+	int HIDDEN_ELEMENT = 63;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.IdentificationImpl <em>Identification</em>}' class.
@@ -3174,7 +3193,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getIdentification()
 	 * @generated
 	 */
-	int IDENTIFICATION = 64;
+	int IDENTIFICATION = 65;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.ImportImpl <em>Import</em>}' class.
@@ -3184,7 +3203,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getImport()
 	 * @generated
 	 */
-	int IMPORT = 66;
+	int IMPORT = 67;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.PrimitiveImpl <em>Primitive</em>}' class.
@@ -3194,7 +3213,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getPrimitive()
 	 * @generated
 	 */
-	int PRIMITIVE = 86;
+	int PRIMITIVE = 87;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.InputPrimitiveImpl <em>Input Primitive</em>}' class.
@@ -3204,7 +3223,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getInputPrimitive()
 	 * @generated
 	 */
-	int INPUT_PRIMITIVE = 68;
+	int INPUT_PRIMITIVE = 69;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.InterfaceListImpl <em>Interface List</em>}' class.
@@ -3214,7 +3233,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getInterfaceList()
 	 * @generated
 	 */
-	int INTERFACE_LIST = 69;
+	int INTERFACE_LIST = 70;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.IVarElement <em>IVar Element</em>}' class.
@@ -3224,7 +3243,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getIVarElement()
 	 * @generated
 	 */
-	int IVAR_ELEMENT = 71;
+	int IVAR_ELEMENT = 72;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.LinkImpl <em>Link</em>}' class.
@@ -3234,7 +3253,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getLink()
 	 * @generated
 	 */
-	int LINK = 73;
+	int LINK = 74;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.VarDeclarationImpl <em>Var Declaration</em>}' class.
@@ -3244,7 +3263,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getVarDeclaration()
 	 * @generated
 	 */
-	int VAR_DECLARATION = 118;
+	int VAR_DECLARATION = 119;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -3353,7 +3372,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getContainerVarDeclaration()
 	 * @generated
 	 */
-	int CONTAINER_VAR_DECLARATION = 29;
+	int CONTAINER_VAR_DECLARATION = 30;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -4200,7 +4219,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getErrorAdapterType()
 	 * @generated
 	 */
-	int ERROR_ADAPTER_TYPE = 38;
+	int ERROR_ADAPTER_TYPE = 39;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -4309,7 +4328,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getErrorAttributeDeclaration()
 	 * @generated
 	 */
-	int ERROR_ATTRIBUTE_DECLARATION = 39;
+	int ERROR_ATTRIBUTE_DECLARATION = 40;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -4400,7 +4419,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getErrorAutomationSystem()
 	 * @generated
 	 */
-	int ERROR_AUTOMATION_SYSTEM = 40;
+	int ERROR_AUTOMATION_SYSTEM = 41;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -4509,7 +4528,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getErrorDeviceType()
 	 * @generated
 	 */
-	int ERROR_DEVICE_TYPE = 41;
+	int ERROR_DEVICE_TYPE = 42;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -4645,7 +4664,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getErrorFBType()
 	 * @generated
 	 */
-	int ERROR_FB_TYPE = 42;
+	int ERROR_FB_TYPE = 43;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -4844,7 +4863,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getErrorFunctionFBType()
 	 * @generated
 	 */
-	int ERROR_FUNCTION_FB_TYPE = 43;
+	int ERROR_FUNCTION_FB_TYPE = 44;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -5043,7 +5062,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getErrorGlobalConstants()
 	 * @generated
 	 */
-	int ERROR_GLOBAL_CONSTANTS = 44;
+	int ERROR_GLOBAL_CONSTANTS = 45;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -5143,7 +5162,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getErrorLibraryElement()
 	 * @generated
 	 */
-	int ERROR_LIBRARY_ELEMENT = 45;
+	int ERROR_LIBRARY_ELEMENT = 46;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -5396,7 +5415,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getLocalVariable()
 	 * @generated
 	 */
-	int LOCAL_VARIABLE = 74;
+	int LOCAL_VARIABLE = 75;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.MappingImpl <em>Mapping</em>}' class.
@@ -5406,7 +5425,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getMapping()
 	 * @generated
 	 */
-	int MAPPING = 75;
+	int MAPPING = 76;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.MemberVarDeclarationImpl <em>Member Var Declaration</em>}' class.
@@ -5416,7 +5435,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getMemberVarDeclaration()
 	 * @generated
 	 */
-	int MEMBER_VAR_DECLARATION = 77;
+	int MEMBER_VAR_DECLARATION = 78;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.MethodImpl <em>Method</em>}' class.
@@ -5426,7 +5445,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getMethod()
 	 * @generated
 	 */
-	int METHOD = 78;
+	int METHOD = 79;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.MultiplexerImpl <em>Multiplexer</em>}' class.
@@ -5436,7 +5455,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getMultiplexer()
 	 * @generated
 	 */
-	int MULTIPLEXER = 79;
+	int MULTIPLEXER = 80;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.OriginalSourceImpl <em>Original Source</em>}' class.
@@ -5446,7 +5465,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getOriginalSource()
 	 * @generated
 	 */
-	int ORIGINAL_SOURCE = 80;
+	int ORIGINAL_SOURCE = 81;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.TextAlgorithmImpl <em>Text Algorithm</em>}' class.
@@ -5456,7 +5475,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getTextAlgorithm()
 	 * @generated
 	 */
-	int TEXT_ALGORITHM = 109;
+	int TEXT_ALGORITHM = 110;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.OtherAlgorithmImpl <em>Other Algorithm</em>}' class.
@@ -5466,7 +5485,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getOtherAlgorithm()
 	 * @generated
 	 */
-	int OTHER_ALGORITHM = 81;
+	int OTHER_ALGORITHM = 82;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.TextMethodImpl <em>Text Method</em>}' class.
@@ -5476,7 +5495,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getTextMethod()
 	 * @generated
 	 */
-	int TEXT_METHOD = 112;
+	int TEXT_METHOD = 113;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.OtherMethodImpl <em>Other Method</em>}' class.
@@ -5486,7 +5505,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getOtherMethod()
 	 * @generated
 	 */
-	int OTHER_METHOD = 82;
+	int OTHER_METHOD = 83;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.OutputPrimitiveImpl <em>Output Primitive</em>}' class.
@@ -5496,7 +5515,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getOutputPrimitive()
 	 * @generated
 	 */
-	int OUTPUT_PRIMITIVE = 83;
+	int OUTPUT_PRIMITIVE = 84;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.PositionImpl <em>Position</em>}' class.
@@ -5506,7 +5525,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getPosition()
 	 * @generated
 	 */
-	int POSITION = 84;
+	int POSITION = 85;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.ResourceImpl <em>Resource</em>}' class.
@@ -5516,7 +5535,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getResource()
 	 * @generated
 	 */
-	int RESOURCE = 87;
+	int RESOURCE = 88;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.ResourceTypeNameImpl <em>Resource Type Name</em>}' class.
@@ -5526,7 +5545,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getResourceTypeName()
 	 * @generated
 	 */
-	int RESOURCE_TYPE_NAME = 88;
+	int RESOURCE_TYPE_NAME = 89;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.ResourceTypeImpl <em>Resource Type</em>}' class.
@@ -5536,7 +5555,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getResourceType()
 	 * @generated
 	 */
-	int RESOURCE_TYPE = 89;
+	int RESOURCE_TYPE = 90;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -5645,7 +5664,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getErrorResourceType()
 	 * @generated
 	 */
-	int ERROR_RESOURCE_TYPE = 48;
+	int ERROR_RESOURCE_TYPE = 49;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -5754,7 +5773,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getResourceTypeFB()
 	 * @generated
 	 */
-	int RESOURCE_TYPE_FB = 90;
+	int RESOURCE_TYPE_FB = 91;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.SegmentImpl <em>Segment</em>}' class.
@@ -5764,7 +5783,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getSegment()
 	 * @generated
 	 */
-	int SEGMENT = 91;
+	int SEGMENT = 92;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.SegmentTypeImpl <em>Segment Type</em>}' class.
@@ -5774,7 +5793,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getSegmentType()
 	 * @generated
 	 */
-	int SEGMENT_TYPE = 92;
+	int SEGMENT_TYPE = 93;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -5865,7 +5884,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getErrorSegmentType()
 	 * @generated
 	 */
-	int ERROR_SEGMENT_TYPE = 49;
+	int ERROR_SEGMENT_TYPE = 50;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -5956,7 +5975,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getService()
 	 * @generated
 	 */
-	int SERVICE = 93;
+	int SERVICE = 94;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.ServiceSequenceImpl <em>Service Sequence</em>}' class.
@@ -5966,7 +5985,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getServiceSequence()
 	 * @generated
 	 */
-	int SERVICE_SEQUENCE = 94;
+	int SERVICE_SEQUENCE = 95;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.ServiceTransactionImpl <em>Service Transaction</em>}' class.
@@ -5976,7 +5995,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getServiceTransaction()
 	 * @generated
 	 */
-	int SERVICE_TRANSACTION = 95;
+	int SERVICE_TRANSACTION = 96;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.ServiceInterfaceImpl <em>Service Interface</em>}' class.
@@ -5986,7 +6005,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getServiceInterface()
 	 * @generated
 	 */
-	int SERVICE_INTERFACE = 96;
+	int SERVICE_INTERFACE = 97;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.ServiceInterfaceFBTypeImpl <em>Service Interface FB Type</em>}' class.
@@ -5996,7 +6015,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getServiceInterfaceFBType()
 	 * @generated
 	 */
-	int SERVICE_INTERFACE_FB_TYPE = 97;
+	int SERVICE_INTERFACE_FB_TYPE = 98;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.SimpleECActionImpl <em>Simple EC Action</em>}' class.
@@ -6006,7 +6025,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getSimpleECAction()
 	 * @generated
 	 */
-	int SIMPLE_EC_ACTION = 98;
+	int SIMPLE_EC_ACTION = 99;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.SimpleECStateImpl <em>Simple EC State</em>}' class.
@@ -6016,7 +6035,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getSimpleECState()
 	 * @generated
 	 */
-	int SIMPLE_EC_STATE = 99;
+	int SIMPLE_EC_STATE = 100;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.SimpleFBTypeImpl <em>Simple FB Type</em>}' class.
@@ -6026,7 +6045,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getSimpleFBType()
 	 * @generated
 	 */
-	int SIMPLE_FB_TYPE = 100;
+	int SIMPLE_FB_TYPE = 101;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.STAlgorithmImpl <em>ST Algorithm</em>}' class.
@@ -6036,7 +6055,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getSTAlgorithm()
 	 * @generated
 	 */
-	int ST_ALGORITHM = 101;
+	int ST_ALGORITHM = 102;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.TextFunctionImpl <em>Text Function</em>}' class.
@@ -6046,7 +6065,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getTextFunction()
 	 * @generated
 	 */
-	int TEXT_FUNCTION = 110;
+	int TEXT_FUNCTION = 111;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.STFunctionImpl <em>ST Function</em>}' class.
@@ -6056,7 +6075,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getSTFunction()
 	 * @generated
 	 */
-	int ST_FUNCTION = 102;
+	int ST_FUNCTION = 103;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.TextFunctionBodyImpl <em>Text Function Body</em>}' class.
@@ -6066,7 +6085,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getTextFunctionBody()
 	 * @generated
 	 */
-	int TEXT_FUNCTION_BODY = 111;
+	int TEXT_FUNCTION_BODY = 112;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.STFunctionBodyImpl <em>ST Function Body</em>}' class.
@@ -6076,7 +6095,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getSTFunctionBody()
 	 * @generated
 	 */
-	int ST_FUNCTION_BODY = 103;
+	int ST_FUNCTION_BODY = 104;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.STMethodImpl <em>ST Method</em>}' class.
@@ -6086,7 +6105,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getSTMethod()
 	 * @generated
 	 */
-	int ST_METHOD = 104;
+	int ST_METHOD = 105;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.SubAppImpl <em>Sub App</em>}' class.
@@ -6096,7 +6115,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getSubApp()
 	 * @generated
 	 */
-	int SUB_APP = 106;
+	int SUB_APP = 107;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.SubAppTypeImpl <em>Sub App Type</em>}' class.
@@ -6106,7 +6125,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getSubAppType()
 	 * @generated
 	 */
-	int SUB_APP_TYPE = 107;
+	int SUB_APP_TYPE = 108;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -6215,7 +6234,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getErrorSubAppType()
 	 * @generated
 	 */
-	int ERROR_SUB_APP_TYPE = 50;
+	int ERROR_SUB_APP_TYPE = 51;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -8943,7 +8962,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getSystemConfiguration()
 	 * @generated
 	 */
-	int SYSTEM_CONFIGURATION = 108;
+	int SYSTEM_CONFIGURATION = 109;
 
 	/**
 	 * The feature id for the '<em><b>Devices</b></em>' containment reference list.
@@ -8989,7 +9008,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getTypedSubApp()
 	 * @generated
 	 */
-	int TYPED_SUB_APP = 114;
+	int TYPED_SUB_APP = 115;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -9125,7 +9144,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getUntypedSubApp()
 	 * @generated
 	 */
-	int UNTYPED_SUB_APP = 115;
+	int UNTYPED_SUB_APP = 116;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -9252,7 +9271,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getValue()
 	 * @generated
 	 */
-	int VALUE = 116;
+	int VALUE = 117;
 
 	/**
 	 * The feature id for the '<em><b>Value</b></em>' attribute.
@@ -9280,7 +9299,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getVersionInfo()
 	 * @generated
 	 */
-	int VERSION_INFO = 119;
+	int VERSION_INFO = 120;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.WithImpl <em>With</em>}' class.
@@ -9290,7 +9309,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getWith()
 	 * @generated
 	 */
-	int WITH = 120;
+	int WITH = 121;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.VarConfigInstanceImpl <em>Var Config Instance</em>}' class.
@@ -9300,7 +9319,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getVarConfigInstance()
 	 * @generated
 	 */
-	int VAR_CONFIG_INSTANCE = 117;
+	int VAR_CONFIG_INSTANCE = 118;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
@@ -9481,7 +9500,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getLanguage()
 	 * @generated
 	 */
-	int LANGUAGE = 121;
+	int LANGUAGE = 122;
 
 	/**
 	 * The meta object id for the '<em>IFile</em>' data type.
@@ -9491,7 +9510,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getIFile()
 	 * @generated
 	 */
-	int IFILE = 122;
+	int IFILE = 123;
 
 	/**
 	 * The meta object id for the '<em>Interface Element Stream</em>' data type.
@@ -9501,7 +9520,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getInterfaceElementStream()
 	 * @generated
 	 */
-	int INTERFACE_ELEMENT_STREAM = 123;
+	int INTERFACE_ELEMENT_STREAM = 124;
 
 	/**
 	 * The meta object id for the '<em>IProject</em>' data type.
@@ -9511,7 +9530,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getIProject()
 	 * @generated
 	 */
-	int IPROJECT = 124;
+	int IPROJECT = 125;
 
 	/**
 	 * The meta object id for the '<em>Named Element Stream</em>' data type.
@@ -9521,7 +9540,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getNamedElementStream()
 	 * @generated
 	 */
-	int NAMED_ELEMENT_STREAM = 125;
+	int NAMED_ELEMENT_STREAM = 126;
 
 	/**
 	 * The meta object id for the '<em>Point</em>' data type.
@@ -9531,7 +9550,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getPoint()
 	 * @generated
 	 */
-	int POINT = 126;
+	int POINT = 127;
 
 	/**
 	 * The meta object id for the '<em>Type Entry</em>' data type.
@@ -9541,7 +9560,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getTypeEntry()
 	 * @generated
 	 */
-	int TYPE_ENTRY = 127;
+	int TYPE_ENTRY = 128;
 
 	/**
 	 * The meta object id for the '<em>Type Library</em>' data type.
@@ -9551,7 +9570,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getTypeLibrary()
 	 * @generated
 	 */
-	int TYPE_LIBRARY = 128;
+	int TYPE_LIBRARY = 129;
 
 	/**
 	 * The meta object id for the '<em>Var Decl List</em>' data type.
@@ -9561,7 +9580,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getVarDeclList()
 	 * @generated
 	 */
-	int VAR_DECL_LIST = 129;
+	int VAR_DECL_LIST = 130;
 
 	/**
 	 * The meta object id for the '<em>Interface Type Entry</em>' data type.
@@ -9571,7 +9590,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getInterfaceTypeEntry()
 	 * @generated
 	 */
-	int INTERFACE_TYPE_ENTRY = 130;
+	int INTERFACE_TYPE_ENTRY = 131;
 
 	/**
 	 * The meta object id for the '<em>Block FBNW Element Stream</em>' data type.
@@ -9581,7 +9600,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getBlockFBNWElementStream()
 	 * @generated
 	 */
-	int BLOCK_FBNW_ELEMENT_STREAM = 131;
+	int BLOCK_FBNW_ELEMENT_STREAM = 132;
 
 
 	/**
@@ -9591,7 +9610,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getStringArray()
 	 * @generated
 	 */
-	int STRING_ARRAY = 132;
+	int STRING_ARRAY = 133;
 
 
 	/**
@@ -9602,7 +9621,7 @@ public interface LibraryElementPackage extends EPackage {
 	 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getStringList()
 	 * @generated
 	 */
-	int STRING_LIST = 133;
+	int STRING_LIST = 134;
 
 
 	/**
@@ -9901,6 +9920,16 @@ public interface LibraryElementPackage extends EPackage {
 	 * @generated
 	 */
 	EAttribute getBaseECAction_Algorithm();
+
+	/**
+	 * Returns the meta object for class '{@link org.eclipse.fordiac.ide.model.libraryElement.BaseECState <em>Base EC State</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for class '<em>Base EC State</em>'.
+	 * @see org.eclipse.fordiac.ide.model.libraryElement.BaseECState
+	 * @generated
+	 */
+	EClass getBaseECState();
 
 	/**
 	 * Returns the meta object for class '{@link org.eclipse.fordiac.ide.model.libraryElement.BaseFBType <em>Base FB Type</em>}'.
@@ -13500,6 +13529,16 @@ public interface LibraryElementPackage extends EPackage {
 		 * @generated
 		 */
 		EAttribute BASE_EC_ACTION__ALGORITHM = eINSTANCE.getBaseECAction_Algorithm();
+
+		/**
+		 * The meta object literal for the '{@link org.eclipse.fordiac.ide.model.libraryElement.BaseECState <em>Base EC State</em>}' class.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @see org.eclipse.fordiac.ide.model.libraryElement.BaseECState
+		 * @see org.eclipse.fordiac.ide.model.libraryElement.impl.LibraryElementPackageImpl#getBaseECState()
+		 * @generated
+		 */
+		EClass BASE_EC_STATE = eINSTANCE.getBaseECState();
 
 		/**
 		 * The meta object literal for the '{@link org.eclipse.fordiac.ide.model.libraryElement.impl.BaseFBTypeImpl <em>Base FB Type</em>}' class.

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/SimpleECState.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/SimpleECState.java
@@ -36,7 +36,7 @@ import org.eclipse.emf.common.util.EList;
  * @model
  * @generated
  */
-public interface SimpleECState extends INamedElement {
+public interface SimpleECState extends INamedElement, BaseECState<SimpleECAction> {
 	/**
 	 * Returns the value of the '<em><b>Simple EC Actions</b></em>' containment reference list.
 	 * The list contents are of type {@link org.eclipse.fordiac.ide.model.libraryElement.SimpleECAction}.
@@ -97,5 +97,37 @@ public interface SimpleECState extends INamedElement {
 	 * @generated
 	 */
 	void setSimpleFBType(SimpleFBType value);
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @model kind="operation"
+	 * @generated
+	 */
+	EList<SimpleECAction> getECActions();
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @model kind="operation"
+	 * @generated
+	 */
+	BaseFBType getBaseFBType();
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @model kind="operation" dataType="org.eclipse.emf.ecore.xml.type.Boolean"
+	 * @generated
+	 */
+	boolean isStartState();
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @model
+	 * @generated
+	 */
+	SimpleECAction createNewAction();
 
 } // SimpleECState

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/ECStateImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/ECStateImpl.java
@@ -2,13 +2,13 @@
  * *******************************************************************************
  * Copyright (c) 2008 - 2018 Profactor GmbH, TU Wien ACIN, fortiss GmbH
  *               2022 Martin Erich Jobst
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *    Gerhard Ebenhofer, Alois Zoitl, Ingo Hegny, Monika Wenger, Martin Jobst
  *      - initial API and implementation and/or initial documentation
@@ -17,41 +17,37 @@
 package org.eclipse.fordiac.ide.model.libraryElement.impl;
 
 import java.util.Collection;
-
 import java.util.Map;
 import java.util.stream.Stream;
-import org.eclipse.draw2d.geometry.Point;
 
+import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;
-
 import org.eclipse.emf.common.util.DiagnosticChain;
 import org.eclipse.emf.common.util.EList;
-
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.InternalEObject;
-
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.impl.EObjectImpl;
-
 import org.eclipse.emf.ecore.util.EObjectContainmentWithInverseEList;
 import org.eclipse.emf.ecore.util.EObjectWithInverseResolvingEList;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecore.util.InternalEList;
-
+import org.eclipse.fordiac.ide.model.libraryElement.BaseECState;
+import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.ECAction;
 import org.eclipse.fordiac.ide.model.libraryElement.ECC;
 import org.eclipse.fordiac.ide.model.libraryElement.ECState;
 import org.eclipse.fordiac.ide.model.libraryElement.ECTransition;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.libraryElement.Position;
 import org.eclipse.fordiac.ide.model.libraryElement.PositionableElement;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>EC State</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>EC
+ * State</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * </p>
@@ -69,9 +65,9 @@ import org.eclipse.fordiac.ide.model.libraryElement.PositionableElement;
  */
 public class ECStateImpl extends EObjectImpl implements ECState {
 	/**
-	 * The default value of the '{@link #getName() <em>Name</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getName() <em>Name</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getName()
 	 * @generated
 	 * @ordered
@@ -79,9 +75,9 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	protected static final String NAME_EDEFAULT = ""; //$NON-NLS-1$
 
 	/**
-	 * The cached value of the '{@link #getName() <em>Name</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getName() <em>Name</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getName()
 	 * @generated
 	 * @ordered
@@ -90,8 +86,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 
 	/**
 	 * The default value of the '{@link #getComment() <em>Comment</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @see #getComment()
 	 * @generated
 	 * @ordered
@@ -100,8 +95,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 
 	/**
 	 * The cached value of the '{@link #getComment() <em>Comment</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @see #getComment()
 	 * @generated
 	 * @ordered
@@ -110,8 +104,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 
 	/**
 	 * The cached value of the '{@link #getPosition() <em>Position</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @see #getPosition()
 	 * @generated
 	 * @ordered
@@ -120,8 +113,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 
 	/**
 	 * The cached value of the '{@link #getECAction() <em>EC Action</em>}' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @see #getECAction()
 	 * @generated
 	 * @ordered
@@ -129,9 +121,10 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	protected EList<ECAction> eCAction;
 
 	/**
-	 * The cached value of the '{@link #getOutTransitions() <em>Out Transitions</em>}' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getOutTransitions() <em>Out
+	 * Transitions</em>}' reference list. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 *
 	 * @see #getOutTransitions()
 	 * @generated
 	 * @ordered
@@ -140,8 +133,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 
 	/**
 	 * The cached value of the '{@link #getInTransitions() <em>In Transitions</em>}' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @see #getInTransitions()
 	 * @generated
 	 * @ordered
@@ -149,8 +141,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	protected EList<ECTransition> inTransitions;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	protected ECStateImpl() {
@@ -158,8 +149,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -168,8 +158,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -178,8 +167,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -191,8 +179,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -201,8 +188,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -214,8 +200,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -224,8 +209,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -234,8 +218,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -244,8 +227,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -254,8 +236,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -264,8 +245,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -288,8 +268,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	public Position basicGetPosition() {
@@ -297,8 +276,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	public NotificationChain basicSetPosition(Position newPosition, NotificationChain msgs) {
@@ -312,8 +290,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -332,8 +309,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -345,8 +321,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -358,8 +333,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -371,8 +345,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -382,8 +355,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	public ECC basicGetECC() {
@@ -392,8 +364,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	public NotificationChain basicSetECC(ECC newECC, NotificationChain msgs) {
@@ -402,8 +373,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -424,8 +394,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -434,8 +403,34 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public EList<ECAction> getECActions() {
+		return getECAction();
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public BaseFBType getBaseFBType() {
+		return getECC().getBasicFBType();
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public ECAction createNewAction() {
+		return LibraryElementFactory.eINSTANCE.createECAction();
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -444,8 +439,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -454,8 +448,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -478,8 +471,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -501,8 +493,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -516,8 +507,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -545,8 +535,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -584,8 +573,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -619,8 +607,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -646,8 +633,7 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -658,12 +644,16 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 				default: return -1;
 			}
 		}
+		if (baseClass == BaseECState.class) {
+			switch (derivedFeatureID) {
+				default: return -1;
+			}
+		}
 		return super.eBaseStructuralFeatureID(derivedFeatureID, baseClass);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -674,12 +664,16 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 				default: return -1;
 			}
 		}
+		if (baseClass == BaseECState.class) {
+			switch (baseFeatureID) {
+				default: return -1;
+			}
+		}
 		return super.eDerivedStructuralFeatureID(baseFeatureID, baseClass);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -695,4 +689,4 @@ public class ECStateImpl extends EObjectImpl implements ECState {
 		return result.toString();
 	}
 
-} //ECStateImpl
+} // ECStateImpl

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/LibraryElementPackageImpl.java
@@ -33,6 +33,7 @@ import org.eclipse.emf.ecore.EGenericType;
 import org.eclipse.emf.ecore.EOperation;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.ETypeParameter;
 import org.eclipse.emf.ecore.EValidator;
 
 import org.eclipse.emf.ecore.impl.EPackageImpl;
@@ -136,6 +137,13 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 	 * @generated
 	 */
 	private EClass baseECActionEClass = null;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private EClass baseECStateEClass = null;
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -1359,6 +1367,16 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 	@Override
 	public EAttribute getBaseECAction_Algorithm() {
 		return (EAttribute)baseECActionEClass.getEStructuralFeatures().get(1);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public EClass getBaseECState() {
+		return baseECStateEClass;
 	}
 
 	/**
@@ -4559,6 +4577,8 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 		createEReference(baseECActionEClass, BASE_EC_ACTION__OUTPUT);
 		createEAttribute(baseECActionEClass, BASE_EC_ACTION__ALGORITHM);
 
+		baseECStateEClass = createEClass(BASE_EC_STATE);
+
 		baseFBTypeEClass = createEClass(BASE_FB_TYPE);
 		createEReference(baseFBTypeEClass, BASE_FB_TYPE__INTERNAL_VARS);
 		createEReference(baseFBTypeEClass, BASE_FB_TYPE__INTERNAL_CONST_VARS);
@@ -5015,8 +5035,11 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 		DataPackage theDataPackage = (DataPackage)EPackage.Registry.INSTANCE.getEPackage(DataPackage.eNS_URI);
 
 		// Create type parameters
+		ETypeParameter baseECStateEClass_T = addETypeParameter(baseECStateEClass, "T"); //$NON-NLS-1$
 
 		// Set bounds for type parameters
+		EGenericType g1 = createEGenericType(this.getBaseECAction());
+		baseECStateEClass_T.getEBounds().add(g1);
 
 		// Add supertypes to classes
 		adapterConnectionEClass.getESuperTypes().add(this.getConnection());
@@ -5052,8 +5075,14 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 		deviceEClass.getESuperTypes().add(this.getIVarElement());
 		deviceTypeEClass.getESuperTypes().add(this.getLibraryElement());
 		ecActionEClass.getESuperTypes().add(this.getBaseECAction());
-		ecStateEClass.getESuperTypes().add(this.getINamedElement());
-		ecStateEClass.getESuperTypes().add(this.getPositionableElement());
+		g1 = createEGenericType(this.getINamedElement());
+		ecStateEClass.getEGenericSuperTypes().add(g1);
+		g1 = createEGenericType(this.getPositionableElement());
+		ecStateEClass.getEGenericSuperTypes().add(g1);
+		g1 = createEGenericType(this.getBaseECState());
+		EGenericType g2 = createEGenericType(this.getECAction());
+		g1.getETypeArguments().add(g2);
+		ecStateEClass.getEGenericSuperTypes().add(g1);
 		ecTransitionEClass.getESuperTypes().add(this.getPositionableElement());
 		errorAdapterTypeEClass.getESuperTypes().add(this.getAdapterType());
 		errorAdapterTypeEClass.getESuperTypes().add(this.getErrorFBType());
@@ -5125,7 +5154,12 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 		serviceInterfaceEClass.getESuperTypes().add(this.getINamedElement());
 		serviceInterfaceFBTypeEClass.getESuperTypes().add(this.getFBType());
 		simpleECActionEClass.getESuperTypes().add(this.getBaseECAction());
-		simpleECStateEClass.getESuperTypes().add(this.getINamedElement());
+		g1 = createEGenericType(this.getINamedElement());
+		simpleECStateEClass.getEGenericSuperTypes().add(g1);
+		g1 = createEGenericType(this.getBaseECState());
+		g2 = createEGenericType(this.getSimpleECAction());
+		g1.getETypeArguments().add(g2);
+		simpleECStateEClass.getEGenericSuperTypes().add(g1);
 		simpleFBTypeEClass.getESuperTypes().add(this.getBaseFBType());
 		stAlgorithmEClass.getESuperTypes().add(this.getTextAlgorithm());
 		stFunctionEClass.getESuperTypes().add(this.getTextFunction());
@@ -5204,8 +5238,8 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 
 		op = addEOperation(attributeEClass, ecorePackage.getEBoolean(), "validateName", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 		addEParameter(op, ecorePackage.getEDiagnosticChain(), "diagnostics", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
-		EGenericType g1 = createEGenericType(ecorePackage.getEMap());
-		EGenericType g2 = createEGenericType(ecorePackage.getEJavaObject());
+		g1 = createEGenericType(ecorePackage.getEMap());
+		g2 = createEGenericType(ecorePackage.getEJavaObject());
 		g1.getETypeArguments().add(g2);
 		g2 = createEGenericType(ecorePackage.getEJavaObject());
 		g1.getETypeArguments().add(g2);
@@ -5245,6 +5279,20 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 		initEClass(baseECActionEClass, BaseECAction.class, "BaseECAction", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getBaseECAction_Output(), this.getEvent(), null, "output", null, 0, 1, BaseECAction.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEAttribute(getBaseECAction_Algorithm(), theXMLTypePackage.getString(), "algorithm", null, 0, 1, BaseECAction.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
+
+		initEClass(baseECStateEClass, BaseECState.class, "BaseECState", IS_ABSTRACT, IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
+
+		op = addEOperation(baseECStateEClass, null, "getECActions", 0, -1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		g1 = createEGenericType(baseECStateEClass_T);
+		initEOperation(op, g1);
+
+		addEOperation(baseECStateEClass, this.getBaseFBType(), "getBaseFBType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+
+		addEOperation(baseECStateEClass, theXMLTypePackage.getBoolean(), "isStartState", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+
+		op = addEOperation(baseECStateEClass, null, "createNewAction", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		g1 = createEGenericType(baseECStateEClass_T);
+		initEOperation(op, g1);
 
 		initEClass(baseFBTypeEClass, BaseFBType.class, "BaseFBType", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getBaseFBType_InternalVars(), this.getVarDeclaration(), null, "internalVars", null, 0, -1, BaseFBType.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
@@ -5629,7 +5677,13 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 		initEReference(getECState_InTransitions(), this.getECTransition(), this.getECTransition_Destination(), "inTransitions", null, 0, -1, ECState.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEReference(getECState_ECC(), this.getECC(), this.getECC_ECState(), "eCC", null, 0, 1, ECState.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 
+		addEOperation(ecStateEClass, this.getECAction(), "getECActions", 0, -1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+
+		addEOperation(ecStateEClass, this.getBaseFBType(), "getBaseFBType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+
 		addEOperation(ecStateEClass, theXMLTypePackage.getBoolean(), "isStartState", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+
+		addEOperation(ecStateEClass, this.getECAction(), "createNewAction", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(ecTransitionEClass, ECTransition.class, "ECTransition", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEAttribute(getECTransition_Comment(), theXMLTypePackage.getString(), "comment", "", 0, 1, ECTransition.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$ //$NON-NLS-2$
@@ -6225,6 +6279,14 @@ public class LibraryElementPackageImpl extends EPackageImpl implements LibraryEl
 		initEReference(getSimpleECState_SimpleECActions(), this.getSimpleECAction(), this.getSimpleECAction_SimpleECState(), "simpleECActions", null, 0, -1, SimpleECState.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEReference(getSimpleECState_InputEvent(), this.getEvent(), null, "inputEvent", null, 1, 1, SimpleECState.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
 		initEReference(getSimpleECState_SimpleFBType(), this.getSimpleFBType(), this.getSimpleFBType_SimpleECStates(), "simpleFBType", null, 1, 1, SimpleECState.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$
+
+		addEOperation(simpleECStateEClass, this.getSimpleECAction(), "getECActions", 0, -1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+
+		addEOperation(simpleECStateEClass, this.getBaseFBType(), "getBaseFBType", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+
+		addEOperation(simpleECStateEClass, theXMLTypePackage.getBoolean(), "isStartState", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+
+		addEOperation(simpleECStateEClass, this.getSimpleECAction(), "createNewAction", 0, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(simpleFBTypeEClass, SimpleFBType.class, "SimpleFBType", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 		initEReference(getSimpleFBType_SimpleECStates(), this.getSimpleECState(), this.getSimpleECState_SimpleFBType(), "simpleECStates", null, 1, -1, SimpleFBType.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED); //$NON-NLS-1$

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/SimpleECStateImpl.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/impl/SimpleECStateImpl.java
@@ -2,13 +2,13 @@
  * *******************************************************************************
  * Copyright (c) 2008 - 2018 Profactor GmbH, TU Wien ACIN, fortiss GmbH
  *               2022-2023 Martin Erich Jobst
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *    Gerhard Ebenhofer, Alois Zoitl, Ingo Hegny, Monika Wenger, Martin Jobst
  *      - initial API and implementation and/or initial documentation
@@ -19,32 +19,30 @@ package org.eclipse.fordiac.ide.model.libraryElement.impl;
 import java.util.Collection;
 import java.util.Map;
 import java.util.stream.Stream;
+
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;
-
 import org.eclipse.emf.common.util.DiagnosticChain;
 import org.eclipse.emf.common.util.EList;
-
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.InternalEObject;
-
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.impl.EObjectImpl;
 import org.eclipse.emf.ecore.util.EObjectContainmentWithInverseEList;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecore.util.InternalEList;
-
+import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.Event;
 import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
 import org.eclipse.fordiac.ide.model.libraryElement.SimpleECAction;
 import org.eclipse.fordiac.ide.model.libraryElement.SimpleECState;
 import org.eclipse.fordiac.ide.model.libraryElement.SimpleFBType;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Simple EC State</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Simple
+ * EC State</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * </p>
@@ -60,9 +58,9 @@ import org.eclipse.fordiac.ide.model.libraryElement.SimpleFBType;
  */
 public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	/**
-	 * The default value of the '{@link #getName() <em>Name</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getName() <em>Name</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getName()
 	 * @generated
 	 * @ordered
@@ -70,9 +68,9 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	protected static final String NAME_EDEFAULT = ""; //$NON-NLS-1$
 
 	/**
-	 * The cached value of the '{@link #getName() <em>Name</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getName() <em>Name</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 *
 	 * @see #getName()
 	 * @generated
 	 * @ordered
@@ -81,8 +79,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 
 	/**
 	 * The default value of the '{@link #getComment() <em>Comment</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @see #getComment()
 	 * @generated
 	 * @ordered
@@ -91,8 +88,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 
 	/**
 	 * The cached value of the '{@link #getComment() <em>Comment</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @see #getComment()
 	 * @generated
 	 * @ordered
@@ -101,8 +97,8 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 
 	/**
 	 * The cached value of the '{@link #getSimpleECActions() <em>Simple EC Actions</em>}' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
 	 * @see #getSimpleECActions()
 	 * @generated
 	 * @ordered
@@ -111,8 +107,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 
 	/**
 	 * The cached value of the '{@link #getInputEvent() <em>Input Event</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @see #getInputEvent()
 	 * @generated
 	 * @ordered
@@ -120,8 +115,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	protected Event inputEvent;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	protected SimpleECStateImpl() {
@@ -129,8 +123,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -139,8 +132,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -149,8 +141,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -162,8 +153,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -172,8 +162,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -185,8 +174,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -198,8 +186,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -216,8 +203,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	public Event basicGetInputEvent() {
@@ -225,8 +211,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -238,8 +223,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -249,8 +233,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	public SimpleFBType basicGetSimpleFBType() {
@@ -259,8 +242,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	public NotificationChain basicSetSimpleFBType(SimpleFBType newSimpleFBType, NotificationChain msgs) {
@@ -269,8 +251,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -291,8 +272,43 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public EList<SimpleECAction> getECActions() {
+		return getSimpleECActions();
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public BaseFBType getBaseFBType() {
+		return getSimpleFBType();
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public boolean isStartState() {
+		return false;
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public SimpleECAction createNewAction() {
+		return LibraryElementFactory.eINSTANCE.createSimpleECAction();
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -301,8 +317,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -311,8 +326,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -321,8 +335,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -331,8 +344,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -341,8 +353,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -361,8 +372,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -378,8 +388,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -393,8 +402,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -418,8 +426,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -449,8 +456,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -478,8 +484,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -501,8 +506,7 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
 	@Override
@@ -518,4 +522,4 @@ public class SimpleECStateImpl extends EObjectImpl implements SimpleECState {
 		return result.toString();
 	}
 
-} //SimpleECStateImpl
+} // SimpleECStateImpl

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/util/LibraryElementAdapterFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/util/LibraryElementAdapterFactory.java
@@ -127,6 +127,10 @@ public class LibraryElementAdapterFactory extends AdapterFactoryImpl {
 				return createBaseECActionAdapter();
 			}
 			@Override
+			public <T extends BaseECAction> Adapter caseBaseECState(BaseECState<T> object) {
+				return createBaseECStateAdapter();
+			}
+			@Override
 			public Adapter caseBaseFBType(BaseFBType object) {
 				return createBaseFBTypeAdapter();
 			}
@@ -783,6 +787,20 @@ public class LibraryElementAdapterFactory extends AdapterFactoryImpl {
 	 * @generated
 	 */
 	public Adapter createBaseECActionAdapter() {
+		return null;
+	}
+
+	/**
+	 * Creates a new adapter for an object of class '{@link org.eclipse.fordiac.ide.model.libraryElement.BaseECState <em>Base EC State</em>}'.
+	 * <!-- begin-user-doc -->
+	 * This default implementation returns null so that we can easily ignore cases;
+	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
+	 * <!-- end-user-doc -->
+	 * @return the new adapter.
+	 * @see org.eclipse.fordiac.ide.model.libraryElement.BaseECState
+	 * @generated
+	 */
+	public Adapter createBaseECStateAdapter() {
 		return null;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/util/LibraryElementSwitch.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/util/LibraryElementSwitch.java
@@ -37,7 +37,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.*;
  * @see org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage
  * @generated
  */
-public class LibraryElementSwitch<T> extends Switch<T> {
+public class LibraryElementSwitch<T1> extends Switch<T1> {
 	/**
 	 * The cached model package
 	 * <!-- begin-user-doc -->
@@ -79,11 +79,11 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @generated
 	 */
 	@Override
-	protected T doSwitch(int classifierID, EObject theEObject) {
+	protected T1 doSwitch(int classifierID, EObject theEObject) {
 		switch (classifierID) {
 			case LibraryElementPackage.ADAPTER_CONNECTION: {
 				AdapterConnection adapterConnection = (AdapterConnection)theEObject;
-				T result = caseAdapterConnection(adapterConnection);
+				T1 result = caseAdapterConnection(adapterConnection);
 				if (result == null) result = caseConnection(adapterConnection);
 				if (result == null) result = caseHiddenElement(adapterConnection);
 				if (result == null) result = caseConfigurableObject(adapterConnection);
@@ -92,7 +92,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.ADAPTER_DECLARATION: {
 				AdapterDeclaration adapterDeclaration = (AdapterDeclaration)theEObject;
-				T result = caseAdapterDeclaration(adapterDeclaration);
+				T1 result = caseAdapterDeclaration(adapterDeclaration);
 				if (result == null) result = caseIInterfaceElement(adapterDeclaration);
 				if (result == null) result = caseITypedElement(adapterDeclaration);
 				if (result == null) result = caseHiddenElement(adapterDeclaration);
@@ -103,7 +103,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.ADAPTER_FB: {
 				AdapterFB adapterFB = (AdapterFB)theEObject;
-				T result = caseAdapterFB(adapterFB);
+				T1 result = caseAdapterFB(adapterFB);
 				if (result == null) result = caseFB(adapterFB);
 				if (result == null) result = caseBlockFBNetworkElement(adapterFB);
 				if (result == null) result = caseICallable(adapterFB);
@@ -118,7 +118,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.ADAPTER_TYPE: {
 				AdapterType adapterType = (AdapterType)theEObject;
-				T result = caseAdapterType(adapterType);
+				T1 result = caseAdapterType(adapterType);
 				if (result == null) result = caseDataType(adapterType);
 				if (result == null) result = caseFBType(adapterType);
 				if (result == null) result = caseLibraryElement(adapterType);
@@ -130,7 +130,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.ALGORITHM: {
 				Algorithm algorithm = (Algorithm)theEObject;
-				T result = caseAlgorithm(algorithm);
+				T1 result = caseAlgorithm(algorithm);
 				if (result == null) result = caseICallable(algorithm);
 				if (result == null) result = caseINamedElement(algorithm);
 				if (result == null) result = defaultCase(theEObject);
@@ -138,7 +138,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.APPLICATION: {
 				Application application = (Application)theEObject;
-				T result = caseApplication(application);
+				T1 result = caseApplication(application);
 				if (result == null) result = caseINamedElement(application);
 				if (result == null) result = caseConfigurableObject(application);
 				if (result == null) result = defaultCase(theEObject);
@@ -146,13 +146,13 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.ARRAY_SIZE: {
 				ArraySize arraySize = (ArraySize)theEObject;
-				T result = caseArraySize(arraySize);
+				T1 result = caseArraySize(arraySize);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.ATTRIBUTE: {
 				Attribute attribute = (Attribute)theEObject;
-				T result = caseAttribute(attribute);
+				T1 result = caseAttribute(attribute);
 				if (result == null) result = caseITypedElement(attribute);
 				if (result == null) result = caseINamedElement(attribute);
 				if (result == null) result = defaultCase(theEObject);
@@ -160,7 +160,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.ATTRIBUTE_DECLARATION: {
 				AttributeDeclaration attributeDeclaration = (AttributeDeclaration)theEObject;
-				T result = caseAttributeDeclaration(attributeDeclaration);
+				T1 result = caseAttributeDeclaration(attributeDeclaration);
 				if (result == null) result = caseITypedElement(attributeDeclaration);
 				if (result == null) result = caseLibraryElement(attributeDeclaration);
 				if (result == null) result = caseINamedElement(attributeDeclaration);
@@ -170,7 +170,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.AUTOMATION_SYSTEM: {
 				AutomationSystem automationSystem = (AutomationSystem)theEObject;
-				T result = caseAutomationSystem(automationSystem);
+				T1 result = caseAutomationSystem(automationSystem);
 				if (result == null) result = caseLibraryElement(automationSystem);
 				if (result == null) result = caseINamedElement(automationSystem);
 				if (result == null) result = caseConfigurableObject(automationSystem);
@@ -179,13 +179,19 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.BASE_EC_ACTION: {
 				BaseECAction baseECAction = (BaseECAction)theEObject;
-				T result = caseBaseECAction(baseECAction);
+				T1 result = caseBaseECAction(baseECAction);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case LibraryElementPackage.BASE_EC_STATE: {
+				BaseECState<?> baseECState = (BaseECState<?>)theEObject;
+				T1 result = caseBaseECState(baseECState);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.BASE_FB_TYPE: {
 				BaseFBType baseFBType = (BaseFBType)theEObject;
-				T result = caseBaseFBType(baseFBType);
+				T1 result = caseBaseFBType(baseFBType);
 				if (result == null) result = caseFBType(baseFBType);
 				if (result == null) result = caseLibraryElement(baseFBType);
 				if (result == null) result = caseICallable(baseFBType);
@@ -196,7 +202,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.BASIC_FB_TYPE: {
 				BasicFBType basicFBType = (BasicFBType)theEObject;
-				T result = caseBasicFBType(basicFBType);
+				T1 result = caseBasicFBType(basicFBType);
 				if (result == null) result = caseBaseFBType(basicFBType);
 				if (result == null) result = caseFBType(basicFBType);
 				if (result == null) result = caseLibraryElement(basicFBType);
@@ -208,7 +214,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.BLOCK_FB_NETWORK_ELEMENT: {
 				BlockFBNetworkElement blockFBNetworkElement = (BlockFBNetworkElement)theEObject;
-				T result = caseBlockFBNetworkElement(blockFBNetworkElement);
+				T1 result = caseBlockFBNetworkElement(blockFBNetworkElement);
 				if (result == null) result = caseFBNetworkElement(blockFBNetworkElement);
 				if (result == null) result = caseTypedConfigureableObject(blockFBNetworkElement);
 				if (result == null) result = casePositionableElement(blockFBNetworkElement);
@@ -220,7 +226,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.CFB_INSTANCE: {
 				CFBInstance cfbInstance = (CFBInstance)theEObject;
-				T result = caseCFBInstance(cfbInstance);
+				T1 result = caseCFBInstance(cfbInstance);
 				if (result == null) result = caseFB(cfbInstance);
 				if (result == null) result = caseBlockFBNetworkElement(cfbInstance);
 				if (result == null) result = caseICallable(cfbInstance);
@@ -235,19 +241,19 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.COLOR: {
 				Color color = (Color)theEObject;
-				T result = caseColor(color);
+				T1 result = caseColor(color);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.COLORIZABLE_ELEMENT: {
 				ColorizableElement colorizableElement = (ColorizableElement)theEObject;
-				T result = caseColorizableElement(colorizableElement);
+				T1 result = caseColorizableElement(colorizableElement);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.COMMENT: {
 				Comment comment = (Comment)theEObject;
-				T result = caseComment(comment);
+				T1 result = caseComment(comment);
 				if (result == null) result = caseFBNetworkElement(comment);
 				if (result == null) result = caseTypedConfigureableObject(comment);
 				if (result == null) result = casePositionableElement(comment);
@@ -259,7 +265,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.COMMUNICATION_CHANNEL: {
 				CommunicationChannel communicationChannel = (CommunicationChannel)theEObject;
-				T result = caseCommunicationChannel(communicationChannel);
+				T1 result = caseCommunicationChannel(communicationChannel);
 				if (result == null) result = caseFB(communicationChannel);
 				if (result == null) result = caseBlockFBNetworkElement(communicationChannel);
 				if (result == null) result = caseICallable(communicationChannel);
@@ -274,13 +280,13 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.COMMUNICATION_CONFIGURATION: {
 				CommunicationConfiguration communicationConfiguration = (CommunicationConfiguration)theEObject;
-				T result = caseCommunicationConfiguration(communicationConfiguration);
+				T1 result = caseCommunicationConfiguration(communicationConfiguration);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.COMMUNICATION_MAPPING_TARGET: {
 				CommunicationMappingTarget communicationMappingTarget = (CommunicationMappingTarget)theEObject;
-				T result = caseCommunicationMappingTarget(communicationMappingTarget);
+				T1 result = caseCommunicationMappingTarget(communicationMappingTarget);
 				if (result == null) result = caseMappingTarget(communicationMappingTarget);
 				if (result == null) result = caseINamedElement(communicationMappingTarget);
 				if (result == null) result = defaultCase(theEObject);
@@ -288,19 +294,19 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.COMPILER: {
 				org.eclipse.fordiac.ide.model.libraryElement.Compiler compiler = (org.eclipse.fordiac.ide.model.libraryElement.Compiler)theEObject;
-				T result = caseCompiler(compiler);
+				T1 result = caseCompiler(compiler);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.COMPILER_INFO: {
 				CompilerInfo compilerInfo = (CompilerInfo)theEObject;
-				T result = caseCompilerInfo(compilerInfo);
+				T1 result = caseCompilerInfo(compilerInfo);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.COMPOSITE_FB_TYPE: {
 				CompositeFBType compositeFBType = (CompositeFBType)theEObject;
-				T result = caseCompositeFBType(compositeFBType);
+				T1 result = caseCompositeFBType(compositeFBType);
 				if (result == null) result = caseFBType(compositeFBType);
 				if (result == null) result = caseLibraryElement(compositeFBType);
 				if (result == null) result = caseICallable(compositeFBType);
@@ -311,13 +317,13 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.CONFIGURABLE_OBJECT: {
 				ConfigurableObject configurableObject = (ConfigurableObject)theEObject;
-				T result = caseConfigurableObject(configurableObject);
+				T1 result = caseConfigurableObject(configurableObject);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.CONFIGURABLE_FB: {
 				ConfigurableFB configurableFB = (ConfigurableFB)theEObject;
-				T result = caseConfigurableFB(configurableFB);
+				T1 result = caseConfigurableFB(configurableFB);
 				if (result == null) result = caseFB(configurableFB);
 				if (result == null) result = caseBlockFBNetworkElement(configurableFB);
 				if (result == null) result = caseICallable(configurableFB);
@@ -332,7 +338,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.CONFIGURABLE_MOVE_FB: {
 				ConfigurableMoveFB configurableMoveFB = (ConfigurableMoveFB)theEObject;
-				T result = caseConfigurableMoveFB(configurableMoveFB);
+				T1 result = caseConfigurableMoveFB(configurableMoveFB);
 				if (result == null) result = caseConfigurableFB(configurableMoveFB);
 				if (result == null) result = caseFB(configurableMoveFB);
 				if (result == null) result = caseBlockFBNetworkElement(configurableMoveFB);
@@ -348,7 +354,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.CONNECTION: {
 				Connection connection = (Connection)theEObject;
-				T result = caseConnection(connection);
+				T1 result = caseConnection(connection);
 				if (result == null) result = caseHiddenElement(connection);
 				if (result == null) result = caseConfigurableObject(connection);
 				if (result == null) result = defaultCase(theEObject);
@@ -356,13 +362,13 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.CONNECTION_ROUTING_DATA: {
 				ConnectionRoutingData connectionRoutingData = (ConnectionRoutingData)theEObject;
-				T result = caseConnectionRoutingData(connectionRoutingData);
+				T1 result = caseConnectionRoutingData(connectionRoutingData);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.CONTAINER_VAR_DECLARATION: {
 				ContainerVarDeclaration containerVarDeclaration = (ContainerVarDeclaration)theEObject;
-				T result = caseContainerVarDeclaration(containerVarDeclaration);
+				T1 result = caseContainerVarDeclaration(containerVarDeclaration);
 				if (result == null) result = caseVarDeclaration(containerVarDeclaration);
 				if (result == null) result = caseIInterfaceElement(containerVarDeclaration);
 				if (result == null) result = caseITypedElement(containerVarDeclaration);
@@ -374,7 +380,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.DATA_CONNECTION: {
 				DataConnection dataConnection = (DataConnection)theEObject;
-				T result = caseDataConnection(dataConnection);
+				T1 result = caseDataConnection(dataConnection);
 				if (result == null) result = caseConnection(dataConnection);
 				if (result == null) result = caseHiddenElement(dataConnection);
 				if (result == null) result = caseConfigurableObject(dataConnection);
@@ -383,7 +389,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.DEMULTIPLEXER: {
 				Demultiplexer demultiplexer = (Demultiplexer)theEObject;
-				T result = caseDemultiplexer(demultiplexer);
+				T1 result = caseDemultiplexer(demultiplexer);
 				if (result == null) result = caseStructManipulator(demultiplexer);
 				if (result == null) result = caseConfigurableFB(demultiplexer);
 				if (result == null) result = caseFB(demultiplexer);
@@ -400,7 +406,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.DEVICE: {
 				Device device = (Device)theEObject;
-				T result = caseDevice(device);
+				T1 result = caseDevice(device);
 				if (result == null) result = caseTypedConfigureableObject(device);
 				if (result == null) result = casePositionableElement(device);
 				if (result == null) result = caseColorizableElement(device);
@@ -413,7 +419,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.DEVICE_TYPE: {
 				DeviceType deviceType = (DeviceType)theEObject;
-				T result = caseDeviceType(deviceType);
+				T1 result = caseDeviceType(deviceType);
 				if (result == null) result = caseLibraryElement(deviceType);
 				if (result == null) result = caseINamedElement(deviceType);
 				if (result == null) result = caseConfigurableObject(deviceType);
@@ -422,35 +428,36 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.EC_ACTION: {
 				ECAction ecAction = (ECAction)theEObject;
-				T result = caseECAction(ecAction);
+				T1 result = caseECAction(ecAction);
 				if (result == null) result = caseBaseECAction(ecAction);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.ECC: {
 				ECC ecc = (ECC)theEObject;
-				T result = caseECC(ecc);
+				T1 result = caseECC(ecc);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.EC_STATE: {
 				ECState ecState = (ECState)theEObject;
-				T result = caseECState(ecState);
+				T1 result = caseECState(ecState);
 				if (result == null) result = caseINamedElement(ecState);
 				if (result == null) result = casePositionableElement(ecState);
+				if (result == null) result = caseBaseECState(ecState);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.EC_TRANSITION: {
 				ECTransition ecTransition = (ECTransition)theEObject;
-				T result = caseECTransition(ecTransition);
+				T1 result = caseECTransition(ecTransition);
 				if (result == null) result = casePositionableElement(ecTransition);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.ERROR_ADAPTER_TYPE: {
 				ErrorAdapterType errorAdapterType = (ErrorAdapterType)theEObject;
-				T result = caseErrorAdapterType(errorAdapterType);
+				T1 result = caseErrorAdapterType(errorAdapterType);
 				if (result == null) result = caseAdapterType(errorAdapterType);
 				if (result == null) result = caseErrorFBType(errorAdapterType);
 				if (result == null) result = caseDataType(errorAdapterType);
@@ -465,7 +472,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.ERROR_ATTRIBUTE_DECLARATION: {
 				ErrorAttributeDeclaration errorAttributeDeclaration = (ErrorAttributeDeclaration)theEObject;
-				T result = caseErrorAttributeDeclaration(errorAttributeDeclaration);
+				T1 result = caseErrorAttributeDeclaration(errorAttributeDeclaration);
 				if (result == null) result = caseAttributeDeclaration(errorAttributeDeclaration);
 				if (result == null) result = caseErrorLibraryElement(errorAttributeDeclaration);
 				if (result == null) result = caseITypedElement(errorAttributeDeclaration);
@@ -477,7 +484,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.ERROR_AUTOMATION_SYSTEM: {
 				ErrorAutomationSystem errorAutomationSystem = (ErrorAutomationSystem)theEObject;
-				T result = caseErrorAutomationSystem(errorAutomationSystem);
+				T1 result = caseErrorAutomationSystem(errorAutomationSystem);
 				if (result == null) result = caseAutomationSystem(errorAutomationSystem);
 				if (result == null) result = caseErrorLibraryElement(errorAutomationSystem);
 				if (result == null) result = caseLibraryElement(errorAutomationSystem);
@@ -488,7 +495,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.ERROR_DEVICE_TYPE: {
 				ErrorDeviceType errorDeviceType = (ErrorDeviceType)theEObject;
-				T result = caseErrorDeviceType(errorDeviceType);
+				T1 result = caseErrorDeviceType(errorDeviceType);
 				if (result == null) result = caseDeviceType(errorDeviceType);
 				if (result == null) result = caseErrorLibraryElement(errorDeviceType);
 				if (result == null) result = caseLibraryElement(errorDeviceType);
@@ -499,7 +506,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.ERROR_FB_TYPE: {
 				ErrorFBType errorFBType = (ErrorFBType)theEObject;
-				T result = caseErrorFBType(errorFBType);
+				T1 result = caseErrorFBType(errorFBType);
 				if (result == null) result = caseFBType(errorFBType);
 				if (result == null) result = caseErrorLibraryElement(errorFBType);
 				if (result == null) result = caseLibraryElement(errorFBType);
@@ -511,7 +518,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.ERROR_FUNCTION_FB_TYPE: {
 				ErrorFunctionFBType errorFunctionFBType = (ErrorFunctionFBType)theEObject;
-				T result = caseErrorFunctionFBType(errorFunctionFBType);
+				T1 result = caseErrorFunctionFBType(errorFunctionFBType);
 				if (result == null) result = caseFunctionFBType(errorFunctionFBType);
 				if (result == null) result = caseErrorFBType(errorFunctionFBType);
 				if (result == null) result = caseFBType(errorFunctionFBType);
@@ -525,7 +532,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.ERROR_GLOBAL_CONSTANTS: {
 				ErrorGlobalConstants errorGlobalConstants = (ErrorGlobalConstants)theEObject;
-				T result = caseErrorGlobalConstants(errorGlobalConstants);
+				T1 result = caseErrorGlobalConstants(errorGlobalConstants);
 				if (result == null) result = caseGlobalConstants(errorGlobalConstants);
 				if (result == null) result = caseErrorLibraryElement(errorGlobalConstants);
 				if (result == null) result = caseLibraryElement(errorGlobalConstants);
@@ -536,7 +543,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.ERROR_LIBRARY_ELEMENT: {
 				ErrorLibraryElement errorLibraryElement = (ErrorLibraryElement)theEObject;
-				T result = caseErrorLibraryElement(errorLibraryElement);
+				T1 result = caseErrorLibraryElement(errorLibraryElement);
 				if (result == null) result = caseLibraryElement(errorLibraryElement);
 				if (result == null) result = caseINamedElement(errorLibraryElement);
 				if (result == null) result = caseConfigurableObject(errorLibraryElement);
@@ -545,7 +552,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.ERROR_MARKER_FBN_ELEMENT: {
 				ErrorMarkerFBNElement errorMarkerFBNElement = (ErrorMarkerFBNElement)theEObject;
-				T result = caseErrorMarkerFBNElement(errorMarkerFBNElement);
+				T1 result = caseErrorMarkerFBNElement(errorMarkerFBNElement);
 				if (result == null) result = caseBlockFBNetworkElement(errorMarkerFBNElement);
 				if (result == null) result = caseFBNetworkElement(errorMarkerFBNElement);
 				if (result == null) result = caseTypedConfigureableObject(errorMarkerFBNElement);
@@ -558,7 +565,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.ERROR_MARKER_INTERFACE: {
 				ErrorMarkerInterface errorMarkerInterface = (ErrorMarkerInterface)theEObject;
-				T result = caseErrorMarkerInterface(errorMarkerInterface);
+				T1 result = caseErrorMarkerInterface(errorMarkerInterface);
 				if (result == null) result = caseIInterfaceElement(errorMarkerInterface);
 				if (result == null) result = caseITypedElement(errorMarkerInterface);
 				if (result == null) result = caseHiddenElement(errorMarkerInterface);
@@ -569,7 +576,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.ERROR_RESOURCE_TYPE: {
 				ErrorResourceType errorResourceType = (ErrorResourceType)theEObject;
-				T result = caseErrorResourceType(errorResourceType);
+				T1 result = caseErrorResourceType(errorResourceType);
 				if (result == null) result = caseResourceType(errorResourceType);
 				if (result == null) result = caseErrorLibraryElement(errorResourceType);
 				if (result == null) result = caseLibraryElement(errorResourceType);
@@ -580,7 +587,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.ERROR_SEGMENT_TYPE: {
 				ErrorSegmentType errorSegmentType = (ErrorSegmentType)theEObject;
-				T result = caseErrorSegmentType(errorSegmentType);
+				T1 result = caseErrorSegmentType(errorSegmentType);
 				if (result == null) result = caseSegmentType(errorSegmentType);
 				if (result == null) result = caseErrorLibraryElement(errorSegmentType);
 				if (result == null) result = caseLibraryElement(errorSegmentType);
@@ -591,7 +598,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.ERROR_SUB_APP_TYPE: {
 				ErrorSubAppType errorSubAppType = (ErrorSubAppType)theEObject;
-				T result = caseErrorSubAppType(errorSubAppType);
+				T1 result = caseErrorSubAppType(errorSubAppType);
 				if (result == null) result = caseSubAppType(errorSubAppType);
 				if (result == null) result = caseErrorFBType(errorSubAppType);
 				if (result == null) result = caseCompositeFBType(errorSubAppType);
@@ -606,7 +613,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.EVENT: {
 				Event event = (Event)theEObject;
-				T result = caseEvent(event);
+				T1 result = caseEvent(event);
 				if (result == null) result = caseIInterfaceElement(event);
 				if (result == null) result = caseICallable(event);
 				if (result == null) result = caseITypedElement(event);
@@ -618,7 +625,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.EVENT_CONNECTION: {
 				EventConnection eventConnection = (EventConnection)theEObject;
-				T result = caseEventConnection(eventConnection);
+				T1 result = caseEventConnection(eventConnection);
 				if (result == null) result = caseConnection(eventConnection);
 				if (result == null) result = caseHiddenElement(eventConnection);
 				if (result == null) result = caseConfigurableObject(eventConnection);
@@ -627,7 +634,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.FB: {
 				FB fb = (FB)theEObject;
-				T result = caseFB(fb);
+				T1 result = caseFB(fb);
 				if (result == null) result = caseBlockFBNetworkElement(fb);
 				if (result == null) result = caseICallable(fb);
 				if (result == null) result = caseFBNetworkElement(fb);
@@ -641,13 +648,13 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.FB_NETWORK: {
 				FBNetwork fbNetwork = (FBNetwork)theEObject;
-				T result = caseFBNetwork(fbNetwork);
+				T1 result = caseFBNetwork(fbNetwork);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.FB_NETWORK_ELEMENT: {
 				FBNetworkElement fbNetworkElement = (FBNetworkElement)theEObject;
-				T result = caseFBNetworkElement(fbNetworkElement);
+				T1 result = caseFBNetworkElement(fbNetworkElement);
 				if (result == null) result = caseTypedConfigureableObject(fbNetworkElement);
 				if (result == null) result = casePositionableElement(fbNetworkElement);
 				if (result == null) result = caseITypedElement(fbNetworkElement);
@@ -658,7 +665,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.FB_TYPE: {
 				FBType fbType = (FBType)theEObject;
-				T result = caseFBType(fbType);
+				T1 result = caseFBType(fbType);
 				if (result == null) result = caseLibraryElement(fbType);
 				if (result == null) result = caseICallable(fbType);
 				if (result == null) result = caseINamedElement(fbType);
@@ -668,7 +675,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.FUNCTION: {
 				Function function = (Function)theEObject;
-				T result = caseFunction(function);
+				T1 result = caseFunction(function);
 				if (result == null) result = caseICallable(function);
 				if (result == null) result = caseINamedElement(function);
 				if (result == null) result = defaultCase(theEObject);
@@ -676,13 +683,13 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.FUNCTION_BODY: {
 				FunctionBody functionBody = (FunctionBody)theEObject;
-				T result = caseFunctionBody(functionBody);
+				T1 result = caseFunctionBody(functionBody);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.FUNCTION_FB_TYPE: {
 				FunctionFBType functionFBType = (FunctionFBType)theEObject;
-				T result = caseFunctionFBType(functionFBType);
+				T1 result = caseFunctionFBType(functionFBType);
 				if (result == null) result = caseFBType(functionFBType);
 				if (result == null) result = caseLibraryElement(functionFBType);
 				if (result == null) result = caseICallable(functionFBType);
@@ -693,7 +700,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.GLOBAL_CONSTANTS: {
 				GlobalConstants globalConstants = (GlobalConstants)theEObject;
-				T result = caseGlobalConstants(globalConstants);
+				T1 result = caseGlobalConstants(globalConstants);
 				if (result == null) result = caseLibraryElement(globalConstants);
 				if (result == null) result = caseINamedElement(globalConstants);
 				if (result == null) result = caseConfigurableObject(globalConstants);
@@ -702,7 +709,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.GROUP: {
 				Group group = (Group)theEObject;
-				T result = caseGroup(group);
+				T1 result = caseGroup(group);
 				if (result == null) result = caseFBNetworkElement(group);
 				if (result == null) result = caseTypedConfigureableObject(group);
 				if (result == null) result = casePositionableElement(group);
@@ -714,27 +721,27 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.HIDDEN_ELEMENT: {
 				HiddenElement hiddenElement = (HiddenElement)theEObject;
-				T result = caseHiddenElement(hiddenElement);
+				T1 result = caseHiddenElement(hiddenElement);
 				if (result == null) result = caseConfigurableObject(hiddenElement);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.ICALLABLE: {
 				ICallable iCallable = (ICallable)theEObject;
-				T result = caseICallable(iCallable);
+				T1 result = caseICallable(iCallable);
 				if (result == null) result = caseINamedElement(iCallable);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.IDENTIFICATION: {
 				Identification identification = (Identification)theEObject;
-				T result = caseIdentification(identification);
+				T1 result = caseIdentification(identification);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.IINTERFACE_ELEMENT: {
 				IInterfaceElement iInterfaceElement = (IInterfaceElement)theEObject;
-				T result = caseIInterfaceElement(iInterfaceElement);
+				T1 result = caseIInterfaceElement(iInterfaceElement);
 				if (result == null) result = caseITypedElement(iInterfaceElement);
 				if (result == null) result = caseHiddenElement(iInterfaceElement);
 				if (result == null) result = caseINamedElement(iInterfaceElement);
@@ -744,45 +751,45 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.IMPORT: {
 				Import import_ = (Import)theEObject;
-				T result = caseImport(import_);
+				T1 result = caseImport(import_);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.INAMED_ELEMENT: {
 				INamedElement iNamedElement = (INamedElement)theEObject;
-				T result = caseINamedElement(iNamedElement);
+				T1 result = caseINamedElement(iNamedElement);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.INPUT_PRIMITIVE: {
 				InputPrimitive inputPrimitive = (InputPrimitive)theEObject;
-				T result = caseInputPrimitive(inputPrimitive);
+				T1 result = caseInputPrimitive(inputPrimitive);
 				if (result == null) result = casePrimitive(inputPrimitive);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.INTERFACE_LIST: {
 				InterfaceList interfaceList = (InterfaceList)theEObject;
-				T result = caseInterfaceList(interfaceList);
+				T1 result = caseInterfaceList(interfaceList);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.ITYPED_ELEMENT: {
 				ITypedElement iTypedElement = (ITypedElement)theEObject;
-				T result = caseITypedElement(iTypedElement);
+				T1 result = caseITypedElement(iTypedElement);
 				if (result == null) result = caseINamedElement(iTypedElement);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.IVAR_ELEMENT: {
 				IVarElement iVarElement = (IVarElement)theEObject;
-				T result = caseIVarElement(iVarElement);
+				T1 result = caseIVarElement(iVarElement);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.LIBRARY_ELEMENT: {
 				LibraryElement libraryElement = (LibraryElement)theEObject;
-				T result = caseLibraryElement(libraryElement);
+				T1 result = caseLibraryElement(libraryElement);
 				if (result == null) result = caseINamedElement(libraryElement);
 				if (result == null) result = caseConfigurableObject(libraryElement);
 				if (result == null) result = defaultCase(theEObject);
@@ -790,7 +797,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.LINK: {
 				Link link = (Link)theEObject;
-				T result = caseLink(link);
+				T1 result = caseLink(link);
 				if (result == null) result = caseINamedElement(link);
 				if (result == null) result = caseConfigurableObject(link);
 				if (result == null) result = defaultCase(theEObject);
@@ -798,7 +805,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.LOCAL_VARIABLE: {
 				LocalVariable localVariable = (LocalVariable)theEObject;
-				T result = caseLocalVariable(localVariable);
+				T1 result = caseLocalVariable(localVariable);
 				if (result == null) result = caseVarDeclaration(localVariable);
 				if (result == null) result = caseIInterfaceElement(localVariable);
 				if (result == null) result = caseITypedElement(localVariable);
@@ -810,20 +817,20 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.MAPPING: {
 				Mapping mapping = (Mapping)theEObject;
-				T result = caseMapping(mapping);
+				T1 result = caseMapping(mapping);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.MAPPING_TARGET: {
 				MappingTarget mappingTarget = (MappingTarget)theEObject;
-				T result = caseMappingTarget(mappingTarget);
+				T1 result = caseMappingTarget(mappingTarget);
 				if (result == null) result = caseINamedElement(mappingTarget);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.MEMBER_VAR_DECLARATION: {
 				MemberVarDeclaration memberVarDeclaration = (MemberVarDeclaration)theEObject;
-				T result = caseMemberVarDeclaration(memberVarDeclaration);
+				T1 result = caseMemberVarDeclaration(memberVarDeclaration);
 				if (result == null) result = caseVarDeclaration(memberVarDeclaration);
 				if (result == null) result = caseIInterfaceElement(memberVarDeclaration);
 				if (result == null) result = caseITypedElement(memberVarDeclaration);
@@ -835,7 +842,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.METHOD: {
 				Method method = (Method)theEObject;
-				T result = caseMethod(method);
+				T1 result = caseMethod(method);
 				if (result == null) result = caseICallable(method);
 				if (result == null) result = caseINamedElement(method);
 				if (result == null) result = defaultCase(theEObject);
@@ -843,7 +850,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.MULTIPLEXER: {
 				Multiplexer multiplexer = (Multiplexer)theEObject;
-				T result = caseMultiplexer(multiplexer);
+				T1 result = caseMultiplexer(multiplexer);
 				if (result == null) result = caseStructManipulator(multiplexer);
 				if (result == null) result = caseConfigurableFB(multiplexer);
 				if (result == null) result = caseFB(multiplexer);
@@ -860,13 +867,13 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.ORIGINAL_SOURCE: {
 				OriginalSource originalSource = (OriginalSource)theEObject;
-				T result = caseOriginalSource(originalSource);
+				T1 result = caseOriginalSource(originalSource);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.OTHER_ALGORITHM: {
 				OtherAlgorithm otherAlgorithm = (OtherAlgorithm)theEObject;
-				T result = caseOtherAlgorithm(otherAlgorithm);
+				T1 result = caseOtherAlgorithm(otherAlgorithm);
 				if (result == null) result = caseTextAlgorithm(otherAlgorithm);
 				if (result == null) result = caseAlgorithm(otherAlgorithm);
 				if (result == null) result = caseICallable(otherAlgorithm);
@@ -876,7 +883,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.OTHER_METHOD: {
 				OtherMethod otherMethod = (OtherMethod)theEObject;
-				T result = caseOtherMethod(otherMethod);
+				T1 result = caseOtherMethod(otherMethod);
 				if (result == null) result = caseTextMethod(otherMethod);
 				if (result == null) result = caseMethod(otherMethod);
 				if (result == null) result = caseICallable(otherMethod);
@@ -886,32 +893,32 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.OUTPUT_PRIMITIVE: {
 				OutputPrimitive outputPrimitive = (OutputPrimitive)theEObject;
-				T result = caseOutputPrimitive(outputPrimitive);
+				T1 result = caseOutputPrimitive(outputPrimitive);
 				if (result == null) result = casePrimitive(outputPrimitive);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.POSITION: {
 				Position position = (Position)theEObject;
-				T result = casePosition(position);
+				T1 result = casePosition(position);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.POSITIONABLE_ELEMENT: {
 				PositionableElement positionableElement = (PositionableElement)theEObject;
-				T result = casePositionableElement(positionableElement);
+				T1 result = casePositionableElement(positionableElement);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.PRIMITIVE: {
 				Primitive primitive = (Primitive)theEObject;
-				T result = casePrimitive(primitive);
+				T1 result = casePrimitive(primitive);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.RESOURCE: {
 				Resource resource = (Resource)theEObject;
-				T result = caseResource(resource);
+				T1 result = caseResource(resource);
 				if (result == null) result = caseTypedConfigureableObject(resource);
 				if (result == null) result = caseIVarElement(resource);
 				if (result == null) result = caseMappingTarget(resource);
@@ -923,13 +930,13 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.RESOURCE_TYPE_NAME: {
 				ResourceTypeName resourceTypeName = (ResourceTypeName)theEObject;
-				T result = caseResourceTypeName(resourceTypeName);
+				T1 result = caseResourceTypeName(resourceTypeName);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.RESOURCE_TYPE: {
 				ResourceType resourceType = (ResourceType)theEObject;
-				T result = caseResourceType(resourceType);
+				T1 result = caseResourceType(resourceType);
 				if (result == null) result = caseLibraryElement(resourceType);
 				if (result == null) result = caseINamedElement(resourceType);
 				if (result == null) result = caseConfigurableObject(resourceType);
@@ -938,7 +945,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.RESOURCE_TYPE_FB: {
 				ResourceTypeFB resourceTypeFB = (ResourceTypeFB)theEObject;
-				T result = caseResourceTypeFB(resourceTypeFB);
+				T1 result = caseResourceTypeFB(resourceTypeFB);
 				if (result == null) result = caseFB(resourceTypeFB);
 				if (result == null) result = caseBlockFBNetworkElement(resourceTypeFB);
 				if (result == null) result = caseICallable(resourceTypeFB);
@@ -953,7 +960,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.SEGMENT: {
 				Segment segment = (Segment)theEObject;
-				T result = caseSegment(segment);
+				T1 result = caseSegment(segment);
 				if (result == null) result = caseTypedConfigureableObject(segment);
 				if (result == null) result = casePositionableElement(segment);
 				if (result == null) result = caseColorizableElement(segment);
@@ -966,7 +973,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.SEGMENT_TYPE: {
 				SegmentType segmentType = (SegmentType)theEObject;
-				T result = caseSegmentType(segmentType);
+				T1 result = caseSegmentType(segmentType);
 				if (result == null) result = caseLibraryElement(segmentType);
 				if (result == null) result = caseINamedElement(segmentType);
 				if (result == null) result = caseConfigurableObject(segmentType);
@@ -975,13 +982,13 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.SERVICE: {
 				Service service = (Service)theEObject;
-				T result = caseService(service);
+				T1 result = caseService(service);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.SERVICE_SEQUENCE: {
 				ServiceSequence serviceSequence = (ServiceSequence)theEObject;
-				T result = caseServiceSequence(serviceSequence);
+				T1 result = caseServiceSequence(serviceSequence);
 				if (result == null) result = caseINamedElement(serviceSequence);
 				if (result == null) result = caseConfigurableObject(serviceSequence);
 				if (result == null) result = defaultCase(theEObject);
@@ -989,20 +996,20 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.SERVICE_TRANSACTION: {
 				ServiceTransaction serviceTransaction = (ServiceTransaction)theEObject;
-				T result = caseServiceTransaction(serviceTransaction);
+				T1 result = caseServiceTransaction(serviceTransaction);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.SERVICE_INTERFACE: {
 				ServiceInterface serviceInterface = (ServiceInterface)theEObject;
-				T result = caseServiceInterface(serviceInterface);
+				T1 result = caseServiceInterface(serviceInterface);
 				if (result == null) result = caseINamedElement(serviceInterface);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.SERVICE_INTERFACE_FB_TYPE: {
 				ServiceInterfaceFBType serviceInterfaceFBType = (ServiceInterfaceFBType)theEObject;
-				T result = caseServiceInterfaceFBType(serviceInterfaceFBType);
+				T1 result = caseServiceInterfaceFBType(serviceInterfaceFBType);
 				if (result == null) result = caseFBType(serviceInterfaceFBType);
 				if (result == null) result = caseLibraryElement(serviceInterfaceFBType);
 				if (result == null) result = caseICallable(serviceInterfaceFBType);
@@ -1013,21 +1020,22 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.SIMPLE_EC_ACTION: {
 				SimpleECAction simpleECAction = (SimpleECAction)theEObject;
-				T result = caseSimpleECAction(simpleECAction);
+				T1 result = caseSimpleECAction(simpleECAction);
 				if (result == null) result = caseBaseECAction(simpleECAction);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.SIMPLE_EC_STATE: {
 				SimpleECState simpleECState = (SimpleECState)theEObject;
-				T result = caseSimpleECState(simpleECState);
+				T1 result = caseSimpleECState(simpleECState);
 				if (result == null) result = caseINamedElement(simpleECState);
+				if (result == null) result = caseBaseECState(simpleECState);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.SIMPLE_FB_TYPE: {
 				SimpleFBType simpleFBType = (SimpleFBType)theEObject;
-				T result = caseSimpleFBType(simpleFBType);
+				T1 result = caseSimpleFBType(simpleFBType);
 				if (result == null) result = caseBaseFBType(simpleFBType);
 				if (result == null) result = caseFBType(simpleFBType);
 				if (result == null) result = caseLibraryElement(simpleFBType);
@@ -1039,7 +1047,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.ST_ALGORITHM: {
 				STAlgorithm stAlgorithm = (STAlgorithm)theEObject;
-				T result = caseSTAlgorithm(stAlgorithm);
+				T1 result = caseSTAlgorithm(stAlgorithm);
 				if (result == null) result = caseTextAlgorithm(stAlgorithm);
 				if (result == null) result = caseAlgorithm(stAlgorithm);
 				if (result == null) result = caseICallable(stAlgorithm);
@@ -1049,7 +1057,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.ST_FUNCTION: {
 				STFunction stFunction = (STFunction)theEObject;
-				T result = caseSTFunction(stFunction);
+				T1 result = caseSTFunction(stFunction);
 				if (result == null) result = caseTextFunction(stFunction);
 				if (result == null) result = caseFunction(stFunction);
 				if (result == null) result = caseICallable(stFunction);
@@ -1059,7 +1067,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.ST_FUNCTION_BODY: {
 				STFunctionBody stFunctionBody = (STFunctionBody)theEObject;
-				T result = caseSTFunctionBody(stFunctionBody);
+				T1 result = caseSTFunctionBody(stFunctionBody);
 				if (result == null) result = caseTextFunctionBody(stFunctionBody);
 				if (result == null) result = caseFunctionBody(stFunctionBody);
 				if (result == null) result = defaultCase(theEObject);
@@ -1067,7 +1075,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.ST_METHOD: {
 				STMethod stMethod = (STMethod)theEObject;
-				T result = caseSTMethod(stMethod);
+				T1 result = caseSTMethod(stMethod);
 				if (result == null) result = caseTextMethod(stMethod);
 				if (result == null) result = caseMethod(stMethod);
 				if (result == null) result = caseICallable(stMethod);
@@ -1077,7 +1085,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.STRUCT_MANIPULATOR: {
 				StructManipulator structManipulator = (StructManipulator)theEObject;
-				T result = caseStructManipulator(structManipulator);
+				T1 result = caseStructManipulator(structManipulator);
 				if (result == null) result = caseConfigurableFB(structManipulator);
 				if (result == null) result = caseFB(structManipulator);
 				if (result == null) result = caseBlockFBNetworkElement(structManipulator);
@@ -1093,7 +1101,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.SUB_APP: {
 				SubApp subApp = (SubApp)theEObject;
-				T result = caseSubApp(subApp);
+				T1 result = caseSubApp(subApp);
 				if (result == null) result = caseBlockFBNetworkElement(subApp);
 				if (result == null) result = caseFBNetworkElement(subApp);
 				if (result == null) result = caseTypedConfigureableObject(subApp);
@@ -1106,7 +1114,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.SUB_APP_TYPE: {
 				SubAppType subAppType = (SubAppType)theEObject;
-				T result = caseSubAppType(subAppType);
+				T1 result = caseSubAppType(subAppType);
 				if (result == null) result = caseCompositeFBType(subAppType);
 				if (result == null) result = caseFBType(subAppType);
 				if (result == null) result = caseLibraryElement(subAppType);
@@ -1118,13 +1126,13 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.SYSTEM_CONFIGURATION: {
 				SystemConfiguration systemConfiguration = (SystemConfiguration)theEObject;
-				T result = caseSystemConfiguration(systemConfiguration);
+				T1 result = caseSystemConfiguration(systemConfiguration);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.TEXT_ALGORITHM: {
 				TextAlgorithm textAlgorithm = (TextAlgorithm)theEObject;
-				T result = caseTextAlgorithm(textAlgorithm);
+				T1 result = caseTextAlgorithm(textAlgorithm);
 				if (result == null) result = caseAlgorithm(textAlgorithm);
 				if (result == null) result = caseICallable(textAlgorithm);
 				if (result == null) result = caseINamedElement(textAlgorithm);
@@ -1133,7 +1141,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.TEXT_FUNCTION: {
 				TextFunction textFunction = (TextFunction)theEObject;
-				T result = caseTextFunction(textFunction);
+				T1 result = caseTextFunction(textFunction);
 				if (result == null) result = caseFunction(textFunction);
 				if (result == null) result = caseICallable(textFunction);
 				if (result == null) result = caseINamedElement(textFunction);
@@ -1142,14 +1150,14 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.TEXT_FUNCTION_BODY: {
 				TextFunctionBody textFunctionBody = (TextFunctionBody)theEObject;
-				T result = caseTextFunctionBody(textFunctionBody);
+				T1 result = caseTextFunctionBody(textFunctionBody);
 				if (result == null) result = caseFunctionBody(textFunctionBody);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.TEXT_METHOD: {
 				TextMethod textMethod = (TextMethod)theEObject;
-				T result = caseTextMethod(textMethod);
+				T1 result = caseTextMethod(textMethod);
 				if (result == null) result = caseMethod(textMethod);
 				if (result == null) result = caseICallable(textMethod);
 				if (result == null) result = caseINamedElement(textMethod);
@@ -1158,7 +1166,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.TYPED_CONFIGUREABLE_OBJECT: {
 				TypedConfigureableObject typedConfigureableObject = (TypedConfigureableObject)theEObject;
-				T result = caseTypedConfigureableObject(typedConfigureableObject);
+				T1 result = caseTypedConfigureableObject(typedConfigureableObject);
 				if (result == null) result = caseITypedElement(typedConfigureableObject);
 				if (result == null) result = caseConfigurableObject(typedConfigureableObject);
 				if (result == null) result = caseINamedElement(typedConfigureableObject);
@@ -1167,7 +1175,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.TYPED_SUB_APP: {
 				TypedSubApp typedSubApp = (TypedSubApp)theEObject;
-				T result = caseTypedSubApp(typedSubApp);
+				T1 result = caseTypedSubApp(typedSubApp);
 				if (result == null) result = caseSubApp(typedSubApp);
 				if (result == null) result = caseBlockFBNetworkElement(typedSubApp);
 				if (result == null) result = caseFBNetworkElement(typedSubApp);
@@ -1181,7 +1189,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.UNTYPED_SUB_APP: {
 				UntypedSubApp untypedSubApp = (UntypedSubApp)theEObject;
-				T result = caseUntypedSubApp(untypedSubApp);
+				T1 result = caseUntypedSubApp(untypedSubApp);
 				if (result == null) result = caseSubApp(untypedSubApp);
 				if (result == null) result = caseBlockFBNetworkElement(untypedSubApp);
 				if (result == null) result = caseFBNetworkElement(untypedSubApp);
@@ -1195,13 +1203,13 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.VALUE: {
 				Value value = (Value)theEObject;
-				T result = caseValue(value);
+				T1 result = caseValue(value);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.VAR_CONFIG_INSTANCE: {
 				VarConfigInstance varConfigInstance = (VarConfigInstance)theEObject;
-				T result = caseVarConfigInstance(varConfigInstance);
+				T1 result = caseVarConfigInstance(varConfigInstance);
 				if (result == null) result = caseVarDeclaration(varConfigInstance);
 				if (result == null) result = caseIInterfaceElement(varConfigInstance);
 				if (result == null) result = caseITypedElement(varConfigInstance);
@@ -1213,7 +1221,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.VAR_DECLARATION: {
 				VarDeclaration varDeclaration = (VarDeclaration)theEObject;
-				T result = caseVarDeclaration(varDeclaration);
+				T1 result = caseVarDeclaration(varDeclaration);
 				if (result == null) result = caseIInterfaceElement(varDeclaration);
 				if (result == null) result = caseITypedElement(varDeclaration);
 				if (result == null) result = caseHiddenElement(varDeclaration);
@@ -1224,13 +1232,13 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 			}
 			case LibraryElementPackage.VERSION_INFO: {
 				VersionInfo versionInfo = (VersionInfo)theEObject;
-				T result = caseVersionInfo(versionInfo);
+				T1 result = caseVersionInfo(versionInfo);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case LibraryElementPackage.WITH: {
 				With with = (With)theEObject;
-				T result = caseWith(with);
+				T1 result = caseWith(with);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -1249,7 +1257,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseAdapterConnection(AdapterConnection object) {
+	public T1 caseAdapterConnection(AdapterConnection object) {
 		return null;
 	}
 
@@ -1264,7 +1272,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseAdapterDeclaration(AdapterDeclaration object) {
+	public T1 caseAdapterDeclaration(AdapterDeclaration object) {
 		return null;
 	}
 
@@ -1279,7 +1287,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseAdapterFB(AdapterFB object) {
+	public T1 caseAdapterFB(AdapterFB object) {
 		return null;
 	}
 
@@ -1294,7 +1302,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseAdapterType(AdapterType object) {
+	public T1 caseAdapterType(AdapterType object) {
 		return null;
 	}
 
@@ -1309,7 +1317,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseAlgorithm(Algorithm object) {
+	public T1 caseAlgorithm(Algorithm object) {
 		return null;
 	}
 
@@ -1324,7 +1332,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseApplication(Application object) {
+	public T1 caseApplication(Application object) {
 		return null;
 	}
 
@@ -1339,7 +1347,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseArraySize(ArraySize object) {
+	public T1 caseArraySize(ArraySize object) {
 		return null;
 	}
 
@@ -1354,7 +1362,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseAttribute(Attribute object) {
+	public T1 caseAttribute(Attribute object) {
 		return null;
 	}
 
@@ -1369,7 +1377,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseAttributeDeclaration(AttributeDeclaration object) {
+	public T1 caseAttributeDeclaration(AttributeDeclaration object) {
 		return null;
 	}
 
@@ -1384,7 +1392,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseBaseFBType(BaseFBType object) {
+	public T1 caseBaseFBType(BaseFBType object) {
 		return null;
 	}
 
@@ -1399,7 +1407,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseBasicFBType(BasicFBType object) {
+	public T1 caseBasicFBType(BasicFBType object) {
 		return null;
 	}
 
@@ -1414,7 +1422,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseBlockFBNetworkElement(BlockFBNetworkElement object) {
+	public T1 caseBlockFBNetworkElement(BlockFBNetworkElement object) {
 		return null;
 	}
 
@@ -1429,7 +1437,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseAutomationSystem(AutomationSystem object) {
+	public T1 caseAutomationSystem(AutomationSystem object) {
 		return null;
 	}
 
@@ -1444,7 +1452,22 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseBaseECAction(BaseECAction object) {
+	public T1 caseBaseECAction(BaseECAction object) {
+		return null;
+	}
+
+	/**
+	 * Returns the result of interpreting the object as an instance of '<em>Base EC State</em>'.
+	 * <!-- begin-user-doc -->
+	 * This implementation returns null;
+	 * returning a non-null result will terminate the switch.
+	 * <!-- end-user-doc -->
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Base EC State</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
+	public <T extends BaseECAction> T1 caseBaseECState(BaseECState<T> object) {
 		return null;
 	}
 
@@ -1459,7 +1482,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseCFBInstance(CFBInstance object) {
+	public T1 caseCFBInstance(CFBInstance object) {
 		return null;
 	}
 
@@ -1474,7 +1497,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseColor(Color object) {
+	public T1 caseColor(Color object) {
 		return null;
 	}
 
@@ -1489,7 +1512,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseColorizableElement(ColorizableElement object) {
+	public T1 caseColorizableElement(ColorizableElement object) {
 		return null;
 	}
 
@@ -1504,7 +1527,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseComment(Comment object) {
+	public T1 caseComment(Comment object) {
 		return null;
 	}
 
@@ -1519,7 +1542,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseCommunicationChannel(CommunicationChannel object) {
+	public T1 caseCommunicationChannel(CommunicationChannel object) {
 		return null;
 	}
 
@@ -1534,7 +1557,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseCommunicationConfiguration(CommunicationConfiguration object) {
+	public T1 caseCommunicationConfiguration(CommunicationConfiguration object) {
 		return null;
 	}
 
@@ -1549,7 +1572,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseCommunicationMappingTarget(CommunicationMappingTarget object) {
+	public T1 caseCommunicationMappingTarget(CommunicationMappingTarget object) {
 		return null;
 	}
 
@@ -1564,7 +1587,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseCompiler(org.eclipse.fordiac.ide.model.libraryElement.Compiler object) {
+	public T1 caseCompiler(org.eclipse.fordiac.ide.model.libraryElement.Compiler object) {
 		return null;
 	}
 
@@ -1579,7 +1602,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseCompilerInfo(CompilerInfo object) {
+	public T1 caseCompilerInfo(CompilerInfo object) {
 		return null;
 	}
 
@@ -1594,7 +1617,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseCompositeFBType(CompositeFBType object) {
+	public T1 caseCompositeFBType(CompositeFBType object) {
 		return null;
 	}
 
@@ -1609,7 +1632,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseConfigurableObject(ConfigurableObject object) {
+	public T1 caseConfigurableObject(ConfigurableObject object) {
 		return null;
 	}
 
@@ -1624,7 +1647,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseConfigurableFB(ConfigurableFB object) {
+	public T1 caseConfigurableFB(ConfigurableFB object) {
 		return null;
 	}
 
@@ -1639,7 +1662,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseConfigurableMoveFB(ConfigurableMoveFB object) {
+	public T1 caseConfigurableMoveFB(ConfigurableMoveFB object) {
 		return null;
 	}
 
@@ -1654,7 +1677,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseConnection(Connection object) {
+	public T1 caseConnection(Connection object) {
 		return null;
 	}
 
@@ -1669,7 +1692,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseConnectionRoutingData(ConnectionRoutingData object) {
+	public T1 caseConnectionRoutingData(ConnectionRoutingData object) {
 		return null;
 	}
 
@@ -1684,7 +1707,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseContainerVarDeclaration(ContainerVarDeclaration object) {
+	public T1 caseContainerVarDeclaration(ContainerVarDeclaration object) {
 		return null;
 	}
 
@@ -1699,7 +1722,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseDataConnection(DataConnection object) {
+	public T1 caseDataConnection(DataConnection object) {
 		return null;
 	}
 
@@ -1714,7 +1737,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseDemultiplexer(Demultiplexer object) {
+	public T1 caseDemultiplexer(Demultiplexer object) {
 		return null;
 	}
 
@@ -1729,7 +1752,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseDevice(Device object) {
+	public T1 caseDevice(Device object) {
 		return null;
 	}
 
@@ -1744,7 +1767,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseDeviceType(DeviceType object) {
+	public T1 caseDeviceType(DeviceType object) {
 		return null;
 	}
 
@@ -1759,7 +1782,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseECAction(ECAction object) {
+	public T1 caseECAction(ECAction object) {
 		return null;
 	}
 
@@ -1774,7 +1797,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseECC(ECC object) {
+	public T1 caseECC(ECC object) {
 		return null;
 	}
 
@@ -1789,7 +1812,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseECState(ECState object) {
+	public T1 caseECState(ECState object) {
 		return null;
 	}
 
@@ -1804,7 +1827,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseECTransition(ECTransition object) {
+	public T1 caseECTransition(ECTransition object) {
 		return null;
 	}
 
@@ -1819,7 +1842,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseErrorAdapterType(ErrorAdapterType object) {
+	public T1 caseErrorAdapterType(ErrorAdapterType object) {
 		return null;
 	}
 
@@ -1834,7 +1857,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseErrorAttributeDeclaration(ErrorAttributeDeclaration object) {
+	public T1 caseErrorAttributeDeclaration(ErrorAttributeDeclaration object) {
 		return null;
 	}
 
@@ -1849,7 +1872,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseErrorAutomationSystem(ErrorAutomationSystem object) {
+	public T1 caseErrorAutomationSystem(ErrorAutomationSystem object) {
 		return null;
 	}
 
@@ -1864,7 +1887,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseErrorDeviceType(ErrorDeviceType object) {
+	public T1 caseErrorDeviceType(ErrorDeviceType object) {
 		return null;
 	}
 
@@ -1879,7 +1902,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseErrorFBType(ErrorFBType object) {
+	public T1 caseErrorFBType(ErrorFBType object) {
 		return null;
 	}
 
@@ -1894,7 +1917,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseErrorFunctionFBType(ErrorFunctionFBType object) {
+	public T1 caseErrorFunctionFBType(ErrorFunctionFBType object) {
 		return null;
 	}
 
@@ -1909,7 +1932,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseErrorGlobalConstants(ErrorGlobalConstants object) {
+	public T1 caseErrorGlobalConstants(ErrorGlobalConstants object) {
 		return null;
 	}
 
@@ -1924,7 +1947,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseErrorLibraryElement(ErrorLibraryElement object) {
+	public T1 caseErrorLibraryElement(ErrorLibraryElement object) {
 		return null;
 	}
 
@@ -1939,7 +1962,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseErrorMarkerFBNElement(ErrorMarkerFBNElement object) {
+	public T1 caseErrorMarkerFBNElement(ErrorMarkerFBNElement object) {
 		return null;
 	}
 
@@ -1954,7 +1977,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseErrorMarkerInterface(ErrorMarkerInterface object) {
+	public T1 caseErrorMarkerInterface(ErrorMarkerInterface object) {
 		return null;
 	}
 
@@ -1969,7 +1992,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseErrorResourceType(ErrorResourceType object) {
+	public T1 caseErrorResourceType(ErrorResourceType object) {
 		return null;
 	}
 
@@ -1984,7 +2007,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseErrorSegmentType(ErrorSegmentType object) {
+	public T1 caseErrorSegmentType(ErrorSegmentType object) {
 		return null;
 	}
 
@@ -1999,7 +2022,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseErrorSubAppType(ErrorSubAppType object) {
+	public T1 caseErrorSubAppType(ErrorSubAppType object) {
 		return null;
 	}
 
@@ -2014,7 +2037,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseEvent(Event object) {
+	public T1 caseEvent(Event object) {
 		return null;
 	}
 
@@ -2029,7 +2052,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseEventConnection(EventConnection object) {
+	public T1 caseEventConnection(EventConnection object) {
 		return null;
 	}
 
@@ -2044,7 +2067,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseFB(FB object) {
+	public T1 caseFB(FB object) {
 		return null;
 	}
 
@@ -2059,7 +2082,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseFBNetwork(FBNetwork object) {
+	public T1 caseFBNetwork(FBNetwork object) {
 		return null;
 	}
 
@@ -2074,7 +2097,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseFBNetworkElement(FBNetworkElement object) {
+	public T1 caseFBNetworkElement(FBNetworkElement object) {
 		return null;
 	}
 
@@ -2089,7 +2112,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseFBType(FBType object) {
+	public T1 caseFBType(FBType object) {
 		return null;
 	}
 
@@ -2104,7 +2127,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseFunction(Function object) {
+	public T1 caseFunction(Function object) {
 		return null;
 	}
 
@@ -2119,7 +2142,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseFunctionBody(FunctionBody object) {
+	public T1 caseFunctionBody(FunctionBody object) {
 		return null;
 	}
 
@@ -2134,7 +2157,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseFunctionFBType(FunctionFBType object) {
+	public T1 caseFunctionFBType(FunctionFBType object) {
 		return null;
 	}
 
@@ -2149,7 +2172,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseGlobalConstants(GlobalConstants object) {
+	public T1 caseGlobalConstants(GlobalConstants object) {
 		return null;
 	}
 
@@ -2164,7 +2187,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseGroup(Group object) {
+	public T1 caseGroup(Group object) {
 		return null;
 	}
 
@@ -2179,7 +2202,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseHiddenElement(HiddenElement object) {
+	public T1 caseHiddenElement(HiddenElement object) {
 		return null;
 	}
 
@@ -2194,7 +2217,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseICallable(ICallable object) {
+	public T1 caseICallable(ICallable object) {
 		return null;
 	}
 
@@ -2209,7 +2232,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseIdentification(Identification object) {
+	public T1 caseIdentification(Identification object) {
 		return null;
 	}
 
@@ -2224,7 +2247,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseIInterfaceElement(IInterfaceElement object) {
+	public T1 caseIInterfaceElement(IInterfaceElement object) {
 		return null;
 	}
 
@@ -2239,7 +2262,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseImport(Import object) {
+	public T1 caseImport(Import object) {
 		return null;
 	}
 
@@ -2254,7 +2277,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseINamedElement(INamedElement object) {
+	public T1 caseINamedElement(INamedElement object) {
 		return null;
 	}
 
@@ -2269,7 +2292,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseInputPrimitive(InputPrimitive object) {
+	public T1 caseInputPrimitive(InputPrimitive object) {
 		return null;
 	}
 
@@ -2284,7 +2307,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseInterfaceList(InterfaceList object) {
+	public T1 caseInterfaceList(InterfaceList object) {
 		return null;
 	}
 
@@ -2299,7 +2322,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseITypedElement(ITypedElement object) {
+	public T1 caseITypedElement(ITypedElement object) {
 		return null;
 	}
 
@@ -2314,7 +2337,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseIVarElement(IVarElement object) {
+	public T1 caseIVarElement(IVarElement object) {
 		return null;
 	}
 
@@ -2329,7 +2352,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseLibraryElement(LibraryElement object) {
+	public T1 caseLibraryElement(LibraryElement object) {
 		return null;
 	}
 
@@ -2344,7 +2367,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseLink(Link object) {
+	public T1 caseLink(Link object) {
 		return null;
 	}
 
@@ -2359,7 +2382,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseLocalVariable(LocalVariable object) {
+	public T1 caseLocalVariable(LocalVariable object) {
 		return null;
 	}
 
@@ -2374,7 +2397,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseMapping(Mapping object) {
+	public T1 caseMapping(Mapping object) {
 		return null;
 	}
 
@@ -2389,7 +2412,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseMappingTarget(MappingTarget object) {
+	public T1 caseMappingTarget(MappingTarget object) {
 		return null;
 	}
 
@@ -2404,7 +2427,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseMethod(Method object) {
+	public T1 caseMethod(Method object) {
 		return null;
 	}
 
@@ -2419,7 +2442,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseMultiplexer(Multiplexer object) {
+	public T1 caseMultiplexer(Multiplexer object) {
 		return null;
 	}
 
@@ -2434,7 +2457,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseOriginalSource(OriginalSource object) {
+	public T1 caseOriginalSource(OriginalSource object) {
 		return null;
 	}
 
@@ -2449,7 +2472,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseOtherAlgorithm(OtherAlgorithm object) {
+	public T1 caseOtherAlgorithm(OtherAlgorithm object) {
 		return null;
 	}
 
@@ -2464,7 +2487,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseOtherMethod(OtherMethod object) {
+	public T1 caseOtherMethod(OtherMethod object) {
 		return null;
 	}
 
@@ -2479,7 +2502,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseOutputPrimitive(OutputPrimitive object) {
+	public T1 caseOutputPrimitive(OutputPrimitive object) {
 		return null;
 	}
 
@@ -2494,7 +2517,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T casePosition(Position object) {
+	public T1 casePosition(Position object) {
 		return null;
 	}
 
@@ -2509,7 +2532,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T casePositionableElement(PositionableElement object) {
+	public T1 casePositionableElement(PositionableElement object) {
 		return null;
 	}
 
@@ -2524,7 +2547,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T casePrimitive(Primitive object) {
+	public T1 casePrimitive(Primitive object) {
 		return null;
 	}
 
@@ -2539,7 +2562,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseResource(Resource object) {
+	public T1 caseResource(Resource object) {
 		return null;
 	}
 
@@ -2554,7 +2577,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseResourceTypeName(ResourceTypeName object) {
+	public T1 caseResourceTypeName(ResourceTypeName object) {
 		return null;
 	}
 
@@ -2569,7 +2592,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseResourceType(ResourceType object) {
+	public T1 caseResourceType(ResourceType object) {
 		return null;
 	}
 
@@ -2584,7 +2607,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseResourceTypeFB(ResourceTypeFB object) {
+	public T1 caseResourceTypeFB(ResourceTypeFB object) {
 		return null;
 	}
 
@@ -2599,7 +2622,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseSegment(Segment object) {
+	public T1 caseSegment(Segment object) {
 		return null;
 	}
 
@@ -2614,7 +2637,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseSegmentType(SegmentType object) {
+	public T1 caseSegmentType(SegmentType object) {
 		return null;
 	}
 
@@ -2629,7 +2652,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseService(Service object) {
+	public T1 caseService(Service object) {
 		return null;
 	}
 
@@ -2644,7 +2667,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseServiceSequence(ServiceSequence object) {
+	public T1 caseServiceSequence(ServiceSequence object) {
 		return null;
 	}
 
@@ -2659,7 +2682,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseServiceTransaction(ServiceTransaction object) {
+	public T1 caseServiceTransaction(ServiceTransaction object) {
 		return null;
 	}
 
@@ -2674,7 +2697,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseServiceInterface(ServiceInterface object) {
+	public T1 caseServiceInterface(ServiceInterface object) {
 		return null;
 	}
 
@@ -2689,7 +2712,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseServiceInterfaceFBType(ServiceInterfaceFBType object) {
+	public T1 caseServiceInterfaceFBType(ServiceInterfaceFBType object) {
 		return null;
 	}
 
@@ -2704,7 +2727,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseSimpleECAction(SimpleECAction object) {
+	public T1 caseSimpleECAction(SimpleECAction object) {
 		return null;
 	}
 
@@ -2719,7 +2742,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseSimpleECState(SimpleECState object) {
+	public T1 caseSimpleECState(SimpleECState object) {
 		return null;
 	}
 
@@ -2734,7 +2757,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseSimpleFBType(SimpleFBType object) {
+	public T1 caseSimpleFBType(SimpleFBType object) {
 		return null;
 	}
 
@@ -2749,7 +2772,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseSTAlgorithm(STAlgorithm object) {
+	public T1 caseSTAlgorithm(STAlgorithm object) {
 		return null;
 	}
 
@@ -2764,7 +2787,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseSTFunction(STFunction object) {
+	public T1 caseSTFunction(STFunction object) {
 		return null;
 	}
 
@@ -2779,7 +2802,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseSTFunctionBody(STFunctionBody object) {
+	public T1 caseSTFunctionBody(STFunctionBody object) {
 		return null;
 	}
 
@@ -2794,7 +2817,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseSTMethod(STMethod object) {
+	public T1 caseSTMethod(STMethod object) {
 		return null;
 	}
 
@@ -2809,7 +2832,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseSubApp(SubApp object) {
+	public T1 caseSubApp(SubApp object) {
 		return null;
 	}
 
@@ -2824,7 +2847,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseStructManipulator(StructManipulator object) {
+	public T1 caseStructManipulator(StructManipulator object) {
 		return null;
 	}
 
@@ -2839,7 +2862,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseSubAppType(SubAppType object) {
+	public T1 caseSubAppType(SubAppType object) {
 		return null;
 	}
 
@@ -2854,7 +2877,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseSystemConfiguration(SystemConfiguration object) {
+	public T1 caseSystemConfiguration(SystemConfiguration object) {
 		return null;
 	}
 
@@ -2869,7 +2892,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseTextAlgorithm(TextAlgorithm object) {
+	public T1 caseTextAlgorithm(TextAlgorithm object) {
 		return null;
 	}
 
@@ -2884,7 +2907,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseTextFunction(TextFunction object) {
+	public T1 caseTextFunction(TextFunction object) {
 		return null;
 	}
 
@@ -2899,7 +2922,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseTextFunctionBody(TextFunctionBody object) {
+	public T1 caseTextFunctionBody(TextFunctionBody object) {
 		return null;
 	}
 
@@ -2914,7 +2937,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseTextMethod(TextMethod object) {
+	public T1 caseTextMethod(TextMethod object) {
 		return null;
 	}
 
@@ -2929,7 +2952,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseTypedConfigureableObject(TypedConfigureableObject object) {
+	public T1 caseTypedConfigureableObject(TypedConfigureableObject object) {
 		return null;
 	}
 
@@ -2944,7 +2967,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseTypedSubApp(TypedSubApp object) {
+	public T1 caseTypedSubApp(TypedSubApp object) {
 		return null;
 	}
 
@@ -2959,7 +2982,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseUntypedSubApp(UntypedSubApp object) {
+	public T1 caseUntypedSubApp(UntypedSubApp object) {
 		return null;
 	}
 
@@ -2974,7 +2997,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseValue(Value object) {
+	public T1 caseValue(Value object) {
 		return null;
 	}
 
@@ -2989,7 +3012,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseVarDeclaration(VarDeclaration object) {
+	public T1 caseVarDeclaration(VarDeclaration object) {
 		return null;
 	}
 
@@ -3004,7 +3027,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseVersionInfo(VersionInfo object) {
+	public T1 caseVersionInfo(VersionInfo object) {
 		return null;
 	}
 
@@ -3019,7 +3042,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseWith(With object) {
+	public T1 caseWith(With object) {
 		return null;
 	}
 
@@ -3034,7 +3057,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseVarConfigInstance(VarConfigInstance object) {
+	public T1 caseVarConfigInstance(VarConfigInstance object) {
 		return null;
 	}
 
@@ -3049,7 +3072,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseMemberVarDeclaration(MemberVarDeclaration object) {
+	public T1 caseMemberVarDeclaration(MemberVarDeclaration object) {
 		return null;
 	}
 
@@ -3064,7 +3087,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
-	public T caseDataType(DataType object) {
+	public T1 caseDataType(DataType object) {
 		return null;
 	}
 
@@ -3080,7 +3103,7 @@ public class LibraryElementSwitch<T> extends Switch<T> {
 	 * @generated
 	 */
 	@Override
-	public T defaultCase(EObject object) {
+	public T1 defaultCase(EObject object) {
 		return null;
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/util/LibraryElementValidator.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src-gen/org/eclipse/fordiac/ide/model/libraryElement/util/LibraryElementValidator.java
@@ -43,6 +43,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
 import org.eclipse.fordiac.ide.model.libraryElement.AttributeDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
 import org.eclipse.fordiac.ide.model.libraryElement.BaseECAction;
+import org.eclipse.fordiac.ide.model.libraryElement.BaseECState;
 import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.BasicFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
@@ -646,6 +647,8 @@ public class LibraryElementValidator extends EObjectValidator {
 				return validateAutomationSystem((AutomationSystem)value, diagnostics, context);
 			case LibraryElementPackage.BASE_EC_ACTION:
 				return validateBaseECAction((BaseECAction)value, diagnostics, context);
+			case LibraryElementPackage.BASE_EC_STATE:
+				return validateBaseECState((BaseECState<?>)value, diagnostics, context);
 			case LibraryElementPackage.BASE_FB_TYPE:
 				return validateBaseFBType((BaseFBType)value, diagnostics, context);
 			case LibraryElementPackage.BASIC_FB_TYPE:
@@ -1125,6 +1128,15 @@ public class LibraryElementValidator extends EObjectValidator {
 	 */
 	public boolean validateBaseECAction(BaseECAction baseECAction, DiagnosticChain diagnostics, Map<Object, Object> context) {
 		return validate_EveryDefaultConstraint(baseECAction, diagnostics, context);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public boolean validateBaseECState(BaseECState<?> baseECState, DiagnosticChain diagnostics, Map<Object, Object> context) {
+		return validate_EveryDefaultConstraint(baseECState, diagnostics, context);
 	}
 
 	/**


### PR DESCRIPTION
This is the second preparation commit to allow reuse of ECC editing UIs for `SimpleECActions`. It adds the interface `BaseECState` to `ECState` and `SimpleECState`.
Widgets and Commands such as `ActionEditingComposite` and `CreateECActionCommand` now work based on this common interface to allow reuse.