### PR TITLE
Consider event types when creating EC states for legacy simple FBs

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/FBTImporter.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/dataimport/FBTImporter.java
@@ -232,7 +232,8 @@ public class FBTImporter extends BlockTypeImporter {
 				state.setInputEvent(inEvent);
 				final var action = LibraryElementFactory.eINSTANCE.createSimpleECAction();
 				action.setAlgorithm(inEvent.getName());
-				action.setOutput(stdOutEvent);
+				action.setOutput(type.getInterfaceList().getEventOutputs().stream()
+						.filter(outEvent -> outEvent.getType() == inEvent.getType()).findFirst().orElse(stdOutEvent));
 				state.getSimpleECActions().add(action);
 				type.getSimpleECStates().add(state);
 			}


### PR DESCRIPTION
The importer creates EC states for each input event without an EC state to convert legagcy simple FBs. This always used the first output event for the new EC state, not accounting for event type.

This uses the first output event with a matching event type instead and only afterwards falls back to the first event.