### PR TITLE
Avoid repeated GitLab metadata downloads

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.gitlab/src/org/eclipse/fordiac/ide/gitlab/management/GitLabDownloader.java
+++ b/plugins/org.eclipse.fordiac.ide.gitlab/src/org/eclipse/fordiac/ide/gitlab/management/GitLabDownloader.java
@@ -183,6 +183,8 @@ public class GitLabDownloader implements IArchiveDownloader {
 		final HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
 		httpConn.setRequestMethod(Messages.GET);
 		httpConn.setRequestProperty(Messages.Private_Token, token);
+		httpConn.setConnectTimeout(10_000);
+		httpConn.setReadTimeout(30_000);
 		return httpConn;
 	}
 
@@ -429,11 +431,13 @@ public class GitLabDownloader implements IArchiveDownloader {
 	public DownloadResult<Path> downloadManifest(final String symbolicName, final Version version,
 			final IProgressMonitor monitor) throws OperationCanceledException {
 		final SubMonitor progress = SubMonitor.convert(monitor, "Downloading Manifest from Gitlab", 5); //$NON-NLS-1$
-		final var fetchResult = fetchProjectsAndPackages();
-		progress.worked(4);
-		if (fetchResult.status() != DownloadResult.Status.OK) {
-			return new DownloadResult<>(fetchResult.status(), fetchResult.message());
+		if (packagesAndLeaves == null || projectAndPackageMap == null) {
+			final var fetchResult = fetchProjectsAndPackages();
+			if (fetchResult.status() != DownloadResult.Status.OK) {
+				return new DownloadResult<>(fetchResult.status(), fetchResult.message());
+			}
 		}
+		progress.worked(4);
 		if (!packagesAndLeaves.containsKey(symbolicName)) {
 			return new DownloadResult<>(DownloadResult.Status.NOT_FOUND, Messages.Library_Not_Found);
 		}

--- a/plugins/org.eclipse.fordiac.ide.gitlab/src/org/eclipse/fordiac/ide/gitlab/management/GitLabDownloader.java
+++ b/plugins/org.eclipse.fordiac.ide.gitlab/src/org/eclipse/fordiac/ide/gitlab/management/GitLabDownloader.java
@@ -137,11 +137,11 @@ public class GitLabDownloader implements IArchiveDownloader {
 	}
 
 	public Map<String, List<LeafNode>> getPackagesAndLeaves() {
-		return packagesAndLeaves;
+		return packagesAndLeaves != null ? packagesAndLeaves : Map.of();
 	}
 
 	public Map<Project, List<Package>> getProjectsAndPackages() {
-		return projectAndPackageMap;
+		return projectAndPackageMap != null ? projectAndPackageMap : Map.of();
 	}
 
 	public DownloadResult<Void> fetchProjectsAndPackages() {
@@ -320,7 +320,10 @@ public class GitLabDownloader implements IArchiveDownloader {
 				}
 			} catch (final IOException e) {
 				httpConn.disconnect();
-				return;
+				// propagate so a failed package fetch invalidates the cache in
+				// fetchProjectsAndPackages() instead of being silently swallowed
+				throw new IOException(MessageFormat.format("Request to GitLab failed: {0} {1}", //$NON-NLS-1$
+						Integer.valueOf(httpConn.getResponseCode()), httpConn.getResponseMessage()), e);
 			}
 			httpConn.disconnect();
 		}

--- a/plugins/org.eclipse.fordiac.ide.gitlab/src/org/eclipse/fordiac/ide/gitlab/management/GitLabDownloader.java
+++ b/plugins/org.eclipse.fordiac.ide.gitlab/src/org/eclipse/fordiac/ide/gitlab/management/GitLabDownloader.java
@@ -161,6 +161,10 @@ public class GitLabDownloader implements IArchiveDownloader {
 				getPackages(project);
 			}
 		} catch (final IOException e) {
+			// clear the partially populated cache so a failed fetch is never mistaken
+			// for a valid (but empty) cache by later manifest/library requests
+			projectAndPackageMap = null;
+			packagesAndLeaves = null;
 			return new DownloadResult<>(DownloadResult.Status.ERROR,
 					MessageFormat.format(Messages.Download_Error, e.getMessage()));
 		}
@@ -267,7 +271,7 @@ public class GitLabDownloader implements IArchiveDownloader {
 
 	private void getProjects() throws IOException {
 		String page = "1"; //$NON-NLS-1$
-		final String regex = "\\{\\\"id\\\"\\s*:\\s*(?<projectID>\\d+)\\s*,\\s*\\\"description\\\".*?,\\s*\\\"name\\\"\\s*:\\s*\\\"(?<projectName>[\\w\\s\\-\\.]+)\\\"\\s*,\\s*\\\"name_with_namespace\\\"[^\\}]*+\\}"; //$NON-NLS-1$
+		final String regex = "\\{\\\"id\\\"\\s*:\\s*(?<projectID>\\d+)\\s*,\\s*\\\"description\\\".*?,\\s*\\\"name\\\"\\s*:\\s*\\\"(?<projectName>[\\w\\s\\-\\.]+)\\\"\\s*,\\s*\\\"name_with_namespace\\\"\\s*:\\s*\\\"[^\\\"]*\\\"[^}]*\\}"; //$NON-NLS-1$
 		final Pattern p = Pattern.compile(regex);
 
 		while (page != null && !"".equals(page)) { //$NON-NLS-1$
@@ -293,7 +297,7 @@ public class GitLabDownloader implements IArchiveDownloader {
 
 	private void getPackages(final Project project) throws IOException {
 		String page = "1"; //$NON-NLS-1$
-		final String regex = "(?<packageID>\\d+),\\\"name\\\":\\\"(?<packageName>[\\w\\s\\-\\.]*)\\\",\\\"version\\\":\\\"(?<packageVersion>[\\w\\s\\-\\.]*)\\\",\\\"package_type\\\":\\\"(?<packageType>[\\w\\s\\-\\.]*)"; //$NON-NLS-1$
+		final String regex = "(?<packageID>\\d+),\\\"name\\\":\\\"(?<packageName>[\\w\\s\\-\\.]*)\\\",\\\"version\\\":\\\"(?<packageVersion>[\\w\\s\\-\\.]*)\\\",\\\"package_type\\\":\\\"(?<packageType>[\\w\\s\\-\\.]*)\\\""; //$NON-NLS-1$
 		final Pattern p = Pattern.compile(regex);
 		while (page != null && !"".equals(page)) { //$NON-NLS-1$
 			final HttpURLConnection httpConn = createConnection(buildPackagesForProjectURL(project, page));


### PR DESCRIPTION
Reuse already fetched project and package metadata when downloading
library manifests and add connection/read timeouts to prevent stalled
GitLab requests.