### PR TITLE
[Replay Debugging] Fix zooming issue in timeline view and highlight steps also when selecting the watch

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/SelectionService.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/SelectionService.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.fordiac.ide.deployment.debug.ui.annotation.WatchValueAnnotation;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.IInterfaceElement;
 import org.eclipse.gef.EditPart;
@@ -69,12 +70,12 @@ public class SelectionService implements ISelectionListener {
 				continue;
 			}
 
-			if (ep.getModel() instanceof final IInterfaceElement mo) {
-				lastSelectedDatapoints.add(mo.getQualifiedName());
-			} else if (ep.getModel() instanceof final FBNetworkElement mo) {
+			switch (ep.getModel()) {
+			case final IInterfaceElement interf -> lastSelectedDatapoints.add(interf.getQualifiedName());
+			case final FBNetworkElement fb -> {
 				// find all interfaces and variables from a FB block
 				// omit non interface elements, or interface from subApps
-				final var fbBlockIt = mo.eAllContents();
+				final var fbBlockIt = fb.eAllContents();
 				while (fbBlockIt.hasNext()) {
 					final EObject obj = fbBlockIt.next();
 					if (!(obj instanceof final IInterfaceElement interfaceElement)) {
@@ -82,14 +83,20 @@ public class SelectionService implements ISelectionListener {
 					}
 					lastSelectedDatapoints.add(interfaceElement.getQualifiedName());
 				}
-			} else if (ep.getModel() instanceof final org.eclipse.fordiac.ide.model.libraryElement.Connection mo) {
-				lastSelectedDatapoints.add(mo.getSource().getQualifiedName());
-				lastSelectedDatapoints.add(mo.getDestination().getQualifiedName());
 			}
-
+			case final org.eclipse.fordiac.ide.model.libraryElement.Connection conn -> {
+				lastSelectedDatapoints.add(conn.getSource().getQualifiedName());
+				lastSelectedDatapoints.add(conn.getDestination().getQualifiedName());
+			}
+			case final WatchValueAnnotation watch -> lastSelectedDatapoints.add(watch.getElement().getQualifiedName());
+			default -> {
+				// ignore other types of elements
+			}
+			}
 		}
 
 		pcs.firePropertyChange(PROPERTY_SELECTION, null, null);
+
 	}
 
 	public List<String> getSelectedElements() {

--- a/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/TimelineAnchor.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.replaydebugging.ui/src/org/eclipse/fordiac/ide/debug/replaydebugging/ui/figure/TimelineAnchor.java
@@ -47,11 +47,12 @@ public class TimelineAnchor extends AbstractConnectionAnchor {
 	public Point getLocation(final Point reference) {
 
 		final Rectangle bounds = getOwner().getBounds().getCopy();
-		getOwner().translateToAbsolute(bounds);
 
 		final var currentNumberOfEvents = numberOfEvents.getAsInt();
 		if (currentNumberOfEvents < 1) {
-			return new Point(bounds.x, bounds.y);
+			final Point p = new Point(bounds.x, bounds.y);
+			getOwner().translateToAbsolute(p);
+			return p;
 		}
 
 		final int availableWidth = bounds.width;
@@ -59,6 +60,9 @@ public class TimelineAnchor extends AbstractConnectionAnchor {
 
 		final int x = bounds.x + (eventIndex * markerSpacing) + (isSource ? markerSpacing / 2 : 0);
 		final int y = bounds.y + (isSource ? bounds.height : bounds.height / 2);
-		return new Point(x, y);
+
+		final Point result = new Point(x, y);
+		getOwner().translateToAbsolute(result);
+		return result;
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.deployment.debug.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug.ui/META-INF/MANIFEST.MF
@@ -35,6 +35,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.fordiac.ide.model.edit,
  org.eclipse.fordiac.ide.fbtypeeditor.network
 Export-Package: org.eclipse.fordiac.ide.deployment.debug.ui,
+ org.eclipse.fordiac.ide.deployment.debug.ui.annotation,
  org.eclipse.fordiac.ide.deployment.debug.ui.actions,
  org.eclipse.fordiac.ide.deployment.debug.ui.fb,
  org.eclipse.fordiac.ide.deployment.debug.ui.handler,


### PR DESCRIPTION
- Zooming for connections is applied only after everything is calculated
- When the user selects a monitoring value (watch) it also hightlights steps in the timeline, similar to selecting the actual interface.