### PR TITLE
Register missing VarDeclaration search factories

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.search.st/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.model.search.st/plugin.xml
@@ -21,6 +21,12 @@
                type="org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration">
          </source>
          <source
+               type="org.eclipse.fordiac.ide.model.libraryElement.ContainerVarDeclaration">
+         </source>
+         <source
+               type="org.eclipse.fordiac.ide.model.libraryElement.VarConfigInstance">
+         </source>
+         <source
                type="org.eclipse.fordiac.ide.model.libraryElement.Attribute">
          </source>
          <source

--- a/plugins/org.eclipse.fordiac.ide.model.search.st/src/org/eclipse/fordiac/ide/model/search/st/StructuredTextSearchFactory.java
+++ b/plugins/org.eclipse.fordiac.ide.model.search.st/src/org/eclipse/fordiac/ide/model/search/st/StructuredTextSearchFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, 2023 Martin Erich Jobst
+ * Copyright (c) 2022 Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,15 +9,18 @@
  *
  * Contributors:
  *   Martin Jobst - initial API and implementation and/or initial documentation
+ *   Franz Höpfinger - register VarDeclaration subtypes for search support
  */
 package org.eclipse.fordiac.ide.model.search.st;
 
 import org.eclipse.fordiac.ide.model.data.DirectlyDerivedType;
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
+import org.eclipse.fordiac.ide.model.libraryElement.ContainerVarDeclaration;
 import org.eclipse.fordiac.ide.model.libraryElement.ECTransition;
 import org.eclipse.fordiac.ide.model.libraryElement.STAlgorithm;
 import org.eclipse.fordiac.ide.model.libraryElement.STFunctionBody;
 import org.eclipse.fordiac.ide.model.libraryElement.STMethod;
+import org.eclipse.fordiac.ide.model.libraryElement.VarConfigInstance;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.search.ISearchFactory;
 import org.eclipse.fordiac.ide.model.search.ISearchSupport;
@@ -57,6 +60,8 @@ public class StructuredTextSearchFactory implements ISearchFactory {
 		ISearchFactory.Registry.INSTANCE.registerFactory(STMethod.class, factory);
 		ISearchFactory.Registry.INSTANCE.registerFactory(STFunctionBody.class, factory);
 		ISearchFactory.Registry.INSTANCE.registerFactory(VarDeclaration.class, factory);
+		ISearchFactory.Registry.INSTANCE.registerFactory(ContainerVarDeclaration.class, factory);
+		ISearchFactory.Registry.INSTANCE.registerFactory(VarConfigInstance.class, factory);
 		ISearchFactory.Registry.INSTANCE.registerFactory(Attribute.class, factory);
 		ISearchFactory.Registry.INSTANCE.registerFactory(DirectlyDerivedType.class, factory);
 	}

--- a/tests/org.eclipse.fordiac.ide.test.model.search/src/org/eclipse/fordiac/ide/test/model/search/st/VarDeclarationSearchSupportTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model.search/src/org/eclipse/fordiac/ide/test/model/search/st/VarDeclarationSearchSupportTest.java
@@ -9,13 +9,21 @@
  *
  * Contributors:
  *   Martin Jobst - initial API and implementation and/or initial documentation
+ *   Franz Höpfinger - test search support registration for VarDeclaration subtypes
  *******************************************************************************/
 package org.eclipse.fordiac.ide.test.model.search.st;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
 import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes.ElementaryTypes;
+import org.eclipse.fordiac.ide.model.libraryElement.ContainerVarDeclaration;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.SimpleFBType;
+import org.eclipse.fordiac.ide.model.libraryElement.VarConfigInstance;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.search.CrossReferenceMatcher;
+import org.eclipse.fordiac.ide.model.search.ISearchFactory;
+import org.eclipse.fordiac.ide.model.search.st.VarDeclarationSearchSupport;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings({ "nls", "static-method" })
@@ -33,5 +41,20 @@ class VarDeclarationSearchSupportTest extends StructuredTextSearchSupportTest {
 		assertNoMatch(type.getInterfaceList().getInputVars().getFirst(), new CrossReferenceMatcher(varDeclaration));
 		assertMatch(type.getInterfaceList().getInputVars().getFirst(), new CrossReferenceMatcher(varDeclarationConst),
 				0, 0, 14);
+	}
+
+	@Test
+	void testContainerVarDeclarationHasSearchSupport() {
+		final ContainerVarDeclaration containerVarDeclaration = LibraryElementFactory.eINSTANCE
+				.createContainerVarDeclaration();
+		assertInstanceOf(VarDeclarationSearchSupport.class, ISearchFactory.createSearchSupport(containerVarDeclaration,
+				containerVarDeclaration.eClass().getInstanceClass()));
+	}
+
+	@Test
+	void testVarConfigInstanceHasSearchSupport() {
+		final VarConfigInstance varConfigInstance = LibraryElementFactory.eINSTANCE.createVarConfigInstance();
+		assertInstanceOf(VarDeclarationSearchSupport.class, ISearchFactory.createSearchSupport(varConfigInstance,
+				varConfigInstance.eClass().getInstanceClass()));
 	}
 }


### PR DESCRIPTION
## Summary
- `Organize Imports` (and, by the same mechanism, the unused-import check) never correctly detected usage of a Global Constant referenced from an FB-instance `Parameter` that is mirrored through an adapter interface (e.g. an `Input`/`Output` pin on an IXA/QXA-style wrapper FB), regardless of whether the referenced constant was defined locally or in an external library. In the worst case (a wildcard import combined with such a parameter) the existing import got deleted outright instead of kept or corrected.
- Root cause: such parameters are modeled as `ContainerVarDeclaration` or `VarConfigInstance` - both subtypes of `VarDeclaration` - but the `org.eclipse.fordiac.ide.model.search.factory` extension point in `org.eclipse.fordiac.ide.model.search.st/plugin.xml` only declared the plain `VarDeclaration` type as a source. Since `ISearchFactory`'s registry does an exact-class lookup (no supertype matching), `ISearchFactory.createSearchSupport()` returned `null` for these subtypes, so `OrganizeImportsCommand`'s whole-model traversal silently skipped them - the import-usage computation never saw the reference at all.
- Registered the two subtypes alongside `VarDeclaration`, both in the extension point (what the running IDE actually uses) and in `StructuredTextSearchFactory.register()` (the equivalent path used by unit tests, so both stay in sync).

Verified against a real reproduction project: an FB-instance `Output` parameter referencing an external-library Global Constant is now correctly recognized, its import gets re-added when missing, and it's no longer dropped when running Organize Imports with a wildcard import present.

This addresses the "External Libraries" part of #2816. A second, independent root cause reported under the same issue (the `TypeHash` attribute pulling in a needless import) is fixed separately in #2829.

## Test plan
- Added `VarDeclarationSearchSupportTest.test{ContainerVarDeclaration,VarConfigInstance}HasSearchSupport`, each asserting `ISearchFactory.createSearchSupport(...)` returns a `VarDeclarationSearchSupport` instance instead of `null`. Confirmed these tests fail without the fix and pass with it.
- Manually verified end-to-end in a real project: an `Output` parameter referencing an external-library constant is correctly re-imported by Organize Imports after the fix (previously required manually re-adding the import, and a related wildcard-import case had the import deleted outright).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8togXrcoFdUHuc2oi88yD