### PR TITLE
Add generic MUL_2/3/4 arithmetic FBs

### DIFF
--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/MUL_2.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/MUL_2.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="MUL_2" Comment="Calculate arithmetical product of numeric inputs (generic FB)">
+	<Identification Standard="61131-3" Classification="standard arithmetic function" Description="Copyright (c) 2026 HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-28" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61131::arithmetic">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_NUM" Comment="first factor"/>
+			<VarDeclaration Name="IN2" Type="ANY_NUM" Comment="second factor"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_NUM" Comment="MUL result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_MUL'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/MUL_3.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/MUL_3.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="MUL_3" Comment="Calculate arithmetical product of numeric inputs (generic FB)">
+	<Identification Standard="61131-3" Classification="standard arithmetic function" Description="Copyright (c) 2026 HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-28" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61131::arithmetic">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_NUM" Comment="first factor"/>
+			<VarDeclaration Name="IN2" Type="ANY_NUM" Comment="second factor"/>
+			<VarDeclaration Name="IN3" Type="ANY_NUM" Comment="third factor"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_NUM" Comment="MUL result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_MUL'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/MUL_4.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/MUL_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="MUL_4" Comment="Calculate arithmetical product of numeric inputs (generic FB)">
+	<Identification Standard="61131-3" Classification="standard arithmetic function" Description="Copyright (c) 2026 HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-28" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="iec61131::arithmetic">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN1"/>
+				<With Var="IN2"/>
+				<With Var="IN3"/>
+				<With Var="IN4"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN1" Type="ANY_NUM" Comment="first factor"/>
+			<VarDeclaration Name="IN2" Type="ANY_NUM" Comment="second factor"/>
+			<VarDeclaration Name="IN3" Type="ANY_NUM" Comment="third factor"/>
+			<VarDeclaration Name="IN4" Type="ANY_NUM" Comment="fourth factor"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="ANY_NUM" Comment="MUL result"/>
+		</OutputVars>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_MUL'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>


### PR DESCRIPTION
IEC 61131-3 defines MUL as an extensible arithmetical function
(OUT := IN1 * IN2 * ... * INn), same as ADD (already covered by
ADD_2/3/4). The standard library was missing the multiplication
counterpart, forcing users to chain multiple fixed 2-input F_MUL
blocks instead of using a single generic FB.

Mirrors ADD_2/3/4.fbt (ANY_NUM instead of ANY_MAGNITUDE, matching
F_MUL's type bound); resolves via GenericClassName 'GEN_MUL', to be
backed by a native GEN_MUL implementation in 4diac-forte (analogous
to GEN_ADD) in a follow-up.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Vz8xYd2LAKErHenHuF7BXt

fixes https://github.com/eclipse-4diac/4diac-ide/issues/2383

- https://github.com/eclipse-4diac/4diac-ide/issues/2383
- https://github.com/eclipse-4diac/4diac-ide/pull/2789
- https://github.com/eclipse-4diac/4diac-forte/pull/1025
