### PR TITLE
Add package folder rename tests and fix struct reference repointing

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/TypeRefactoringHelper.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/refactoring/TypeRefactoringHelper.java
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *   Michael Oberlehner - initial API and implementation and/or initial documentation
+ *   Dimitrios Kalligaridis - fix struct reference repointing on package folder rename
  *******************************************************************************/
 package org.eclipse.fordiac.ide.typemanagement.refactoring;
 
@@ -70,8 +71,10 @@ public final class TypeRefactoringHelper {
 	public static void addModelEditsForRenamedType(final List<ModelEdit<?>> modelEdits, final TypeEntry typeEntry,
 			final IPath newPath) {
 		if (typeEntry instanceof final DataTypeEntry dtEntry) {
+			// Derive the target name from the new path, so a package folder rename repoints struct
+			// references to the new package instead of the type entry's old package name.
 			DataTypeEditBuilder.createStructuredDataTypeChanges(dtEntry, modelEdits,
-					DataTypeEditBuilder.getFullTypeName(typeEntry, newPath));
+					DataTypeEditBuilder.getFullTypeName(newPath));
 		} else {
 			addInstanceChanges(modelEdits, typeEntry);
 		}

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/PackageRenameTest/.project
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/PackageRenameTest/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>PackageRenameTest</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.fordiac.ide.library.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.fordiac.ide.export.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.fordiac.ide.systemmanagement.FordiacNature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/PackageRenameTest/PackageRenameTest.sys
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/PackageRenameTest/PackageRenameTest.sys
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<System Name="PackageRenameTest" Comment="">
+	<VersionInfo Version="1.0" Author="Dimitrios Kalligaridis" Date="2026-07-29">
+	</VersionInfo>
+	<Application Name="App" Comment="">
+		<SubAppNetwork>
+			<FB Name="Producer" Type="mypackage::Producer" Comment="" x="500.0" y="500.0">
+			</FB>
+			<FB Name="Consumer" Type="mypackage::Consumer" Comment="" x="1500.0" y="500.0">
+			</FB>
+			<EventConnections>
+				<Connection Source="Producer.CNF" Destination="Consumer.REQ" Comment=""/>
+			</EventConnections>
+			<DataConnections>
+				<Connection Source="Producer.OUT" Destination="Consumer.DI" Comment=""/>
+			</DataConnections>
+		</SubAppNetwork>
+	</Application>
+</System>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/PackageRenameTest/Type Library/ControlBlock.fbt
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/PackageRenameTest/Type Library/ControlBlock.fbt
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ControlBlock" Comment="">
+	<Identification Standard="61499-2">
+	</Identification>
+	<VersionInfo Version="1.0" Author="Dimitrios Kalligaridis" Date="2026-07-29">
+	</VersionInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="">
+				<With Var="IN"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="BOOL" Comment=""/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="BOOL" Comment=""/>
+		</OutputVars>
+	</InterfaceList>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="">
+	</Service>
+</FBType>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/PackageRenameTest/Type Library/mypackage/Consumer.fbt
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/PackageRenameTest/Type Library/mypackage/Consumer.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="Consumer" Comment="">
+	<Identification Standard="61499-1">
+	</Identification>
+	<VersionInfo Version="1.0" Author="Dimitrios Kalligaridis" Date="2026-07-29">
+	</VersionInfo>
+	<CompilerInfo packageName="mypackage">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="">
+				<With Var="DI"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="">
+				<With Var="DO1"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="DI" Type="mypackage::MyStruct"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="DO1" Type="mypackage::MyStruct"/>
+		</OutputVars>
+	</InterfaceList>
+	<SimpleFB>
+		<ECState Name="REQ">
+			<ECAction Algorithm="REQ" Output="CNF"/>
+		</ECState>
+		<Algorithm Name="REQ">
+			<ST><![CDATA[]]></ST>
+		</Algorithm>
+	</SimpleFB>
+</FBType>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/PackageRenameTest/Type Library/mypackage/MyStruct.dtp
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/PackageRenameTest/Type Library/mypackage/MyStruct.dtp
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DataType Name="MyStruct" Comment="">
+	<Identification Standard="61499-1">
+	</Identification>
+	<VersionInfo Version="1.0" Author="Dimitrios Kalligaridis" Date="2026-07-29">
+	</VersionInfo>
+	<CompilerInfo packageName="mypackage">
+	</CompilerInfo>
+	<StructuredType>
+		<VarDeclaration Name="A" Type="BOOL" Comment=""/>
+		<VarDeclaration Name="B" Type="BOOL" Comment=""/>
+	</StructuredType>
+</DataType>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/PackageRenameTest/Type Library/mypackage/Producer.fbt
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/data/PackageRenameTest/Type Library/mypackage/Producer.fbt
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="Producer" Comment="">
+	<Identification Standard="61499-2">
+	</Identification>
+	<VersionInfo Version="1.0" Author="Dimitrios Kalligaridis" Date="2026-07-29">
+	</VersionInfo>
+	<CompilerInfo packageName="mypackage">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment=""/>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="mypackage::MyStruct" Comment=""/>
+		</OutputVars>
+	</InterfaceList>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="">
+	</Service>
+</FBType>

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/PackageFolderRenameTest.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/PackageFolderRenameTest.java
@@ -1,0 +1,257 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Dimitrios Kalligaridis
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Dimitrios Kalligaridis - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.tests;
+
+import static org.eclipse.fordiac.ide.typemanagement.tests.PackageRenameTestFixture.APPLICATION_NAME;
+import static org.eclipse.fordiac.ide.typemanagement.tests.PackageRenameTestFixture.CONSUMER_DI_PIN;
+import static org.eclipse.fordiac.ide.typemanagement.tests.PackageRenameTestFixture.CONSUMER_DO1_PIN;
+import static org.eclipse.fordiac.ide.typemanagement.tests.PackageRenameTestFixture.CONSUMER_FILE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.PackageRenameTestFixture.CONSUMER_INSTANCE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.PackageRenameTestFixture.CONSUMER_RENAMED_FILE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.PackageRenameTestFixture.CONSUMER_TYPE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.PackageRenameTestFixture.CONSUMER_TYPE_RENAMED;
+import static org.eclipse.fordiac.ide.typemanagement.tests.PackageRenameTestFixture.MY_STRUCT;
+import static org.eclipse.fordiac.ide.typemanagement.tests.PackageRenameTestFixture.MY_STRUCT_FILE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.PackageRenameTestFixture.MY_STRUCT_RENAMED;
+import static org.eclipse.fordiac.ide.typemanagement.tests.PackageRenameTestFixture.MY_STRUCT_RENAMED_FILE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.PackageRenameTestFixture.OUTSIDE_TYPE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.PackageRenameTestFixture.OUTSIDE_TYPE_FILE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.PackageRenameTestFixture.PACKAGE_FOLDER;
+import static org.eclipse.fordiac.ide.typemanagement.tests.PackageRenameTestFixture.PRODUCER_FILE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.PackageRenameTestFixture.PRODUCER_INSTANCE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.PackageRenameTestFixture.PRODUCER_OUT_PIN;
+import static org.eclipse.fordiac.ide.typemanagement.tests.PackageRenameTestFixture.PRODUCER_RENAMED_FILE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.PackageRenameTestFixture.PRODUCER_TYPE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.PackageRenameTestFixture.PRODUCER_TYPE_RENAMED;
+import static org.eclipse.fordiac.ide.typemanagement.tests.PackageRenameTestFixture.PROJECT_NAME;
+import static org.eclipse.fordiac.ide.typemanagement.tests.PackageRenameTestFixture.PROJECT_PATH;
+import static org.eclipse.fordiac.ide.typemanagement.tests.PackageRenameTestFixture.RENAMED_PACKAGE_FOLDER;
+import static org.eclipse.fordiac.ide.typemanagement.tests.PackageRenameTestFixture.RENAMED_PACKAGE_NAME;
+import static org.eclipse.fordiac.ide.typemanagement.tests.PackageRenameTestFixture.SYSTEM_FILE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.CONVERT;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.CORE;
+import static org.eclipse.fordiac.ide.typemanagement.tests.StandardLibrary.IEC_61131_3;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
+import org.eclipse.fordiac.ide.model.libraryElement.AutomationSystem;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
+import org.eclipse.fordiac.ide.model.libraryElement.FBType;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
+import org.eclipse.fordiac.ide.systemmanagement.SystemManager;
+import org.eclipse.fordiac.ide.typemanagement.refactoring.rename.RenameTypeRefactoringParticipant;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+import org.eclipse.ltk.core.refactoring.participants.RefactoringProcessor;
+import org.eclipse.ltk.core.refactoring.participants.RenameArguments;
+import org.eclipse.ltk.core.refactoring.participants.RenameRefactoring;
+import org.eclipse.ltk.core.refactoring.resource.RenameResourceDescriptor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PackageFolderRenameTest {
+
+	private static final String RENAMED_PRODUCER_FILE_NAME = "ProducerRenamed.fbt"; //$NON-NLS-1$
+	private static final String RENAMED_PRODUCER_FILE = "Type Library/mypackage/ProducerRenamed.fbt"; //$NON-NLS-1$
+	private static final String RENAMED_PRODUCER_TYPE = "mypackage::ProducerRenamed"; //$NON-NLS-1$
+
+	private IProject project;
+	private TypeLibrary typeLibrary;
+
+	@BeforeAll
+	static void preloadSystemManager() {
+		SystemManager.INSTANCE.name();
+	}
+
+	@BeforeEach
+	void loadFixture() throws Exception {
+		RefactoringTestSupport.flushUndoHistory();
+		project = RefactoringTestSupport.importProjectIntoWorkspace(PROJECT_NAME, PROJECT_PATH);
+		RefactoringTestSupport.linkStandardLibraries(project, CORE, CONVERT, IEC_61131_3);
+		typeLibrary = TypeLibraryManager.INSTANCE.getTypeLibrary(project);
+	}
+
+	@AfterEach
+	void disposeFixture() throws Exception {
+		RefactoringTestSupport.deleteProject(project);
+	}
+
+	@Test
+	void renamePackageFolder_repointsContainedTypesToNewPackage() throws Exception {
+		assertTypeEntryFullTypeNameEqual(file(MY_STRUCT_FILE), MY_STRUCT);
+		assertTypeEntryFullTypeNameEqual(file(PRODUCER_FILE), PRODUCER_TYPE);
+		assertTypeEntryFullTypeNameEqual(file(CONSUMER_FILE), CONSUMER_TYPE);
+		assertTypeEntryFullTypeNameEqual(file(OUTSIDE_TYPE_FILE), OUTSIDE_TYPE);
+
+		renamePackageFolder();
+
+		assertFalse(folder(PACKAGE_FOLDER).exists());
+		assertTrue(folder(RENAMED_PACKAGE_FOLDER).exists());
+		assertTypeEntryFullTypeNameEqual(file(MY_STRUCT_RENAMED_FILE), MY_STRUCT_RENAMED);
+		assertTypeEntryFullTypeNameEqual(file(PRODUCER_RENAMED_FILE), PRODUCER_TYPE_RENAMED);
+		assertTypeEntryFullTypeNameEqual(file(CONSUMER_RENAMED_FILE), CONSUMER_TYPE_RENAMED);
+		// ControlBlock lives outside mypackage, so the folder rename must leave it in place.
+		assertTypeEntryFullTypeNameEqual(file(OUTSIDE_TYPE_FILE), OUTSIDE_TYPE);
+	}
+
+	@Test
+	void renamePackageFolder_keepsInstancesResolvable() throws Exception {
+		assertEquals(PRODUCER_TYPE, producerInstance().getFullTypeName());
+		assertEquals(CONSUMER_TYPE, consumerInstance().getFullTypeName());
+		assertFalse(systemEntry().hasError());
+
+		renamePackageFolder();
+
+		assertEquals(PRODUCER_TYPE_RENAMED, producerInstance().getFullTypeName());
+		assertEquals(CONSUMER_TYPE_RENAMED, consumerInstance().getFullTypeName());
+		assertFalse(systemEntry().hasError());
+	}
+
+	@Test
+	void renameTypeFile_changesTypeNameButNotPackage() throws Exception {
+		assertTypeEntryFullTypeNameEqual(file(PRODUCER_FILE), PRODUCER_TYPE);
+		assertEquals(PRODUCER_TYPE, producerInstance().getFullTypeName());
+
+		RefactoringTestSupport.performRename(file(PRODUCER_FILE), RENAMED_PRODUCER_FILE_NAME);
+
+		// The file rename changes the type name but stays in mypackage, and the producer
+		// instance follows it, unlike the folder rename which moves the package instead.
+		assertFalse(file(PRODUCER_FILE).exists());
+		assertTypeEntryFullTypeNameEqual(file(RENAMED_PRODUCER_FILE), RENAMED_PRODUCER_TYPE);
+		assertEquals(RENAMED_PRODUCER_TYPE, producerInstance().getFullTypeName());
+	}
+
+	@Test
+	void createPreChange_returnsNullForFileRename() throws Exception {
+		final IFile producerFile = file(PRODUCER_FILE);
+		final RenameResourceDescriptor descriptor = new RenameResourceDescriptor();
+		descriptor.setResourcePath(producerFile.getFullPath());
+		descriptor.setNewName(RENAMED_PRODUCER_FILE_NAME);
+		final RenameRefactoring refactoring = (RenameRefactoring) descriptor.createRefactoring(new RefactoringStatus());
+		final RefactoringProcessor processor = refactoring.getProcessor();
+
+		final RenameTypeRefactoringParticipant participant = new RenameTypeRefactoringParticipant();
+		final boolean initialized = participant.initialize(processor, producerFile,
+				new RenameArguments(RENAMED_PRODUCER_FILE_NAME, true));
+
+		assertTrue(initialized);
+		assertNull(participant.createPreChange(new NullProgressMonitor()));
+	}
+
+	@Test
+	void renamePackageFolder_repointsStructReferencingPins() throws Exception {
+		assertEquals(MY_STRUCT, pinType(PRODUCER_TYPE, PRODUCER_OUT_PIN));
+		assertEquals(MY_STRUCT, pinType(CONSUMER_TYPE, CONSUMER_DI_PIN));
+		assertEquals(MY_STRUCT, pinType(CONSUMER_TYPE, CONSUMER_DO1_PIN));
+
+		renamePackageFolder();
+
+		// Producer.OUT, Consumer.DI and Consumer.DO1 are typed with MyStruct, so the folder rename
+		// must repoint their data type to renamedpackage::MyStruct, not only rename the type entries.
+		assertEquals(MY_STRUCT_RENAMED, pinType(PRODUCER_TYPE_RENAMED, PRODUCER_OUT_PIN));
+		assertEquals(MY_STRUCT_RENAMED, pinType(CONSUMER_TYPE_RENAMED, CONSUMER_DI_PIN));
+		assertEquals(MY_STRUCT_RENAMED, pinType(CONSUMER_TYPE_RENAMED, CONSUMER_DO1_PIN));
+	}
+
+	@Test
+	void renamePackageFolder_undoRedoRoundTrip() throws Exception {
+		assertOriginalState();
+
+		renamePackageFolder();
+		assertRenamedState();
+
+		RefactoringTestSupport.undoLastRefactoring();
+		assertOriginalState();
+
+		RefactoringTestSupport.redoLastRefactoring();
+		assertRenamedState();
+	}
+
+	private void assertOriginalState() {
+		assertTrue(folder(PACKAGE_FOLDER).exists());
+		assertFalse(folder(RENAMED_PACKAGE_FOLDER).exists());
+		assertTypeEntryFullTypeNameEqual(file(MY_STRUCT_FILE), MY_STRUCT);
+		assertTypeEntryFullTypeNameEqual(file(PRODUCER_FILE), PRODUCER_TYPE);
+		assertTypeEntryFullTypeNameEqual(file(CONSUMER_FILE), CONSUMER_TYPE);
+		assertEquals(PRODUCER_TYPE, producerInstance().getFullTypeName());
+		assertEquals(CONSUMER_TYPE, consumerInstance().getFullTypeName());
+		assertFalse(systemEntry().hasError());
+	}
+
+	private void assertRenamedState() {
+		assertFalse(folder(PACKAGE_FOLDER).exists());
+		assertTrue(folder(RENAMED_PACKAGE_FOLDER).exists());
+		assertTypeEntryFullTypeNameEqual(file(MY_STRUCT_RENAMED_FILE), MY_STRUCT_RENAMED);
+		assertTypeEntryFullTypeNameEqual(file(PRODUCER_RENAMED_FILE), PRODUCER_TYPE_RENAMED);
+		assertTypeEntryFullTypeNameEqual(file(CONSUMER_RENAMED_FILE), CONSUMER_TYPE_RENAMED);
+		assertEquals(PRODUCER_TYPE_RENAMED, producerInstance().getFullTypeName());
+		assertEquals(CONSUMER_TYPE_RENAMED, consumerInstance().getFullTypeName());
+		assertFalse(systemEntry().hasError());
+	}
+
+	// Reads the resolved data type of an interface pin on the given FB type, so a stale reference
+	// after the package rename shows up as the old qualified name instead of the renamed one.
+	private String pinType(final String fbTypeName, final String pinName) {
+		final FBType fbType = (FBType) typeLibrary.getFBTypeEntry(fbTypeName).getType();
+		final VarDeclaration pin = fbType.getInterfaceList().getVariable(pinName);
+		return PackageNameHelper.getFullTypeName(pin.getType());
+	}
+
+	private void renamePackageFolder() throws Exception {
+		final IFolder packageFolder = project.getFolder(PACKAGE_FOLDER);
+		RefactoringTestSupport.performFolderRename(packageFolder, RENAMED_PACKAGE_NAME);
+	}
+
+	private FBNetworkElement producerInstance() {
+		return RefactoringTestSupport.findInstance(system(), APPLICATION_NAME, PRODUCER_INSTANCE);
+	}
+
+	private FBNetworkElement consumerInstance() {
+		return RefactoringTestSupport.findInstance(system(), APPLICATION_NAME, CONSUMER_INSTANCE);
+	}
+
+	private AutomationSystem system() {
+		return (AutomationSystem) systemEntry().getType();
+	}
+
+	private TypeEntry systemEntry() {
+		return typeLibrary.getTypeEntry(file(SYSTEM_FILE));
+	}
+
+	private void assertTypeEntryFullTypeNameEqual(final IFile typeFile, final String expectedFullTypeName) {
+		final TypeEntry entry = typeLibrary.getTypeEntry(typeFile);
+		assertNotNull(entry);
+		assertFalse(entry.hasError());
+		assertEquals(expectedFullTypeName, entry.getFullTypeName());
+	}
+
+	private IFile file(final String projectRelativePath) {
+		return project.getFile(projectRelativePath);
+	}
+
+	private IFolder folder(final String projectRelativePath) {
+		return project.getFolder(projectRelativePath);
+	}
+}

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/PackageRenameTestFixture.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/PackageRenameTestFixture.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Dimitrios Kalligaridis
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Dimitrios Kalligaridis - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.typemanagement.tests;
+
+/**
+ * Coordinates of the shared PackageRenameTest fixture under data, where
+ * mypackage holds a struct and a connected producer/consumer FB type, and
+ * ControlBlock sits outside mypackage, referenced by the package folder
+ * rename test.
+ */
+public final class PackageRenameTestFixture {
+
+	public static final String PROJECT_NAME = "PackageRenameTest"; //$NON-NLS-1$
+	public static final String PROJECT_PATH = "data/PackageRenameTest"; //$NON-NLS-1$
+	public static final String SYSTEM_FILE = "PackageRenameTest.sys"; //$NON-NLS-1$
+	public static final String APPLICATION_NAME = "App"; //$NON-NLS-1$
+
+	public static final String PACKAGE_FOLDER = "Type Library/mypackage"; //$NON-NLS-1$
+	public static final String RENAMED_PACKAGE_NAME = "renamedpackage"; //$NON-NLS-1$
+	public static final String RENAMED_PACKAGE_FOLDER = "Type Library/renamedpackage"; //$NON-NLS-1$
+
+	public static final String MY_STRUCT_FILE = "Type Library/mypackage/MyStruct.dtp"; //$NON-NLS-1$
+	public static final String MY_STRUCT_RENAMED_FILE = "Type Library/renamedpackage/MyStruct.dtp"; //$NON-NLS-1$
+	public static final String MY_STRUCT = "mypackage::MyStruct"; //$NON-NLS-1$
+	public static final String MY_STRUCT_RENAMED = "renamedpackage::MyStruct"; //$NON-NLS-1$
+
+	public static final String PRODUCER_FILE = "Type Library/mypackage/Producer.fbt"; //$NON-NLS-1$
+	public static final String PRODUCER_RENAMED_FILE = "Type Library/renamedpackage/Producer.fbt"; //$NON-NLS-1$
+	public static final String PRODUCER_TYPE = "mypackage::Producer"; //$NON-NLS-1$
+	public static final String PRODUCER_TYPE_RENAMED = "renamedpackage::Producer"; //$NON-NLS-1$
+	public static final String PRODUCER_INSTANCE = "Producer"; //$NON-NLS-1$
+
+	public static final String CONSUMER_FILE = "Type Library/mypackage/Consumer.fbt"; //$NON-NLS-1$
+	public static final String CONSUMER_RENAMED_FILE = "Type Library/renamedpackage/Consumer.fbt"; //$NON-NLS-1$
+	public static final String CONSUMER_TYPE = "mypackage::Consumer"; //$NON-NLS-1$
+	public static final String CONSUMER_TYPE_RENAMED = "renamedpackage::Consumer"; //$NON-NLS-1$
+	public static final String CONSUMER_INSTANCE = "Consumer"; //$NON-NLS-1$
+
+	// Interface pins typed with MyStruct, so a package rename has to repoint their data type.
+	public static final String PRODUCER_OUT_PIN = "OUT"; //$NON-NLS-1$
+	public static final String CONSUMER_DI_PIN = "DI"; //$NON-NLS-1$
+	public static final String CONSUMER_DO1_PIN = "DO1"; //$NON-NLS-1$
+
+	public static final String OUTSIDE_TYPE_FILE = "Type Library/ControlBlock.fbt"; //$NON-NLS-1$
+	public static final String OUTSIDE_TYPE = "ControlBlock"; //$NON-NLS-1$
+
+	private PackageRenameTestFixture() {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/RefactoringTestSupport.java
+++ b/tests/org.eclipse.fordiac.ide.typemanagement.tests/src/org/eclipse/fordiac/ide/typemanagement/tests/RefactoringTestSupport.java
@@ -131,6 +131,13 @@ public final class RefactoringTestSupport {
 		return performRefactoring(descriptor.createRefactoring(new RefactoringStatus()));
 	}
 
+	public static Change performFolderRename(final IFolder folder, final String newName) throws CoreException {
+		final RenameResourceDescriptor descriptor = new RenameResourceDescriptor();
+		descriptor.setResourcePath(folder.getFullPath());
+		descriptor.setNewName(newName);
+		return performRefactoring(descriptor.createRefactoring(new RefactoringStatus()));
+	}
+
 	public static Change performDelete(final IFile file) throws CoreException {
 		final DeleteResourcesDescriptor descriptor = new DeleteResourcesDescriptor();
 		descriptor.setResourcePaths(new IPath[] { file.getFullPath() });


### PR DESCRIPTION
Adds tests for the package folder rename, and fixes a bug they surfaced.

The tests cover that renaming a package folder repackages the contained types and keeps their instances resolvable, with an undo and redo round trip, while a single type file rename only changes the type name.

While writing them I found that the folder rename left struct-typed interface pins pointing at the old package: `Producer.OUT`, `Consumer.DI` and `Consumer.DO1` stayed `mypackage::MyStruct` after renaming `mypackage` to `renamedpackage`. The rename path computed the struct reference target from the type entry's old package name, unlike the move path. It now derives the target from the new path, so the pins repoint to the new package. Verified in the UI on develop and guarded by the new `renamePackageFolder_repointsStructReferencingPins` test.

This addresses the two Copilot review comments: the undo/redo round trip is added, and the struct-referencing pins are asserted, which is green now that the underlying bug is fixed.

Closes #2779.