### PR TITLE
Use proper mathematical terminology for arithmetic FB inputs

### DIFF
--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/ADD_2.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/ADD_2.fbt
@@ -21,8 +21,8 @@
 			</Event>
 		</EventOutputs>
 		<InputVars>
-			<VarDeclaration Name="IN1" Type="ANY_MAGNITUDE" Comment="ADD input 1"/>
-			<VarDeclaration Name="IN2" Type="ANY_MAGNITUDE" Comment="ADD input 2"/>
+			<VarDeclaration Name="IN1" Type="ANY_MAGNITUDE" Comment="first summand"/>
+			<VarDeclaration Name="IN2" Type="ANY_MAGNITUDE" Comment="second summand"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="OUT" Type="ANY_MAGNITUDE" Comment="ADD result"/>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/ADD_3.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/ADD_3.fbt
@@ -22,9 +22,9 @@
 			</Event>
 		</EventOutputs>
 		<InputVars>
-			<VarDeclaration Name="IN1" Type="ANY_MAGNITUDE" Comment="ADD input 1"/>
-			<VarDeclaration Name="IN2" Type="ANY_MAGNITUDE" Comment="ADD input 2"/>
-			<VarDeclaration Name="IN3" Type="ANY_MAGNITUDE" Comment="ADD input 3"/>
+			<VarDeclaration Name="IN1" Type="ANY_MAGNITUDE" Comment="first summand"/>
+			<VarDeclaration Name="IN2" Type="ANY_MAGNITUDE" Comment="second summand"/>
+			<VarDeclaration Name="IN3" Type="ANY_MAGNITUDE" Comment="third summand"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="OUT" Type="ANY_MAGNITUDE" Comment="ADD result"/>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/ADD_4.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/ADD_4.fbt
@@ -23,10 +23,10 @@
 			</Event>
 		</EventOutputs>
 		<InputVars>
-			<VarDeclaration Name="IN1" Type="ANY_MAGNITUDE" Comment="ADD input 1"/>
-			<VarDeclaration Name="IN2" Type="ANY_MAGNITUDE" Comment="ADD input 2"/>
-			<VarDeclaration Name="IN3" Type="ANY_MAGNITUDE" Comment="ADD input 3"/>
-			<VarDeclaration Name="IN4" Type="ANY_MAGNITUDE" Comment="ADD input 4"/>
+			<VarDeclaration Name="IN1" Type="ANY_MAGNITUDE" Comment="first summand"/>
+			<VarDeclaration Name="IN2" Type="ANY_MAGNITUDE" Comment="second summand"/>
+			<VarDeclaration Name="IN3" Type="ANY_MAGNITUDE" Comment="third summand"/>
+			<VarDeclaration Name="IN4" Type="ANY_MAGNITUDE" Comment="fourth summand"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="OUT" Type="ANY_MAGNITUDE" Comment="ADD result"/>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_ADD.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_ADD.fbt
@@ -20,8 +20,8 @@
       </Event>
     </EventOutputs>
     <InputVars>
-      <VarDeclaration Comment="First function input" Name="IN1" Type="ANY_MAGNITUDE"/>
-      <VarDeclaration Comment="Second function input" Name="IN2" Type="ANY_MAGNITUDE"/>
+      <VarDeclaration Comment="first summand" Name="IN1" Type="ANY_MAGNITUDE"/>
+      <VarDeclaration Comment="second summand" Name="IN2" Type="ANY_MAGNITUDE"/>
     </InputVars>
     <OutputVars>
       <VarDeclaration Comment="IN1 plus IN2" Name="OUT" Type="ANY_MAGNITUDE"/>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_DIV.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_DIV.fbt
@@ -20,8 +20,8 @@
       </Event>
     </EventOutputs>
     <InputVars>
-      <VarDeclaration Comment="First function input" Name="IN1" Type="ANY_NUM"/>
-      <VarDeclaration Comment="Second function input" Name="IN2" Type="ANY_NUM"/>
+      <VarDeclaration Comment="dividend" Name="IN1" Type="ANY_NUM"/>
+      <VarDeclaration Comment="divisor" Name="IN2" Type="ANY_NUM"/>
     </InputVars>
     <OutputVars>
       <VarDeclaration Comment="Function output" Name="OUT" Type="ANY_NUM"/>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_MUL.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_MUL.fbt
@@ -20,8 +20,8 @@
       </Event>
     </EventOutputs>
     <InputVars>
-      <VarDeclaration Comment="First function input" Name="IN1" Type="ANY_NUM"/>
-      <VarDeclaration Comment="Second function input" Name="IN2" Type="ANY_NUM"/>
+      <VarDeclaration Comment="first factor" Name="IN1" Type="ANY_NUM"/>
+      <VarDeclaration Comment="second factor" Name="IN2" Type="ANY_NUM"/>
     </InputVars>
     <OutputVars>
       <VarDeclaration Comment="IN1 multiplied by IN2" Name="OUT" Type="ANY_NUM"/>

--- a/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_SUB.fbt
+++ b/data/typelibrary/iec61131-3-3.0.0/typelib/arithmetic/F_SUB.fbt
@@ -20,8 +20,8 @@
       </Event>
     </EventOutputs>
     <InputVars>
-      <VarDeclaration Comment="First function input" Name="IN1" Type="ANY_MAGNITUDE"/>
-      <VarDeclaration Comment="Second function input" Name="IN2" Type="ANY_MAGNITUDE"/>
+      <VarDeclaration Comment="minuend" Name="IN1" Type="ANY_MAGNITUDE"/>
+      <VarDeclaration Comment="subtrahend" Name="IN2" Type="ANY_MAGNITUDE"/>
     </InputVars>
     <OutputVars>
       <VarDeclaration Comment="IN2 subtracted from IN1" Name="OUT" Type="ANY_MAGNITUDE"/>


### PR DESCRIPTION
IN1/IN2 comments were generic ("First/Second function input") across
F_ADD, F_SUB, F_MUL, F_DIV and the generic ADD_2/3/4, unlike e.g.
F_DIVTIME which already names its divisor input properly. Renamed to
the standard terms for each operation: summand (ADD), minuend/
subtrahend (SUB), factor (MUL), dividend/divisor (DIV).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Vz8xYd2LAKErHenHuF7BXt
