### PR TITLE
Register missing VarDeclaration types for forte_ng codegen

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/plugin.xml
@@ -25,6 +25,12 @@
                type="org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration">
          </source>
          <source
+               type="org.eclipse.fordiac.ide.model.libraryElement.ContainerVarDeclaration">
+         </source>
+         <source
+               type="org.eclipse.fordiac.ide.model.libraryElement.VarConfigInstance">
+         </source>
+         <source
                type="org.eclipse.fordiac.ide.model.libraryElement.STFunctionBody">
          </source>
       </factory>

--- a/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/StructuredTextSupportFactory.xtend
+++ b/plugins/org.eclipse.fordiac.ide.export.forte_ng.st/src/org/eclipse/fordiac/ide/export/forte_ng/st/StructuredTextSupportFactory.xtend
@@ -9,16 +9,19 @@
  * 
  * Contributors:
  *   Martin Jobst - initial API and implementation and/or initial documentation
+ *   Franz Höpfinger - register VarDeclaration subtypes for forte_ng codegen
  *******************************************************************************/
 package org.eclipse.fordiac.ide.export.forte_ng.st
 
 import java.util.Map
 import org.eclipse.fordiac.ide.export.language.ILanguageSupportFactory
 import org.eclipse.fordiac.ide.globalconstantseditor.globalConstants.STGlobalConstsSource
+import org.eclipse.fordiac.ide.model.libraryElement.ContainerVarDeclaration
 import org.eclipse.fordiac.ide.model.libraryElement.ECTransition
 import org.eclipse.fordiac.ide.model.libraryElement.STAlgorithm
 import org.eclipse.fordiac.ide.model.libraryElement.STFunctionBody
 import org.eclipse.fordiac.ide.model.libraryElement.STMethod
+import org.eclipse.fordiac.ide.model.libraryElement.VarConfigInstance
 import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration
 import org.eclipse.fordiac.ide.structuredtextfunctioneditor.stfunction.STFunctionSource
 
@@ -50,6 +53,8 @@ class StructuredTextSupportFactory implements ILanguageSupportFactory {
 		ILanguageSupportFactory.Registry.INSTANCE.registerFactory("forte_ng", STFunctionSource, factory)
 		ILanguageSupportFactory.Registry.INSTANCE.registerFactory("forte_ng", STGlobalConstsSource, factory)
 		ILanguageSupportFactory.Registry.INSTANCE.registerFactory("forte_ng", VarDeclaration, factory)
+		ILanguageSupportFactory.Registry.INSTANCE.registerFactory("forte_ng", ContainerVarDeclaration, factory)
+		ILanguageSupportFactory.Registry.INSTANCE.registerFactory("forte_ng", VarConfigInstance, factory)
 		ILanguageSupportFactory.Registry.INSTANCE.registerFactory("forte_ng", STFunctionBody, factory)
 	}
 }

--- a/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/CompositeFBStructValueExportTest.java
+++ b/tests/org.eclipse.fordiac.ide.test.export/src/org/eclipse/fordiac/ide/test/export/CompositeFBStructValueExportTest.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Franz Höpfinger
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Franz Höpfinger - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.fordiac.ide.test.export;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.fordiac.ide.model.data.DataFactory;
+import org.eclipse.fordiac.ide.model.data.StructuredType;
+import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes.ElementaryTypes;
+import org.eclipse.fordiac.ide.model.helpers.BlockInstanceFactory;
+import org.eclipse.fordiac.ide.model.libraryElement.CompositeFBType;
+import org.eclipse.fordiac.ide.model.libraryElement.FB;
+import org.eclipse.fordiac.ide.model.libraryElement.FBNetwork;
+import org.eclipse.fordiac.ide.model.libraryElement.LibraryElementFactory;
+import org.eclipse.fordiac.ide.model.libraryElement.SimpleFBType;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
+import org.eclipse.fordiac.ide.model.resource.FordiacTypeResourceFactory;
+import org.eclipse.fordiac.ide.model.typelibrary.FBTypeEntry;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibrary;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryManager;
+import org.eclipse.fordiac.ide.model.typelibrary.TypeLibraryTags;
+import org.eclipse.fordiac.ide.test.model.typelibrary.DataTypeEntryMock;
+import org.eclipse.fordiac.ide.test.model.typelibrary.FBTypeEntryMock;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that a struct literal assigned to a struct-typed input variable of
+ * a plain (non-adapter) FB instance is exported with that value as the
+ * generated assignment's right-hand side.
+ */
+@SuppressWarnings("nls")
+class CompositeFBStructValueExportTest extends ExporterTestBase<CompositeFBType> {
+
+	private static final String STRUCT_TYPE_NAME = "TestScrollStruct";
+	private static final String LEAF_FB_NAME = "TestLeafFB";
+	private static final String LEAF_INSTANCE_NAME = "LeafInstance";
+	private static final String STRUCT_VAR_NAME = "InputEvent";
+	private static final String STRUCT_LITERAL_VALUE = "(code := 255, bCyclic := TRUE)";
+
+	@Override
+	void setupFunctionBlock() {
+		final TypeLibrary typeLib = TypeLibraryManager.INSTANCE.getTypeLibrary(null);
+
+		final StructuredType structType = DataFactory.eINSTANCE.createStructuredType();
+		structType.setName(STRUCT_TYPE_NAME);
+		structType.getMemberVariables().add(createStructMember("code", ElementaryTypes.DINT));
+		structType.getMemberVariables().add(createStructMember("bCyclic", ElementaryTypes.BOOL));
+		typeLib.addTypeEntry(new DataTypeEntryMock(structType, typeLib, null));
+		FordiacTypeResourceFactory.INSTANCE
+				.createResource(URI.createFileURI(STRUCT_TYPE_NAME + TypeLibraryTags.DATA_TYPE_FILE_ENDING_WITH_DOT))
+				.getContents().add(structType);
+
+		final SimpleFBType leafType = LibraryElementFactory.eINSTANCE.createSimpleFBType();
+		leafType.setName(LEAF_FB_NAME);
+		leafType.setInterfaceList(LibraryElementFactory.eINSTANCE.createInterfaceList());
+		leafType.getInterfaceList().getInputVars().add(createStructMember(STRUCT_VAR_NAME, structType));
+		final FBTypeEntry leafEntry = new FBTypeEntryMock(leafType, typeLib, null);
+		typeLib.addTypeEntry(leafEntry);
+		FordiacTypeResourceFactory.INSTANCE
+				.createResource(URI.createFileURI(LEAF_FB_NAME + TypeLibraryTags.FB_TYPE_FILE_ENDING_WITH_DOT))
+				.getContents().add(leafType);
+
+		final FB leafInstance = BlockInstanceFactory.createFBInstanceForTypeEntry(leafEntry);
+		leafInstance.setName(LEAF_INSTANCE_NAME);
+		leafInstance.setInterface(leafEntry.getInterface().instanceCopy());
+		leafInstance.setTypeEntry(leafEntry);
+		leafInstance.getInterface().getVariable(STRUCT_VAR_NAME).setValueString(STRUCT_LITERAL_VALUE);
+
+		functionBlock = LibraryElementFactory.eINSTANCE.createCompositeFBType();
+		functionBlock.setInterfaceList(LibraryElementFactory.eINSTANCE.createInterfaceList());
+		functionBlock.setName(COMPOSITEFUNCTIONBLOCK_NAME);
+		final FBNetwork fbNetwork = LibraryElementFactory.eINSTANCE.createFBNetwork();
+		fbNetwork.getNetworkElements().add(leafInstance);
+		functionBlock.setFBNetwork(fbNetwork);
+		functionBlock.setTypeEntry(prepareTypeEntryWithTypeLib());
+	}
+
+	@Test
+	void structLiteralValueOnPlainFbInstanceIsExported() {
+		final List<FileObject> files = generateFunctionBlock(functionBlock);
+		final FileObject implFile = files.stream().filter(f -> f.getName().endsWith(".cpp")).findFirst()
+				.orElseThrow(() -> new AssertionError("No .cpp file was generated"));
+		final String content = implFile.getData().toString();
+		final String expectedAssignment = "fb_" + LEAF_INSTANCE_NAME + "->var_" + STRUCT_VAR_NAME + " = ";
+		final int assignmentIndex = content.indexOf(expectedAssignment);
+		assertTrue(assignmentIndex >= 0, () -> "Expected to find \"" + expectedAssignment + "\" in:\n" + content);
+		final int lineEnd = content.indexOf(';', assignmentIndex);
+		final String rightHandSide = content.substring(assignmentIndex + expectedAssignment.length(), lineEnd).strip();
+		assertTrue(!rightHandSide.isEmpty(),
+				() -> "Expected a non-empty initializer for " + STRUCT_VAR_NAME + ", but the assignment was empty");
+	}
+
+	private static VarDeclaration createStructMember(final String name, final org.eclipse.fordiac.ide.model.data.DataType type) {
+		final VarDeclaration member = LibraryElementFactory.eINSTANCE.createVarDeclaration();
+		member.setName(name);
+		member.setType(type);
+		return member;
+	}
+}


### PR DESCRIPTION
## What & why

A regular (non-adapter) FB instance's struct-typed input variable,
given a value (either a plain global-constant reference, or a bare
struct literal like `(code := 255, bCyclic := TRUE)`), was exported
with an empty right-hand side, producing invalid C++ - see #2737. PR
#2743 already fixed the same symptom for adapter parameters; this
covers a separate, still-open path for plain FB instances.

## Root cause

Same bug class as #2828 (a different registry, same mistake). When a
regular `VarDeclaration`'s declared type is a `StructuredType`,
`InterfaceListCopier`/`VarDeclarationFactory` creates a
`ContainerVarDeclaration` for the per-instance copy (used for later
struct-member decomposition) instead of a plain `VarDeclaration`. The
forte_ng codegen's `ILanguageSupportFactory.Registry` does an
exact-class lookup (no supertype matching) keyed by
`org.eclipse.fordiac.ide.export.language.supportFactory`'s declared
`<source type="...">` entries, which only listed the plain
`VarDeclaration` type. So `ILanguageSupportFactory.createLanguageSupport("forte_ng", ...)`
returned `null` for the `ContainerVarDeclaration` case *before* ever
reaching `StructuredTextSupportFactory`'s own `instanceof VarDeclaration`
dispatch (which already handles it correctly, polymorphically) -
`CompositeFBImplTemplate`'s
`fbNetworkInitialVariableLanguageSupport` map then legitimately stored
`null` for that variable, and `generateFBNetworkInitialValue` silently
generated nothing for it.

## Fix

Register `ContainerVarDeclaration` and `VarConfigInstance` alongside
`VarDeclaration`, both in the extension point (what the running IDE
actually uses) and in `StructuredTextSupportFactory.register()` (the
equivalent path used by unit tests, so both stay in sync).

## Verified

Added `CompositeFBStructValueExportTest`: builds a composite FB
containing a plain (non-adapter) FB instance whose struct-typed input
variable has a struct-literal value, runs the actual forte_ng export
headlessly, and asserts the generated `setFBNetworkInitialValues()`
assignment is non-empty. Confirmed it fails
(`fb_LeafInstance->var_InputEvent = ;`) without the fix and passes
(`... = forte::CIEC_TestScrollStruct(255_DINT, true_BOOL);`) with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


- https://github.com/eclipse-4diac/4diac-ide/issues/2737
