### PR TITLE
Handle Documentation Links Asynchronously

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.asciidoc/src/org/eclipse/fordiac/ide/fbtypeeditor/asciidoc/editors/ModelLocationListener.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.asciidoc/src/org/eclipse/fordiac/ide/fbtypeeditor/asciidoc/editors/ModelLocationListener.java
@@ -34,7 +34,12 @@ final class ModelLocationListener extends LocationAdapter {
 	@Override
 	public void changing(final LocationEvent event) {
 		if (event.location != null && event.location.startsWith(FbtMacroProcessor.FBT_TYPE_ENTRY_URI)) {
-			openFbtEntry(event.location.substring(FbtMacroProcessor.FBT_TYPE_ENTRY_URI.length()));
+			final String typeFileUri = event.location.substring(FbtMacroProcessor.FBT_TYPE_ENTRY_URI.length());
+			PlatformUI.getWorkbench().getDisplay().asyncExec(() -> {
+				if (PlatformUI.isWorkbenchRunning()) {
+					openFbtEntry(typeFileUri);
+				}
+			});
 			event.doit = false;
 		}
 	}


### PR DESCRIPTION
Especially on windows when the documentation link will lead to opening a new browser window may lead to a deadlock. Therefore it is now moved to an async context.