### PR TITLE
Preserve whitespace around top-level comments in ST partitioner

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.tests/src/org/eclipse/fordiac/ide/structuredtextalgorithm/tests/STAlgorithmPartitionerTest.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.tests/src/org/eclipse/fordiac/ide/structuredtextalgorithm/tests/STAlgorithmPartitionerTest.java
@@ -65,6 +65,11 @@ class STAlgorithmPartitionerTest {
 	}
 
 	@Test
+	void testCombineEmpty() {
+		assertEquals("", partitioner.combine(createSimpleFBType()));
+	}
+
+	@Test
 	void testCombine() {
 		final SimpleFBType fbType = createSimpleFBType();
 		final String text = """
@@ -137,6 +142,68 @@ class STAlgorithmPartitionerTest {
 	}
 
 	@Test
+	void testCombineLostAndFound() {
+		final SimpleFBType fbType = createSimpleFBType();
+		final String algorithm = """
+				ALGORITHM REQ
+				END_ALGORITHM
+				""";
+		fbType.getCallables().add(createSTAlgorithm("REQ", ""));
+		final String lostAndFound = """
+
+
+				""";
+		fbType.getCallables().add(createSTMethod("LOST_AND_FOUND_1", "\n\n\n"));
+		final String method = """
+				METHOD TEST
+				END_METHOD
+				""";
+		fbType.getCallables().add(createSTMethod("TEST", ""));
+		assertEquals(algorithm + lostAndFound + method, partitioner.combine(fbType));
+	}
+
+	@Test
+	void testCombineLostAndFoundLegacy() {
+		final SimpleFBType fbType = createSimpleFBType();
+		final String algorithm = """
+				ALGORITHM REQ
+				END_ALGORITHM
+				""".stripTrailing();
+		fbType.getCallables().add(createSTAlgorithm("REQ", algorithm));
+		final String lostAndFound = "// comment\n";
+		fbType.getCallables().add(createSTMethod("LOST_AND_FOUND_1", lostAndFound));
+		final String method = """
+				METHOD TEST
+				END_METHOD
+				""";
+		fbType.getCallables().add(createSTMethod("TEST", method));
+		assertEquals(algorithm + lostAndFound + method, partitioner.combine(fbType));
+	}
+
+	@Test
+	void testCombineTrailingBodyWhitespace() {
+		final SimpleFBType fbType = createSimpleFBType();
+		final String text = """
+				ALGORITHM REQ
+				OUT := TRUE;\s
+				END_ALGORITHM
+				""";
+		fbType.getCallables().add(createSTAlgorithm("REQ", "OUT := TRUE; "));
+		assertEquals(text, partitioner.combine(fbType));
+	}
+
+	@Test
+	void testCombineLeadingBodyWhitespace() {
+		final SimpleFBType fbType = createSimpleFBType();
+		final String text = """
+				ALGORITHM REQ OUT := TRUE;
+				END_ALGORITHM
+				""";
+		fbType.getCallables().add(createSTAlgorithm("REQ", " OUT := TRUE;"));
+		assertEquals(text, partitioner.combine(fbType));
+	}
+
+	@Test
 	void testPartition() throws Exception {
 		assertCallablesEquals(List.of(), partition(""));
 		assertCallablesEquals(List.of("error"), partition("error"));
@@ -149,7 +216,7 @@ class STAlgorithmPartitionerTest {
 				METHOD TEST
 				END_METHOD
 				""";
-		assertCallablesEquals(List.of("", ""), partition(algorithm + method));
+		assertCallablesEquals(List.of("", ""), partition(algorithm + CommonElementExporter.LINE_END + method));
 	}
 
 	@Test
@@ -172,6 +239,98 @@ class STAlgorithmPartitionerTest {
 				END_METHOD
 				""";
 		assertCallablesEquals(List.of("// inner comment 1", "// outer comment", "// inner comment 2"), partition(text));
+	}
+
+	@Test
+	void testPartitionCombine() throws Exception {
+		final String text = """
+				ALGORITHM REQ
+				END_ALGORITHM
+
+				METHOD TEST
+				// inner comment
+				END_METHOD
+
+
+				METHOD TEST2
+				// inner comment
+				END_METHOD
+				METHOD TEST3
+				// inner comment
+				END_METHOD
+				""";
+		assertPartitionCombine(text);
+	}
+
+	@Test
+	void testPartitionCombineComment() throws Exception {
+		final String text = """
+				// outer leading comment
+				ALGORITHM REQ
+				END_ALGORITHM
+
+				// outer comment
+				METHOD TEST // inner comment
+				END_METHOD // end-of-line comment
+
+				// outer comment 2
+
+				METHOD TEST2
+				 // inner comment with leading space
+				END_METHOD// end-of-line comment w/o space
+
+				METHOD TEST3
+
+				// inner comment
+
+				END_METHOD
+				// last comment
+				""";
+		assertPartitionCombine(text);
+	}
+
+	@Test
+	void testPartitionCombineLeadingWhitespace() throws Exception {
+		final String text = """
+
+				ALGORITHM REQ
+				END_ALGORITHM
+				""";
+		assertPartitionCombine(text);
+	}
+
+	@Test
+	void testPartitionCombineTrailingWhitespace() throws Exception {
+		final String text = """
+				ALGORITHM REQ
+				END_ALGORITHM
+				\s
+				""";
+		final String expected = """
+				ALGORITHM REQ
+				END_ALGORITHM
+				""";
+		assertPartitionCombine(expected, text);
+	}
+
+	@Test
+	void testPartitionCombineWhitespaceInSeparator() throws Exception {
+		final String text = """
+				ALGORITHM REQ
+				END_ALGORITHM
+				\s
+				METHOD TEST
+				END_METHOD
+				""";
+		assertPartitionCombine(text);
+	}
+
+	@Test
+	void testPartitionCombineWhitespaceOnly() throws Exception {
+		final String text = """
+
+				""";
+		assertPartitionCombine(text);
 	}
 
 	private static SimpleFBType createSimpleFBType() {
@@ -203,6 +362,16 @@ class STAlgorithmPartitionerTest {
 		assertTrue(partition.get() instanceof STAlgorithmPartition);
 		assertEquals(text, partition.get().getOriginalSource());
 		return (STAlgorithmPartition) partition.get();
+	}
+
+	private void assertPartitionCombine(final String text) throws Exception {
+		assertPartitionCombine(text, text);
+	}
+
+	private void assertPartitionCombine(final String expected, final String original) throws Exception {
+		final SimpleFBType fbType = createSimpleFBType();
+		fbType.getCallables().addAll(partition(original).getCallables());
+		assertEquals(expected, partitioner.combine(fbType));
 	}
 
 	private static void assertCallablesEquals(final List<String> expected, final STAlgorithmPartition actual) {

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm/src/org/eclipse/fordiac/ide/structuredtextalgorithm/util/STAlgorithmPartitioner.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm/src/org/eclipse/fordiac/ide/structuredtextalgorithm/util/STAlgorithmPartitioner.java
@@ -15,7 +15,6 @@ package org.eclipse.fordiac.ide.structuredtextalgorithm.util;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.fordiac.ide.model.dataexport.CommonElementExporter;
@@ -55,8 +54,34 @@ public class STAlgorithmPartitioner extends STRecoveringPartitioner<STAlgorithmS
 	}
 
 	public String combine(final List<? extends ICallable> callables) {
-		return callables.stream().map(this::toSTText).collect(Collectors.joining(
-				CommonElementExporter.LINE_END + CommonElementExporter.LINE_END, "", CommonElementExporter.LINE_END)); //$NON-NLS-1$
+		final StringBuilder builder = new StringBuilder();
+		ICallable last = null;
+		for (final ICallable callable : callables) {
+			final String text = toSTText(callable);
+			appendSeparator(builder, last, callable, text);
+			builder.append(text);
+			last = callable;
+		}
+		// ensure newline at the end
+		if (!builder.isEmpty() && !isLineDelimiter(builder.charAt(builder.length() - 1))) {
+			builder.append(CommonElementExporter.LINE_END);
+		}
+		return builder.toString();
+	}
+
+	private static void appendSeparator(final StringBuilder builder, final ICallable previous, final ICallable current,
+			final String text) {
+		if (builder.isEmpty() || text.isEmpty()) {
+			return;
+		}
+		if (!isLostAndFound(current) && !isLostAndFound(previous)) {
+			// add empty line, except around lost+found
+			builder.append(CommonElementExporter.LINE_END);
+			builder.append(CommonElementExporter.LINE_END);
+		} else if (isWordCharacter(builder.charAt(builder.length() - 1)) && isWordCharacter(text.charAt(0))) {
+			// add line separator if appended text has no word boundary
+			builder.append(CommonElementExporter.LINE_END);
+		}
 	}
 
 	public String toSTText(final ICallable callable) {
@@ -86,10 +111,11 @@ public class STAlgorithmPartitioner extends STRecoveringPartitioner<STAlgorithmS
 	}
 
 	private String toSTText(final STMethod method) {
-		final String name = method.getName();
 		final String text = method.getText();
-		if ((name != null && name.startsWith(LOST_AND_FOUND_NAME))
-				|| containsToken(text, InternalSTAlgorithmLexer.METHOD)) {
+		if (isLostAndFound(method)) {
+			return text;
+		}
+		if (containsToken(text, InternalSTAlgorithmLexer.METHOD)) {
 			return text.trim();
 		}
 		return generateMethodDefinition(method);
@@ -211,5 +237,10 @@ public class STAlgorithmPartitioner extends STRecoveringPartitioner<STAlgorithmS
 		default:
 			break;
 		}
+	}
+
+	private static boolean isLostAndFound(final ICallable callable) {
+		return callable instanceof STMethod && callable.getName() != null
+				&& callable.getName().startsWith(LOST_AND_FOUND_NAME);
 	}
 }

--- a/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/util/STRecoveringPartitioner.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextcore/src/org/eclipse/fordiac/ide/structuredtextcore/util/STRecoveringPartitioner.java
@@ -98,9 +98,20 @@ public abstract class STRecoveringPartitioner<S extends EObject, E extends IName
 	protected void handleLostAndFound(final ICompositeNode rootNode, final int start, final int end,
 			final List<E> result) {
 		final String text = rootNode.getText().substring(start, end);
-		if (!text.isBlank()) {
-			result.add(createLostAndFound(text.trim(), result.size()));
+		if (!text.isEmpty() && shouldPreserveText(rootNode, start, end, text)) {
+			result.add(createLostAndFound(text, result.size()));
 		}
+	}
+
+	private static boolean shouldPreserveText(final ICompositeNode rootNode, final int start, final int end,
+			final String text) {
+		// preserve text if it is non-blank, at the beginning, or a non-canonical
+		// separator before the end, ignore blank text at the end
+		return !text.isBlank() || start == 0 || (end < rootNode.getTotalEndOffset() && isNonCanonicalSeparator(text));
+	}
+
+	private static boolean isNonCanonicalSeparator(final String text) {
+		return !text.equals(CommonElementExporter.LINE_END + CommonElementExporter.LINE_END);
 	}
 
 	protected static String generateLostAndFoundName(final int index) {
@@ -127,13 +138,21 @@ public abstract class STRecoveringPartitioner<S extends EObject, E extends IName
 	}
 
 	protected static void appendText(final String text, final StringBuilder builder) {
-		if (!text.startsWith(CommonElementExporter.LINE_END)) {
+		if (text.isEmpty() || !Character.isWhitespace(text.charAt(0))) {
 			builder.append(CommonElementExporter.LINE_END);
 		}
 		builder.append(text);
-		if (!text.endsWith(CommonElementExporter.LINE_END) && !text.isEmpty()) {
+		if (!text.isEmpty() && !isLineDelimiter(text.charAt(text.length() - 1))) {
 			builder.append(CommonElementExporter.LINE_END);
 		}
+	}
+
+	protected static boolean isLineDelimiter(final char c) {
+		return c == '\n' || c == '\r';
+	}
+
+	protected static boolean isWordCharacter(final char c) {
+		return Character.isLetterOrDigit(c) || c == '_';
 	}
 
 	protected static String getText(final INode node) {

--- a/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.tests/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/tests/STFunctionPartitionerTest.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextfunctioneditor.tests/src/org/eclipse/fordiac/ide/structuredtextfunctioneditor/tests/STFunctionPartitionerTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.eclipse.fordiac.ide.model.data.DataType;
+import org.eclipse.fordiac.ide.model.dataexport.CommonElementExporter;
 import org.eclipse.fordiac.ide.model.datatype.helper.IecTypes.ElementaryTypes;
 import org.eclipse.fordiac.ide.model.helpers.ArraySizeHelper;
 import org.eclipse.fordiac.ide.model.libraryElement.FunctionFBType;
@@ -202,7 +203,8 @@ class STFunctionPartitionerTest {
 				FUNCTION TEST2
 				END_FUNCTION
 				""";
-		assertFunctionsEquals(List.of(function, function2), partition(function + function2));
+		assertFunctionsEquals(List.of(function, function2),
+				partition(function + CommonElementExporter.LINE_END + function2));
 	}
 
 	private static FunctionFBType createFunctionFBType() {


### PR DESCRIPTION
The ST partitioner discarded whitespace surrounding top-level comments and replaced it with an empty line. This led to a mismatch between the ST formatter and the re-combined source.

This preserves whitespace surrounding top-level comments and avoids adding an empty line between top-level comments and regular ST elements. It also avoids adding an additional newline inside regular ST elements if the text begins with a whitespace character, instead of just checking for an existing newline.