### PR TITLE
Fix connection policy not updating style field

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/policies/ConnectionMovementHighlightEditPolicy.java
+++ b/plugins/org.eclipse.fordiac.ide.gef/src/org/eclipse/fordiac/ide/gef/policies/ConnectionMovementHighlightEditPolicy.java
@@ -67,7 +67,8 @@ public class ConnectionMovementHighlightEditPolicy extends org.eclipse.gef.editp
 			final Point pos = selReq.getLocation();
 			getHostFigure().translateToRelative(pos);
 			if (getHostFigure() instanceof final InteractionStyleFigure isFigure) {
-				switch (isFigure.getIntersectionStyle(pos)) {
+				style = isFigure.getIntersectionStyle(pos);
+				switch (style) {
 				case InteractionStyleFigure.REGION_CONNECTION ->
 					getHostFigure().setCursor(Display.getDefault().getSystemCursor(SWT.CURSOR_CROSS));
 				case InteractionStyleFigure.REGION_DRAG ->


### PR DESCRIPTION
The style field of the `ConnectionMovementHighlightEditPolicy` is no longer updated since PR #2699, causing the cursor to still be displayed correctly, but the connection tool is always used.