### PR TITLE
Correctly parse legacy struct demux parameters and connections

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/CommonElementImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/CommonElementImporter.java
@@ -697,7 +697,7 @@ public abstract class CommonElementImporter {
 		final Value val = LibraryElementFactory.eINSTANCE.createValue();
 		val.setValue(value);
 
-		final IInterfaceElement ie = getInterfaceElement(block, name, val);
+		final IInterfaceElement ie = getParameterTargetInterfaceElement(block, name, val);
 
 		if (ie instanceof final VarDeclaration varDecl) {
 			varDecl.setValue(val);
@@ -715,11 +715,18 @@ public abstract class CommonElementImporter {
 		});
 	}
 
-	private static IInterfaceElement getInterfaceElement(final BlockFBNetworkElement block, final String name,
-			final Value val) {
+	private static IInterfaceElement getParameterTargetInterfaceElement(final BlockFBNetworkElement block,
+			final String name, final Value val) {
 		final var ie = block.getInterface().getInterfaceElement(List.of(name.split("\\.")), true); //$NON-NLS-1$
 		if (ie != null) {
 			return ie;
+		}
+		if (block instanceof Demultiplexer) {
+			// check if we have a legacy demultiplexer parameter pin
+			final var dmuxIE = block.getInterface().getInterfaceElement(List.of(name.split("%")), true); //$NON-NLS-1$
+			if (dmuxIE != null) {
+				return dmuxIE;
+			}
 		}
 
 		if (block instanceof final TypedSubApp tsa) {

--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/FBNetworkImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/FBNetworkImporter.java
@@ -25,6 +25,7 @@
 package org.eclipse.fordiac.ide.model.dataimport;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -40,6 +41,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
 import org.eclipse.fordiac.ide.model.libraryElement.BlockFBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.Comment;
 import org.eclipse.fordiac.ide.model.libraryElement.Connection;
+import org.eclipse.fordiac.ide.model.libraryElement.Demultiplexer;
 import org.eclipse.fordiac.ide.model.libraryElement.FB;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
 import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
@@ -254,7 +256,19 @@ class FBNetworkImporter extends CommonElementImporter {
 	static IInterfaceElement getInterfaceElement(final InterfaceList il, final String interfaceElement,
 			final EClass conType, final boolean isInput) {
 		final Stream<? extends IInterfaceElement> ies = getInterfaceElementList(il, conType, isInput);
-		return ies.filter(ie -> ie.getName().equalsIgnoreCase(interfaceElement)).findAny().orElse(null);
+		final IInterfaceElement targetIE = ies.filter(ie -> ie.getName().equalsIgnoreCase(interfaceElement)).findAny()
+				.orElse(null);
+		if (targetIE != null) {
+			return targetIE;
+		}
+		if (il.eContainer() instanceof Demultiplexer) {
+			// check if we have a legacy demultiplexer member access pin
+			final var dmuxIE = il.getInterfaceElement(List.of(interfaceElement.split("%")), true); //$NON-NLS-1$
+			if (dmuxIE != null) {
+				return dmuxIE;
+			}
+		}
+		return null;
 	}
 
 	private static Stream<? extends IInterfaceElement> getInterfaceElementList(final InterfaceList il,


### PR DESCRIPTION
Connections from struct member output pins where previously stored with a % delimiter. In order to correctly parse existing projects this is added.