### PR TITLE
Check Dispose State on Refreshes of the FBDebugViewClockWdiget

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/FBDebugView.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/FBDebugView.java
@@ -237,6 +237,7 @@ public class FBDebugView extends ViewPart implements IDebugContextListener, ISel
 
 	@Override
 	public void dispose() {
+		clockWidget.setProcess(null);
 		DebugUITools.removePartDebugContextListener(getSite(), this);
 		getSite().getWorkbenchWindow().getSelectionService().removeSelectionListener(this);
 	}

--- a/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/FBDebugViewClockWidget.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/view/FBDebugViewClockWidget.java
@@ -50,7 +50,8 @@ public class FBDebugViewClockWidget extends DebugClockWidget {
 
 		@Override
 		public void update(final Collection<? extends Variable<?>> variables, final Evaluator evaluator) {
-			if (process != null && evaluator == process.getEvaluator() && !refreshing) {
+			final EvaluatorProcess curProcess = process;
+			if (curProcess != null && evaluator == curProcess.getEvaluator() && !refreshing) {
 				refreshing = true;
 				Display.getDefault().asyncExec(FBDebugViewClockWidget.this::refresh);
 			}
@@ -100,7 +101,7 @@ public class FBDebugViewClockWidget extends DebugClockWidget {
 	}
 
 	public void refresh(final boolean force) {
-		if (process != null && (force || !isDirty())) {
+		if (process != null && (force || !isDirty()) && !isDisposed()) {
 			final Clock realtimeClock = process.getExecutor().getRealtimeClock();
 			final Clock monotonicClock = process.getExecutor().getMonotonicClock();
 			setRealtimeClockValue(realtimeClock.instant());

--- a/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/widgets/DebugClockWidget.java
+++ b/plugins/org.eclipse.fordiac.ide.debug.ui/src/org/eclipse/fordiac/ide/debug/ui/widgets/DebugClockWidget.java
@@ -288,4 +288,14 @@ public class DebugClockWidget {
 	public void setUpdateRunnable(final Runnable updateRunnable) {
 		this.updateRunnable = updateRunnable;
 	}
+
+	protected boolean isDisposed() {
+		return group == null || group.isDisposed() //
+				|| systemClockRadio == null || systemClockRadio.isDisposed()//
+				|| intervalClockRadio == null || intervalClockRadio.isDisposed()//
+				|| fixedClockRadio == null || fixedClockRadio.isDisposed()//
+				|| clockIntervalText == null || clockIntervalText.isDisposed() //
+				|| realtimeClockText == null || realtimeClockText.isDisposed() //
+				|| monotonicClockText == null || monotonicClockText.isDisposed();
+	}
 }


### PR DESCRIPTION
As refreshes are processed asynchronously the widget may be closed leading to dispose exceptions.