### PR TITLE
Fix broken connections for untyped subapps in resource deployment data

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.deployment/src/org/eclipse/fordiac/ide/deployment/data/ResourceDeploymentData.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment/src/org/eclipse/fordiac/ide/deployment/data/ResourceDeploymentData.java
@@ -44,7 +44,6 @@ import org.eclipse.fordiac.ide.model.libraryElement.Resource;
 import org.eclipse.fordiac.ide.model.libraryElement.SubApp;
 import org.eclipse.fordiac.ide.model.libraryElement.SubAppType;
 import org.eclipse.fordiac.ide.model.libraryElement.TypedSubApp;
-import org.eclipse.fordiac.ide.model.libraryElement.UntypedSubApp;
 import org.eclipse.fordiac.ide.model.libraryElement.VarConfigInstance;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.typelibrary.DataTypeEntry;
@@ -292,10 +291,16 @@ public class ResourceDeploymentData {
 	}
 
 	private static IInterfaceElement getSubAppExternalElement(final IInterfaceElement element, final SubApp subApp) {
-		if (subApp instanceof UntypedSubApp) {
+		final InterfaceList interfaceList;
+		if (subApp instanceof TypedSubApp) {
+			interfaceList = subApp.getInterface();
+		} else if (subApp.isMapped() && subApp.getMapping().getTo() instanceof final SubApp subAppOpposite) {
+			// go back to mapped untyped subapp
+			interfaceList = subAppOpposite.getInterface();
+		} else {
 			return element;
 		}
-		return subApp.getInterface().getInterfaceElement(element);
+		return interfaceList.getInterfaceElement(element);
 	}
 
 	private static FBNetwork getFBNetworkForSubApp(final SubApp subApp) {


### PR DESCRIPTION
There were broken connections (between different resources) for untyped subapps in the resource deployment data, because we did not go back to the resource network when looking for the external interface element.

This changes `getSubAppExternalElement()` to mirror the behavior of `getSubAppInternalElement()` and go back to the mapped untyped subapp.