### PR TITLE
Detect import usage inside SystemConfiguration

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/builder/STAlgorithmInitialValueBuilderParticipant.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.ui/src/org/eclipse/fordiac/ide/structuredtextalgorithm/ui/builder/STAlgorithmInitialValueBuilderParticipant.java
@@ -9,6 +9,8 @@
  *
  * Contributors:
  *   Martin Jobst - initial API and implementation and/or initial documentation
+ *   Franz Höpfinger - fix false unused-import warnings for values used only
+ *                      in System Configuration
  *******************************************************************************/
 package org.eclipse.fordiac.ide.structuredtextalgorithm.ui.builder;
 
@@ -41,10 +43,10 @@ import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
 import org.eclipse.fordiac.ide.model.libraryElement.BaseFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.ECTransition;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetworkElement;
 import org.eclipse.fordiac.ide.model.libraryElement.Import;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElement;
 import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementPackage;
-import org.eclipse.fordiac.ide.model.libraryElement.SystemConfiguration;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.value.TypedValueConverter;
 import org.eclipse.fordiac.ide.structuredtextalgorithm.resource.STAlgorithmResource;
@@ -157,7 +159,8 @@ public class STAlgorithmInitialValueBuilderParticipant implements IXtextBuilderP
 				throw new OperationCanceledException();
 			}
 			switch (allContents.next()) {
-			case final SystemConfiguration configuration -> allContents.prune();
+			case final FBNetworkElement fbNetworkElement when fbNetworkElement.isMapped()
+					&& fbNetworkElement.getMapping().getTo() == fbNetworkElement -> allContents.prune();
 			case final Attribute attribute -> {
 				validateType(attribute, delta, typeUsageCollector, ignoreWarnings, context, monitor);
 				validateValue(attribute, delta, typeUsageCollector, variableUsageValidator, ignoreWarnings, context,


### PR DESCRIPTION
## Summary
The whole-project builder that computes used/unused imports pruned the
entire SystemConfiguration subtree, so Device/Resource/FB-instance
parameters referencing an import (e.g. a Global Constant used as a
Device's MGR_ID or as an FB instance parameter inside a Resource) were
never seen and got reported as unused.

Replaced the blanket SystemConfiguration prune with a narrower one for
FBNetworkElements that are the mapped-to side of a Mapping (the shadow
copy of an Application FB instance inside a Resource's FBNetwork),
since those are already validated as part of the Application network
and would otherwise be processed a second time.

Fixes eclipse-4diac/4diac-ide#1764

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8togXrcoFdUHuc2oi88yD


- eclipse-4diac/4diac-ide#1764