### PR TITLE
Fix missing adapter initial values for composite FBs in forte_ng export

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/composite/CompositeFBHeaderTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/composite/CompositeFBHeaderTemplate.xtend
@@ -31,7 +31,7 @@ class CompositeFBHeaderTemplate extends ForteFBTemplate<CompositeFBType> {
 
 	final List<FB> fbs
 
-	new(CompositeFBType type, String name, Path prefix, Map<?,?> options) {
+	new(CompositeFBType type, String name, Path prefix, Map<?, ?> options) {
 		super(type, name, prefix, "CCompositeFB", options)
 		fbs = type.FBNetwork.networkElements.filter(FB).reject(AdapterFB).toList
 	}
@@ -66,9 +66,9 @@ class CompositeFBHeaderTemplate extends ForteFBTemplate<CompositeFBType> {
 		«generateIncludeGuardEnd»
 		
 	'''
-	
+
 	def generateSetFBNetworkInitialValuesDeclaration() '''
-		«IF fbs.flatMap[interface.inputVars].exists[!value?.value.nullOrEmpty]»
+		«IF type.FBNetwork.networkElements.filter(FB).flatMap[interface.inputVars].exists[!value?.value.nullOrEmpty]»
 			void setFBNetworkInitialValues() override;
 		«ENDIF»
 	'''
@@ -91,7 +91,7 @@ class CompositeFBHeaderTemplate extends ForteFBTemplate<CompositeFBType> {
 		«type.interfaceList.inputVars.generateDataConnectionDeclarations(false, true)»
 		«type.interfaceList.outMappedInOutVars.generateDataConnectionDeclarations(false, true)»
 	'''
-	
+
 	def private needsOutputVariable(VarDeclaration varDeclaration) {
 		varDeclaration.inputConnections.empty || varDeclaration.inputConnections.first.negated
 	}
@@ -103,7 +103,7 @@ class CompositeFBHeaderTemplate extends ForteFBTemplate<CompositeFBType> {
 			«generateConnectionAccessorsDeclaration("getDIOOutConInternalUnchecked", "CInOutDataConnection *")»
 		«ENDIF»
 	'''
-	
+
 	override generateEventAccessorDefinitions() ''''''
 
 	override Set<INamedElement> getDependencies(Map<?, ?> options) {

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/composite/CompositeFBImplTemplate.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng/src/org/eclipse/fordiac/ide/export/forte_ng/composite/CompositeFBImplTemplate.xtend
@@ -40,8 +40,8 @@ class CompositeFBImplTemplate extends ForteFBTemplate<CompositeFBType> {
 	new(CompositeFBType type, String name, Path prefix, Map<?, ?> options) {
 		super(type, name, prefix, "CCompositeFB", options)
 		fbs = type.FBNetwork.networkElements.filter(FB).reject(AdapterFB).toList
-		fbNetworkInitialVariableLanguageSupport = fbs.flatMap[interface.inputVars].filter[!value?.value.nullOrEmpty].
-			toInvertedMap [
+		fbNetworkInitialVariableLanguageSupport = type.FBNetwork.networkElements.filter(FB).
+			flatMap[interface.inputVars].filter[!value?.value.nullOrEmpty].toInvertedMap [
 				ILanguageSupportFactory.createLanguageSupport("forte_ng", it, options)
 			]
 	}
@@ -144,9 +144,9 @@ class CompositeFBImplTemplate extends ForteFBTemplate<CompositeFBType> {
 	def private generateConnectionEndpointDeclaration(Iterable<String> path) '''
 		const auto «path.generateConnectionEndpointName» = std::array{«path.generateConnectionEndpointValue»};
 	'''
-	
+
 	def private generateConnectionEndpointReference(Iterable<String> path) {
-		if(path.size > 1)
+		if (path.size > 1)
 			path.generateConnectionEndpointName
 		else
 			path.head.FORTEStringId
@@ -188,9 +188,9 @@ class CompositeFBImplTemplate extends ForteFBTemplate<CompositeFBType> {
 	}
 
 	def generateSetFBNetworkInitialValuesDefinition() '''
-		«IF fbs.flatMap[interface.inputVars].exists[!value?.value.nullOrEmpty]»
+		«IF type.FBNetwork.networkElements.filter(FB).flatMap[interface.inputVars].exists[!value?.value.nullOrEmpty]»
 			void «FBClassName»::setFBNetworkInitialValues() {
-			  «FOR fb : fbs»
+			  «FOR fb : type.FBNetwork.networkElements.filter(FB)»
 			  	«FOR variable : fb.interface.inputVars.filter[!value?.value.nullOrEmpty]»
 			  		«IF fb.genericType»
 			  			if (auto v = «fb.generateName»->getDataInput(«variable.name.FORTEStringId»)) { v->setValue(«variable.generateFBNetworkInitialValue»); }


### PR DESCRIPTION
The export did not include initial values for adapters in composite FBs.