### PR TITLE
Ensure newline after lost-and-found in ST partitioner

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.tests/src/org/eclipse/fordiac/ide/structuredtextalgorithm/tests/STAlgorithmPartitionerTest.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm.tests/src/org/eclipse/fordiac/ide/structuredtextalgorithm/tests/STAlgorithmPartitionerTest.java
@@ -181,6 +181,24 @@ class STAlgorithmPartitionerTest {
 	}
 
 	@Test
+	void testCombineLostAndFoundLegacy2() {
+		final SimpleFBType fbType = createSimpleFBType();
+		final String algorithm = """
+				ALGORITHM REQ
+				END_ALGORITHM
+				""".stripTrailing();
+		fbType.getCallables().add(createSTAlgorithm("REQ", algorithm));
+		final String lostAndFound = "// ------";
+		fbType.getCallables().add(createSTMethod("LOST_AND_FOUND_1", lostAndFound));
+		final String method = """
+				METHOD TEST
+				END_METHOD
+				""";
+		fbType.getCallables().add(createSTMethod("TEST", method));
+		assertEquals(algorithm + lostAndFound + CommonElementExporter.LINE_END + method, partitioner.combine(fbType));
+	}
+
+	@Test
 	void testCombineTrailingBodyWhitespace() {
 		final SimpleFBType fbType = createSimpleFBType();
 		final String text = """

--- a/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm/src/org/eclipse/fordiac/ide/structuredtextalgorithm/util/STAlgorithmPartitioner.java
+++ b/plugins/org.eclipse.fordiac.ide.structuredtextalgorithm/src/org/eclipse/fordiac/ide/structuredtextalgorithm/util/STAlgorithmPartitioner.java
@@ -78,6 +78,11 @@ public class STAlgorithmPartitioner extends STRecoveringPartitioner<STAlgorithmS
 			// add empty line, except around lost+found
 			builder.append(CommonElementExporter.LINE_END);
 			builder.append(CommonElementExporter.LINE_END);
+		} else if (isLostAndFound(previous) && !isLostAndFound(current)
+				&& !isLineDelimiter(builder.charAt(builder.length() - 1))) {
+			// ensure line delimiter after previous lost+found element
+			// and before appending a regular ST element
+			builder.append(CommonElementExporter.LINE_END);
 		} else if (isWordCharacter(builder.charAt(builder.length() - 1)) && isWordCharacter(text.charAt(0))) {
 			// add line separator if appended text has no word boundary
 			builder.append(CommonElementExporter.LINE_END);


### PR DESCRIPTION
The ST partitioner only checked for a word boundary when appending a regular ST element, but this could append a method or algorithm header after a previous end-of-line comment.

This additionally ensures a newline after a lost-and-found and before a regular ST element.