### PR TITLE
Remove duplicate and early adding of deployment device

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/DeploymentDebugDevice.java
+++ b/plugins/org.eclipse.fordiac.ide.deployment.debug/src/org/eclipse/fordiac/ide/deployment/debug/DeploymentDebugDevice.java
@@ -82,7 +82,6 @@ public class DeploymentDebugDevice extends DeploymentDebugElement implements IDe
 		this.pollingInterval = pollingInterval;
 		this.launchWatches = launchWatches;
 
-		debugTarget.getLaunch().addDebugTarget(this);
 		deviceManagementExecutor = IDeviceManagementExecutorService.of(new SharedWatchDeviceManagementInteractor(
 				DeviceManagementInteractorFactory.INSTANCE.getDeviceManagementInteractor(device, null, profile)));
 


### PR DESCRIPTION
The deployment device was added twice and before it was fully initialized the first time. This removes the duplicate and early addition.

Fixes #2801 