### PR TITLE
Add direct UP/DOWN transitions to DualHysteresis

### DIFF
--- a/data/typelibrary/signalprocessing-3.0.0/typelib/DualHysteresis.fbt
+++ b/data/typelibrary/signalprocessing-3.0.0/typelib/DualHysteresis.fbt
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="DualHysteresis" Comment="2-way conversion of Analog to Digital with Hysteresis">
-	<Identification Standard="61499-2" Description="Copyright (c) 2023 HR Agrartechnik GmbH   &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 ">
+<FBType Name="DualHysteresis" Comment="2-way conversion of Analog to Digital with Hysteresis (Switch-on = MI +/- (ABS(DEAD) + ABS(HYSTERESIS)), Switch-off = MI +/- ABS(DEAD))">
+	<Identification Standard="61499-2" Description="Copyright (c) 2023 HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 ">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-09-11" Remarks="clarify description/comments and wrap DEAD/HYSTERESIS in ABS() so switch points stay correct for negative parameter values">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2023-06-06">
@@ -31,26 +33,26 @@
 			</Event>
 		</EventOutputs>
 		<InputVars>
-			<VarDeclaration Name="QI" Type="BOOL" Comment="Input event qualifier" />
-			<VarDeclaration Name="MI" Type="REAL" Comment="MID Setting can e.g. be 0.5 meaning 50%"  InitialValue="0.5"/>
-			<VarDeclaration Name="DEAD" Type="REAL" Comment="Deadband around MID can be e.g. 0.1 meaning 10%"  InitialValue="0.1"/>
-			<VarDeclaration Name="HYSTERESIS" Type="REAL" Comment="Hysteresis can be 0.1 meaning 10%"  InitialValue="0.1"/>
-			<VarDeclaration Name="INPUT" Type="REAL" Comment="Value" />
+			<VarDeclaration Name="QI" Type="BOOL" Comment="Input event qualifier"/>
+			<VarDeclaration Name="MI" Type="REAL" Comment="Center point (e.g. 0.5 for 50%)" InitialValue="0.5"/>
+			<VarDeclaration Name="DEAD" Type="REAL" Comment="Deadband around MI (Switch-off points = MI +/- ABS(DEAD))" InitialValue="0.1"/>
+			<VarDeclaration Name="HYSTERESIS" Type="REAL" Comment="Hysteresis value (Switch-on points = MI +/- (ABS(DEAD) + ABS(HYSTERESIS)))" InitialValue="0.1"/>
+			<VarDeclaration Name="INPUT" Type="REAL" Comment="Value"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
-			<VarDeclaration Name="DO_UP" Type="BOOL" Comment=" UP" />
-			<VarDeclaration Name="DO_DOWN" Type="BOOL" Comment="DOWN" />
+			<VarDeclaration Name="DO_UP" Type="BOOL" Comment=" UP"/>
+			<VarDeclaration Name="DO_DOWN" Type="BOOL" Comment="DOWN"/>
 		</OutputVars>
 	</InterfaceList>
 	<BasicFB>
 		<ECC>
-			<ECState Name="START" Comment="Initial State"  x="840" y="2460">
+			<ECState Name="START" Comment="Initial State" x="840" y="2460">
 			</ECState>
-			<ECState Name="Init" Comment="Initialization"  x="1600" y="2000">
+			<ECState Name="Init" Comment="Initialization" x="1600" y="2000">
 				<ECAction Algorithm="initialize" Output="INITO"/>
 			</ECState>
-			<ECState Name="UP" Comment="Normal execution"  x="6666.67" y="1066.67">
+			<ECState Name="UP" Comment="Normal execution" x="6666.67" y="1066.67">
 				<ECAction Algorithm="alUp" Output="CNF"/>
 			</ECState>
 			<ECState Name="Neutral" x="2266.67" y="2480">
@@ -65,11 +67,11 @@
 			<ECTransition Source="START" Destination="Init" Condition="INIT[TRUE = QI]" Comment="" x="1206.67" y="2260"/>
 			<ECTransition Source="Init" Destination="Neutral" Condition="REQ" Comment="" x="2026.67" y="2313.33"/>
 			<ECTransition Source="Neutral" Destination="DeInit" Condition="INIT[FALSE = QI]" Comment="" x="2053.33" y="2680"/>
-			<ECTransition Source="Neutral" Destination="UP" Condition="REQ[INPUT &gt;= MI + DEAD + HYSTERESIS]" Comment="" x="5040" y="1173.33"/>
+			<ECTransition Source="Neutral" Destination="UP" Condition="REQ[INPUT &gt;= MI + ABS(DEAD) + ABS(HYSTERESIS)]" Comment="Switch-on UP (inclusive)" x="5040" y="1173.33"/>
 			<ECTransition Source="DeInit" Destination="START" Condition="1" Comment="" x="1306.67" y="2780"/>
-			<ECTransition Source="Neutral" Destination="DOWN" Condition="REQ[INPUT &lt;= MI - DEAD - HYSTERESIS]" Comment="" x="5513.33" y="3013.33"/>
-			<ECTransition Source="DOWN" Destination="Neutral" Condition="REQ[INPUT &gt; MI - DEAD]" Comment="" x="5173.33" y="3480"/>
-			<ECTransition Source="UP" Destination="Neutral" Condition="REQ[INPUT &lt; MI + DEAD]" Comment="" x="5173.33" y="2026.67"/>
+			<ECTransition Source="Neutral" Destination="DOWN" Condition="REQ[INPUT &lt;= MI - ABS(DEAD) - ABS(HYSTERESIS)]" Comment="Switch-on DOWN (inclusive)" x="5513.33" y="3013.33"/>
+			<ECTransition Source="DOWN" Destination="Neutral" Condition="REQ[INPUT &gt; MI - ABS(DEAD)]" Comment="Switch-off DOWN (strict)" x="5173.33" y="3480"/>
+			<ECTransition Source="UP" Destination="Neutral" Condition="REQ[INPUT &lt; MI + ABS(DEAD)]" Comment="Switch-off UP (strict)" x="5173.33" y="2026.67"/>
 		</ECC>
 		<Algorithm Name="initialize">
 			<ST><![CDATA[ALGORITHM initialize

--- a/data/typelibrary/signalprocessing-3.0.0/typelib/DualHysteresis.fbt
+++ b/data/typelibrary/signalprocessing-3.0.0/typelib/DualHysteresis.fbt
@@ -2,7 +2,7 @@
 <FBType Name="DualHysteresis" Comment="2-way conversion of Analog to Digital with Hysteresis (Switch-on = MI +/- (ABS(DEAD) + ABS(HYSTERESIS)), Switch-off = MI +/- ABS(DEAD))">
 	<Identification Standard="61499-2" Description="Copyright (c) 2023 HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 ">
 	</Identification>
-	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-09-11" Remarks="clarify description/comments and wrap DEAD/HYSTERESIS in ABS() so switch points stay correct for negative parameter values">
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-09-11" Remarks="clarify description/comments and wrap DEAD/HYSTERESIS in ABS() so switch points stay correct for negative parameter values; add direct UP/DOWN transitions so INPUT crossing both switch-on thresholds within one REQ no longer causes a spurious one-cycle Neutral output">
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
@@ -70,6 +70,8 @@
 			<ECTransition Source="Neutral" Destination="UP" Condition="REQ[INPUT &gt;= MI + ABS(DEAD) + ABS(HYSTERESIS)]" Comment="Switch-on UP (inclusive)" x="5040" y="1173.33"/>
 			<ECTransition Source="DeInit" Destination="START" Condition="1" Comment="" x="1306.67" y="2780"/>
 			<ECTransition Source="Neutral" Destination="DOWN" Condition="REQ[INPUT &lt;= MI - ABS(DEAD) - ABS(HYSTERESIS)]" Comment="Switch-on DOWN (inclusive)" x="5513.33" y="3013.33"/>
+			<ECTransition Source="UP" Destination="DOWN" Condition="REQ[INPUT &lt;= MI - ABS(DEAD) - ABS(HYSTERESIS)]" Comment="Direct switch-on DOWN (inclusive)" x="6666.67" y="3013.33"/>
+			<ECTransition Source="DOWN" Destination="UP" Condition="REQ[INPUT &gt;= MI + ABS(DEAD) + ABS(HYSTERESIS)]" Comment="Direct switch-on UP (inclusive)" x="6666.67" y="1173.33"/>
 			<ECTransition Source="DOWN" Destination="Neutral" Condition="REQ[INPUT &gt; MI - ABS(DEAD)]" Comment="Switch-off DOWN (strict)" x="5173.33" y="3480"/>
 			<ECTransition Source="UP" Destination="Neutral" Condition="REQ[INPUT &lt; MI + ABS(DEAD)]" Comment="Switch-off UP (strict)" x="5173.33" y="2026.67"/>
 		</ECC>


### PR DESCRIPTION
## What

Adds `UP -> DOWN` and `DOWN -> UP` transitions to the `DualHysteresis` ECC, with the same switch-on conditions as the existing `Neutral -> DOWN`/`Neutral -> UP` transitions, checked before the existing switch-off-to-`Neutral` transitions.

Stacked on #2873 (comment/ABS cleanup) - the diff here is just the two new transitions plus the version Remarks update; no new VersionInfo entry (kept at 3.1, extended the existing Remarks per the "bump once per cycle" convention).

## Why

Previously `UP` and `DOWN` each only had a transition back to `Neutral`. If `INPUT` crossed both switch-on thresholds within a single `REQ` event (a scan-to-scan jump larger than `2*(ABS(DEAD)+ABS(HYSTERESIS))`), the ECC would land in `Neutral` for one cycle - `REQ`-guarded transitions don't chain within one event - before reaching the correct state on the next `REQ`.

Fixes #2872.