### PR TITLE
Improve comments in TIMESTAMP_NS

### DIFF
--- a/data/typelibrary/utils-3.0.0/typelib/timing/TIMESTAMP_NS.fct
+++ b/data/typelibrary/utils-3.0.0/typelib/timing/TIMESTAMP_NS.fct
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Function Name="TIMESTAMP_NS" Comment="creates default a Unix-Epoch-Timestamp in nanoseconds use other start dates for other timestamp types">
+<Function Name="TIMESTAMP_NS" Comment="Creates by default a Unix-Epoch-Timestamp in nanoseconds. Use other start dates for other timestamp types.">
 	<Identification Standard="61499-1" Description="Copyright (c) 2024 Monika Wenger&#10;  &#10;This program and the accompanying materials are made &#10;available under the terms of the Eclipse Public License 2.0 &#10;which is available at https://www.eclipse.org/legal/epl-2.0/ &#10; &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.0.1" Author="Franz Höpfinger" Date="2026-09-02" Remarks="improved comments">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Version="1.0" Author="Monika Wenger" Date="2024-10-14">
@@ -27,9 +29,11 @@
 		</OutputVars>
 	</InterfaceList>
 	<FunctionBody>
-		<ST><![CDATA[FUNCTION TIMESTAMP_NS : ULINT
+		<ST><![CDATA[(* Creates by default a Unix-Epoch-Timestamp in nanoseconds. Use other start dates for other
+ * timestamp types. *)
+FUNCTION TIMESTAMP_NS : ULINT // the new timestamp in nanoseconds, default Unix-Epoch
 VAR_INPUT
-	startDate : DT := DT#1970-01-01-00:00:00;
+	startDate : DT := DT#1970-01-01-00:00:00; // the start date used to calculate different timestamp types
 END_VAR
 TIMESTAMP_NS := TIME_IN_NS_TO_ULINT(NOW() - startDate);
 END_FUNCTION


### PR DESCRIPTION
## Summary
- Reworded `data/typelibrary/utils-3.0.0/typelib/timing/TIMESTAMP_NS.fct`'s Function comment for grammar/punctuation.
- Added matching inline ST comments for the function signature and its `startDate` parameter.
- Bumped the type's own version to 3.0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8togXrcoFdUHuc2oi88yD