### PR TITLE
Fix service sequence editor scaling

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/ServiceSequenceEditor.java
+++ b/plugins/org.eclipse.fordiac.ide.fbtypeeditor.servicesequence/src/org/eclipse/fordiac/ide/fbtypeeditor/servicesequence/ServiceSequenceEditor.java
@@ -29,7 +29,7 @@ import org.eclipse.fordiac.ide.gef.DiagramEditorWithFlyoutPalette;
 import org.eclipse.fordiac.ide.gef.FordiacContextMenuProvider;
 import org.eclipse.fordiac.ide.gef.editparts.ZoomScalableFreeformRootEditPart;
 import org.eclipse.fordiac.ide.gef.figures.AbstractFreeformFigure;
-import org.eclipse.fordiac.ide.gef.figures.ModuloFreeformFigure;
+import org.eclipse.fordiac.ide.gef.figures.MinSpaceFreeformFigure;
 import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 import org.eclipse.fordiac.ide.model.libraryElement.Service;
 import org.eclipse.fordiac.ide.ui.imageprovider.FordiacImage;
@@ -150,7 +150,7 @@ public class ServiceSequenceEditor extends DiagramEditorWithFlyoutPalette implem
 		return new ZoomScalableFreeformRootEditPart(getSite(), getActionRegistry()) {
 			@Override
 			protected AbstractFreeformFigure createDrawingAreaContainer() {
-				return new ModuloFreeformFigure(this, false);
+				return new MinSpaceFreeformFigure();
 			}
 		};
 	}


### PR DESCRIPTION
Changed the rooteditpart of the editor so it doesn't blow up length-wise when switching tabs.