### PR TITLE
Fix NPE in RecordExecutionTraceHandler

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/Messages.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/Messages.java
@@ -18,7 +18,7 @@ import org.eclipse.osgi.util.NLS;
 public class Messages extends NLS {
 	private static final String BUNDLE_NAME = Messages.class.getPackageName() + ".messages"; //$NON-NLS-1$
 	public static String RecordExecutionTraceHandler_Incorrect_Selection;
-	public static String RecordExecutionTraceHandler_Select_FB_input_event;
+	public static String RecordExecutionTraceHandler_Select_FB_event;
 	public static String CreateRuntimeTestFunctionBlockHandler_Select_Service_Model;
 	public static String SelectAdapterEventDialog_Select_Event_Contained_In_Selected_Adapter;
 	public static String SelectAdapterEventDialog_Choose_Event_From_List;

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/handler/RecordExecutionTraceHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/handler/RecordExecutionTraceHandler.java
@@ -65,6 +65,10 @@ public class RecordExecutionTraceHandler extends AbstractHandler {
 
 		// user should have selected an event pin of an FB
 		var selectedPin = getSelectedPin(selection);
+		if (selectedPin == null) {
+			openSelectionErrorDialog(event);
+			return Status.CANCEL_STATUS;
+		}
 
 		// identify the FB network associated with this pin
 		final FBNetwork network;
@@ -80,9 +84,7 @@ public class RecordExecutionTraceHandler extends AbstractHandler {
 			selectedPin = handleAdapterSelection(aDecl, event);
 		}
 		if (!(selectedPin instanceof final Event triggerEvent)) {
-			MessageDialog.openInformation(HandlerUtil.getActiveShell(event),
-					Messages.RecordExecutionTraceHandler_Incorrect_Selection,
-					Messages.RecordExecutionTraceHandler_Select_FB_input_event);
+			openSelectionErrorDialog(event);
 			return Status.CANCEL_STATUS;
 		}
 
@@ -98,9 +100,7 @@ public class RecordExecutionTraceHandler extends AbstractHandler {
 
 		if (typelib != null) {
 			final IProject project = typelib.getProject();
-			typelib.getAllTypes().forEach(type -> {
-				addResourceForFile(type, type.getFile(), reset);
-			});
+			typelib.getAllTypes().forEach(type -> addResourceForFile(type, type.getFile(), reset));
 			addResourceForEventTypeLib(reset);
 			addResourceForDataTypeLib(typelib.getDataTypeLibrary(), reset);
 
@@ -132,6 +132,12 @@ public class RecordExecutionTraceHandler extends AbstractHandler {
 			}
 		}
 		return Status.OK_STATUS;
+	}
+
+	private static void openSelectionErrorDialog(final ExecutionEvent event) {
+		MessageDialog.openInformation(HandlerUtil.getActiveShell(event),
+				Messages.RecordExecutionTraceHandler_Incorrect_Selection,
+				Messages.RecordExecutionTraceHandler_Select_FB_event);
 	}
 
 	private static void addResourceForEventTypeLib(final ResourceSet reset) {
@@ -181,8 +187,8 @@ public class RecordExecutionTraceHandler extends AbstractHandler {
 
 	private static IInterfaceElement getSelectedPin(final IStructuredSelection structuredSelection) {
 		Object selected = structuredSelection.getFirstElement();
-		if (selected instanceof EditPart) {
-			selected = ((EditPart) structuredSelection.getFirstElement()).getModel();
+		if (selected instanceof final EditPart editPart) {
+			selected = editPart.getModel();
 		}
 		if (selected instanceof final IInterfaceElement pin) {
 			return pin;

--- a/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/messages.properties
+++ b/plugins/org.eclipse.fordiac.ide.fb.interpreter/src/org/eclipse/fordiac/ide/fb/interpreter/messages.properties
@@ -1,5 +1,5 @@
 RecordExecutionTraceHandler_Incorrect_Selection=Incorrect selection
-RecordExecutionTraceHandler_Select_FB_input_event=Please select an input event of an FB instance
+RecordExecutionTraceHandler_Select_FB_event=Please select an event of an FB instance
 CreateRuntimeTestFunctionBlockHandler_Select_Service_Model=Please open a Service model
 SelectAdapterEventDialog_Select_Event_Contained_In_Selected_Adapter=Select the event pin to trigger
 SelectAdapterEventDialog_Choose_Event_From_List=Choose one of the events of the adapter to start the execution


### PR DESCRIPTION
Fix `NullPointerException` in `RecordExecutionTraceHandler` for wrong selections and show the error dialog instead.
Update the dialog error message from "input event" to just "event", since selecting output events is also valid for a while now.