### PR TITLE
Remove RGB Dependency from util plugin

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/commands/DeviceCreateCommand.java
+++ b/plugins/org.eclipse.fordiac.ide.systemconfiguration/src/org/eclipse/fordiac/ide/systemconfiguration/commands/DeviceCreateCommand.java
@@ -11,7 +11,7 @@
  * Contributors:
  *   Gerhard Ebenhofer, Alois Zoitl, Gerd Kainz, Monika Wenger, Kiril Dorofeev
  *     - initial API and implementation and/or initial documentation
- *   Alois Zoitl 
+ *   Alois Zoitl
  *     - removed editor check from canUndo
  *   Pedro Ricardo
  *     - set default profile as the first supported
@@ -44,7 +44,6 @@ import org.eclipse.fordiac.ide.ui.preferences.UIPreferenceConstants;
 import org.eclipse.fordiac.ide.util.FordiacLogHelper;
 import org.eclipse.fordiac.ide.util.YUV;
 import org.eclipse.gef.commands.Command;
-import org.eclipse.swt.graphics.RGB;
 
 public class DeviceCreateCommand extends Command {
 
@@ -102,8 +101,10 @@ public class DeviceCreateCommand extends Command {
 		device.setProfile(profile);
 	}
 
-	/* Return the first of 'SupportedProfiles' attribute if declared,
-     * else returns null to enable fallback to previous behaviour. */
+	/*
+	 * Return the first of 'SupportedProfiles' attribute if declared, else returns
+	 * null to enable fallback to previous behaviour.
+	 */
 	private static String getDefaultSupportedProfile(final DeviceType type) {
 		final List<String> supportedProfiles = DeviceProfileHelper.getSupportedProfiles(type);
 		if (supportedProfiles.isEmpty()) {
@@ -164,14 +165,14 @@ public class DeviceCreateCommand extends Command {
 		final List<YUV> existingColors = new ArrayList<>();
 		for (final Device dev : parent.getDevices()) {
 			final Color devcolor = dev.getColor();
-			existingColors.add(new YUV(new RGB(devcolor.getRed(), devcolor.getGreen(), devcolor.getBlue())));
+			existingColors.add(new YUV(devcolor.getRed(), devcolor.getGreen(), devcolor.getBlue()));
 		}
 		if (existingColors.isEmpty()) {
 			return ColorHelper.getStartingColor();
 		}
 		do {
 			randomColor = ColorHelper.createRandomColor();
-			final YUV randYUV = new YUV(new RGB(randomColor.getRed(), randomColor.getGreen(), randomColor.getBlue()));
+			final YUV randYUV = new YUV(randomColor.getRed(), randomColor.getGreen(), randomColor.getBlue());
 			exist = false;
 			for (final YUV yuv : existingColors) {
 				if (randYUV.nearbyColor(yuv)) {

--- a/plugins/org.eclipse.fordiac.ide.util/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.util/META-INF/MANIFEST.MF
@@ -1,10 +1,6 @@
 Manifest-Version: 1.0
 Export-Package: org.eclipse.fordiac.ide.util
-Require-Bundle: org.eclipse.swt,
- org.eclipse.osgi,
- org.eclipse.core.runtime,
- org.eclipse.e4.core.services,
- org.eclipse.e4.core.contexts
+Require-Bundle: org.eclipse.core.runtime
 Bundle-Vendor: Eclipse 4diac
 Bundle-ActivationPolicy: lazy
 Bundle-Version: 3.3.0.qualifier
@@ -13,4 +9,6 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.fordiac.ide.util;singleton:=true
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.eclipse.fordiac.ide.util
-Import-Package: org.eclipse.core.resources
+Import-Package: org.eclipse.e4.core.contexts,
+ org.eclipse.e4.core.services.events,
+ org.osgi.framework

--- a/plugins/org.eclipse.fordiac.ide.util/src/org/eclipse/fordiac/ide/util/YUV.java
+++ b/plugins/org.eclipse.fordiac.ide.util/src/org/eclipse/fordiac/ide/util/YUV.java
@@ -1,6 +1,7 @@
 /*******************************************************************************
- * Copyright (c) 2016 fortiss GmbH, 2018 TU Vienna/ACIN
- * 
+ * Copyright (c) 2016 fortiss GmbH, TU Vienna/ACIN,
+ *                    Johannes Kepler University Linz
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -12,33 +13,28 @@
  *     - initial API and implementation and/or initial documentation
  *   Martin Melik Merkumians
  *     - reduces visibility of fields
+ *   Alois Zoitl
+ *     - turned into record class removed RGB dependency
  *******************************************************************************/
 package org.eclipse.fordiac.ide.util;
 
-import org.eclipse.swt.graphics.RGB;
-
 /**
  * simple class for representing colors in YUV color space
- * 
+ *
  */
-public class YUV {
+public record YUV(double y, double u, double v) {
 
-	private double y;
-	private double u;
-	private double v;
-
-	public YUV(RGB rgb) {
-		y = 0.299 * rgb.red + 0.587 * rgb.green + 0.114 * rgb.blue;
-		u = -0.14713 * rgb.red - 0.28886 * rgb.green + 0.436 * rgb.blue;
-		v = 0.615 * rgb.red - 0.51499 * rgb.green - 0.10001 * rgb.blue;
+	public YUV(final int r, final int g, final int b) {
+		this(0.299 * r + 0.587 * g + 0.114 * b, -0.14713 * r - 0.28886 * g + 0.436 * b,
+				0.615 * r - 0.51499 * g - 0.10001 * b);
 	}
 
-	public boolean nearbyColor(YUV yuv) {
-		double diffY = y - yuv.y;
-		double diffU = u - yuv.u;
-		double diffV = v - yuv.v;
+	public boolean nearbyColor(final YUV yuv) {
+		final double diffY = y - yuv.y;
+		final double diffU = u - yuv.u;
+		final double diffV = v - yuv.v;
 
-		double squaredDistance = (diffY * diffY + diffU * diffU + diffV * diffV);
+		final double squaredDistance = (diffY * diffY + diffU * diffU + diffV * diffV);
 		return (squaredDistance < 600);
 	}
 


### PR DESCRIPTION
YUV class turned into an record class and initialize it from discrete RGB values removing the need for the RGB dependency.

Furthermore moved all requirements to import package.