### PR TITLE
Fix INIT/INITO event type to EInit in 3.0.0 typelib FB types

### DIFF
--- a/data/typelibrary/io-3.0.0/typelib/GPIOChip/GPIOChip.fbt
+++ b/data/typelibrary/io-3.0.0/typelib/GPIOChip/GPIOChip.fbt
@@ -2,6 +2,8 @@
 <FBType Name="GPIOChip" Comment="Service Interface Function Block Type">
 	<Identification Description="Copyright (c) 2023 OFFIS e.V.&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-09-04" Remarks="changed INIT/INITO event type to EInit">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="OFFIS e.V." Version="1.0" Author="Jörg Walter" Date="2023-11-10">
@@ -10,7 +12,7 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="Event" Comment="Service Initialization">
+			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
 				<With Var="VALUE"/>
 				<With Var="ChipNumber"/>
@@ -21,7 +23,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="Event" Comment="Initialization Confirm">
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>

--- a/data/typelibrary/net-3.0.0/typelib/CLIENT_0.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/CLIENT_0.fbt
@@ -2,13 +2,15 @@
 <FBType Name="CLIENT_0" Comment="Connect to a SERVER_0 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2025 Monika Wenger&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-09-04" Remarks="changed INIT/INITO event type to EInit">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Monika Wenger" Date="2025-12-05" Remarks="created from existing">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::net">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="Event">
+			<Event Name="INIT" Type="EInit">
 				<With Var="QI"/>
 				<With Var="ID"/>
 			</Event>
@@ -17,7 +19,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="Event">
+			<Event Name="INITO" Type="EInit">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>

--- a/data/typelibrary/net-3.0.0/typelib/SERVER_0.fbt
+++ b/data/typelibrary/net-3.0.0/typelib/SERVER_0.fbt
@@ -2,13 +2,15 @@
 <FBType Name="SERVER_0" Comment="Connects to a CLIENT_0 Block">
 	<Identification Standard="61499-2" Description="Copyright (c) 2025 Monika Wenger&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-09-04" Remarks="changed INIT/INITO event type to EInit">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Monika Wenger" Date="2025-12-05" Remarks="created from existing">
 	</VersionInfo>
 	<CompilerInfo packageName="iec61499::net">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="Event" Comment="Service Initialization">
+			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
 				<With Var="ID"/>
 			</Event>
@@ -17,7 +19,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="Event" Comment="Initialization Confirm">
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>

--- a/data/typelibrary/powerlink-3.0.0/typelib/POWERLINK_MN.fbt
+++ b/data/typelibrary/powerlink-3.0.0/typelib/POWERLINK_MN.fbt
@@ -2,6 +2,8 @@
 <FBType Name="POWERLINK_MN" Comment="Configures the openPOWERLINK fieldbus">
 	<Identification Standard="61499-2" Description="Copyright (c) 2011 AIT&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-09-04" Remarks="changed INIT/INITO event type to EInit">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="AIT" Version="1.0" Author="Filip Andren, Thomas Strasser" Date="2011-05-31">
@@ -12,7 +14,7 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="Event" Comment="Service Initialization">
+			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
 				<With Var="CDC_CFG"/>
 				<With Var="APP_CFG"/>
@@ -20,7 +22,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="Event" Comment="Initialization Confirm">
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 			</Event>

--- a/data/typelibrary/powerlink-3.0.0/typelib/X20AI2622.fbt
+++ b/data/typelibrary/powerlink-3.0.0/typelib/X20AI2622.fbt
@@ -2,6 +2,8 @@
 <FBType Name="X20AI2622" Comment="Analog inputs at the openPOWERLINK fieldbus">
 	<Identification Standard="61499-2" Description="Copyright (c) 2014 AIT&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-09-04" Remarks="changed INIT/INITO event type to EInit">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="AIT" Version="1.0" Author="Michael Gafert" Date="2024-09-13">
@@ -10,7 +12,7 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="Event" Comment="Service Initialization">
+			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
 				<With Var="CNID"/>
 				<With Var="MODID"/>
@@ -20,7 +22,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="Event" Comment="Initialization Confirm">
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
 				<With Var="QO"/>
 				<With Var="CNIDO"/>
 				<With Var="STATUS"/>

--- a/data/typelibrary/powerlink-3.0.0/typelib/X20AI4622.fbt
+++ b/data/typelibrary/powerlink-3.0.0/typelib/X20AI4622.fbt
@@ -2,6 +2,8 @@
 <FBType Name="X20AI4622" Comment="Analog inputs at the openPOWERLINK fieldbus">
 	<Identification Standard="61499-2" Description="Copyright (c) 2011 AIT&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-09-04" Remarks="changed INIT/INITO event type to EInit">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="AIT" Version="1.0" Author="Filip Andren" Date="2011-08-01">
@@ -10,7 +12,7 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="Event" Comment="Service Initialization">
+			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
 				<With Var="CNID"/>
 				<With Var="MODID"/>
@@ -20,7 +22,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="Event" Comment="Initialization Confirm">
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
 				<With Var="QO"/>
 				<With Var="CNIDO"/>
 				<With Var="STATUS"/>

--- a/data/typelibrary/powerlink-3.0.0/typelib/X20AO4622.fbt
+++ b/data/typelibrary/powerlink-3.0.0/typelib/X20AO4622.fbt
@@ -2,6 +2,8 @@
 <FBType Name="X20AO4622" Comment="Analog outputs at the openPOWERLINK fieldbus">
 	<Identification Standard="61499-2" Description="Copyright (c) 2011 AIT&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-09-04" Remarks="changed INIT/INITO event type to EInit">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="AIT" Version="1.0" Author="Filip Andren" Date="2011-08-01">
@@ -10,7 +12,7 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="Event" Comment="Service Initialization">
+			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
 				<With Var="CNID"/>
 				<With Var="MODID"/>
@@ -24,7 +26,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="Event" Comment="Initialization Confirm">
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
 				<With Var="QO"/>
 				<With Var="CNIDO"/>
 				<With Var="STATUS"/>

--- a/data/typelibrary/powerlink-3.0.0/typelib/X20AT2402.fbt
+++ b/data/typelibrary/powerlink-3.0.0/typelib/X20AT2402.fbt
@@ -2,6 +2,8 @@
 <FBType Name="X20AT2402" Comment="Analog temperature inputs at the openPOWERLINK fieldbus">
 	<Identification Standard="61499-2" Description="Copyright (c) 2012 AIT&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-09-04" Remarks="changed INIT/INITO event type to EInit">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="AIT" Version="1.0" Author="Filip Andren" Date="2012-03-06">
@@ -10,7 +12,7 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="Event" Comment="Service Initialization">
+			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
 				<With Var="CNID"/>
 				<With Var="MODID"/>
@@ -20,7 +22,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="Event" Comment="Initialization Confirm">
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
 				<With Var="QO"/>
 				<With Var="CNIDO"/>
 				<With Var="STATUS"/>

--- a/data/typelibrary/powerlink-3.0.0/typelib/X20AT4222.fbt
+++ b/data/typelibrary/powerlink-3.0.0/typelib/X20AT4222.fbt
@@ -2,6 +2,8 @@
 <FBType Name="X20AT4222" Comment="Analog temperature inputs at the openPOWERLINK fieldbus">
 	<Identification Standard="61499-2" Description="Copyright (c) 2012 AIT&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-09-04" Remarks="changed INIT/INITO event type to EInit">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="AIT" Version="1.0" Author="Filip Andren" Date="2012-03-06">
@@ -10,7 +12,7 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="Event" Comment="Service Initialization">
+			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
 				<With Var="CNID"/>
 				<With Var="MODID"/>
@@ -20,7 +22,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="Event" Comment="Initialization Confirm">
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
 				<With Var="QO"/>
 				<With Var="CNIDO"/>
 				<With Var="STATUS"/>

--- a/data/typelibrary/powerlink-3.0.0/typelib/X20DI4653.fbt
+++ b/data/typelibrary/powerlink-3.0.0/typelib/X20DI4653.fbt
@@ -2,6 +2,8 @@
 <FBType Name="X20DI4653" Comment="Digital inputs at the openPOWERLINK fieldbus">
 	<Identification Standard="61499-2" Description="Copyright (c) 2011 AIT&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-09-04" Remarks="changed INIT/INITO event type to EInit">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="AIT" Version="1.0" Author="Filip Andren, Thomas Strasser" Date="2013-02-11">
@@ -12,7 +14,7 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="Event" Comment="Service Initialization">
+			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
 				<With Var="CNID"/>
 				<With Var="MODID"/>
@@ -22,7 +24,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="Event" Comment="Initialization Confirm">
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 				<With Var="CNIDO"/>

--- a/data/typelibrary/powerlink-3.0.0/typelib/X20DI9371.fbt
+++ b/data/typelibrary/powerlink-3.0.0/typelib/X20DI9371.fbt
@@ -2,6 +2,8 @@
 <FBType Name="X20DI9371" Comment="Digital inputs at the openPOWERLINK fieldbus">
 	<Identification Standard="61499-2" Description="Copyright (c) 2011 AIT&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-09-04" Remarks="changed INIT/INITO event type to EInit">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="AIT" Version="1.0" Author="Filip Andren, Thomas Strasser" Date="2011-05-31">
@@ -12,7 +14,7 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="Event" Comment="Service Initialization">
+			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
 				<With Var="CNID"/>
 				<With Var="MODID"/>
@@ -22,7 +24,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="Event" Comment="Initialization Confirm">
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 				<With Var="CNIDO"/>

--- a/data/typelibrary/powerlink-3.0.0/typelib/X20DI9372.fbt
+++ b/data/typelibrary/powerlink-3.0.0/typelib/X20DI9372.fbt
@@ -2,6 +2,8 @@
 <FBType Name="X20DI9372" Comment="Digital inputs at the openPOWERLINK fieldbus">
 	<Identification Standard="61499-2" Description="Copyright (c) 2012 AIT&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-09-04" Remarks="changed INIT/INITO event type to EInit">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="AIT" Version="1.0" Author="Filip Andren, Thomas Strasser" Date="2011-05-31">
@@ -12,7 +14,7 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="Event" Comment="Service Initialization">
+			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
 				<With Var="CNID"/>
 				<With Var="MODID"/>
@@ -22,7 +24,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="Event" Comment="Initialization Confirm">
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 				<With Var="CNIDO"/>

--- a/data/typelibrary/powerlink-3.0.0/typelib/X20DO4623.fbt
+++ b/data/typelibrary/powerlink-3.0.0/typelib/X20DO4623.fbt
@@ -2,6 +2,8 @@
 <FBType Name="X20DO4623" Comment="Digital outputs at the openPOWERLINK fieldbus">
 	<Identification Standard="61499-2" Description="Copyright (c) 2011 AIT&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-09-04" Remarks="changed INIT/INITO event type to EInit">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="AIT" Version="1.0" Author="Filip Andren, Thomas Strasser" Date="2011-05-31">
@@ -12,7 +14,7 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="Event" Comment="Service Initialization">
+			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
 				<With Var="CNID"/>
 				<With Var="MODID"/>
@@ -26,7 +28,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="Event" Comment="Initialization Confirm">
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 				<With Var="CNIDO"/>

--- a/data/typelibrary/powerlink-3.0.0/typelib/X20DO4649.fbt
+++ b/data/typelibrary/powerlink-3.0.0/typelib/X20DO4649.fbt
@@ -2,6 +2,8 @@
 <FBType Name="X20DO4649" Comment="Digital outputs at the openPOWERLINK fieldbus">
 	<Identification Standard="61499-2" Description="Copyright (c) 2011 AIT&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-09-04" Remarks="changed INIT/INITO event type to EInit">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="AIT" Version="1.0" Author="Filip Andren, Thomas Strasser" Date="2011-05-31">
@@ -12,7 +14,7 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="Event" Comment="Service Initialization">
+			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
 				<With Var="CNID"/>
 				<With Var="MODID"/>
@@ -26,7 +28,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="Event" Comment="Initialization Confirm">
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 				<With Var="CNIDO"/>

--- a/data/typelibrary/powerlink-3.0.0/typelib/X20DO9321.fbt
+++ b/data/typelibrary/powerlink-3.0.0/typelib/X20DO9321.fbt
@@ -2,6 +2,8 @@
 <FBType Name="X20DO9321" Comment="Digital outputs at the openPOWERLINK fieldbus">
 	<Identification Standard="61499-2" Description="Copyright (c) 2012 AIT&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-09-04" Remarks="changed INIT/INITO event type to EInit">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="AIT" Version="1.0" Author="Filip Andren, Thomas Strasser" Date="2011-05-31">
@@ -12,7 +14,7 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="Event" Comment="Service Initialization">
+			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
 				<With Var="CNID"/>
 				<With Var="MODID"/>
@@ -34,7 +36,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="Event" Comment="Initialization Confirm">
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 				<With Var="CNIDO"/>

--- a/data/typelibrary/powerlink-3.0.0/typelib/X20DO9322.fbt
+++ b/data/typelibrary/powerlink-3.0.0/typelib/X20DO9322.fbt
@@ -2,6 +2,8 @@
 <FBType Name="X20DO9322" Comment="Digital outputs at the openPOWERLINK fieldbus">
 	<Identification Standard="61499-2" Description="Copyright (c) 2011 AIT&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-09-04" Remarks="changed INIT/INITO event type to EInit">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="AIT" Version="1.0" Author="Filip Andren, Thomas Strasser" Date="2011-05-31">
@@ -12,7 +14,7 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="INIT" Type="Event" Comment="Service Initialization">
+			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
 				<With Var="CNID"/>
 				<With Var="MODID"/>
@@ -34,7 +36,7 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
-			<Event Name="INITO" Type="Event" Comment="Initialization Confirm">
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
 				<With Var="QO"/>
 				<With Var="STATUS"/>
 				<With Var="CNIDO"/>


### PR DESCRIPTION
## Summary
- Several FB types in the actively maintained `-3.0.0` type libraries (`io`, `net`, `powerlink`) declared their standard `INIT`/`INITO` service-interface events with the generic `Type="Event"` instead of `Type="EInit"`, which is used consistently by every other FB in these libraries for this exact `INIT`/`INITO` pattern (`Comment="Service Initialization"` / `Comment="Initialization Confirm"`).
- Aligned all 16 affected FB types with the `EInit` convention: `data/typelibrary/net-3.0.0/typelib/{CLIENT_0,SERVER_0}.fbt`, `data/typelibrary/io-3.0.0/typelib/GPIOChip/GPIOChip.fbt`, and 13 files under `data/typelibrary/powerlink-3.0.0/typelib/` (`POWERLINK_MN.fbt`, `X20AI2622.fbt`, `X20AI4622.fbt`, `X20AO4622.fbt`, `X20AT2402.fbt`, `X20AT4222.fbt`, `X20DI4653.fbt`, `X20DI9371.fbt`, `X20DI9372.fbt`, `X20DO4623.fbt`, `X20DO4649.fbt`, `X20DO9321.fbt`, `X20DO9322.fbt`).
- Scope intentionally limited to `-3.0.0` libraries; the equivalent `-1.0.0` libraries have the same pattern but were left untouched.
- **Confirmed exception:** `data/typelibrary/events-3.0.0/typelib/E_TABLE_CTRL.fbt` has the same `INIT`/`Type="Event"` pattern but is deliberately left unchanged. `E_TABLE_CTRL` is used as an internal FB inside `E_TABLE.fbt`, which wires its own composite interface event `START` (`Type="Event"`) directly to `E_TABLE_CTRL.INIT`. Since an interface-to-internal event connection requires the destination type to be either generic (`Event`) or an exact name match, changing `E_TABLE_CTRL.INIT` to `Type="EInit"` would make that connection a type mismatch and break the build of `E_TABLE.fbt`.
- Per review feedback, this is an FB interface change, so bumped each of the 16 affected FB types' `VersionInfo` from `3.0` to `3.1`.

## Test plan
- Confirmed the `EInit` type is the dominant, established convention for `INIT`/`INITO` in these same `-3.0.0` libraries (e.g. `io-3.0.0/typelib/ADS/*`, `io-3.0.0/typelib/eIO/*`) before changing the outliers.
- Purely a type-attribute change on FB interface events; no attribute value/logic content changed.
- Verified the `E_TABLE_CTRL.fbt` exception against `org.eclipse.fordiac.ide.model`'s connection type-check (`ConnectionAnnotations.typeCheckIf2In` / `DataTypeAnnotations.isAssignableFrom(EventType, DataType)`), which rejects a connection from a generic `Event` source to a non-generic, non-matching destination type such as `EInit`.
- Verified the `3.0` → `3.1` version bump follows existing minor-bump precedent for interface/behavior changes in this repo (e.g. `data/typelibrary/events-3.0.0/typelib/timers/E_TON.fbt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XkvPsbNGhnQoVxxFsvtQCt
