### PR TITLE
Fix Service comment being read onto the wrong element

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/BlockTypeImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/BlockTypeImporter.java
@@ -20,6 +20,7 @@
  *  Martin Jobst - refactor marker handling
  *  Alois Zoitl  - updated for new adapter FB handling
  *  Martin Jobst - extract interface importer
+ *  Franz Höpfinger - fix Service comment being read onto the wrong element
  ********************************************************************************/
 package org.eclipse.fordiac.ide.model.dataimport;
 
@@ -122,7 +123,7 @@ public abstract class BlockTypeImporter extends TypeImporter {
 		final ServiceInterface leftInter = LibraryElementFactory.eINSTANCE.createServiceInterface();
 		leftInter.setName(leftInterface);
 		type.getService().setLeftInterface(leftInter);
-		readCommentAttribute(type);
+		readCommentAttribute().ifPresent(type.getService()::setComment);
 
 		processChildren(LibraryElementTags.SERVICE_ELEMENT, name -> {
 			if (LibraryElementTags.SERVICE_SEQUENCE_ELEMENT.equals(name)) {

--- a/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/dataimport/ServiceCommentImportExportTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.model/src/org/eclipse/fordiac/ide/test/model/dataimport/ServiceCommentImportExportTest.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Franz Höpfinger
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Franz Höpfinger - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.test.model.dataimport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.InputStream;
+
+import org.eclipse.fordiac.ide.model.dataexport.FbtExporter;
+import org.eclipse.fordiac.ide.model.dataimport.FBTImporter;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
+import org.eclipse.fordiac.ide.model.libraryElement.Service;
+import org.eclipse.fordiac.ide.model.libraryElement.ServiceInterface;
+import org.eclipse.fordiac.ide.model.libraryElement.ServiceInterfaceFBType;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("nls")
+class ServiceCommentImportExportTest {
+
+	@Test
+	void reimportedServiceKeepsItsComment() throws Exception {
+		final ServiceInterfaceFBType type = LibraryElementFactory.eINSTANCE.createServiceInterfaceFBType();
+		type.setName("Test");
+		type.setInterfaceList(LibraryElementFactory.eINSTANCE.createInterfaceList());
+
+		final Service service = LibraryElementFactory.eINSTANCE.createService();
+		service.setRightInterface(createServiceInterface("RESOURCE"));
+		service.setLeftInterface(createServiceInterface("APPLICATION"));
+		service.setComment("Subscribe to a PUBLISH_10 Block");
+		type.setService(service);
+
+		final TypeLibrary typeLib = TypeLibraryManager.INSTANCE.getTypeLibrary(null);
+		final ServiceInterfaceFBType reimported;
+		try (InputStream exported = new FbtExporter(type).getFileContent()) {
+			final FBTImporter importer = new FBTImporter(exported, typeLib);
+			importer.loadElement();
+			reimported = (ServiceInterfaceFBType) importer.getElement();
+		}
+
+		assertEquals(service.getComment(), reimported.getService().getComment());
+	}
+
+	private static ServiceInterface createServiceInterface(final String name) {
+		final ServiceInterface result = LibraryElementFactory.eINSTANCE.createServiceInterface();
+		result.setName(name);
+		return result;
+	}
+}


### PR DESCRIPTION
## What & why

Opening a `.fbt` file with a `ServiceInterfaceFBType`'s `Service`
`Comment` attribute set, then saving it again, silently dropped the
comment - see #2584. Same symptom class as #2520 (`ECTransition`
comments), fixed for that element in #2521.

## Root cause

`BlockTypeImporter.parseService(FBType type)` called
`readCommentAttribute(type)` - but `readCommentAttribute(INamedElement)`
sets the comment on the `INamedElement` it's given, and `type` here is
the *containing* `FBType`, not the `Service` being parsed (`Service`
isn't itself an `INamedElement`, so it couldn't be passed directly).
This silently set the `FBType`'s own comment instead of the
`Service`'s.

Since `FbtExporter`'s `addService()` already correctly writes
`sfb.getService().getComment()`, a comment set through the UI *was*
present in the file after the first save - but because it was never
read back into `Service.comment` on the next import, that in-memory
value was empty, and the following save wrote out an empty comment,
i.e. none at all.

## Fix

Read the comment value and set it on `type.getService()` directly,
using the same `readCommentAttribute()` (no-arg, returns
`Optional<String>`) helper introduced by #2521 for the analogous fix.

## Verified

Added `ServiceCommentImportExportTest`: builds a `ServiceInterfaceFBType`
with a `Service` comment in memory, exports it via `FbtExporter`,
re-imports the result via `FBTImporter`, and asserts the comment
survived the round trip. Confirmed it fails (`expected: <...> but was:
<>`) without the fix and passes with it.

Also verified manually: an `.fbt` with a `Service Comment="..."`
attribute now keeps the comment across an open/save cycle instead of
losing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


- https://github.com/eclipse-4diac/4diac-ide/issues/2584
- https://github.com/eclipse-4diac/4diac-ide/issues/2520
- https://github.com/eclipse-4diac/4diac-ide/pull/2521