### PR TITLE
Fix builder abort affecting all projects

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/builder/ExportBuilder.java
+++ b/plugins/org.eclipse.fordiac.ide.export/src/org/eclipse/fordiac/ide/export/builder/ExportBuilder.java
@@ -14,7 +14,6 @@
 package org.eclipse.fordiac.ide.export.builder;
 
 import java.text.MessageFormat;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -79,7 +78,8 @@ public class ExportBuilder extends IncrementalProjectBuilder {
 
 		final BuildContext context = createBuildContext();
 
-		if (context.filter == null || !ExportFilterUtil.validateExportPath(context.outputDirectory, getProject())) {
+		if (context.filter == null || !ExportFilterUtil.validateExportPath(context.outputDirectory, getProject())
+				|| hasRelevantErrorMarker(getProject())) {
 			return new IProject[0];
 		}
 
@@ -294,9 +294,9 @@ public class ExportBuilder extends IncrementalProjectBuilder {
 		}
 	}
 
-	private static boolean hasRelevantErrorMarker(final IFile file) throws CoreException {
-		return Arrays.stream(file.findMarkers(FordiacErrorMarker.PROBLEM_MARKER, true, IResource.DEPTH_INFINITE))
-				.anyMatch(m -> m.getAttribute(IMarker.SEVERITY, -1) == IMarker.SEVERITY_ERROR);
+	private static boolean hasRelevantErrorMarker(final IResource resource) throws CoreException {
+		return resource.findMaxProblemSeverity(FordiacErrorMarker.PROBLEM_MARKER, true,
+				IResource.DEPTH_ZERO) >= IMarker.SEVERITY_ERROR;
 	}
 
 	private boolean isExportCanceled(final IProgressMonitor monitor) {

--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/src/org/eclipse/fordiac/ide/globalconstantseditor/ui/GlobalConstantsSharedModule.java
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/src/org/eclipse/fordiac/ide/globalconstantseditor/ui/GlobalConstantsSharedModule.java
@@ -12,16 +12,20 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.globalconstantseditor.ui;
 
+import org.eclipse.fordiac.ide.globalconstantseditor.ui.builder.GlobalConstantsToBeBuiltComputerContribution;
 import org.eclipse.fordiac.ide.globalconstantseditor.ui.resource.GlobalConstantsResourceSetInitializer;
+import org.eclipse.xtext.builder.impl.IToBeBuiltComputerContribution;
 import org.eclipse.xtext.ui.resource.IResourceSetInitializer;
 
 import com.google.inject.Binder;
 import com.google.inject.Module;
 
+@SuppressWarnings("restriction")
 public class GlobalConstantsSharedModule implements Module {
 
 	@Override
 	public void configure(final Binder binder) {
 		binder.bind(IResourceSetInitializer.class).to(GlobalConstantsResourceSetInitializer.class);
+		binder.bind(IToBeBuiltComputerContribution.class).to(GlobalConstantsToBeBuiltComputerContribution.class);
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/src/org/eclipse/fordiac/ide/globalconstantseditor/ui/builder/GlobalConstantsToBeBuiltComputerContribution.java
+++ b/plugins/org.eclipse.fordiac.ide.globalconstantseditor.ui/src/org/eclipse/fordiac/ide/globalconstantseditor/ui/builder/GlobalConstantsToBeBuiltComputerContribution.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Martin Erich Jobst
+ * Copyright (c) 2026 Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -10,16 +10,16 @@
  * Contributors:
  *   Martin Jobst - initial API and implementation and/or initial documentation
  *******************************************************************************/
-package org.eclipse.fordiac.ide.structuredtextalgorithm.ui.builder;
+package org.eclipse.fordiac.ide.globalconstantseditor.ui.builder;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.fordiac.ide.structuredtextalgorithm.resource.STAlgorithmResource;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.builder.STCoreToBeBuiltComputerContribution;
 
-public class STAlgorithmToBeBuiltComputerContribution extends STCoreToBeBuiltComputerContribution {
+public class GlobalConstantsToBeBuiltComputerContribution extends STCoreToBeBuiltComputerContribution {
 
 	@Override
 	protected boolean isValidFileExtension(final IFile file) {
-		return STAlgorithmResource.isValidFileExtension(file.getFileExtension());
+		return TypeLibraryTags.GLOBAL_CONST_FILE_ENDING.equalsIgnoreCase(file.getFileExtension());
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/LibraryManager.java
+++ b/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/LibraryManager.java
@@ -706,8 +706,11 @@ public enum LibraryManager {
 
 		final int maxSeverity = markerList.stream().mapToInt(ErrorMarkerBuilder::getSeverity).max().orElse(-1);
 		if (maxSeverity >= IMarker.SEVERITY_ERROR) {
-			markerList.add(ErrorMarkerBuilder.createErrorMarkerBuilder(Messages.LibraryManager_UnresolvableDependencies)
-					.setType(FordiacErrorMarker.LIBRARY_MARKER));
+			FordiacMarkerHelper.updateMarkers(project, FordiacErrorMarker.LIBRARY_MARKER,
+					List.of(ErrorMarkerBuilder
+							.createErrorMarkerBuilder(Messages.LibraryManager_UnresolvableDependencies)
+							.setType(FordiacErrorMarker.LIBRARY_MARKER)),
+					true);
 		}
 
 		FordiacMarkerHelper.updateMarkers(project.getFile(MANIFEST), FordiacErrorMarker.LIBRARY_MARKER, markerList,

--- a/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/LibraryManager.java
+++ b/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/LibraryManager.java
@@ -717,10 +717,6 @@ public enum LibraryManager {
 				true);
 
 		TypeLibraryManager.INSTANCE.getTypeLibrary(project).refresh();
-
-		if (maxSeverity >= IMarker.SEVERITY_ERROR) {
-			throw new OperationCanceledException("Unresolvable dependencies"); //$NON-NLS-1$
-		}
 	}
 
 	/**

--- a/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/builder/LibraryBuilder.java
+++ b/plugins/org.eclipse.fordiac.ide.library/src/org/eclipse/fordiac/ide/library/builder/LibraryBuilder.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.library.builder;
 
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -35,12 +34,10 @@ import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.fordiac.ide.library.LibraryManager;
 import org.eclipse.fordiac.ide.library.LibraryValidation;
-import org.eclipse.fordiac.ide.library.LinkedLibrary;
 import org.eclipse.fordiac.ide.library.Messages;
 import org.eclipse.fordiac.ide.library.model.library.Manifest;
 import org.eclipse.fordiac.ide.library.model.util.ManifestHelper;
 import org.eclipse.fordiac.ide.model.errormarker.FordiacErrorMarker;
-import org.eclipse.fordiac.ide.model.errormarker.FordiacMarkerHelper;
 import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 
 public class LibraryBuilder extends IncrementalProjectBuilder {
@@ -79,21 +76,11 @@ public class LibraryBuilder extends IncrementalProjectBuilder {
 
 	@Override
 	protected void clean(final IProgressMonitor monitor) throws CoreException {
-		final SubMonitor progress = SubMonitor.convert(monitor, Messages.LibraryBuilder_CleaningLibrary, 3);
+		final SubMonitor progress = SubMonitor.convert(monitor, Messages.LibraryBuilder_CleaningLibrary, 1);
 
-		// clean manifest library marker
-		final IFile manifestFile = getProject().getFile(LibraryManager.MANIFEST);
-		if (manifestFile.exists()) {
-			manifestFile.deleteMarkers(FordiacErrorMarker.LIBRARY_MARKER, true, IResource.DEPTH_ZERO);
-		}
+		// clean all library markers
+		getProject().deleteMarkers(FordiacErrorMarker.LIBRARY_MARKER, true, IResource.DEPTH_INFINITE);
 		progress.worked(1);
-
-		// clean broken link markers
-		LinkedLibrary.getAll(getProject(), progress).filter(LinkedLibrary::isValid)
-				.map(LinkedLibrary::getFolder).forEach(f -> FordiacMarkerHelper.updateMarkers(f,
-						FordiacErrorMarker.LIBRARY_MARKER, Collections.emptyList(), true));
-
-		progress.worked(2);
 
 		SubMonitor.done(monitor);
 	}

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/META-INF/MANIFEST.MF
@@ -34,6 +34,7 @@ Import-Package: org.apache.log4j,
  org.eclipse.xtext.ui.codemining;resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.fordiac.ide.structuredtextcore.ui,
+ org.eclipse.fordiac.ide.structuredtextcore.ui.builder;x-friends:="org.eclipse.fordiac.ide.structuredtextalgorithm.ui,org.eclipse.fordiac.ide.globalconstantseditor.ui,org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui",
  org.eclipse.fordiac.ide.structuredtextcore.ui.cleanup,
  org.eclipse.fordiac.ide.structuredtextcore.ui.codemining,
  org.eclipse.fordiac.ide.structuredtextcore.ui.contentassist,

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/builder/STCoreToBeBuiltComputerContribution.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/src/org/eclipse/fordiac/ide/structuredtextcore/ui/builder/STCoreToBeBuiltComputerContribution.java
@@ -1,0 +1,166 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Martin Erich Jobst
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Martin Jobst - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.structuredtextcore.ui.builder;
+
+import java.util.Set;
+import java.util.stream.StreamSupport;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IStorage;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.emf.common.util.TreeIterator;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.fordiac.ide.model.data.AnyType;
+import org.eclipse.fordiac.ide.model.datatype.helper.InternalAttributeDeclarations;
+import org.eclipse.fordiac.ide.model.datatype.helper.TypeDeclarationParser;
+import org.eclipse.fordiac.ide.model.errormarker.FordiacErrorMarker;
+import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
+import org.eclipse.fordiac.ide.structuredtextcore.stcore.util.STCoreUtil;
+import org.eclipse.fordiac.ide.structuredtextcore.ui.validation.ValidationUtil;
+import org.eclipse.xtext.builder.builderState.IBuilderState;
+import org.eclipse.xtext.builder.impl.IToBeBuiltComputerContribution;
+import org.eclipse.xtext.builder.impl.ToBeBuilt;
+import org.eclipse.xtext.resource.IResourceDescription;
+
+import com.google.inject.Inject;
+
+@SuppressWarnings("restriction")
+public abstract class STCoreToBeBuiltComputerContribution implements IToBeBuiltComputerContribution {
+
+	@Inject
+	private IBuilderState builderState;
+
+	@Override
+	public void removeProject(final ToBeBuilt toBeBuilt, final IProject project, final IProgressMonitor monitor) {
+		// do nothing
+	}
+
+	@Override
+	public void updateProject(final ToBeBuilt toBeBuilt, final IProject project, final IProgressMonitor monitor)
+			throws CoreException {
+		// do nothing
+	}
+
+	@Override
+	public boolean removeStorage(final ToBeBuilt toBeBuilt, final IStorage storage, final IProgressMonitor monitor) {
+		if (storage instanceof final IFile file && isValidFileExtension(file)) {
+			return removeTypeEntry(toBeBuilt, file);
+		}
+		return false;
+	}
+
+	@Override
+	public boolean updateStorage(final ToBeBuilt toBeBuilt, final IStorage storage, final IProgressMonitor monitor) {
+		if (storage instanceof final IFile file && isValidFileExtension(file)) {
+			if (hasLibraryErrorMarker(file)) {
+				return removeTypeEntry(toBeBuilt, file);
+			}
+
+			final TypeEntry typeEntry = TypeLibraryManager.INSTANCE.getTypeEntryForFile(file);
+			if (typeEntry != null) {
+				return updateTypeEntry(toBeBuilt, typeEntry);
+			}
+		}
+		return false;
+	}
+
+	protected static boolean hasLibraryErrorMarker(final IFile file) {
+		try {
+			return file.getProject().findMaxProblemSeverity(FordiacErrorMarker.LIBRARY_MARKER, false,
+					IResource.DEPTH_ZERO) >= IMarker.SEVERITY_ERROR;
+		} catch (final CoreException e) {
+			// do nothing
+		}
+		return false;
+	}
+
+	protected boolean removeTypeEntry(final ToBeBuilt toBeBuilt, final IFile file) {
+		final URI uri = URI.createPlatformResourceURI(file.getFullPath().toString(), true);
+		toBeBuilt.getToBeDeleted().add(uri);
+		collectRelatedURIs(uri, toBeBuilt.getToBeDeleted());
+		return true;
+	}
+
+	protected static void updateAttribute(final ToBeBuilt toBeBuilt, final Attribute attribute) {
+		if (attribute.getType() instanceof AnyType
+				&& !InternalAttributeDeclarations.isInternalAttribute(attribute.getAttributeDeclaration())
+				&& !STCoreUtil.isSimpleAttributeValue(attribute, false)) {
+			updateElement(toBeBuilt, attribute);
+		}
+	}
+
+	protected boolean updateTypeEntry(final ToBeBuilt toBeBuilt, final TypeEntry typeEntry) {
+		final URI uri = typeEntry.getURI();
+		toBeBuilt.getToBeUpdated().add(uri);
+		collectRelatedURIs(uri, toBeBuilt.getToBeDeleted());
+		final LibraryElement type = typeEntry.getType();
+		if (type != null) {
+			final TreeIterator<EObject> contents = type.eAllContents();
+			while (contents.hasNext()) {
+				final EObject next = contents.next();
+				if (next instanceof final Attribute attribute) {
+					updateAttribute(toBeBuilt, attribute);
+				} else if (next instanceof final VarDeclaration varDeclaration) {
+					updateVarDeclaration(toBeBuilt, varDeclaration);
+				}
+			}
+		}
+		return true;
+	}
+
+	protected static void updateVarDeclaration(final ToBeBuilt toBeBuilt, final VarDeclaration varDeclaration) {
+		if (varDeclaration.isArray() && !ValidationUtil.isContainedInTypedInstance(varDeclaration)
+				&& !TypeDeclarationParser.isSimpleTypeDeclaration(varDeclaration.getArraySize().getValue())) {
+			updateElement(toBeBuilt, varDeclaration.getArraySize());
+		}
+		if (!STCoreUtil.isSimpleInitialValue(varDeclaration, false)) {
+			updateElement(toBeBuilt, varDeclaration.getValue());
+		}
+	}
+
+	protected static void updateElement(final ToBeBuilt toBeBuilt, final EObject element) {
+		final Resource resource = element.eResource();
+		final URI uri = resource.getURI().appendQuery(resource.getURIFragment(element));
+		toBeBuilt.getToBeUpdated().add(uri);
+		toBeBuilt.getToBeDeleted().remove(uri);
+	}
+
+	protected void collectRelatedURIs(final URI uri, final Set<URI> result) {
+		StreamSupport.stream(builderState.getAllResourceDescriptions().spliterator(), false)
+				.map(IResourceDescription::getURI)
+				.filter(candidate -> candidate.hasQuery() && candidate.trimQuery().equals(uri)).forEach(result::add);
+	}
+
+	@Override
+	public boolean isPossiblyHandled(final IStorage storage) {
+		return storage instanceof final IFile file && TypeLibraryManager.INSTANCE.getTypeEntryForFile(file) != null;
+	}
+
+	@Override
+	public boolean isRejected(final IFolder folder) {
+		return false;
+	}
+
+	protected abstract boolean isValidFileExtension(IFile file);
+}

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/ui/STFunctionSharedModule.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/ui/STFunctionSharedModule.java
@@ -12,15 +12,19 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui;
 
+import org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.builder.STFunctionToBeBuiltComputerContribution;
 import org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.resource.STFunctionResourceSetInitializer;
+import org.eclipse.xtext.builder.impl.IToBeBuiltComputerContribution;
 import org.eclipse.xtext.ui.resource.IResourceSetInitializer;
 
 import com.google.inject.Binder;
 
+@SuppressWarnings("restriction")
 public class STFunctionSharedModule implements com.google.inject.Module {
 
 	@Override
 	public void configure(final Binder binder) {
 		binder.bind(IResourceSetInitializer.class).to(STFunctionResourceSetInitializer.class);
+		binder.bind(IToBeBuiltComputerContribution.class).to(STFunctionToBeBuiltComputerContribution.class);
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/ui/builder/STFunctionToBeBuiltComputerContribution.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/ui/builder/STFunctionToBeBuiltComputerContribution.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Martin Erich Jobst
+ * Copyright (c) 2026 Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -10,16 +10,16 @@
  * Contributors:
  *   Martin Jobst - initial API and implementation and/or initial documentation
  *******************************************************************************/
-package org.eclipse.fordiac.ide.structuredtextalgorithm.ui.builder;
+package org.eclipse.fordiac.ide.structuredtextfunctioneditor.ui.builder;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.fordiac.ide.structuredtextalgorithm.resource.STAlgorithmResource;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 import org.eclipse.fordiac.ide.structuredtextcore.ui.builder.STCoreToBeBuiltComputerContribution;
 
-public class STAlgorithmToBeBuiltComputerContribution extends STCoreToBeBuiltComputerContribution {
+public class STFunctionToBeBuiltComputerContribution extends STCoreToBeBuiltComputerContribution {
 
 	@Override
 	protected boolean isValidFileExtension(final IFile file) {
-		return STAlgorithmResource.isValidFileExtension(file.getFileExtension());
+		return TypeLibraryTags.FC_TYPE_FILE_ENDING.equalsIgnoreCase(file.getFileExtension());
 	}
 }

--- a/tests/org.eclipse.fordiac.ide.test.library/src/org/eclipse/fordiac/ide/test/library/LibraryImportTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.library/src/org/eclipse/fordiac/ide/test/library/LibraryImportTest.java
@@ -14,6 +14,7 @@ package org.eclipse.fordiac.ide.test.library;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.nio.file.Paths;
@@ -298,8 +299,11 @@ class LibraryImportTest {
 		final var markers = manifestFile.findMarkers(FordiacErrorMarker.LIBRARY_MARKER, false,
 				IResource.DEPTH_INFINITE);
 
-		assertEquals(2, markers.length);
+		assertEquals(1, markers.length);
 		assertEquals(TEST01, findFirstDependencyMarker(markers).orElse(null));
+
+		assertTrue(project.findMaxProblemSeverity(FordiacErrorMarker.LIBRARY_MARKER, false,
+				IResource.DEPTH_ZERO) >= IMarker.SEVERITY_ERROR);
 	}
 
 	@Test
@@ -337,8 +341,11 @@ class LibraryImportTest {
 		final var markers = manifestFile.findMarkers(FordiacErrorMarker.LIBRARY_MARKER, false,
 				IResource.DEPTH_INFINITE);
 
-		assertEquals(2, markers.length);
+		assertEquals(1, markers.length);
 		assertEquals(MATH, findFirstDependencyMarker(markers).orElse(null));
+
+		assertTrue(project.findMaxProblemSeverity(FordiacErrorMarker.LIBRARY_MARKER, false,
+				IResource.DEPTH_ZERO) >= IMarker.SEVERITY_ERROR);
 	}
 
 	static Optional<String> findFirstDependencyMarker(final IMarker[] markers) {


### PR DESCRIPTION
This changes the library builder to add an error marker for unresolvable projects on the project itself instead of the manifest, which is then checked by subsequent builders to ignore the project.