### PR TITLE
Fix false unused-import warning for imports used in System Configuration

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/builder/STAlgorithmInitialValueBuilderParticipant.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/builder/STAlgorithmInitialValueBuilderParticipant.java
@@ -9,6 +9,8 @@
  *
  * Contributors:
  *   Martin Jobst - initial API and implementation and/or initial documentation
+ *   Franz Höpfinger - fix false unused-import warnings for values used only
+ *                      in System Configuration
  *******************************************************************************/
 package org.eclipse.fordiac.ide.structuredtextalgorithm.ui.builder;
 
@@ -41,10 +43,10 @@ import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
 import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.ECTransition;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.Import;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
-import org.eclipse.fordiac.ide.model.libraryElement.SystemConfiguration;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.value.TypedValueConverter;
 import org.eclipse.fordiac.ide.structuredtextalgorithm.resource.STAlgorithmResource;
@@ -157,7 +159,8 @@ public class STAlgorithmInitialValueBuilderParticipant implements IXtextBuilderP
 				throw new OperationCanceledException();
 			}
 			switch (allContents.next()) {
-			case final SystemConfiguration _ -> allContents.prune();
+			case final FBNetworkElement fbNetworkElement when fbNetworkElement.isMapped()
+					&& fbNetworkElement.getMapping().getTo() == fbNetworkElement -> allContents.prune();
 			case final Attribute attribute -> {
 				validateType(attribute, delta, typeUsageCollector, ignoreWarnings, context, monitor);
 				validateValue(attribute, delta, typeUsageCollector, variableUsageValidator, ignoreWarnings, context,


### PR DESCRIPTION
## Summary
- The whole-project builder that computes used/unused imports (`STAlgorithmInitialValueBuilderParticipant`) pruned the entire `SystemConfiguration` subtree, so `Device`/`Resource`/FB-instance parameters referencing an import (e.g. a Global Constant used as a Device's `MGR_ID` or as an FB instance parameter inside a `Resource`) were never seen and got reported as `Unused import`.
- Every elementary data type (e.g. `WSTRING`, `BOOL`) extends `AnyType`, so the pre-existing `varDeclaration.getType() instanceof AnyType` check in `validateValue` already covers concrete-typed parameter values such as `MGR_ID` — removing the prune is sufficient to let them be parsed and their import usage registered; no widening of that condition is needed.
- Replaced the blanket `SystemConfiguration` prune with a narrower one for `FBNetworkElement`s that are the mapped-to side of a `Mapping` (the shadow copy of an Application FB instance inside a `Resource`'s `FBNetwork`), since those are already validated as part of the Application network and would otherwise be processed a second time.

Fixes #1764

An unrelated `ErrorDataType` hardening for the same `validateValue` methods was split out per review into #2826.

## Test plan
- Reproduced the false-positive on a real project (`.sys` files using Global Constants as `Device`/`Resource`/FB-instance `Parameter` values, e.g. `MGR_ID="C_11"`, FB `Parameter ID="Q1_REMOTE_WRITE"`) — warnings for those imports disappeared after a rebuild with the fix applied.
- Verified imports that genuinely don't exist are still reported as `The import '...' does not exist` errors.
- Verified genuinely unused imports are still reported as `Unused import` warnings.
- Built the affected plugins plus the `org.eclipse.fordiac.ide.product` reactor via `mvn install -pl plugins/org.eclipse.fordiac.ide.product,plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui,plugins/org.eclipse.fordiac.ide.structuredtextcore.ui -am -DskipTests` — `BUILD SUCCESS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8togXrcoFdUHuc2oi88yD


## References

- https://github.com/eclipse-4diac/4diac-ide/pull/2817
- https://github.com/Meisterschulen-am-Ostbahnhof-Munchen/4diac-ide/pull/35
- https://github.com/eclipse-4diac/4diac-ide/pull/2826
- https://github.com/eclipse-4diac/4diac-ide/issues/1764