### PR TITLE
Directly Use Workbench Shell for LibraryElementActivationListener

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/LibraryElementActivationListener.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/LibraryElementActivationListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025, 2026 Martin Erich Jobst
+ * Copyright (c) 2025 Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -20,6 +20,8 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.fordiac.ide.model.ui.Messages;
 import org.eclipse.jface.dialogs.ErrorDialog;
 import org.eclipse.jface.dialogs.PlainMessageDialog;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IPartListener;
@@ -27,6 +29,7 @@ import org.eclipse.ui.IPartService;
 import org.eclipse.ui.IWindowListener;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.IWorkbenchPartSite;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 
@@ -85,7 +88,7 @@ public class LibraryElementActivationListener implements IPartListener, IWindowL
 
 	protected void handleEditorInputChanged(final IEditorInput editorInput) {
 		final PlainMessageDialog replaceContentDialog = PlainMessageDialog
-				.getBuilder(editorPart.getSite().getShell(), Messages.LibraryElementActivationListener_FileChangedTitle)
+				.getBuilder(getShell(), Messages.LibraryElementActivationListener_FileChangedTitle)
 				.message(MessageFormat.format(Messages.LibraryElementActivationListener_FileChangedMessage,
 						editorInput.getToolTipText()))
 				.buttonLabels(List.of(Messages.LibraryElementActivationListener_ReplaceContentButton,
@@ -98,12 +101,21 @@ public class LibraryElementActivationListener implements IPartListener, IWindowL
 		try {
 			LibraryElementProvider.INSTANCE.synchronize(editorInput, new NullProgressMonitor());
 		} catch (final CoreException e) {
-			ErrorDialog.openError(editorPart.getSite().getShell(),
-					Messages.LibraryElementActivationListener_SyncErrorTitle,
-					MessageFormat.format(Messages.LibraryElementActivationListener_SyncErrorMessage,
-							editorInput.getToolTipText()),
+			ErrorDialog.openError(getShell(), Messages.LibraryElementActivationListener_SyncErrorTitle, MessageFormat
+					.format(Messages.LibraryElementActivationListener_SyncErrorMessage, editorInput.getToolTipText()),
 					e.getStatus());
 		}
+	}
+
+	protected final Shell getShell() {
+		final IWorkbenchPartSite site = editorPart.getSite();
+		if (site != null) {
+			final IWorkbenchWindow workbenchWindow = site.getWorkbenchWindow();
+			if (workbenchWindow != null) {
+				return workbenchWindow.getShell();
+			}
+		}
+		return Display.getCurrent().getActiveShell();
 	}
 
 	public IEditorPart getEditorPart() {

--- a/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/MultiLibraryElementActivationListener.java
+++ b/plugins/org.eclipse.fordiac.ide.model.ui/src/org/eclipse/fordiac/ide/model/ui/editors/MultiLibraryElementActivationListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025, 2026 Martin Erich Jobst
+ * Copyright (c) 2025 Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -58,7 +58,7 @@ public class MultiLibraryElementActivationListener extends LibraryElementActivat
 				.okButtonText(Messages.MultiLibraryElementActivationListener_ReplaceContentButton)
 				.okButtonTextWhenNoSelection(Messages.LibraryElementActivationListener_IgnoreChangeButton)
 				.labelProvider(new WorkbenchLabelProvider()).preselect(editorInputs.toArray()).canCancel(false)
-				.asSheet(true).create(getEditorPart().getSite().getShell());
+				.asSheet(true).create(getShell());
 		if (replaceContentDialog.open() != IDialogConstants.OK_ID) {
 			return;
 		}
@@ -75,8 +75,7 @@ public class MultiLibraryElementActivationListener extends LibraryElementActivat
 			}
 		}
 		if (!status.isOK()) {
-			ErrorDialog.openError(getEditorPart().getSite().getShell(),
-					Messages.LibraryElementActivationListener_SyncErrorTitle,
+			ErrorDialog.openError(getShell(), Messages.LibraryElementActivationListener_SyncErrorTitle,
 					Messages.MultiLibraryElementActivationListener_SyncErrorMessage, status);
 		}
 	}


### PR DESCRIPTION
As during input change handling the editor can be closed a saver way to get a shell for showing user feedback is to directly use the workbench's shell.

This workaround is more to not get a Platform error message which is logged and picked up by our logger. However the platform code is in these cases doing a `getWorkbenchWindow().getShell()` so this workaround should be save and we should get the right error message.