### PR TITLE
Fix typos in F_DIVTIME/F_MULTIME parameter descriptions

### DIFF
--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_DIVTIME.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_DIVTIME.fbt
@@ -20,8 +20,8 @@
       </Event>
     </EventOutputs>
     <InputVars>
-      <VarDeclaration Comment="time input to be devided" Name="IN1" Type="TIME"/>
-      <VarDeclaration Comment="divisosr" Name="IN2" Type="ANY_NUM"/>
+      <VarDeclaration Comment="time input to be divided" Name="IN1" Type="TIME"/>
+      <VarDeclaration Comment="divisor" Name="IN2" Type="ANY_NUM"/>
     </InputVars>
     <OutputVars>
       <VarDeclaration Comment="Function output" Name="OUT" Type="TIME"/>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_MULTIME.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_MULTIME.fbt
@@ -20,7 +20,7 @@
       </Event>
     </EventOutputs>
     <InputVars>
-      <VarDeclaration Comment="First funtion input" Name="IN1" Type="TIME"/>
+      <VarDeclaration Comment="First function input" Name="IN1" Type="TIME"/>
       <VarDeclaration Comment="Second function input" Name="IN2" Type="ANY_NUM"/>
     </InputVars>
     <OutputVars>


### PR DESCRIPTION
F_DIVTIME: "devided" -> "divided", "divisosr" -> "divisor"
F_MULTIME: "funtion" -> "function"
