### PR TITLE
Fix boot file creation for devices using the OPC UA profile

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.deployment.bootfile/src/org/eclipse/fordiac/ide/deployment/bootfile/BootFileDeviceManagementCommunicationHandler.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.bootfile/src/org/eclipse/fordiac/ide/deployment/bootfile/BootFileDeviceManagementCommunicationHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 - 2018 fortiss GmbH, Johannes Kepler University
+ * Copyright (c) 2014 fortiss GmbH, Johannes Kepler University
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -11,6 +11,7 @@
  *   Alois Zoitl, Monika Wenger
  *     - initial API and implementation and/or initial documentation
  *   Alois Zoitl - Harmonized deployment and monitoring
+ *   Franz Höpfinger - small bootfile fix.
  *******************************************************************************/
 package org.eclipse.fordiac.ide.deployment.bootfile;
 
@@ -22,10 +23,19 @@ import org.eclipse.swt.widgets.Shell;
 
 public class BootFileDeviceManagementCommunicationHandler extends AbstractFileManagementHandler {
 
+	/*
+	 * Boot files always use the classic FORTE line protocol, regardless of which
+	 * management protocol (e.g. OPC UA) the device is configured to use at
+	 * runtime. Only the HOLOBLOC device management interactor honors an override
+	 * communication handler, so it must be forced here rather than relying on
+	 * the device's own Profile attribute.
+	 */
+	private static final String BOOT_FILE_PROFILE = "HOLOBLOC"; //$NON-NLS-1$
+
 	public static void createBootFile(final List<Object> workList, final String fileName, final Shell shell) {
 		if (null != fileName) {
 			final BootFileDeviceManagementCommunicationHandler bootFileHandler = new BootFileDeviceManagementCommunicationHandler();
-			DeploymentCoordinator.performDeployment(workList.toArray(), bootFileHandler, null);
+			DeploymentCoordinator.performDeployment(workList.toArray(), bootFileHandler, BOOT_FILE_PROFILE);
 			bootFileHandler.writeToBootFile(fileName, false, shell);
 		}
 	}


### PR DESCRIPTION
Boot file export always went through the device's configured management
profile, so devices set to OPC UA tried to open a real connection to the
controller instead of writing the offline boot file, since the OPC UA
interactor ignores the override communication handler. Boot files are
plain FORTE line-protocol text regardless of the live management
protocol, so force the HOLOBLOC profile for boot file export.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GtUc8okiQ4BqrCNRY2T9UA

## Reference

- https://github.com/Meisterschulen-am-Ostbahnhof-Munchen/4diac-ide/pull/34
- https://github.com/eclipse-4diac/4diac-ide/issues/89