### PR TITLE
Fix multiple typos in comments and documentation

### DIFF
--- a/data/typelibrary/convert-3.0.0/typelib/GET_STRUCT_VALUE.fbt
+++ b/data/typelibrary/convert-3.0.0/typelib/GET_STRUCT_VALUE.fbt
@@ -22,10 +22,10 @@
     </EventOutputs>
     <InputVars>
       <VarDeclaration Comment="Structure to look into" Name="in_struct" Type="ANY"/>
-      <VarDeclaration Comment="Member of the strucuture to retrieve. Inner members are access using the dot (.) operator" Name="member" Type="STRING"/>
+      <VarDeclaration Comment="Member of the structure to retrieve. Inner members are accessed using the dot (.) operator" Name="member" Type="STRING"/>
     </InputVars>
     <OutputVars>
-      <VarDeclaration Comment="TRUE if no errors ocurred, FALSE otherwise" Name="QO" Type="BOOL"/>
+      <VarDeclaration Comment="TRUE if no errors occurred, FALSE otherwise" Name="QO" Type="BOOL"/>
       <VarDeclaration Comment="Selected member if QO = TRUE, remains unchanged otherwise" Name="output" Type="ANY"/>
     </OutputVars>
   </InterfaceList>

--- a/data/typelibrary/convert-3.0.0/typelib/SET_STRUCT_VALUE.fbt
+++ b/data/typelibrary/convert-3.0.0/typelib/SET_STRUCT_VALUE.fbt
@@ -23,11 +23,11 @@
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="in_struct" Type="ANY" Comment="Structure to look into"/>
-			<VarDeclaration Name="member" Type="STRING" Comment="Member of the strucuture to retrieve. Inner members are access using the dot (.) operator"/>
+			<VarDeclaration Name="member" Type="STRING" Comment="Member of the structure to set. Inner members are accessed using the dot (.) operator"/>
 			<VarDeclaration Name="element_value" Type="ANY" Comment="new value for the element"/>
 		</InputVars>
 		<OutputVars>
-			<VarDeclaration Name="out_struct" Type="ANY" Comment="TRUE if no errors ocurred, FALSE otherwise"/>
+			<VarDeclaration Name="out_struct" Type="ANY" Comment="Structure with the specified member set to element_value"/>
 		</OutputVars>
 	</InterfaceList>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/data/typelibrary/events-3.0.0/typelib/E_CYCLE.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_CYCLE.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="E_CYCLE" Comment="Peroidic event generator">
+<FBType Name="E_CYCLE" Comment="Periodic event generator">
 	<Identification Standard="61499-1 Annex A" Description="Copyright (c) 2017 fortiss GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -10,7 +10,7 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="START" Type="Event" Comment="Start the perodic generation of events">
+			<Event Name="START" Type="Event" Comment="Start the periodic generation of events">
 				<With Var="DT"/>
 			</Event>
 			<Event Name="STOP" Type="Event" Comment="Stop the generation of events">

--- a/data/typelibrary/events-3.0.0/typelib/E_DEMUX.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_DEMUX.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="E_DEMUX" Comment="Event demultiplexor">
+<FBType Name="E_DEMUX" Comment="Event demultiplexer">
 	<Identification Standard="61499-1 Annex A" Description="Copyright (c) 2017 fortiss GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">

--- a/data/typelibrary/events-3.0.0/typelib/E_N_TABLE.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_N_TABLE.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="E_N_TABLE" Comment="Generation of a finite train of sperate events">
+<FBType Name="E_N_TABLE" Comment="Generation of a finite train of separate events">
 	<Identification Standard="61499-1 Annex A" Description="Copyright (c) 2017 fortiss GmbH &#10;  &#10;This program and the accompanying materials are made &#10;available under the terms of the Eclipse Public License 2.0 &#10;which is available at https://www.eclipse.org/legal/epl-2.0/ &#10; &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0.1" Author="Martin Erich Jobst" Date="2025-08-25" Remarks="remove erroneous F_SUB">

--- a/data/typelibrary/events-3.0.0/typelib/E_PERMIT.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_PERMIT.fbt
@@ -24,7 +24,7 @@
   <BasicFB>
     <ECC>
       <ECState Comment="Initial State" Name="START" x="550.0" y="500.0"/>
-      <ECState Comment="Event propagration permited" Name="EO" x="1500.0" y="500.0">
+      <ECState Comment="Event propagation permitted" Name="EO" x="1500.0" y="500.0">
         <ECAction Output="EO"/>
       </ECState>
       <ECTransition Comment="" Condition="EI[PERMIT]" Destination="EO" Source="START" x="1100.0" y="515.0"/>

--- a/data/typelibrary/events-3.0.0/typelib/E_REND.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_REND.fbt
@@ -14,11 +14,11 @@
 			</Event>
 			<Event Name="EI2" Type="Event" Comment="second event to wait for">
 			</Event>
-			<Event Name="R" Type="Event" Comment="reset the FB to inital state (i.e., wait again for both events)">
+			<Event Name="R" Type="Event" Comment="reset the FB to initial state (i.e., wait again for both events)">
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="EO" Type="Event" Comment="triggered when both EI1 and EI2 occured at least once">
+			<Event Name="EO" Type="Event" Comment="triggered when both EI1 and EI2 occurred at least once">
 			</Event>
 		</EventOutputs>
 	</InterfaceList>
@@ -26,12 +26,12 @@
 		<ECC>
 			<ECState Name="START" Comment="Initial State" x="400" y="1000">
 			</ECState>
-			<ECState Name="EI1" Comment="EI1 occured at least once" x="1155" y="340">
+			<ECState Name="EI1" Comment="EI1 occurred at least once" x="1155" y="340">
 			</ECState>
-			<ECState Name="EO" Comment="Both input events occured at least once send output event" x="1685" y="1010">
+			<ECState Name="EO" Comment="Send the output event after both input events have occurred at least once" x="1685" y="1010">
 				<ECAction Output="EO"/>
 			</ECState>
-			<ECState Name="EI2" Comment="EI2 occured at least once" x="1145" y="1585">
+			<ECState Name="EI2" Comment="EI2 occurred at least once" x="1145" y="1585">
 			</ECState>
 			<ECTransition Source="START" Destination="EI2" Condition="EI2" Comment="" x="1020" y="1180"/>
 			<ECTransition Source="START" Destination="EI1" Condition="EI1" Comment="" x="1040" y="865"/>

--- a/data/typelibrary/events-3.0.0/typelib/E_REND_2.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_REND_2.fbt
@@ -12,11 +12,11 @@
 			</Event>
 			<Event Name="EI2" Type="Event" Comment="Second event to wait for">
 			</Event>
-			<Event Name="R" Type="Event" Comment="Reset the FB to inital state (i.e., wait again for all events)">
+			<Event Name="R" Type="Event" Comment="Reset the FB to initial state (i.e., wait again for all events)">
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="EO" Type="Event" Comment="Triggered when all input events occured at least once">
+			<Event Name="EO" Type="Event" Comment="Triggered when all input events occurred at least once">
 			</Event>
 		</EventOutputs>
 	</InterfaceList>

--- a/data/typelibrary/events-3.0.0/typelib/E_REND_3.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_REND_3.fbt
@@ -14,11 +14,11 @@
 			</Event>
 			<Event Name="EI3" Type="Event" Comment="Third event to wait for">
 			</Event>
-			<Event Name="R" Type="Event" Comment="Reset the FB to inital state (i.e., wait again for all events)">
+			<Event Name="R" Type="Event" Comment="Reset the FB to initial state (i.e., wait again for all events)">
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="EO" Type="Event" Comment="Triggered when all input events occured at least once">
+			<Event Name="EO" Type="Event" Comment="Triggered when all input events occurred at least once">
 			</Event>
 		</EventOutputs>
 	</InterfaceList>

--- a/data/typelibrary/events-3.0.0/typelib/E_REND_4.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_REND_4.fbt
@@ -16,11 +16,11 @@
 			</Event>
 			<Event Name="EI4" Type="Event" Comment="Fourth event to wait for">
 			</Event>
-			<Event Name="R" Type="Event" Comment="Reset the FB to inital state (i.e., wait again for all events)">
+			<Event Name="R" Type="Event" Comment="Reset the FB to initial state (i.e., wait again for all events)">
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="EO" Type="Event" Comment="Triggered when all input events occured at least once">
+			<Event Name="EO" Type="Event" Comment="Triggered when all input events occurred at least once">
 			</Event>
 		</EventOutputs>
 	</InterfaceList>

--- a/data/typelibrary/events-3.0.0/typelib/E_TRAIN.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_TRAIN.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="E_TRAIN" Comment="Generate of a finite train of events seperated by the time DT">
+<FBType Name="E_TRAIN" Comment="Generation of a finite train of events separated by the time DT">
 	<Identification Standard="61499-1 Annex A" Description="Copyright (c) 2017, 2025 fortiss GmbH,  HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -25,7 +25,7 @@
 			</Event>
 		</EventOutputs>
 		<InputVars>
-			<VarDeclaration Name="DT" Type="TIME" Comment="Time by which the events should be seperated" />
+			<VarDeclaration Name="DT" Type="TIME" Comment="Time by which the events should be separated" />
 			<VarDeclaration Name="N" Type="UINT" Comment="Number of events to generate" />
 		</InputVars>
 		<OutputVars>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_ADD.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_ADD.fbt
@@ -20,7 +20,7 @@
       </Event>
     </EventOutputs>
     <InputVars>
-      <VarDeclaration Comment="First funtion input" Name="IN1" Type="ANY_MAGNITUDE"/>
+      <VarDeclaration Comment="First function input" Name="IN1" Type="ANY_MAGNITUDE"/>
       <VarDeclaration Comment="Second function input" Name="IN2" Type="ANY_MAGNITUDE"/>
     </InputVars>
     <OutputVars>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_ADD_DT_TIME.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_ADD_DT_TIME.fbt
@@ -20,7 +20,7 @@
       </Event>
     </EventOutputs>
     <InputVars>
-      <VarDeclaration Comment="First funtion input" Name="IN1" Type="DATE_AND_TIME"/>
+      <VarDeclaration Comment="First function input" Name="IN1" Type="DATE_AND_TIME"/>
       <VarDeclaration Comment="Second function input" Name="IN2" Type="TIME"/>
     </InputVars>
     <OutputVars>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_ADD_TOD_TIME.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_ADD_TOD_TIME.fbt
@@ -20,7 +20,7 @@
       </Event>
     </EventOutputs>
     <InputVars>
-      <VarDeclaration Comment="First funtion input" Name="IN1" Type="TIME_OF_DAY"/>
+      <VarDeclaration Comment="First function input" Name="IN1" Type="TIME_OF_DAY"/>
       <VarDeclaration Comment="Second function input" Name="IN2" Type="TIME"/>
     </InputVars>
     <OutputVars>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_DIV.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_DIV.fbt
@@ -20,7 +20,7 @@
       </Event>
     </EventOutputs>
     <InputVars>
-      <VarDeclaration Comment="First funtion input" Name="IN1" Type="ANY_NUM"/>
+      <VarDeclaration Comment="First function input" Name="IN1" Type="ANY_NUM"/>
       <VarDeclaration Comment="Second function input" Name="IN2" Type="ANY_NUM"/>
     </InputVars>
     <OutputVars>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_MOD.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_MOD.fbt
@@ -20,11 +20,11 @@
       </Event>
     </EventOutputs>
     <InputVars>
-      <VarDeclaration Comment="divident input" Name="IN1" Type="ANY_INT"/>
+      <VarDeclaration Comment="dividend input" Name="IN1" Type="ANY_INT"/>
       <VarDeclaration Comment="divisor input" Name="IN2" Type="ANY_INT"/>
     </InputVars>
     <OutputVars>
-      <VarDeclaration Comment="rest of IN1 devided by IN2" Name="OUT" Type="ANY_NUM"/>
+      <VarDeclaration Comment="rest of IN1 divided by IN2" Name="OUT" Type="ANY_NUM"/>
     </OutputVars>
   </InterfaceList>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_MUL.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_MUL.fbt
@@ -20,11 +20,11 @@
       </Event>
     </EventOutputs>
     <InputVars>
-      <VarDeclaration Comment="First funtion input" Name="IN1" Type="ANY_NUM"/>
+      <VarDeclaration Comment="First function input" Name="IN1" Type="ANY_NUM"/>
       <VarDeclaration Comment="Second function input" Name="IN2" Type="ANY_NUM"/>
     </InputVars>
     <OutputVars>
-      <VarDeclaration Comment="IN1 multiplie with IN2" Name="OUT" Type="ANY_NUM"/>
+      <VarDeclaration Comment="IN1 multiplied by IN2" Name="OUT" Type="ANY_NUM"/>
     </OutputVars>
   </InterfaceList>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_SUB.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_SUB.fbt
@@ -20,11 +20,11 @@
       </Event>
     </EventOutputs>
     <InputVars>
-      <VarDeclaration Comment="First funtion input" Name="IN1" Type="ANY_MAGNITUDE"/>
+      <VarDeclaration Comment="First function input" Name="IN1" Type="ANY_MAGNITUDE"/>
       <VarDeclaration Comment="Second function input" Name="IN2" Type="ANY_MAGNITUDE"/>
     </InputVars>
     <OutputVars>
-      <VarDeclaration Comment="IN2 substracted from IN1" Name="OUT" Type="ANY_MAGNITUDE"/>
+      <VarDeclaration Comment="IN2 subtracted from IN1" Name="OUT" Type="ANY_MAGNITUDE"/>
     </OutputVars>
   </InterfaceList>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_SUB_DATE_DATE.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_SUB_DATE_DATE.fbt
@@ -20,11 +20,11 @@
       </Event>
     </EventOutputs>
     <InputVars>
-      <VarDeclaration Comment="First funtion input" Name="IN1" Type="DATE"/>
+      <VarDeclaration Comment="First function input" Name="IN1" Type="DATE"/>
       <VarDeclaration Comment="Second function input" Name="IN2" Type="DATE"/>
     </InputVars>
     <OutputVars>
-      <VarDeclaration Comment="IN2 substracted from IN1" Name="OUT" Type="TIME"/>
+      <VarDeclaration Comment="IN2 subtracted from IN1" Name="OUT" Type="TIME"/>
     </OutputVars>
   </InterfaceList>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_SUB_DT_DT.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_SUB_DT_DT.fbt
@@ -20,11 +20,11 @@
       </Event>
     </EventOutputs>
     <InputVars>
-      <VarDeclaration Comment="First funtion input" Name="IN1" Type="DATE_AND_TIME"/>
+      <VarDeclaration Comment="First function input" Name="IN1" Type="DATE_AND_TIME"/>
       <VarDeclaration Comment="Second function input" Name="IN2" Type="DATE_AND_TIME"/>
     </InputVars>
     <OutputVars>
-      <VarDeclaration Comment="IN2 substracted from IN1" Name="OUT" Type="TIME"/>
+      <VarDeclaration Comment="IN2 subtracted from IN1" Name="OUT" Type="TIME"/>
     </OutputVars>
   </InterfaceList>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_SUB_DT_TIME.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_SUB_DT_TIME.fbt
@@ -20,11 +20,11 @@
       </Event>
     </EventOutputs>
     <InputVars>
-      <VarDeclaration Comment="First funtion input" Name="IN1" Type="DATE_AND_TIME"/>
+      <VarDeclaration Comment="First function input" Name="IN1" Type="DATE_AND_TIME"/>
       <VarDeclaration Comment="Second function input" Name="IN2" Type="TIME"/>
     </InputVars>
     <OutputVars>
-      <VarDeclaration Comment="IN2 substracted from IN1" Name="OUT" Type="DATE_AND_TIME"/>
+      <VarDeclaration Comment="IN2 subtracted from IN1" Name="OUT" Type="DATE_AND_TIME"/>
     </OutputVars>
   </InterfaceList>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_SUB_TOD_TIME.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_SUB_TOD_TIME.fbt
@@ -20,7 +20,7 @@
       </Event>
     </EventOutputs>
     <InputVars>
-      <VarDeclaration Comment="First funtion input" Name="IN1" Type="TIME_OF_DAY"/>
+      <VarDeclaration Comment="First function input" Name="IN1" Type="TIME_OF_DAY"/>
       <VarDeclaration Comment="Second function input" Name="IN2" Type="TIME"/>
     </InputVars>
     <OutputVars>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_SUB_TOD_TOD.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_SUB_TOD_TOD.fbt
@@ -20,11 +20,11 @@
       </Event>
     </EventOutputs>
     <InputVars>
-      <VarDeclaration Comment="First funtion input" Name="IN1" Type="TIME_OF_DAY"/>
+      <VarDeclaration Comment="First function input" Name="IN1" Type="TIME_OF_DAY"/>
       <VarDeclaration Comment="Second function input" Name="IN2" Type="TIME_OF_DAY"/>
     </InputVars>
     <OutputVars>
-      <VarDeclaration Comment="IN2 substracted from IN1" Name="OUT" Type="TIME"/>
+      <VarDeclaration Comment="IN2 subtracted from IN1" Name="OUT" Type="TIME"/>
     </OutputVars>
   </InterfaceList>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/bistableElements/FB_RS.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/bistableElements/FB_RS.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="FB_RS" Comment="Realizes a bistable reset-dominat latch">
+<FBType Name="FB_RS" Comment="Realizes a bistable reset-dominant latch">
 	<Identification Standard="61499-1" Description="Copyright (c) 2023 Martin Erich Jobst&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/bistableElements/FB_SR.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/bistableElements/FB_SR.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="FB_SR" Comment="Realizes a bistable set-dominat latch">
+<FBType Name="FB_SR" Comment="Realizes a bistable set-dominant latch">
 	<Identification Standard="61499-1" Description="Copyright (c) 2023 Martin Erich Jobst&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/selection/F_SEL.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/selection/F_SEL.fbt
@@ -21,7 +21,7 @@
       </Event>
     </EventOutputs>
     <InputVars>
-      <VarDeclaration Comment="Selelctor" InitialValue="" Name="G" Type="BOOL"/>
+      <VarDeclaration Comment="Selector" InitialValue="" Name="G" Type="BOOL"/>
       <VarDeclaration Comment="Selectable input variable" InitialValue="" Name="IN0" Type="ANY"/>
       <VarDeclaration Comment="Selectable input variable" InitialValue="" Name="IN1" Type="ANY"/>
     </InputVars>

--- a/data/typelibrary/io-3.0.0/typelib/ADS/ADS_SERVER_CONFIG.fbt
+++ b/data/typelibrary/io-3.0.0/typelib/ADS/ADS_SERVER_CONFIG.fbt
@@ -25,7 +25,7 @@
 			<VarDeclaration Name="FRIENDLY_NAME" Type="WSTRING" Comment="User friendly server name to use in IO FBs" />
 			<VarDeclaration Name="SERVER_ADS_ADDRESS" Type="WSTRING" Comment="Server ADS address" />
 			<VarDeclaration Name="ADS_PORT" Type="UINT" Comment="Server ADS port" />
-			<VarDeclaration Name="SERVER_IPV4_OR_HOSTNAME" Type="WSTRING" Comment="ADS Server IPv4 address or hostame" />
+			<VarDeclaration Name="SERVER_IPV4_OR_HOSTNAME" Type="WSTRING" Comment="ADS Server IPv4 address or hostname" />
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier" />

--- a/data/typelibrary/io-3.0.0/typelib/wago/Wago636.fbt
+++ b/data/typelibrary/io-3.0.0/typelib/wago/Wago636.fbt
@@ -47,7 +47,7 @@
 			<VarDeclaration Name="PresetInput" Type="STRING" Comment="(Hardware pin) IX"/>
 			<VarDeclaration Name="OptimizeOnZInput" Type="STRING" Comment="(Hardware pin) IX"/>
 			<VarDeclaration Name="OnTarget" Type="STRING" Comment="True when Positioning ended at target area as IX"/>
-			<VarDeclaration Name="ReferenceOk" Type="STRING" Comment="True when reference movement was successfull as IX"/>
+			<VarDeclaration Name="ReferenceOk" Type="STRING" Comment="True when reference movement was successful as IX"/>
 			<VarDeclaration Name="CurrentPosition" Type="STRING" Comment="Current position as ID"/>
 			<VarDeclaration Name="TargetPosition" Type="STRING" Comment="Target position as QD"/>
 			<VarDeclaration Name="MotorN" Type="STRING" Comment="Motor A- (Hardware pin) as QX"/>
@@ -55,7 +55,7 @@
 			<VarDeclaration Name="Positioning" Type="STRING" Comment="Drive to target position (MotorN, MotorP = false) as QX"/>
 			<VarDeclaration Name="OptimizeOn" Type="STRING" Comment="turn prestop optimization on as QX"/>
 			<VarDeclaration Name="Preset" Type="STRING" Comment="A rising edge copies the target position into the current position as QX"/>
-			<VarDeclaration Name="PresetInputEnable" Type="STRING" Comment="preset input enabled (OptimizeOnZInput means optimize on), preset input disbaled (OptimizeOnZInput means z input) as QX"/>
+			<VarDeclaration Name="PresetInputEnable" Type="STRING" Comment="preset input enabled (OptimizeOnZInput means optimize on), preset input disabled (OptimizeOnZInput means z input) as QX"/>
 			<VarDeclaration Name="QuitErrors" Type="STRING" Comment="Quits error Bits as QX"/>
 		</InputVars>
 		<OutputVars>

--- a/data/typelibrary/powerlink-3.0.0/typelib/X20AT2402.fbt
+++ b/data/typelibrary/powerlink-3.0.0/typelib/X20AT2402.fbt
@@ -41,8 +41,8 @@
 			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
 			<VarDeclaration Name="CNIDO" Type="USINT" Comment="Client Node ID out"/>
 			<VarDeclaration Name="STATUS" Type="STRING" Comment="Network Status"/>
-			<VarDeclaration Name="T01" Type="REAL" Comment="Temperatur Input 01"/>
-			<VarDeclaration Name="T02" Type="REAL" Comment="Temperatur Input 02"/>
+			<VarDeclaration Name="T01" Type="REAL" Comment="Temperature Input 01"/>
+			<VarDeclaration Name="T02" Type="REAL" Comment="Temperature Input 02"/>
 		</OutputVars>
 	</InterfaceList>
 	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Service Interface Function Block Type">

--- a/data/typelibrary/powerlink-3.0.0/typelib/X20AT4222.fbt
+++ b/data/typelibrary/powerlink-3.0.0/typelib/X20AT4222.fbt
@@ -43,10 +43,10 @@
 			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
 			<VarDeclaration Name="CNIDO" Type="USINT" Comment="Client Node ID out"/>
 			<VarDeclaration Name="STATUS" Type="STRING" Comment="Network Status"/>
-			<VarDeclaration Name="T01" Type="REAL" Comment="Temperatur Input 01"/>
-			<VarDeclaration Name="T02" Type="REAL" Comment="Temperatur Input 02"/>
-			<VarDeclaration Name="T03" Type="REAL" Comment="Temperatur Input 03"/>
-			<VarDeclaration Name="T04" Type="REAL" Comment="Temperatur Input 04"/>
+			<VarDeclaration Name="T01" Type="REAL" Comment="Temperature Input 01"/>
+			<VarDeclaration Name="T02" Type="REAL" Comment="Temperature Input 02"/>
+			<VarDeclaration Name="T03" Type="REAL" Comment="Temperature Input 03"/>
+			<VarDeclaration Name="T04" Type="REAL" Comment="Temperature Input 04"/>
 		</OutputVars>
 	</InterfaceList>
 	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION" Comment="Service Interface Function Block Type">

--- a/data/typelibrary/utils-3.0.0/typelib/signals/E_BLINK.fbt
+++ b/data/typelibrary/utils-3.0.0/typelib/signals/E_BLINK.fbt
@@ -10,7 +10,7 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="START" Type="Event" Comment="Start the perodic generation of events">
+			<Event Name="START" Type="Event" Comment="Start the periodic generation of events">
 				<With Var="TIMELOW"/>
 				<With Var="TIMEHIGH"/>
 			</Event>

--- a/data/typelibrary/utils-3.0.0/typelib/signals/E_BLINK_TRAIN.fbt
+++ b/data/typelibrary/utils-3.0.0/typelib/signals/E_BLINK_TRAIN.fbt
@@ -10,7 +10,7 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="START" Type="Event" Comment="Start the perodic generation of events">
+			<Event Name="START" Type="Event" Comment="Start the periodic generation of events">
 				<With Var="TIMELOW"/>
 				<With Var="TIMEHIGH"/>
 				<With Var="N"/>

--- a/data/typelibrary/utils-3.0.0/typelib/timing/E_STOPWATCH.fbt
+++ b/data/typelibrary/utils-3.0.0/typelib/timing/E_STOPWATCH.fbt
@@ -40,7 +40,7 @@
 	</InterfaceList>
 	<BasicFB>
 		<InternalVars>
-			<VarDeclaration Name="startTime" Type="TIME" Comment="Holds the time value when the start event occured."/>
+			<VarDeclaration Name="startTime" Type="TIME" Comment="Holds the time value when the start event occurred."/>
 		</InternalVars>
 		<ECC>
 			<ECState Name="START" Comment="" x="373.33" y="746.67">


### PR DESCRIPTION
Corrects spelling errors such as "structure", "occurred", and "permitted" in various function block type files to improve code readability and maintainability.

Fixes https://github.com/eclipse-4diac/4diac-ide/issues/2773
Reference: https://github.com/Meisterschulen-am-Ostbahnhof-Munchen/4diac-ide/pull/30
