### PR TITLE
Fix swapped descriptions and clean up formatting in signalprocessing typelib

### DIFF
--- a/data/typelibrary/signalprocessing-3.0.0/typelib/FIELDBUS_PERCENT_TO_WORD.fct
+++ b/data/typelibrary/signalprocessing-3.0.0/typelib/FIELDBUS_PERCENT_TO_WORD.fct
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Function Name="FIELDBUS_PERCENT_TO_WORD" Comment="Convert a WORD Value Range 0-FAFF to a REAL in the Range 0.0 to 100.0">
-	<Identification Standard="SAE J1939; ISO 11783" Description="Copyright (c) 2023 HR Agrartechnik GmbH   &#10;   &#10;This program and the accompanying materials are made    &#10;available under the terms of the Eclipse Public License 2.0    &#10;which is available at https://www.eclipse.org/legal/epl-2.0/    &#10;    &#10;SPDX-License-Identifier: EPL-2.0">
+<Function Name="FIELDBUS_PERCENT_TO_WORD" Comment="Convert a REAL in the Range 0.0% to 100.0% (0.0 to 1.0) to a WORD Value Range 0-FAFF">
+	<Identification Standard="SAE J1939; ISO 11783" Description="Copyright (c) 2023 HR Agrartechnik GmbH     &#10;   &#10;This program and the accompanying materials are made    &#10;available under the terms of the Eclipse Public License 2.0    &#10;which is available at https://www.eclipse.org/legal/epl-2.0/    &#10;    &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.0.1" Author="Franz Höpfinger" Date="2026-08-27" Remarks="updated description and cleaned up formatting">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.1" Author="Franz Höpfinger" Date="2024-09-19" Remarks="Update to a more Function like Interface">
@@ -22,7 +24,7 @@
 			</Event>
 		</EventOutputs>
 		<InputVars>
-			<VarDeclaration Name="RI" Type="REAL" Comment="Input Value" />
+			<VarDeclaration Name="RI" Type="REAL" Comment="Input Value"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="" Type="WORD"/>
@@ -31,7 +33,7 @@
 	<FunctionBody>
 		<ST><![CDATA[PACKAGE signalprocessing;
 
-(* Convert a WORD Value Range 0-FAFF to a REAL in the Range 0.0 to 100.0 *)
+(* Convert a REAL in the Range 0.0% to 100.0% (0.0 to 1.0) to a WORD Value Range 0-FAFF *)
 FUNCTION FIELDBUS_PERCENT_TO_WORD : WORD
 VAR_INPUT
 	RI : REAL; // Input Value

--- a/data/typelibrary/signalprocessing-3.0.0/typelib/FIELDBUS_WORD_TO_PERCENT.fct
+++ b/data/typelibrary/signalprocessing-3.0.0/typelib/FIELDBUS_WORD_TO_PERCENT.fct
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Function Name="FIELDBUS_WORD_TO_PERCENT" Comment="Convert a REAL in the Range 0.0 to 100.0 to a WORD Value Range 0-FAFF">
+<Function Name="FIELDBUS_WORD_TO_PERCENT" Comment="Convert a WORD Value Range 0-FAFF to a REAL in the Range 0.0% to 100.0% (0.0 to 1.0)">
 	<Identification Standard="SAE J1939; ISO 11783" Description="Copyright (c) 2023 HR Agrartechnik GmbH   &#10;   &#10;This program and the accompanying materials are made    &#10;available under the terms of the Eclipse Public License 2.0    &#10;which is available at https://www.eclipse.org/legal/epl-2.0/    &#10;    &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.0.1" Author="Franz Höpfinger" Date="2026-08-27" Remarks="updated description and cleaned up formatting">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.1" Author="Franz Höpfinger" Date="2024-09-19" Remarks="Update to a more Function like Interface">
@@ -23,17 +25,17 @@
 			</Event>
 		</EventOutputs>
 		<InputVars>
-			<VarDeclaration Name="WI" Type="WORD" Comment="Input Value" />
+			<VarDeclaration Name="WI" Type="WORD" Comment="Input Value"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="" Type="REAL"/>
-			<VarDeclaration Name="WO" Type="WORD" Comment="Input Value mirror if Signal Valid." />
+			<VarDeclaration Name="WO" Type="WORD" Comment="Input Value mirror if Signal Valid."/>
 		</OutputVars>
 	</InterfaceList>
 	<FunctionBody>
 		<ST><![CDATA[PACKAGE signalprocessing;
 
-(* Convert a REAL in the Range 0.0 to 100.0 to a WORD Value Range 0-FAFF *)
+(* Convert a WORD Value Range 0-FAFF to a REAL in the Range 0.0% to 100.0% (0.0 to 1.0) *)
 FUNCTION FIELDBUS_WORD_TO_PERCENT : REAL
 VAR_INPUT
 	WI : WORD; // Input Value

--- a/data/typelibrary/signalprocessing-3.0.0/typelib/SCALE.fct
+++ b/data/typelibrary/signalprocessing-3.0.0/typelib/SCALE.fct
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Function Name="SCALE" Comment="Scaling Function Block">
-	<Identification Standard="61499-1" Description="Copyright (c) 2024 HR Agrartechnik GmbH   &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0&#10;&#10;was inspired by this Video: &#10;EP2 - CODESYS: Create Scaling Function Block&#10;https://www.youtube.com/watch?v=Ir6QAxxDarI">
+	<Identification Standard="61499-1" Description="Copyright (c) 2024 HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0&#10;&#10;was inspired by this Video: &#10;EP2 - CODESYS: Create Scaling Function Block&#10;https://www.youtube.com/watch?v=Ir6QAxxDarI">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.0.1" Author="Franz Höpfinger" Date="2026-08-27" Remarks="updated description and cleaned up formatting">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2024-09-19">
@@ -10,7 +12,7 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="REQ" Type="Event" Comment="">
+			<Event Name="REQ" Type="Event">
 				<With Var="IN"/>
 				<With Var="MAX_IN"/>
 				<With Var="MIN_IN"/>
@@ -19,7 +21,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="CNF" Type="Event" Comment="">
+			<Event Name="CNF" Type="Event">
 				<With Var=""/>
 			</Event>
 		</EventOutputs>
@@ -27,11 +29,11 @@
 			<VarDeclaration Name="IN" Type="REAL" Comment="Input to be Scaled"/>
 			<VarDeclaration Name="MAX_IN" Type="REAL" Comment="Maximum Input"/>
 			<VarDeclaration Name="MIN_IN" Type="REAL" Comment="Minimum Input"/>
-			<VarDeclaration Name="MAX_OUT" Type="REAL" Comment="Maximum Ouput"/>
+			<VarDeclaration Name="MAX_OUT" Type="REAL" Comment="Maximum Output"/>
 			<VarDeclaration Name="MIN_OUT" Type="REAL" Comment="Minimum Output"/>
 		</InputVars>
 		<OutputVars>
-			<VarDeclaration Name="" Type="REAL" Comment=""/>
+			<VarDeclaration Name="" Type="REAL"/>
 		</OutputVars>
 	</InterfaceList>
 	<FunctionBody>
@@ -40,11 +42,11 @@
 (* Scaling Function Block *)
 FUNCTION SCALE : REAL
 VAR_INPUT
-	IN : REAL;    // Input to be Scaled
-	MAX_IN : REAL;    // Maximum Input
-	MIN_IN : REAL;    // Minimum Input
-	MAX_OUT : REAL;    // Maximum Ouput
-	MIN_OUT : REAL;    // Minimum Output
+	IN : REAL; // Input to be Scaled
+	MAX_IN : REAL; // Maximum Input
+	MIN_IN : REAL; // Minimum Input
+	MAX_OUT : REAL; // Maximum Output
+	MIN_OUT : REAL; // Minimum Output
 END_VAR
 
 SCALE := (IN - MIN_IN) * (MAX_OUT - MIN_OUT) / (MAX_IN - MIN_IN) + MIN_OUT;

--- a/data/typelibrary/signalprocessing-3.0.0/typelib/SCALE_LIM.fct
+++ b/data/typelibrary/signalprocessing-3.0.0/typelib/SCALE_LIM.fct
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Function Name="SCALE_LIM" Comment="Scaling Function Block with limits">
-	<Identification Standard="61499-1" Description="Copyright (c) 2024 HR Agrartechnik GmbH   &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0&#10;&#10;">
+	<Identification Standard="61499-1" Description="Copyright (c) 2024 HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0&#10;&#10;">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.0.1" Author="Franz Höpfinger" Date="2026-08-27" Remarks="updated description and cleaned up formatting">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2024-09-19">
@@ -10,7 +12,7 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="REQ" Type="Event" Comment="">
+			<Event Name="REQ" Type="Event">
 				<With Var="IN"/>
 				<With Var="MAX_IN"/>
 				<With Var="MIN_IN"/>
@@ -23,7 +25,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="CNF" Type="Event" Comment="">
+			<Event Name="CNF" Type="Event">
 				<With Var=""/>
 			</Event>
 		</EventOutputs>
@@ -31,15 +33,15 @@
 			<VarDeclaration Name="IN" Type="REAL" Comment="Input to be Scaled"/>
 			<VarDeclaration Name="MAX_IN" Type="REAL" Comment="Maximum Input"/>
 			<VarDeclaration Name="MIN_IN" Type="REAL" Comment="Minimum Input"/>
-			<VarDeclaration Name="MAX_IN_LIM" Type="REAL" Comment="Maximum Input Limit, if IN is bigger, Output is MAX2_ESC"/>
-			<VarDeclaration Name="MIN_IN_LIM" Type="REAL" Comment="Minimum Input Limit, if IN is smaller, Output is MIN2_ESC"/>
-			<VarDeclaration Name="MAX_OUT" Type="REAL" Comment="Maximum Ouput"/>
+			<VarDeclaration Name="MAX_IN_LIM" Type="REAL" Comment="Maximum Input Limit; if IN is greater than MAX_IN_LIM, the output is MAX_OUT_FIX"/>
+			<VarDeclaration Name="MIN_IN_LIM" Type="REAL" Comment="Minimum Input Limit; if IN is less than MIN_IN_LIM, the output is MIN_OUT_FIX"/>
+			<VarDeclaration Name="MAX_OUT" Type="REAL" Comment="Maximum Output"/>
 			<VarDeclaration Name="MIN_OUT" Type="REAL" Comment="Minimum Output"/>
-			<VarDeclaration Name="MAX_OUT_FIX" Type="REAL" Comment="Maximum Ouput Fix Value, ist set if IN is bigger than MAX_IN_LIM"/>
-			<VarDeclaration Name="MIN_OUT_FIX" Type="REAL" Comment="Minimum Output Fix Value, ist set if IN is smaller than MIN_IN_LIM"/>
+			<VarDeclaration Name="MAX_OUT_FIX" Type="REAL" Comment="Maximum Output Fix Value; is set if IN is greater than MAX_IN_LIM"/>
+			<VarDeclaration Name="MIN_OUT_FIX" Type="REAL" Comment="Minimum Output Fix Value; is set if IN is less than MIN_IN_LIM"/>
 		</InputVars>
 		<OutputVars>
-			<VarDeclaration Name="" Type="REAL" Comment=""/>
+			<VarDeclaration Name="" Type="REAL"/>
 		</OutputVars>
 	</InterfaceList>
 	<FunctionBody>
@@ -48,20 +50,20 @@
 (* Scaling Function Block with limits *)
 FUNCTION SCALE_LIM : REAL
 VAR_INPUT
-	IN : REAL;    // Input to be Scaled
-	MAX_IN : REAL;    // Maximum Input
-	MIN_IN : REAL;    // Minimum Input
-	MAX_IN_LIM : REAL;    // Maximum Input Limit, if IN is bigger, Output is MAX2_ESC
-	MIN_IN_LIM : REAL;    // Minimum Input Limit, if IN is smaller, Output is MIN2_ESC
-	MAX_OUT : REAL;    // Maximum Ouput
-	MIN_OUT : REAL;    // Minimum Output
-	MAX_OUT_FIX : REAL;    // Maximum Ouput Fix Value, ist set if IN is bigger than MAX_IN_LIM
-	MIN_OUT_FIX : REAL;    // Minimum Output Fix Value, ist set if IN is smaller than MIN_IN_LIM
+	IN : REAL; // Input to be Scaled
+	MAX_IN : REAL; // Maximum Input
+	MIN_IN : REAL; // Minimum Input
+	MAX_IN_LIM : REAL; // Maximum Input Limit; if IN is greater than MAX_IN_LIM, the output is MAX_OUT_FIX
+	MIN_IN_LIM : REAL; // Minimum Input Limit; if IN is less than MIN_IN_LIM, the output is MIN_OUT_FIX
+	MAX_OUT : REAL; // Maximum Output
+	MIN_OUT : REAL; // Minimum Output
+	MAX_OUT_FIX : REAL; // Maximum Output Fix Value; is set if IN is greater than MAX_IN_LIM
+	MIN_OUT_FIX : REAL; // Minimum Output Fix Value; is set if IN is less than MIN_IN_LIM
 END_VAR
 
 IF (IN < MIN_IN_LIM) THEN
 	SCALE_LIM := MIN_OUT_FIX;
-ELSIF (IN> MAX_IN_LIM) THEN
+ELSIF (IN > MAX_IN_LIM) THEN
 	SCALE_LIM := MAX_OUT_FIX;
 ELSE
 	SCALE_LIM := (IN - MIN_IN) * (MAX_OUT - MIN_OUT) / (MAX_IN - MIN_IN) + MIN_OUT;


### PR DESCRIPTION
FIELDBUS_PERCENT_TO_WORD and FIELDBUS_WORD_TO_PERCENT had each other's description text (both the `Function` Comment attribute and the matching ST body comment) - PERCENT_TO_WORD described WORD-to-REAL, and vice versa. Swapped them back to match what each function actually does.

SCALE/SCALE_LIM: fixed "Ouput" typos, reworded the MAX_IN_LIM/MIN_IN_LIM/MAX_OUT_FIX/MIN_OUT_FIX comments to reference the actual output variable names instead of the stale "MAX2_ESC"/"MIN2_ESC", and added a missing space around the `>` operator in a comparison.

Also cleans up formatting noise found alongside these fixes: empty `Comment=""` attributes, inconsistent self-closing tag spacing, ST body comment indentation, and copyright header whitespace.

Split out of #2786, together with #2814 (PACKAGE declaration qualification).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KZMwou1aMoeNFPiXrJszsa