### PR TITLE
Remove broken and obsolete resource-relocation strategy for DTP files

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore.ui/plugin.xml
@@ -694,10 +694,4 @@
        </enablement>
     </copyParticipant>
  </extension>
- <extension
-       point="org.eclipse.xtext.ui.resourceRelocationStrategy">
-    <strategy
-          class="org.eclipse.fordiac.ide.structuredtextcore.ui.DTPExecutableExtensionFactory:org.eclipse.fordiac.ide.structuredtextcore.ui.refactoring.LibraryElementResourceRelocationStrategy">
-    </strategy>
- </extension>
 </plugin>


### PR DESCRIPTION
The separate DTP pseudo-language has long been removed, but an extension with a resource-relocation strategy for DTP files was still left over, which led to exceptions when moving files. This removes the extension, since this is now handled differently.