### PR TITLE
Add generic E_D_FF_ANY_1..5 Service Interface FBTypes (ANY family)

### DIFF
--- a/data/typelibrary/events-3.0.0/typelib/E_D_FF_ANY_1.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_D_FF_ANY_1.fbt
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="E_D_FF_ANY_1" Comment="Data latch (d) flip flop for 1 ANY variable, EO only on change of at least one Q (generic FB)">
+	<Identification Standard="61499-1 Annex A" Description="Copyright (c) 2017, 2026 fortiss GmbH, HR Agrartechnik GmbH&#10;&#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-26" Remarks="E_D_FF_ANY extended to 1 variable - EO fires only if at least one Di differs from the latched Qi. Service Interface FB, native implementation GEN_E_D_FF_ANY (FORTE) required.">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::events">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="CLK" Type="Event" Comment="Clock">
+				<With Var="D1"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="EO" Type="Event" Comment="Triggered if clock results in a change of at least one Q">
+				<With Var="Q1"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="D1" Type="ANY" Comment="Value 1 to latch"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="Q1" Type="ANY" Comment="Latched value 1"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_E_D_FF_ANY'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/events-3.0.0/typelib/E_D_FF_ANY_2.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_D_FF_ANY_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="E_D_FF_ANY_2" Comment="Data latch (d) flip flop for 2 ANY variables, EO only on change of at least one Q (generic FB)">
+	<Identification Standard="61499-1 Annex A" Description="Copyright (c) 2017, 2026 fortiss GmbH, HR Agrartechnik GmbH&#10;&#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-26" Remarks="E_D_FF_ANY extended to 2 variables - EO fires only if at least one Di differs from the latched Qi. Service Interface FB, native implementation GEN_E_D_FF_ANY (FORTE) required.">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::events">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="CLK" Type="Event" Comment="Clock">
+				<With Var="D1"/>
+				<With Var="D2"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="EO" Type="Event" Comment="Triggered if clock results in a change of at least one Q">
+				<With Var="Q1"/>
+				<With Var="Q2"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="D1" Type="ANY" Comment="Value 1 to latch"/>
+			<VarDeclaration Name="D2" Type="ANY" Comment="Value 2 to latch"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="Q1" Type="ANY" Comment="Latched value 1"/>
+			<VarDeclaration Name="Q2" Type="ANY" Comment="Latched value 2"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_E_D_FF_ANY'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/events-3.0.0/typelib/E_D_FF_ANY_3.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_D_FF_ANY_3.fbt
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="E_D_FF_ANY_3" Comment="Data latch (d) flip flop for 3 ANY variables, EO only on change of at least one Q (generic FB)">
+	<Identification Standard="61499-1 Annex A" Description="Copyright (c) 2017, 2026 fortiss GmbH, HR Agrartechnik GmbH&#10;&#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-26" Remarks="E_D_FF_ANY extended to 3 variables - EO fires only if at least one Di differs from the latched Qi. Service Interface FB, native implementation GEN_E_D_FF_ANY (FORTE) required.">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::events">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="CLK" Type="Event" Comment="Clock">
+				<With Var="D1"/>
+				<With Var="D2"/>
+				<With Var="D3"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="EO" Type="Event" Comment="Triggered if clock results in a change of at least one Q">
+				<With Var="Q1"/>
+				<With Var="Q2"/>
+				<With Var="Q3"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="D1" Type="ANY" Comment="Value 1 to latch"/>
+			<VarDeclaration Name="D2" Type="ANY" Comment="Value 2 to latch"/>
+			<VarDeclaration Name="D3" Type="ANY" Comment="Value 3 to latch"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="Q1" Type="ANY" Comment="Latched value 1"/>
+			<VarDeclaration Name="Q2" Type="ANY" Comment="Latched value 2"/>
+			<VarDeclaration Name="Q3" Type="ANY" Comment="Latched value 3"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_E_D_FF_ANY'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/events-3.0.0/typelib/E_D_FF_ANY_4.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_D_FF_ANY_4.fbt
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="E_D_FF_ANY_4" Comment="Data latch (d) flip flop for 4 ANY variables, EO only on change of at least one Q (generic FB)">
+	<Identification Standard="61499-1 Annex A" Description="Copyright (c) 2017, 2026 fortiss GmbH, HR Agrartechnik GmbH&#10;&#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-26" Remarks="E_D_FF_ANY extended to 4 variables - EO fires only if at least one Di differs from the latched Qi. Service Interface FB, native implementation GEN_E_D_FF_ANY (FORTE) required.">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::events">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="CLK" Type="Event" Comment="Clock">
+				<With Var="D1"/>
+				<With Var="D2"/>
+				<With Var="D3"/>
+				<With Var="D4"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="EO" Type="Event" Comment="Triggered if clock results in a change of at least one Q">
+				<With Var="Q1"/>
+				<With Var="Q2"/>
+				<With Var="Q3"/>
+				<With Var="Q4"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="D1" Type="ANY" Comment="Value 1 to latch"/>
+			<VarDeclaration Name="D2" Type="ANY" Comment="Value 2 to latch"/>
+			<VarDeclaration Name="D3" Type="ANY" Comment="Value 3 to latch"/>
+			<VarDeclaration Name="D4" Type="ANY" Comment="Value 4 to latch"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="Q1" Type="ANY" Comment="Latched value 1"/>
+			<VarDeclaration Name="Q2" Type="ANY" Comment="Latched value 2"/>
+			<VarDeclaration Name="Q3" Type="ANY" Comment="Latched value 3"/>
+			<VarDeclaration Name="Q4" Type="ANY" Comment="Latched value 4"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_E_D_FF_ANY'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/events-3.0.0/typelib/E_D_FF_ANY_5.fbt
+++ b/data/typelibrary/events-3.0.0/typelib/E_D_FF_ANY_5.fbt
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="E_D_FF_ANY_5" Comment="Data latch (d) flip flop for 5 ANY variables, EO only on change of at least one Q (generic FB)">
+	<Identification Standard="61499-1 Annex A" Description="Copyright (c) 2017, 2026 fortiss GmbH, HR Agrartechnik GmbH&#10;&#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-26" Remarks="E_D_FF_ANY extended to 5 variables - EO fires only if at least one Di differs from the latched Qi. Service Interface FB, native implementation GEN_E_D_FF_ANY (FORTE) required.">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61499::events">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="CLK" Type="Event" Comment="Clock">
+				<With Var="D1"/>
+				<With Var="D2"/>
+				<With Var="D3"/>
+				<With Var="D4"/>
+				<With Var="D5"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="EO" Type="Event" Comment="Triggered if clock results in a change of at least one Q">
+				<With Var="Q1"/>
+				<With Var="Q2"/>
+				<With Var="Q3"/>
+				<With Var="Q4"/>
+				<With Var="Q5"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="D1" Type="ANY" Comment="Value 1 to latch"/>
+			<VarDeclaration Name="D2" Type="ANY" Comment="Value 2 to latch"/>
+			<VarDeclaration Name="D3" Type="ANY" Comment="Value 3 to latch"/>
+			<VarDeclaration Name="D4" Type="ANY" Comment="Value 4 to latch"/>
+			<VarDeclaration Name="D5" Type="ANY" Comment="Value 5 to latch"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="Q1" Type="ANY" Comment="Latched value 1"/>
+			<VarDeclaration Name="Q2" Type="ANY" Comment="Latched value 2"/>
+			<VarDeclaration Name="Q3" Type="ANY" Comment="Latched value 3"/>
+			<VarDeclaration Name="Q4" Type="ANY" Comment="Latched value 4"/>
+			<VarDeclaration Name="Q5" Type="ANY" Comment="Latched value 5"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_E_D_FF_ANY'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>


### PR DESCRIPTION
Same architecture as E_D_FF_1..5 (21aad9f3c), generalized to ANY-typed
D1..Dn/Q1..Qn using NE() comparisons (matching E_D_FF_ANY's own pattern).
GenericClassName='GEN_E_D_FF_ANY'. Native FORTE implementation
(GEN_E_D_FF_ANY_fbt.h/.cpp) can be found here:

- look: https://github.com/eclipse-4diac/4diac-forte/pull/1022

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WLvA6NB3nnZU73938b3pAU
