### PR TITLE
Improve Ant check tasks with project-wide validation and JSON reporting

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.ant/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.fordiac.ide.ant/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Ant
 Bundle-SymbolicName: org.eclipse.fordiac.ide.ant;singleton:=true
-Bundle-Version: 3.1.200.qualifier
+Bundle-Version: 3.2.0.qualifier
 Automatic-Module-Name: org.eclipse.fordiac.ide.ant
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.resources,
@@ -17,7 +17,8 @@ Require-Bundle: org.eclipse.core.resources,
  org.eclipse.fordiac.ide.library.model,
  org.eclipse.fordiac.ide.hierarchymanager.model,
  org.eclipse.fordiac.ide.hierarchymanager.ui,
- org.eclipse.fordiac.ide.gitlab
+ org.eclipse.fordiac.ide.gitlab,
+ com.google.gson
 Bundle-Vendor: Eclipse 4diac
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.xtext.resource;version="[2.35.0,3.0.0)"

--- a/plugins/org.eclipse.fordiac.ide.ant/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.ant/plugin.xml
@@ -12,6 +12,14 @@
    <extension
          point="org.eclipse.ant.core.antTasks">
       <antTask
+            class="org.eclipse.fordiac.ide.ant.ant.CheckProject"
+            library="ant_tasks/ant-ant.jar"
+            name="fordiac.checkProject">
+      </antTask>
+   </extension>
+   <extension
+         point="org.eclipse.ant.core.antTasks">
+      <antTask
             library="ant_tasks/ant-ant.jar"
             name="fordiac.importProject"
             class="org.eclipse.fordiac.ide.ant.ant.Import4diacProject">

--- a/plugins/org.eclipse.fordiac.ide.ant/scripts/buildExtraJAR.xml
+++ b/plugins/org.eclipse.fordiac.ide.ant/scripts/buildExtraJAR.xml
@@ -53,6 +53,7 @@
                 <include name="plugins/org.eclipse.equinox.security*.jar"/>
                 <include name="plugins/org.eclipse.ant.core*.jar"/>
                 <include name="plugins/org.apache.ant*/lib/*.jar"/>
+                <include name="plugins/com.google.gson*.jar"/>
                 <include name="plugins/org.eclipse.xtext*.jar"/>
             </fileset>
          </classpath>

--- a/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/AbstractCheckTask.java
+++ b/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/AbstractCheckTask.java
@@ -55,7 +55,8 @@ public abstract class AbstractCheckTask extends Task {
 
 		final IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
 		if (!project.exists() || !project.isAccessible()) {
-			throw new BuildException("Project named '" + projectName + "' not in workspace or not accessible"); //$NON-NLS-1$ //$NON-NLS-2$
+			throw new BuildException(
+					"Project named '" + projectName + "' not in workspace or not accessible"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		return project;
 	}

--- a/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/AbstractCheckTask.java
+++ b/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/AbstractCheckTask.java
@@ -1,0 +1,146 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Michael Oberlehner - initial implementation and/or documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.ant.ant;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.Task;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+public abstract class AbstractCheckTask extends Task {
+
+	private static final Gson GSON = new GsonBuilder().serializeNulls().create();
+
+	private static final Comparator<DiagnosticOutput> DIAGNOSTIC_COMPARATOR = Comparator
+			.comparing(DiagnosticOutput::resource)
+			.thenComparing(DiagnosticOutput::line, Comparator.nullsLast(Comparator.naturalOrder()))
+			.thenComparing(DiagnosticOutput::severity)
+			.thenComparing(DiagnosticOutput::message, Comparator.nullsLast(Comparator.naturalOrder()));
+
+	private File reportFile;
+
+	public final void setReportFile(final File reportFile) {
+		this.reportFile = reportFile;
+	}
+
+	protected static IProject requireProject(final String projectName) {
+		if (projectName == null || projectName.isBlank()) {
+			throw new BuildException("Project name not specified!"); //$NON-NLS-1$
+		}
+
+		final IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
+		if (!project.exists() || !project.isAccessible()) {
+			throw new BuildException("Project named '" + projectName + "' not in workspace or not accessible"); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+		return project;
+	}
+
+	protected static void buildProject(final IProject project) {
+		Import4diacProject.runFullBuild(project);
+		Import4diacProject.waitBuilderJobsComplete();
+	}
+
+	protected static List<IMarker> findProblemMarkers(final IResource resource, final int depth) {
+		try {
+			return Arrays.asList(resource.findMarkers(IMarker.PROBLEM, true, depth));
+		} catch (final CoreException e) {
+			throw new BuildException("Cannot get markers for " + resource.getFullPath().toPortableString(), e); //$NON-NLS-1$
+		}
+	}
+
+	protected final void reportAndFail(final String task, final IProject project, final String system,
+			final List<IMarker> markers) {
+		final List<DiagnosticOutput> diagnostics = markers.stream().map(AbstractCheckTask::toDiagnostic)
+				.sorted(DIAGNOSTIC_COMPARATOR).toList();
+		final long errors = countSeverity(diagnostics, "ERROR"); //$NON-NLS-1$
+		final long warnings = countSeverity(diagnostics, "WARNING"); //$NON-NLS-1$
+		final long infos = countSeverity(diagnostics, "INFO"); //$NON-NLS-1$
+		final String json = GSON.toJson(new CheckOutput(task, project.getName(), system, errors == 0, errors, warnings,
+				infos, diagnostics));
+
+		log(json, Project.MSG_INFO);
+		writeReport(json);
+
+		if (errors != 0) {
+			throw new BuildException(task + " failed with " + errors + " error(s)"); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+	}
+
+	private static long countSeverity(final List<DiagnosticOutput> diagnostics, final String severity) {
+		return diagnostics.stream().filter(diagnostic -> severity.equals(diagnostic.severity())).count();
+	}
+
+	private static DiagnosticOutput toDiagnostic(final IMarker marker) {
+		final int line = marker.getAttribute(IMarker.LINE_NUMBER, -1);
+		return new DiagnosticOutput(convertSeverity(marker.getAttribute(IMarker.SEVERITY, -1)),
+				marker.getAttribute(IMarker.MESSAGE, null),
+				marker.getResource().getFullPath().toPortableString(), line >= 0 ? Integer.valueOf(line) : null);
+	}
+
+	private static String convertSeverity(final int severity) {
+		return switch (severity) {
+		case IMarker.SEVERITY_INFO -> "INFO"; //$NON-NLS-1$
+		case IMarker.SEVERITY_WARNING -> "WARNING"; //$NON-NLS-1$
+		case IMarker.SEVERITY_ERROR -> "ERROR"; //$NON-NLS-1$
+		default -> "UNKNOWN"; //$NON-NLS-1$
+		};
+	}
+
+	private void writeReport(final String json) {
+		if (reportFile == null) {
+			return;
+		}
+
+		try {
+			final var path = reportFile.toPath();
+			final var parent = path.getParent();
+			if (parent != null) {
+				Files.createDirectories(parent);
+			}
+			Files.writeString(path, json, StandardCharsets.UTF_8);
+		} catch (final IOException e) {
+			throw new BuildException("Cannot write check report to " + reportFile, e); //$NON-NLS-1$
+		}
+	}
+
+	private record CheckOutput(int schemaVersion, String task, String project, String system, boolean success,
+			long errors, long warnings, long infos, List<DiagnosticOutput> diagnostics) {
+
+		// Increase this number when changing the schema.
+		private static final int SCHEMA_VERSION = 1;
+
+		private CheckOutput(final String task, final String project, final String system, final boolean success,
+				final long errors, final long warnings, final long infos, final List<DiagnosticOutput> diagnostics) {
+			this(SCHEMA_VERSION, task, project, system, success, errors, warnings, infos, diagnostics);
+		}
+	}
+
+	private record DiagnosticOutput(String severity, String message, String resource, Integer line) {
+		// Data transfer object for JSON serialization
+	}
+}

--- a/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/AbstractMarkerCheckTask.java
+++ b/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/AbstractMarkerCheckTask.java
@@ -32,7 +32,7 @@ import org.eclipse.core.runtime.CoreException;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-public abstract class AbstractCheckTask extends Task {
+public abstract class AbstractMarkerCheckTask extends Task {
 
 	private static final Gson GSON = new GsonBuilder().serializeNulls().create();
 
@@ -76,7 +76,7 @@ public abstract class AbstractCheckTask extends Task {
 
 	protected final void reportAndFail(final String task, final IProject project, final String system,
 			final List<IMarker> markers) {
-		final List<DiagnosticOutput> diagnostics = markers.stream().map(AbstractCheckTask::toDiagnostic)
+		final List<DiagnosticOutput> diagnostics = markers.stream().map(AbstractMarkerCheckTask::toDiagnostic)
 				.sorted(DIAGNOSTIC_COMPARATOR).toList();
 		final long errors = countSeverity(diagnostics, "ERROR"); //$NON-NLS-1$
 		final long warnings = countSeverity(diagnostics, "WARNING"); //$NON-NLS-1$

--- a/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/CheckProject.java
+++ b/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/CheckProject.java
@@ -16,7 +16,7 @@ import org.apache.tools.ant.BuildException;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 
-public class CheckProject extends AbstractCheckTask {
+public class CheckProject extends AbstractMarkerCheckTask {
 
 	private String projectNameString;
 

--- a/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/CheckProject.java
+++ b/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/CheckProject.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Michael Oberlehner - initial implementation and/or documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.ant.ant;
+
+import org.apache.tools.ant.BuildException;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+
+public class CheckProject extends AbstractCheckTask {
+
+	private String projectNameString;
+
+	public void setProjectName(final String value) {
+		projectNameString = value;
+	}
+
+	@Override
+	public void execute() throws BuildException {
+		final IProject project = requireProject(projectNameString);
+		buildProject(project);
+		reportAndFail("checkProject", project, null, findProblemMarkers(project, IResource.DEPTH_INFINITE)); //$NON-NLS-1$
+	}
+
+}

--- a/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/CheckSystem.java
+++ b/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/CheckSystem.java
@@ -22,7 +22,7 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.fordiac.ide.systemmanagement.SystemManager;
 
-public class CheckSystem extends AbstractCheckTask {
+public class CheckSystem extends AbstractMarkerCheckTask {
 
 	private String systemPathString;
 

--- a/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/CheckSystem.java
+++ b/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/CheckSystem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2026 Primetals Technologies Austria GmbH
+ * Copyright (c) 2021 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,20 +13,16 @@
 package org.eclipse.fordiac.ide.ant.ant;
 
 import java.text.MessageFormat;
-import java.util.Arrays;
 
 import org.apache.tools.ant.BuildException;
-import org.apache.tools.ant.Task;
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.fordiac.ide.systemmanagement.SystemManager;
 
-public class CheckSystem extends Task {
+public class CheckSystem extends AbstractCheckTask {
 
 	private String systemPathString;
 
@@ -36,7 +32,7 @@ public class CheckSystem extends Task {
 
 	@Override
 	public void execute() throws BuildException {
-		if (systemPathString == null) {
+		if (systemPathString == null || systemPathString.isBlank()) {
 			throw new BuildException("System path not specified!"); //$NON-NLS-1$
 		}
 
@@ -46,22 +42,9 @@ public class CheckSystem extends Task {
 					systemPathString));
 		}
 
-		Import4diacProject.runFullBuild(systemFile.getProject());
-		Import4diacProject.waitBuilderJobsComplete();
-
-		try {
-			final var markers = Arrays.asList(systemFile.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_ZERO));
-
-			// log Markers, only visible in console output
-			CheckTypeLibrary.printMarkers(markers, this);
-			if (systemFile.findMaxProblemSeverity(IMarker.PROBLEM, true,
-					IResource.DEPTH_INFINITE) == IMarker.SEVERITY_ERROR) {
-				throw new BuildException(String.format("The system %s has %d errors or warnings!", systemPathString, //$NON-NLS-1$
-						Integer.valueOf(markers.size())));
-			}
-		} catch (final CoreException e) {
-			throw new BuildException("Cannot get markers", e); //$NON-NLS-1$
-		}
+		buildProject(systemFile.getProject());
+		final var markers = findProblemMarkers(systemFile, IResource.DEPTH_ZERO);
+		reportAndFail("checkSystem", systemFile.getProject(), systemFile.getFullPath().toPortableString(), markers); //$NON-NLS-1$
 	}
 
 	private IFile getSystemFile() {

--- a/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/CheckSystem.java
+++ b/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/CheckSystem.java
@@ -44,7 +44,8 @@ public class CheckSystem extends AbstractCheckTask {
 
 		buildProject(systemFile.getProject());
 		final var markers = findProblemMarkers(systemFile, IResource.DEPTH_ZERO);
-		reportAndFail("checkSystem", systemFile.getProject(), systemFile.getFullPath().toPortableString(), markers); //$NON-NLS-1$
+		reportAndFail("checkSystem", systemFile.getProject(), systemFile.getFullPath().toPortableString(), //$NON-NLS-1$
+				markers);
 	}
 
 	private IFile getSystemFile() {

--- a/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/CheckTypeLibrary.java
+++ b/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/CheckTypeLibrary.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 Primetals Technologies Austria GmbH
+ * Copyright (c) 2022 Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,22 +13,13 @@
  *******************************************************************************/
 package org.eclipse.fordiac.ide.ant.ant;
 
-import java.util.Arrays;
-import java.util.Optional;
-
 import org.apache.tools.ant.BuildException;
-import org.apache.tools.ant.ProjectComponent;
-import org.apache.tools.ant.Task;
-import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
-import org.eclipse.core.resources.IWorkspace;
-import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IPath;
 import org.eclipse.fordiac.ide.systemmanagement.SystemManager;
 
-public class CheckTypeLibrary extends Task {
+public class CheckTypeLibrary extends AbstractCheckTask {
 
 	private String projectNameString;
 
@@ -38,74 +29,13 @@ public class CheckTypeLibrary extends Task {
 
 	@Override
 	public void execute() throws BuildException {
-		log("=======================================================");//$NON-NLS-1$
-		log("                CHECK TYPE LIBRARY TASK                ");//$NON-NLS-1$
-		log("=======================================================");//$NON-NLS-1$
-
-		if (projectNameString == null) {
-			throw new BuildException("Project name not specified!"); //$NON-NLS-1$
-		}
-
-		final IWorkspace workspace = ResourcesPlugin.getWorkspace();
-		final IProject project = workspace.getRoot().getProject(projectNameString);
-		if (project == null) {
-			throw new BuildException("Project named '" + projectNameString + "' not in workspace");//$NON-NLS-1$ //$NON-NLS-2$
-		}
-		AbstractCheckTask.buildProject(project);
-
-		// log Markers, only visible in console output
-		try {
-			final var markers = Arrays.asList(project.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE))
-					.stream().filter(m -> !SystemManager.isSystemFile(m.getResource().getLocation())).toList();
-
-			printMarkers(markers, this);
-
-			if (markers.stream().anyMatch(m -> getIntegerAttribute(m, IMarker.SEVERITY)
-					.filter(s -> s.intValue() == IMarker.SEVERITY_ERROR).isPresent())) {
-				throw new BuildException(String.format("The project %s has %d errors or warnings!", projectNameString, //$NON-NLS-1$
-						Integer.valueOf(markers.size())));
-			}
-		} catch (final CoreException e) {
-			throw new BuildException("Cannot get markers", e); //$NON-NLS-1$
-		}
-
-	}
-
-	public static void printMarkers(final Iterable<IMarker> markers, final ProjectComponent loggingTask) {
-		markers.forEach(marker -> Optional.ofNullable(marker).ifPresent(m -> loggingTask.log(markerToLogString(m))));
-	}
-
-	private static String markerToLogString(final IMarker marker) { //@formatter:off
-		return getIntegerAttribute(marker, IMarker.SEVERITY).map(CheckTypeLibrary::convertToSeverity)
-						.orElse("PROBLEM: ") + //$NON-NLS-1$
-				marker.getAttribute(IMarker.MESSAGE,
-						"NO ERROR MESSAGE") + //$NON-NLS-1$
-				" | " + //$NON-NLS-1$
-				Optional.ofNullable(marker.getResource().getLocation()).map(IPath::lastSegment)
-						.orElse("NO PATH") + //$NON-NLS-1$
-				" : " + //$NON-NLS-1$
-				getIntegerAttribute(marker, IMarker.LINE_NUMBER).map(i -> i.toString())
-						.orElse("NO LINE NUMBER"); //$NON-NLS-1$
-	} //@formatter:on
-
-	private static String convertToSeverity(final Integer severity) {
-		return switch (severity.intValue()) {
-		case IMarker.SEVERITY_INFO -> "INFO: "; //$NON-NLS-1$
-		case IMarker.SEVERITY_WARNING -> "WARNING: "; //$NON-NLS-1$
-		case IMarker.SEVERITY_ERROR -> "ERROR: "; //$NON-NLS-1$
-		default -> null;
-		};
-	}
-
-	private static Optional<Integer> getIntegerAttribute(final IMarker marker, final String attributeName) {
-		try {
-			if (marker.getAttribute(attributeName) instanceof final Integer i) {
-				return Optional.of(i);
-			}
-		} catch (final CoreException e) {
-			// The exception tells us that this attribute does not exist, return empty
-		}
-		return Optional.empty();
+		final IProject project = requireProject(projectNameString);
+		buildProject(project);
+		final var markers = findProblemMarkers(project, IResource.DEPTH_INFINITE).stream()
+				.filter(marker -> !(marker.getResource() instanceof final IFile file
+						&& SystemManager.isSystemFile(file)))
+				.toList();
+		reportAndFail("checkTypeLibrary", project, null, markers); //$NON-NLS-1$
 	}
 
 }

--- a/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/CheckTypeLibrary.java
+++ b/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/CheckTypeLibrary.java
@@ -51,6 +51,7 @@ public class CheckTypeLibrary extends Task {
 		if (project == null) {
 			throw new BuildException("Project named '" + projectNameString + "' not in workspace");//$NON-NLS-1$ //$NON-NLS-2$
 		}
+		AbstractCheckTask.buildProject(project);
 
 		// log Markers, only visible in console output
 		try {

--- a/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/CheckTypeLibrary.java
+++ b/plugins/org.eclipse.fordiac.ide.ant/src_ant/org/eclipse/fordiac/ide/ant/ant/CheckTypeLibrary.java
@@ -19,7 +19,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.fordiac.ide.systemmanagement.SystemManager;
 
-public class CheckTypeLibrary extends AbstractCheckTask {
+public class CheckTypeLibrary extends AbstractMarkerCheckTask {
 
 	private String projectNameString;
 


### PR DESCRIPTION
Reworked the following ANT Tasks:

- `check-project`: checks the Type Library and all systems in the project.
- `check-type-library`: checks only the Type Library.
- `check-system`: checks only the system specified by `system.path`.




JSON Format:


```json
{
  "schemaVersion": 1,
  "task": "checkProject",
  "project": "My4diacProject",
  "system": null,
  "success": true,
  "errors": 0,
  "warnings": 0,
  "infos": 0,
  "diagnostics": []
}
```

`schemaVersion` allows consumers to detect future incompatible changes to the report format.


Example Config:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<project name="4diac-ant-check-demo" default="check-project">

    <!-- The project must already be imported into the Eclipse workspace passed with -data. -->
    <property name="project.name" value="My4diacProject"/>
    <property name="system.path" value="/${project.name}/MySystem.sys"/>
    <property name="report.dir" location="reports"/>

    <target name="check-type-library">
        <fordiac.checkTypeLibrary
                projectName="${project.name}"
                reportFile="${report.dir}/check-type-library.json"/>
    </target>

    <target name="check-system">
        <fordiac.checkSystem
                systemPath="${system.path}"
                reportFile="${report.dir}/check-system.json"/>
    </target>

    <target name="check-project">
        <fordiac.checkProject
                projectName="${project.name}"
                reportFile="${report.dir}/check-project.json"/>
    </target>

    <!-- reportFile is optional. Without it, the JSON result is written only to the console. -->
</project>
```

The JSON is always written to the console. Remove the optional `reportFile` attribute if no JSON file should be created.
