### PR TITLE
Fix incorrect test comparisons in GitHub workflows

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,30 +17,24 @@ jobs:
   unit-test-results:
     name: Unit Test Results
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion != 'skipped'
-
+    if: >-
+      github.event.workflow_run.conclusion == 'success' ||
+      github.event.workflow_run.conclusion == 'failure'
     steps:
       - name: Download and Extract Artifacts
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
            mkdir -p artifacts && cd artifacts
-
-           artifacts_url=${{ github.event.workflow_run.artifacts_url }}
-
-           gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
-           do
-             IFS=$'\t' read name url <<< "$artifact"
-             gh api $url > "$name.zip"
-             unzip -d "$name" "$name.zip"
-           done
+           gh run download ${{ github.event.workflow_run.id }} --repo ${{ github.repository }} \
+             --name 'event_file' --pattern 'test-results-*'
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         with:
+          check_name: >-
+            Test Results (${{ github.event.workflow_run.event || github.event_name }})
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/event_file/event.json
           event_name: ${{ github.event.workflow_run.event }}
           files: "artifacts/**/*.xml"
-
-


### PR DESCRIPTION
The publish unit tests action could have different event types overwriting each other's results, which could lead to incorrect comparisons for test counts. It could also run on previous workflow runs with incomplete results, such as canceled runs.

This includes the event type in the check name to distinguish between pull request and push events[^1], as well as guards publish runs on only success or failure. It also simplifies the artifact download.

[^1]: see [Running with multiple event types](https://github.com/EnricoMi/publish-unit-test-result-action#running-with-multiple-event-types-pull_request-push-schedule-) in the action documentation