### PR TITLE
Type search (1/5): track recent and frequent FB type usage  

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/AbstractCreateInstanceDirectEditPolicy.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/policies/AbstractCreateInstanceDirectEditPolicy.java
@@ -34,9 +34,34 @@ public abstract class AbstractCreateInstanceDirectEditPolicy extends DirectEditP
 		final Object value = request.getCellEditor().getValue();
 		final Point refPoint = getInsertionPoint(request);
 		if (value instanceof final TypeEntry typeEntry) {
-			return getElementCreateCommand(typeEntry, refPoint);
+			final Command createCommand = getElementCreateCommand(typeEntry, refPoint);
+			return createCommand == null ? null : createCommand.chain(recordUsageCommand(typeEntry));
 		}
 		return null;
+	}
+
+	/**
+	 * Feeds the per-project MRU history (the popup's "Recent" section) and the
+	 * per-project usage counts (the usage-ranked part of "Frequent"). It only runs
+	 * when the creation actually executes (a rejected creation never records), and
+	 * avoids double-counting on redo.
+	 */
+	private Command recordUsageCommand(final TypeEntry typeEntry) {
+		final TypeLibrary typeLibrary = getTypeLibrary();
+		return new Command() {
+			@Override
+			public void execute() {
+				if (typeLibrary != null && typeLibrary.getProject() != null) {
+					typeLibrary.getMostRecentlyUsedTracker().recordUsage(typeEntry);
+					typeLibrary.getTypeUsageTracker().recordUsage(typeEntry);
+				}
+			}
+
+			@Override
+			public void redo() {
+				// record only on the first execution, not on redo
+			}
+		};
 	}
 
 	protected abstract Command getElementCreateCommand(TypeEntry value, Point refPoint);

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/MostRecentlyUsedTracker.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/MostRecentlyUsedTracker.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ProjectScope;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.fordiac.ide.util.FordiacLogHelper;
 import org.osgi.service.prefs.BackingStoreException;
 
 /**
@@ -33,7 +34,7 @@ import org.osgi.service.prefs.BackingStoreException;
 public class MostRecentlyUsedTracker {
 
 	/** Preference node ID for storing MRU data */
-	private static final String PREF_NODE = "org.eclipse.fordiac.ide.gef";
+	private static final String PREF_NODE = "org.eclipse.fordiac.ide.gef"; //$NON-NLS-1$
 
 	/** Preference key for MRU list */
 	private static final String PREF_KEY = "mru_fb_types"; //$NON-NLS-1$
@@ -68,10 +69,6 @@ public class MostRecentlyUsedTracker {
 			final ProjectScope projectScope = new ProjectScope(project);
 			this.preferences = projectScope.getNode(PREF_NODE);
 			loadFromPreferences();
-
-			// TODO: Remove debug output after UI integration is complete
-			System.out.println("[MRU] Initialized for project: " + project.getName());
-			System.out.println("[MRU] Loaded " + mruList.size() + " items: " + mruList);
 		} else {
 			this.preferences = null;
 			this.mruList = new LinkedList<>();
@@ -109,10 +106,6 @@ public class MostRecentlyUsedTracker {
 		}
 
 		saveToPreferences();
-
-		// TODO: Remove debug output after UI integration is complete
-		System.out.println("[MRU] Recorded usage: " + fbTypeName);
-		System.out.println("[MRU] Current list: " + mruList);
 	}
 
 	/**
@@ -164,7 +157,7 @@ public class MostRecentlyUsedTracker {
 		}
 
 		try {
-			final String stored = preferences.get(PREF_KEY, "");
+			final String stored = preferences.get(PREF_KEY, ""); //$NON-NLS-1$
 
 			if (stored != null && !stored.isEmpty()) {
 				final String[] items = stored.split(DELIMITER);
@@ -175,10 +168,9 @@ public class MostRecentlyUsedTracker {
 				}
 			}
 		} catch (final IllegalStateException e) {
-			// TODO: Remove debug output after UI integration is complete
-			System.out.println("[MRU] Preference node removed, cannot load");
+			// preference node has been removed (project is being deleted)
 		} catch (final Exception e) {
-			System.err.println("[MRU] Failed to load preferences: " + e.getMessage());
+			FordiacLogHelper.logWarning("Failed to load MRU preferences", e); //$NON-NLS-1$
 		}
 	}
 
@@ -207,15 +199,10 @@ public class MostRecentlyUsedTracker {
 			preferences.flush();
 
 		} catch (final IllegalStateException e) {
-			// Preference node has been removed (project is being deleted)
-			// TODO: Remove debug output after UI integration is complete
-			System.out.println("[MRU] Preference node removed, cannot save");
+			// preference node has been removed (project is being deleted)
 			disposed = true;
-		} catch (final BackingStoreException e) {
-			System.err.println("[MRU] Failed to save preferences: " + e.getMessage());
-		} catch (final Exception e) {
-			System.err.println("Unexpected error saving MRU: " + e.getMessage());
-			e.printStackTrace();
+		} catch (final BackingStoreException | RuntimeException e) {
+			FordiacLogHelper.logWarning("Failed to save MRU preferences", e); //$NON-NLS-1$
 		}
 	}
 

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/TypeLibrary.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/TypeLibrary.java
@@ -80,6 +80,8 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 
 	private IProject project;
 	private Buildpath buildpath;
+	private MostRecentlyUsedTracker mostRecentlyUsedTracker;
+	private TypeUsageTracker typeUsageTracker;
 	private final DataTypeLibrary dataTypeLib = new DataTypeLibrary(this);
 	private final Map<String, AdapterTypeEntry> adapterTypes = new ConcurrentHashMap<>();
 	private final Map<String, AttributeTypeEntry> attributeTypes = new ConcurrentHashMap<>();
@@ -207,6 +209,28 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 
 	public IProject getProject() {
 		return project;
+	}
+
+	/**
+	 * The per-project tracker of most recently used FB types, feeding the type
+	 * search's "Recent" section.
+	 */
+	public synchronized MostRecentlyUsedTracker getMostRecentlyUsedTracker() {
+		if (mostRecentlyUsedTracker == null) {
+			mostRecentlyUsedTracker = new MostRecentlyUsedTracker(project);
+		}
+		return mostRecentlyUsedTracker;
+	}
+
+	/**
+	 * The per-project tracker of FB type usage counts, feeding the type search's
+	 * "Frequent" section.
+	 */
+	public synchronized TypeUsageTracker getTypeUsageTracker() {
+		if (typeUsageTracker == null) {
+			typeUsageTracker = new TypeUsageTracker(project);
+		}
+		return typeUsageTracker;
 	}
 
 	public Buildpath getBuildpath() {
@@ -717,6 +741,8 @@ public final class TypeLibrary extends ConcurrentNotifierImpl {
 
 	void setProject(final IProject newProject) {
 		project = newProject;
+		mostRecentlyUsedTracker = null;
+		typeUsageTracker = null;
 	}
 
 	private static class TypeLibraryNotificationImpl extends NotificationImpl {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/TypeUsageTracker.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/typelibrary/TypeUsageTracker.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Wolfgang Schedl
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Wolfgang Schedl - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.model.typelibrary;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ProjectScope;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.fordiac.ide.util.FordiacLogHelper;
+import org.osgi.service.prefs.BackingStoreException;
+
+/**
+ * Counts how often each FB type is instantiated, per project, feeding the
+ * usage-based part of the type search's Frequent section. Companion of
+ * {@link MostRecentlyUsedTracker}. Counts persist in project-scoped preferences
+ * as "fullName=count;..." pairs.
+ */
+public class TypeUsageTracker {
+
+	private static final String PREF_NODE = "org.eclipse.fordiac.ide.gef"; //$NON-NLS-1$
+
+	private static final String PREF_KEY = "type_usage_counts"; //$NON-NLS-1$
+
+	private static final String ENTRY_DELIMITER = ";"; //$NON-NLS-1$
+	private static final String COUNT_DELIMITER = "="; //$NON-NLS-1$
+
+	private static final int MAX_STORED_ENTRIES = 50;
+
+	/**
+	 * A type only counts as "frequent" from the second use on.
+	 */
+	private static final int MIN_FREQUENT_COUNT = 2;
+
+	private final IEclipsePreferences preferences;
+	private final IProject project;
+	private final Map<String, Integer> usageCounts = new HashMap<>();
+
+	public TypeUsageTracker(final IProject project) {
+		this.project = project;
+		if (project != null && project.exists()) {
+			preferences = new ProjectScope(project).getNode(PREF_NODE);
+			loadFromPreferences();
+		} else {
+			preferences = null;
+		}
+	}
+
+	public synchronized void recordUsage(final TypeEntry typeEntry) {
+		if (typeEntry == null || project == null || !project.exists()) {
+			return;
+		}
+		final String fullName = typeEntry.getFullTypeName();
+		if (fullName == null || fullName.isEmpty()) {
+			return;
+		}
+		usageCounts.merge(fullName, Integer.valueOf(1), Integer::sum);
+		saveToPreferences();
+	}
+
+	public synchronized List<String> getMostUsed(final int limit) {
+		return usageCounts.entrySet().stream().filter(entry -> entry.getValue().intValue() >= MIN_FREQUENT_COUNT)
+				.sorted(Comparator.<Map.Entry<String, Integer>>comparingInt(entry -> -entry.getValue().intValue())
+						.thenComparing(Map.Entry::getKey))
+				.limit(limit).map(Map.Entry::getKey).toList();
+	}
+
+	public synchronized void clear() {
+		usageCounts.clear();
+		saveToPreferences();
+	}
+
+	private void loadFromPreferences() {
+		if (preferences == null) {
+			return;
+		}
+		try {
+			final String stored = preferences.get(PREF_KEY, ""); //$NON-NLS-1$
+			for (final String item : stored.split(ENTRY_DELIMITER)) {
+				final int split = item.lastIndexOf(COUNT_DELIMITER);
+				if (split > 0) {
+					try {
+						usageCounts.put(item.substring(0, split), Integer.valueOf(item.substring(split + 1)));
+					} catch (final NumberFormatException e) {
+						// skip the malformed entry, keep the rest
+					}
+				}
+			}
+		} catch (final IllegalStateException e) {
+			// preference node has been removed (project is being deleted)
+		} catch (final Exception e) {
+			FordiacLogHelper.logWarning("Failed to load type usage preferences", e); //$NON-NLS-1$
+		}
+	}
+
+	private void saveToPreferences() {
+		if (preferences == null || project == null || !project.exists()) {
+			return;
+		}
+		try {
+			final String serialized = usageCounts.entrySet().stream()
+					.sorted(Comparator.<Map.Entry<String, Integer>>comparingInt(entry -> -entry.getValue().intValue())
+							.thenComparing(Map.Entry::getKey))
+					.limit(MAX_STORED_ENTRIES).map(entry -> entry.getKey() + COUNT_DELIMITER + entry.getValue())
+					.reduce((a, b) -> a + ENTRY_DELIMITER + b).orElse(""); //$NON-NLS-1$
+			preferences.put(PREF_KEY, serialized);
+			preferences.flush();
+		} catch (final IllegalStateException e) {
+			// preference node has been removed (project is being deleted)
+		} catch (final BackingStoreException | RuntimeException e) {
+			FordiacLogHelper.logWarning("Failed to save type usage preferences", e); //$NON-NLS-1$
+		}
+	}
+}


### PR DESCRIPTION
Builds on the `MostRecentlyUsedTracker` from #1799 to add the per-project data foundation
for a reworked type-search dialog (Recent / Favorites / Frequent / All Categories).

Changes:
- Adds `TypeUsageTracker` for per-project usage counts, feeding a future "Frequent" section.
- Makes both trackers fields of `TypeLibrary` (one instance per project), per @azoitl's
  review comment on #1800.
- Records usage in `AbstractCreateInstanceDirectEditPolicy`
- Removes the leftover debug output from #1799 (now logs via `FordiacLogHelper`).

Supersedes #1800 and #1802. 
The UI for this feature will follow in later PRs.