### PR TITLE
Exclude TypeHash attribute from Organize Imports

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model.search.st/src/org/eclipse/fordiac/ide/model/search/st/AttributeSearchSupport.java
+++ b/plugins/org.eclipse.fordiac.ide.model.search.st/src/org/eclipse/fordiac/ide/model/search/st/AttributeSearchSupport.java
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *   Martin Jobst - initial API and implementation and/or initial documentation
+ *   Franz Höpfinger - exclude TypeHash attribute from imported namespaces
  */
 package org.eclipse.fordiac.ide.model.search.st;
 
@@ -20,6 +21,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.fordiac.ide.model.data.AnyType;
 import org.eclipse.fordiac.ide.model.helpers.PackageNameHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 import org.eclipse.fordiac.ide.structuredtextalgorithm.util.STAlgorithmParseUtil;
 import org.eclipse.xtext.parser.IParseResult;
 
@@ -35,7 +37,8 @@ public class AttributeSearchSupport extends StructuredTextSearchSupport {
 	public Set<String> getImportedNamespaces() {
 		final Set<String> result = super.getImportedNamespaces();
 		if (attribute.getAttributeDeclaration() != null) {
-			if (!PackageNameHelper.getPackageName(attribute.getAttributeDeclaration()).isEmpty()) {
+			if (!TypeLibraryTags.TYPE_HASH_ATTRIBUTE_FULL_NAME.equalsIgnoreCase(attribute.getName())
+					&& !PackageNameHelper.getPackageName(attribute.getAttributeDeclaration()).isEmpty()) {
 				result.add(PackageNameHelper.getFullTypeName(attribute.getAttributeDeclaration()));
 			}
 		} else if (!PackageNameHelper.getPackageName(attribute.getType()).isEmpty()) {

--- a/tests/org.eclipse.fordiac.ide.test.model.search/src/org/eclipse/fordiac/ide/test/model/search/st/AttributeSearchSupportTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model.search/src/org/eclipse/fordiac/ide/test/model/search/st/AttributeSearchSupportTest.java
@@ -9,13 +9,22 @@
  *
  * Contributors:
  *   Martin Jobst - initial API and implementation and/or initial documentation
+ *   Franz Höpfinger - test for TypeHash import exclusion
  *******************************************************************************/
 package org.eclipse.fordiac.ide.test.model.search.st;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes.ElementaryTypes;
+import org.eclipse.fordiac.ide.model.libraryElement.Attribute;
+import org.eclipse.fordiac.ide.model.libraryElement.AttributeDeclaration;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
 import org.eclipse.fordiac.ide.model.libraryElement.SimpleFBType;
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 import org.eclipse.fordiac.ide.model.search.CrossReferenceMatcher;
+import org.eclipse.fordiac.ide.model.search.ISearchFactory;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings({ "nls", "static-method" })
@@ -33,5 +42,35 @@ class AttributeSearchSupportTest extends StructuredTextSearchSupportTest {
 		type.getAttributes().add(createAttribute("TestAttribute", ElementaryTypes.DINT, "INTERNALCONST2 * 2"));
 		assertNoMatch(type.getAttributes().getFirst(), new CrossReferenceMatcher(varDeclarationConst));
 		assertMatch(type.getAttributes().getFirst(), new CrossReferenceMatcher(varDeclarationConst2), 0, 0, 14);
+	}
+
+	@Test
+	void testTypeHashAttributeExcludedFromImportedNamespaces() {
+		final Attribute attribute = createDeclaredAttribute(TypeLibraryTags.TYPE_HASH_ATTRIBUTE_FULL_NAME,
+				TypeLibraryTags.TYPE_HASH_ATTRIBUTE_NAME, "eclipse4diac::core");
+		final var namespaces = ISearchFactory.createSearchSupport(attribute, Attribute.class).getImportedNamespaces();
+		assertFalse(namespaces.contains("eclipse4diac::core::TypeHash"),
+				"TypeHash must not be reported as an imported namespace");
+	}
+
+	@Test
+	void testOtherAttributeIncludedInImportedNamespaces() {
+		final Attribute attribute = createDeclaredAttribute("some::package::OtherAttribute", "OtherAttribute",
+				"some::package");
+		final var namespaces = ISearchFactory.createSearchSupport(attribute, Attribute.class).getImportedNamespaces();
+		assertTrue(namespaces.contains("some::package::OtherAttribute"),
+				"a non-TypeHash attribute declaration must still be reported as an imported namespace");
+	}
+
+	private static Attribute createDeclaredAttribute(final String attributeName, final String declarationName,
+			final String packageName) {
+		final AttributeDeclaration declaration = LibraryElementFactory.eINSTANCE.createAttributeDeclaration();
+		declaration.setName(declarationName);
+		final var compilerInfo = LibraryElementFactory.eINSTANCE.createCompilerInfo();
+		compilerInfo.setPackageName(packageName);
+		declaration.setCompilerInfo(compilerInfo);
+		final Attribute attribute = createAttribute(attributeName, ElementaryTypes.STRING, "''");
+		attribute.setAttributeDeclaration(declaration);
+		return attribute;
 	}
 }


### PR DESCRIPTION
## Summary
- Whenever a type file carries the tool-managed `<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>` bookkeeping attribute, Organize Imports added a functionally useless `<Import declaration="eclipse4diac::core::TypeHash"/>` to it.
- `TypeHash` is a real, resolvable `AttributeType` (`data/typelibrary/core-3.0.0/typelib/TypeHash.atp`, package `eclipse4diac::core`), so `AttributeSearchSupport.getImportedNamespaces()` correctly found it had a non-empty package and added its namespace - but its XML `Name` is already the fully-qualified name, so resolution never actually depends on ST scoping or an import. `TypeHash` isn't in `InternalAttributeDeclarations.allAttributes` either (that list only covers synthetic Java-only attributes like `VAR_CONFIG`/`VISIBLE`), so none of the existing `isInternalAttribute()` checks caught this case.
- Added a specific exclusion for `TypeHash` in `AttributeSearchSupport.getImportedNamespaces()`.

This is one of the symptoms reported under #2816 - a separate, independent root cause from the External-Library import-resolution issue also reported there (unrelated code paths, fixed separately in #2828).

## Test plan
- Added `AttributeSearchSupportTest.testTypeHashAttributeExcludedFromImportedNamespaces` (asserts the namespace is not reported) and `testOtherAttributeIncludedInImportedNamespaces` (asserts a non-`TypeHash` attribute declaration still is, so the general mechanism isn't weakened). Confirmed the first test fails without the fix and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8togXrcoFdUHuc2oi88yD