### PR TITLE
Fixes Typo in event comment: "notifcation" -> "notification".

### DIFF
--- a/data/typelibrary/rtevents-3.0.0/typelib/RT_Bridge_1.FBT
+++ b/data/typelibrary/rtevents-3.0.0/typelib/RT_Bridge_1.FBT
@@ -17,7 +17,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="RDO" Type="Event" Comment="Read data notifcation">
+			<Event Name="RDO" Type="Event" Comment="Read data notification">
 				<With Var="RD_1"/>
 			</Event>
 		</EventOutputs>

--- a/data/typelibrary/rtevents-3.0.0/typelib/RT_Bridge_10.FBT
+++ b/data/typelibrary/rtevents-3.0.0/typelib/RT_Bridge_10.FBT
@@ -26,7 +26,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="RDO" Type="Event" Comment="Read data notifcation">
+			<Event Name="RDO" Type="Event" Comment="Read data notification">
 				<With Var="RD_1"/>
 				<With Var="RD_2"/>
 				<With Var="RD_3"/>

--- a/data/typelibrary/rtevents-3.0.0/typelib/RT_Bridge_11.FBT
+++ b/data/typelibrary/rtevents-3.0.0/typelib/RT_Bridge_11.FBT
@@ -27,7 +27,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="RDO" Type="Event" Comment="Read data notifcation">
+			<Event Name="RDO" Type="Event" Comment="Read data notification">
 				<With Var="RD_1"/>
 				<With Var="RD_2"/>
 				<With Var="RD_3"/>

--- a/data/typelibrary/rtevents-3.0.0/typelib/RT_Bridge_2.FBT
+++ b/data/typelibrary/rtevents-3.0.0/typelib/RT_Bridge_2.FBT
@@ -18,7 +18,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="RDO" Type="Event" Comment="Read data notifcation">
+			<Event Name="RDO" Type="Event" Comment="Read data notification">
 				<With Var="RD_1"/>
 				<With Var="RD_2"/>
 			</Event>

--- a/data/typelibrary/rtevents-3.0.0/typelib/RT_Bridge_3.FBT
+++ b/data/typelibrary/rtevents-3.0.0/typelib/RT_Bridge_3.FBT
@@ -19,7 +19,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="RDO" Type="Event" Comment="Read data notifcation">
+			<Event Name="RDO" Type="Event" Comment="Read data notification">
 				<With Var="RD_1"/>
 				<With Var="RD_2"/>
 				<With Var="RD_3"/>

--- a/data/typelibrary/rtevents-3.0.0/typelib/RT_Bridge_4.FBT
+++ b/data/typelibrary/rtevents-3.0.0/typelib/RT_Bridge_4.FBT
@@ -20,7 +20,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="RDO" Type="Event" Comment="Read data notifcation">
+			<Event Name="RDO" Type="Event" Comment="Read data notification">
 				<With Var="RD_1"/>
 				<With Var="RD_2"/>
 				<With Var="RD_3"/>

--- a/data/typelibrary/rtevents-3.0.0/typelib/RT_Bridge_5.FBT
+++ b/data/typelibrary/rtevents-3.0.0/typelib/RT_Bridge_5.FBT
@@ -21,7 +21,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="RDO" Type="Event" Comment="Read data notifcation">
+			<Event Name="RDO" Type="Event" Comment="Read data notification">
 				<With Var="RD_1"/>
 				<With Var="RD_2"/>
 				<With Var="RD_3"/>

--- a/data/typelibrary/rtevents-3.0.0/typelib/RT_Bridge_6.FBT
+++ b/data/typelibrary/rtevents-3.0.0/typelib/RT_Bridge_6.FBT
@@ -22,7 +22,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="RDO" Type="Event" Comment="Read data notifcation">
+			<Event Name="RDO" Type="Event" Comment="Read data notification">
 				<With Var="RD_1"/>
 				<With Var="RD_2"/>
 				<With Var="RD_3"/>

--- a/data/typelibrary/rtevents-3.0.0/typelib/RT_Bridge_7.FBT
+++ b/data/typelibrary/rtevents-3.0.0/typelib/RT_Bridge_7.FBT
@@ -23,7 +23,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="RDO" Type="Event" Comment="Read data notifcation">
+			<Event Name="RDO" Type="Event" Comment="Read data notification">
 				<With Var="RD_1"/>
 				<With Var="RD_2"/>
 				<With Var="RD_3"/>

--- a/data/typelibrary/rtevents-3.0.0/typelib/RT_Bridge_8.FBT
+++ b/data/typelibrary/rtevents-3.0.0/typelib/RT_Bridge_8.FBT
@@ -24,7 +24,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="RDO" Type="Event" Comment="Read data notifcation">
+			<Event Name="RDO" Type="Event" Comment="Read data notification">
 				<With Var="RD_1"/>
 				<With Var="RD_2"/>
 				<With Var="RD_3"/>

--- a/data/typelibrary/rtevents-3.0.0/typelib/RT_Bridge_9.FBT
+++ b/data/typelibrary/rtevents-3.0.0/typelib/RT_Bridge_9.FBT
@@ -25,7 +25,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="RDO" Type="Event" Comment="Read data notifcation">
+			<Event Name="RDO" Type="Event" Comment="Read data notification">
 				<With Var="RD_1"/>
 				<With Var="RD_2"/>
 				<With Var="RD_3"/>


### PR DESCRIPTION
Fixes Typo in event comment: "notifcation" -> "notification".
Fixes https://github.com/eclipse-4diac/4diac-ide/issues/2759
