### PR TITLE
Updates E_DELAY and E_RDELAY service definitions for compatibility

### DIFF
--- a/data/typelibrary/events-3.0.0/typelib/E_DELAY.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_DELAY.fbt
@@ -1,27 +1,30 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-
-<FBType Comment="Delayed event propagation" Name="E_DELAY">
-  <Identification Description="Copyright (c) 2017 fortiss GmbH&#13;&#10;&#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61499-1 Annex A"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="E_DELAY" Comment="Delayed event propagation">
+	<Identification Standard="61499-1 Annex A" Description="Copyright (c) 2017 fortiss GmbH&#10;&#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-  <VersionInfo Author="Alois Zoitl" Date="2017-09-21" Organization="fortiss GmbH" Remarks="initial API and implementation and/or initial documentation" Version="1.0"/>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-09-21" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
 	<CompilerInfo packageName="iec61499::events">
 	</CompilerInfo>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Start delayed event propagation" Name="START" Type="Event">
-        <With Var="DT"/>
-      </Event>
-      <Event Comment="Stop the delayed event propagation" Name="STOP" Type="Event"/>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Delayed event" Name="EO" Type="Event"/>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="Delay time, &gt;0" Name="DT" Type="TIME"/>
-    </InputVars>
-    <OutputVars/>
-  </InterfaceList>
-  <Service Comment="Delayed event propagation" LeftInterface="APPLICATION" RightInterface="RESOURCE"/>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="START" Type="Event" Comment="Start delayed event propagation">
+				<With Var="DT"/>
+			</Event>
+			<Event Name="STOP" Type="Event" Comment="Stop the delayed event propagation">
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="EO" Type="Event" Comment="Delayed event">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="DT" Type="TIME" Comment="Delay time, &gt;0"/>
+		</InputVars>
+	</InterfaceList>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Delayed event propagation">
+	</Service>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/events-3.0.0/typelib/E_DELAY.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_DELAY.fbt
@@ -2,6 +2,8 @@
 <FBType Name="E_DELAY" Comment="Delayed event propagation">
 	<Identification Standard="61499-1 Annex A" Description="Copyright (c) 2017 fortiss GmbH&#10;&#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.0.1" Author="Franz Höpfinger" Date="2026-08-25" Remarks="Add Service Definition per DIN EN 61499-1 Annex A (was empty).">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-09-21" Remarks="initial API and implementation and/or initial documentation">
@@ -24,7 +26,32 @@
 			<VarDeclaration Name="DT" Type="TIME" Comment="Delay time, &gt;0"/>
 		</InputVars>
 	</InterfaceList>
-	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Delayed event propagation">
+	<Service RightInterface="RESOURCE" LeftInterface="E_DELAY" Comment="Delayed event propagation">
+		<ServiceSequence Name="event_delay">
+			<ServiceTransaction>
+				<InputPrimitive Interface="E_DELAY" Event="START" Parameters="DT"/>
+				<OutputPrimitive Interface="E_DELAY" Event="EO"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="delay_canceled">
+			<ServiceTransaction>
+				<InputPrimitive Interface="E_DELAY" Event="START" Parameters="DT"/>
+			</ServiceTransaction>
+			<ServiceTransaction>
+				<InputPrimitive Interface="E_DELAY" Event="STOP"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="no_multiple_delay">
+			<ServiceTransaction>
+				<InputPrimitive Interface="E_DELAY" Event="START" Parameters="DT"/>
+			</ServiceTransaction>
+			<ServiceTransaction>
+				<InputPrimitive Interface="E_DELAY" Event="START" Parameters="DT"/>
+			</ServiceTransaction>
+			<ServiceTransaction>
+				<OutputPrimitive Interface="E_DELAY" Event="EO"/>
+			</ServiceTransaction>
+		</ServiceSequence>
 	</Service>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/events-3.0.0/typelib/E_RDELAY.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_RDELAY.fbt
@@ -1,53 +1,55 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-
-<FBType Comment="Reloadable delayed propagation of an event-Cancellable" Name="E_RDELAY">
-  <Identification Classification="Event processing" Description="Copyright (c) 2017 fortiss GmbH&#13;&#10; &#13;&#10;This program and the accompanying materials are made&#13;&#10;available under the terms of the Eclipse Public License 2.0&#13;&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#13;&#10;&#13;&#10;SPDX-License-Identifier: EPL-2.0" Standard="61499-1"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="E_RDELAY" Comment="Reloadable delayed propagation of an event-Cancellable">
+	<Identification Standard="61499-1" Classification="Event processing" Description="Copyright (c) 2017 fortiss GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-  <VersionInfo Author="Alois Zoitl" Date="2017-09-22" Organization="fortiss GmbH" Remarks="initial API and implementation and/or initial documentation" Version="1.0"/>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-09-22" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
 	<CompilerInfo packageName="iec61499::events">
 	</CompilerInfo>
-  <InterfaceList>
-    <EventInputs>
-      <Event Comment="Begin/Reset Delay" Name="START" Type="Event">
-        <With Var="DT"/>
-      </Event>
-      <Event Comment="Cancel Delay" Name="STOP" Type="Event"/>
-    </EventInputs>
-    <EventOutputs>
-      <Event Comment="Delayed Event" Name="EO" Type="Event"/>
-    </EventOutputs>
-    <InputVars>
-      <VarDeclaration Comment="Delay Time" Name="DT" Type="TIME"/>
-    </InputVars>
-    <OutputVars/>
-  </InterfaceList>
-  <Service Comment="Reloadable delayed propagation of an event-Cancellable" LeftInterface="E_DELAY" RightInterface="RESOURCE">
-    <ServiceSequence Comment="" Name="event_delay">
-      <ServiceTransaction>
-        <InputPrimitive Event="START" Interface="E_DELAY" Parameters="DT"/>
-        <OutputPrimitive Event="EO" Interface="E_DELAY"/>
-      </ServiceTransaction>
-    </ServiceSequence>
-    <ServiceSequence Comment="" Name="delay_canceled">
-      <ServiceTransaction>
-        <InputPrimitive Event="START" Interface="E_DELAY" Parameters="DT"/>
-      </ServiceTransaction>
-      <ServiceTransaction>
-        <InputPrimitive Event="STOP" Interface="E_DELAY"/>
-      </ServiceTransaction>
-    </ServiceSequence>
-    <ServiceSequence Comment="" Name="no_multiple_delay">
-      <ServiceTransaction>
-        <InputPrimitive Event="START" Interface="E_DELAY" Parameters="DT"/>
-      </ServiceTransaction>
-      <ServiceTransaction>
-        <InputPrimitive Event="START" Interface="E_DELAY" Parameters="DT"/>
-      </ServiceTransaction>
-      <ServiceTransaction>
-        <OutputPrimitive Event="EO" Interface="E_DELAY"/>
-      </ServiceTransaction>
-    </ServiceSequence>
-  </Service>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="START" Type="Event" Comment="Begin/Reset Delay">
+				<With Var="DT"/>
+			</Event>
+			<Event Name="STOP" Type="Event" Comment="Cancel Delay">
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="EO" Type="Event" Comment="Delayed Event">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="DT" Type="TIME" Comment="Delay Time"/>
+		</InputVars>
+	</InterfaceList>
+	<Service RightInterface="RESOURCE" LeftInterface="E_DELAY" Comment="Reloadable delayed propagation of an event-Cancellable">
+		<ServiceSequence Name="event_delay">
+			<ServiceTransaction>
+				<InputPrimitive Interface="E_DELAY" Event="START" Parameters="DT"/>
+				<OutputPrimitive Interface="E_DELAY" Event="EO"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="delay_canceled">
+			<ServiceTransaction>
+				<InputPrimitive Interface="E_DELAY" Event="START" Parameters="DT"/>
+			</ServiceTransaction>
+			<ServiceTransaction>
+				<InputPrimitive Interface="E_DELAY" Event="STOP"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="no_multiple_delay">
+			<ServiceTransaction>
+				<InputPrimitive Interface="E_DELAY" Event="START" Parameters="DT"/>
+			</ServiceTransaction>
+			<ServiceTransaction>
+				<InputPrimitive Interface="E_DELAY" Event="START" Parameters="DT"/>
+			</ServiceTransaction>
+			<ServiceTransaction>
+				<OutputPrimitive Interface="E_DELAY" Event="EO"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+	</Service>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/data/typelibrary/events-3.0.0/typelib/E_RDELAY.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_RDELAY.fbt
@@ -2,6 +2,8 @@
 <FBType Name="E_RDELAY" Comment="Reloadable delayed propagation of an event-Cancellable">
 	<Identification Standard="61499-1" Classification="Event processing" Description="Copyright (c) 2017 fortiss GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.0.1" Author="Franz Höpfinger" Date="2026-08-25" Remarks="Fix Service Definition: transactions referenced Interface=&quot;E_DELAY&quot; instead of the FB's own interface E_RDELAY.">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-09-22" Remarks="initial API and implementation and/or initial documentation">
@@ -24,30 +26,30 @@
 			<VarDeclaration Name="DT" Type="TIME" Comment="Delay Time"/>
 		</InputVars>
 	</InterfaceList>
-	<Service RightInterface="RESOURCE" LeftInterface="E_DELAY" Comment="Reloadable delayed propagation of an event-Cancellable">
+	<Service RightInterface="RESOURCE" LeftInterface="E_RDELAY" Comment="Reloadable delayed propagation of an event-Cancellable">
 		<ServiceSequence Name="event_delay">
 			<ServiceTransaction>
-				<InputPrimitive Interface="E_DELAY" Event="START" Parameters="DT"/>
-				<OutputPrimitive Interface="E_DELAY" Event="EO"/>
+				<InputPrimitive Interface="E_RDELAY" Event="START" Parameters="DT"/>
+				<OutputPrimitive Interface="E_RDELAY" Event="EO"/>
 			</ServiceTransaction>
 		</ServiceSequence>
 		<ServiceSequence Name="delay_canceled">
 			<ServiceTransaction>
-				<InputPrimitive Interface="E_DELAY" Event="START" Parameters="DT"/>
+				<InputPrimitive Interface="E_RDELAY" Event="START" Parameters="DT"/>
 			</ServiceTransaction>
 			<ServiceTransaction>
-				<InputPrimitive Interface="E_DELAY" Event="STOP"/>
+				<InputPrimitive Interface="E_RDELAY" Event="STOP"/>
 			</ServiceTransaction>
 		</ServiceSequence>
-		<ServiceSequence Name="no_multiple_delay">
+		<ServiceSequence Name="reload_delay">
 			<ServiceTransaction>
-				<InputPrimitive Interface="E_DELAY" Event="START" Parameters="DT"/>
+				<InputPrimitive Interface="E_RDELAY" Event="START" Parameters="DT"/>
 			</ServiceTransaction>
 			<ServiceTransaction>
-				<InputPrimitive Interface="E_DELAY" Event="START" Parameters="DT"/>
+				<InputPrimitive Interface="E_RDELAY" Event="START" Parameters="DT"/>
 			</ServiceTransaction>
 			<ServiceTransaction>
-				<OutputPrimitive Interface="E_DELAY" Event="EO"/>
+				<OutputPrimitive Interface="E_RDELAY" Event="EO"/>
 			</ServiceTransaction>
 		</ServiceSequence>
 	</Service>

--- a/data/typelibrary/events-3.0.0/typelib/E_RTimeOut.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_RTimeOut.fbt
@@ -10,19 +10,19 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<Sockets>
-			<AdapterDeclaration Name="TimeOutSocket" Type="iec61499::events::ARTimeOut" x="190" y="380"/>
+			<AdapterDeclaration Name="TimeOutSocket" Type="iec61499::events::ARTimeOut" x="200" y="0"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
-		<FB Name="DLY" Type="iec61499::events::E_RDELAY" x="1045" y="380">
+		<FB Name="DLY" Type="iec61499::events::E_RDELAY" x="1100" y="0">
 		</FB>
 		<EventConnections>
-			<Connection Source="TimeOutSocket.START" Destination="DLY.START" dx1="80" dx2="80" dy="160"/>
-			<Connection Source="TimeOutSocket.STOP" Destination="DLY.STOP" dx1="80" dx2="80" dy="160"/>
-			<Connection Source="DLY.EO" Destination="TimeOutSocket.TimeOut" dx1="80" dx2="80" dy="160"/>
+			<Connection Source="TimeOutSocket.START" Destination="DLY.START"/>
+			<Connection Source="TimeOutSocket.STOP" Destination="DLY.STOP"/>
+			<Connection Source="DLY.EO" Destination="TimeOutSocket.TimeOut" dx1="80" dx2="80" dy="-260"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="TimeOutSocket.DT" Destination="DLY.DT" dx1="80" dx2="80" dy="160"/>
+			<Connection Source="TimeOutSocket.DT" Destination="DLY.DT"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/data/typelibrary/events-3.0.0/typelib/E_TimeOut.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_TimeOut.fbt
@@ -10,19 +10,19 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<Sockets>
-			<AdapterDeclaration Name="TimeOutSocket" Type="iec61499::events::ATimeOut"/>
+			<AdapterDeclaration Name="TimeOutSocket" Type="iec61499::events::ATimeOut" x="200" y="0"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
-		<FB Name="DLY" Type="iec61499::events::E_DELAY" x="950" y="380">
+		<FB Name="DLY" Type="iec61499::events::E_DELAY" x="1100" y="0">
 		</FB>
 		<EventConnections>
-			<Connection Source="TimeOutSocket.START" Destination="DLY.START" dx1="80" dx2="80" dy="160"/>
-			<Connection Source="TimeOutSocket.STOP" Destination="DLY.STOP" dx1="80" dx2="80" dy="160"/>
-			<Connection Source="DLY.EO" Destination="TimeOutSocket.TimeOut" dx1="80" dx2="80" dy="160"/>
+			<Connection Source="TimeOutSocket.START" Destination="DLY.START"/>
+			<Connection Source="TimeOutSocket.STOP" Destination="DLY.STOP"/>
+			<Connection Source="DLY.EO" Destination="TimeOutSocket.TimeOut" dx1="80" dx2="80" dy="-260"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="TimeOutSocket.DT" Destination="DLY.DT" dx1="80" dx2="80" dy="160"/>
+			<Connection Source="TimeOutSocket.DT" Destination="DLY.DT"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>


### PR DESCRIPTION
Fixes and enhances service definitions for E_DELAY and E_RDELAY function blocks by aligning them with proper interface usage per DIN EN 61499-1 standards.

- Resolves misreference issue in E_RDELAY's transaction interface.
- Improves documentation and comment clarity.
- Updates positional attributes for elements in the E_RTimeOut and E_TimeOut function blocks to correct layout inconsistencies.

These changes improve reliability and standard compliance of delayed event processing mechanisms.

Reference: https://github.com/Meisterschulen-am-Ostbahnhof-Munchen/4diac-ide/pull/27

made 2 Commits for easier Review, feel free to request a Squash from me after Reviewing. 