### PR TITLE
Qualify PACKAGE declaration with eclipse4diac:: prefix in signalprocessing typelib

### DIFF
--- a/data/typelibrary/signalprocessing-3.0.0/typelib/FIELDBUS_PERCENT_TO_WORD.fct
+++ b/data/typelibrary/signalprocessing-3.0.0/typelib/FIELDBUS_PERCENT_TO_WORD.fct
@@ -2,7 +2,7 @@
 <Function Name="FIELDBUS_PERCENT_TO_WORD" Comment="Convert a REAL in the Range 0.0% to 100.0% (0.0 to 1.0) to a WORD Value Range 0-FAFF">
 	<Identification Standard="SAE J1939; ISO 11783" Description="Copyright (c) 2023 HR Agrartechnik GmbH     &#10;   &#10;This program and the accompanying materials are made    &#10;available under the terms of the Eclipse Public License 2.0    &#10;which is available at https://www.eclipse.org/legal/epl-2.0/    &#10;    &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
-	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.0.1" Author="Franz Höpfinger" Date="2026-08-27" Remarks="updated description and cleaned up formatting">
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.0.1" Author="Franz Höpfinger" Date="2026-08-27" Remarks="updated description, cleaned up formatting, and qualified PACKAGE declaration with eclipse4diac:: prefix to match CompilerInfo packageName">
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
@@ -31,7 +31,7 @@
 		</OutputVars>
 	</InterfaceList>
 	<FunctionBody>
-		<ST><![CDATA[PACKAGE signalprocessing;
+		<ST><![CDATA[PACKAGE eclipse4diac::signalprocessing;
 
 (* Convert a REAL in the Range 0.0% to 100.0% (0.0 to 1.0) to a WORD Value Range 0-FAFF *)
 FUNCTION FIELDBUS_PERCENT_TO_WORD : WORD

--- a/data/typelibrary/signalprocessing-3.0.0/typelib/FIELDBUS_WORD_TO_PERCENT.fct
+++ b/data/typelibrary/signalprocessing-3.0.0/typelib/FIELDBUS_WORD_TO_PERCENT.fct
@@ -2,7 +2,7 @@
 <Function Name="FIELDBUS_WORD_TO_PERCENT" Comment="Convert a WORD Value Range 0-FAFF to a REAL in the Range 0.0% to 100.0% (0.0 to 1.0)">
 	<Identification Standard="SAE J1939; ISO 11783" Description="Copyright (c) 2023 HR Agrartechnik GmbH   &#10;   &#10;This program and the accompanying materials are made    &#10;available under the terms of the Eclipse Public License 2.0    &#10;which is available at https://www.eclipse.org/legal/epl-2.0/    &#10;    &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
-	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.0.1" Author="Franz Höpfinger" Date="2026-08-27" Remarks="updated description and cleaned up formatting">
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.0.1" Author="Franz Höpfinger" Date="2026-08-27" Remarks="updated description, cleaned up formatting, and qualified PACKAGE declaration with eclipse4diac:: prefix to match CompilerInfo packageName">
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
@@ -33,7 +33,7 @@
 		</OutputVars>
 	</InterfaceList>
 	<FunctionBody>
-		<ST><![CDATA[PACKAGE signalprocessing;
+		<ST><![CDATA[PACKAGE eclipse4diac::signalprocessing;
 
 (* Convert a WORD Value Range 0-FAFF to a REAL in the Range 0.0% to 100.0% (0.0 to 1.0) *)
 FUNCTION FIELDBUS_WORD_TO_PERCENT : REAL

--- a/data/typelibrary/signalprocessing-3.0.0/typelib/SCALE.fct
+++ b/data/typelibrary/signalprocessing-3.0.0/typelib/SCALE.fct
@@ -2,7 +2,7 @@
 <Function Name="SCALE" Comment="Scaling Function Block">
 	<Identification Standard="61499-1" Description="Copyright (c) 2024 HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0&#10;&#10;was inspired by this Video: &#10;EP2 - CODESYS: Create Scaling Function Block&#10;https://www.youtube.com/watch?v=Ir6QAxxDarI">
 	</Identification>
-	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.0.1" Author="Franz Höpfinger" Date="2026-08-27" Remarks="updated description and cleaned up formatting">
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.0.1" Author="Franz Höpfinger" Date="2026-08-27" Remarks="updated description, cleaned up formatting, and qualified PACKAGE declaration with eclipse4diac:: prefix to match CompilerInfo packageName">
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
@@ -37,7 +37,7 @@
 		</OutputVars>
 	</InterfaceList>
 	<FunctionBody>
-		<ST><![CDATA[PACKAGE signalprocessing;
+		<ST><![CDATA[PACKAGE eclipse4diac::signalprocessing;
 
 (* Scaling Function Block *)
 FUNCTION SCALE : REAL

--- a/data/typelibrary/signalprocessing-3.0.0/typelib/SCALE_LIM.fct
+++ b/data/typelibrary/signalprocessing-3.0.0/typelib/SCALE_LIM.fct
@@ -2,7 +2,7 @@
 <Function Name="SCALE_LIM" Comment="Scaling Function Block with limits">
 	<Identification Standard="61499-1" Description="Copyright (c) 2024 HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0&#10;&#10;">
 	</Identification>
-	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.0.1" Author="Franz Höpfinger" Date="2026-08-27" Remarks="updated description and cleaned up formatting">
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.0.1" Author="Franz Höpfinger" Date="2026-08-27" Remarks="updated description, cleaned up formatting, and qualified PACKAGE declaration with eclipse4diac:: prefix to match CompilerInfo packageName">
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
@@ -45,7 +45,7 @@
 		</OutputVars>
 	</InterfaceList>
 	<FunctionBody>
-		<ST><![CDATA[PACKAGE signalprocessing;
+		<ST><![CDATA[PACKAGE eclipse4diac::signalprocessing;
 
 (* Scaling Function Block with limits *)
 FUNCTION SCALE_LIM : REAL


### PR DESCRIPTION
FIELDBUS_PERCENT_TO_WORD, FIELDBUS_WORD_TO_PERCENT, SCALE, and SCALE_LIM declared `PACKAGE signalprocessing;` in their ST body, but their `CompilerInfo packageName` is `eclipse4diac::signalprocessing` - the unqualified PACKAGE declaration doesn't match. Qualifies all four to `PACKAGE eclipse4diac::signalprocessing;` to match.

Split out of #2786, which bundled this with unrelated description and formatting fixes - those are in #2786's other half, opened separately.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KZMwou1aMoeNFPiXrJszsa